### PR TITLE
Handle double escaped entity references.

### DIFF
--- a/tests/test_bibliotheca.py
+++ b/tests/test_bibliotheca.py
@@ -1246,6 +1246,16 @@ class TestItemListParser(BibliothecaAPITest):
             "Baum, Frank L. (Frank Lyell)")
         assert "Baum, Frank L." == author.sort_name
 
+        # Contributors may have two levels of entity reference escaping,
+        # one of which will have already been handled by the initial parse.
+        # So, we'll test zero and one escapings here.
+        authors = list(ItemListParser.contributors_from_string(
+            u'Raji Codell, Esmé; Raji Codell, Esm&#233;'))
+        author_names = [a.sort_name for a in authors]
+        assert len(authors) == 2
+        assert len(set(author_names)) == 1
+        assert all(u'Raji Codell, Esmé' == name for name in author_names)
+
         # It's possible to specify some role other than AUTHOR_ROLE.
         narrators = list(
             ItemListParser.contributors_from_string(


### PR DESCRIPTION
## Description

- Adds an extra XML entity dereference for contributor (author, etc.) values in Bibliotheca `item` response data and
- Adds a new test of contributor parsing that includes content containing special characters and an entity reference.

## Motivation and Context

`bibliotheca_format_sweep` is not running to completion.
- `ValueError: Cannot find sort name for a contributor with no display name!`

Items returned by the Bibliotheca CloudLibrary `items` API may have contributors with two-level deep entity references, so `<Authors>Raji Codell, Esmé</Authors>` may be transmitted as `<Authors>Raji Codell, Esm&amp;#233;</Authors>`, rather than `<Authors>Raji Codell, Esm&#233;</Authors>`. This resulted in incorrect parsing of contributor fields, which, in turn lead to:
- invalid contributor entries (existing ones will need remediation) and
- the aforementioned crashes of `bibliotheca_circulation_sweep`.

## How Has This Been Tested?

In addition to the regular tests, ran `bibliotheca_circulation_sweep` against an existing test collection and verified that:
- escaped strings were processed properly and
- the script was able to run to completion.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
