### PR TITLE
Update docker build tag order

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -139,14 +139,14 @@ jobs:
 
       - name: Generate tags for circ-exec image
         id: exec-tags
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3
         with:
           images: ghcr.io/${{ github.repository_owner }}/circ-exec
           tags: |
-            type=sha
-            type=ref,event=branch
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},priority=10
+            type=semver,pattern={{version}},priority=20
+            type=ref,event=branch,priority=30
+            type=sha,priority=40
 
       - name: Build & push circ-exec image
         uses: docker/build-push-action@v2
@@ -217,14 +217,14 @@ jobs:
 
       - name: Generate tags for circ-scripts image
         id: scripts-tags
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3
         with:
           images: ghcr.io/${{ github.repository_owner }}/circ-scripts
           tags: |
-            type=sha
-            type=ref,event=branch
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},priority=10
+            type=semver,pattern={{version}},priority=20
+            type=ref,event=branch,priority=30
+            type=sha,priority=40
 
       - name: Push circ-scripts image
         uses: docker/build-push-action@v2
@@ -295,14 +295,14 @@ jobs:
 
       - name: Generate tags for circ-webapp image
         id: webapp-tags
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: docker/metadata-action@v3
         with:
           images: ghcr.io/${{ github.repository_owner }}/circ-webapp
           tags: |
-            type=sha
-            type=ref,event=branch
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}},priority=10
+            type=semver,pattern={{version}},priority=20
+            type=ref,event=branch,priority=30
+            type=sha,priority=40
 
       - name: Push circ-webapp image
         uses: docker/build-push-action@v2

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -143,10 +143,10 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/circ-exec
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=sha
+            type=ref,event=branch
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
 
       - name: Build & push circ-exec image
         uses: docker/build-push-action@v2
@@ -221,10 +221,10 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/circ-scripts
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=sha
+            type=ref,event=branch
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
 
       - name: Push circ-scripts image
         uses: docker/build-push-action@v2
@@ -299,10 +299,10 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/circ-webapp
           tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=sha
+            type=ref,event=branch
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
 
       - name: Push circ-webapp image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
## Description

When container images have multiple tags, github displays the one with the highest priority. This means that currently the `sha-####` tag is always the one displayed. This is a helpful tag, but I think others should be displayed more prominently. 

`crazy-max/ghaction-docker-meta` was moved into the docker org and renamed to `docker/metadata-action`. This updates to use the latest version from the docker org.

We change the tag order by adding the priority argument to our list of tags. It configures the tags to have the following priority:
- `major.minor`
- `major`
- `branch name`
- `sha-####`

You can see this in action by taking a look at the [image built for this PR](https://github.com/orgs/ThePalaceProject/packages/container/circ-webapp/2495969?tag=sha-b29b042) vs [the one built for PR #3](https://github.com/orgs/ThePalaceProject/packages/container/circ-webapp/2496118?tag=circulation-admin).