### PR TITLE
ODL collections can configure primary identifier preference

### DIFF
--- a/api/odl.py
+++ b/api/odl.py
@@ -38,6 +38,7 @@ from core.model import (
     LicensePool,
     Loan,
     MediaTypes,
+    Representation,
     RightsStatus,
     Session,
     get_one,
@@ -783,8 +784,8 @@ class ODLImporter(OPDSImporter):
     LICENSE_INFO_DOCUMENT_MEDIA_TYPE = 'application/vnd.odl.info+json'
 
     @classmethod
-    def _detail_for_elementtree_entry(cls, parser, entry_tag, feed_url=None, do_get=None):
-        do_get = do_get or Representation.cautious_http_get
+    def _detail_for_elementtree_entry(cls, parser, entry_tag, feed_url=None,
+                                      do_get=Representation.cautious_http_get):
 
         # TODO: Review for consistency when updated ODL spec is ready.
         subtag = parser.text_of_optional_subtag

--- a/api/odl.py
+++ b/api/odl.py
@@ -109,7 +109,7 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI):
             "type": "number",
             "default": Collection.STANDARD_DEFAULT_RESERVATION_PERIOD,
         },
-    ] + BaseSharedCollectionAPI.SETTINGS
+    ] + OPDSImporter.PRIMARY_IDENTIFIER_SOURCE_SETTINGS + BaseSharedCollectionAPI.SETTINGS
 
     LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
         BaseCirculationAPI.EBOOK_LOAN_DURATION_SETTING

--- a/api/odl.py
+++ b/api/odl.py
@@ -1,78 +1,67 @@
 
-import base64
 import json
-import uuid
-import datetime
-from flask_babel import lazy_gettext as _
-import urlparse
-from collections import defaultdict
-import flask
-from flask import Response
-import feedparser
-from lxml import etree
-from problem_details import NO_LICENSES
 from StringIO import StringIO
-import re
+
+import base64
+import datetime
+import feedparser
+import flask
+import uuid
+from flask import url_for
+from flask_babel import lazy_gettext as _
+from lxml import etree
+from sqlalchemy.sql.expression import or_
 from uritemplate import URITemplate
 
-from sqlalchemy.sql.expression import or_
-
-from core.opds_import import (
-    OPDSXMLParser,
-    OPDSImporter,
-    OPDSImportMonitor,
-)
-from core.monitor import (
-    CollectionMonitor,
-    TimelineMonitor,
-)
-from core.model import (
-    Collection,
-    ConfigurationSetting,
-    Credential,
-    DataSource,
-    DeliveryMechanism,
-    Edition,
-    ExternalIntegration,
-    Hold,
-    Hyperlink,
-    Identifier,
-    IntegrationClient,
-    LicensePool,
-    Loan,
-    MediaTypes,
-    RightsStatus,
-    Session,
-    create,
-    get_one,
-    get_one_or_create,
-)
-from core.metadata_layer import (
-    CirculationData,
-    FormatData,
-    IdentifierData,
-    LicenseData,
-    TimestampData,
-)
 from circulation import (
     BaseCirculationAPI,
     LoanInfo,
     FulfillmentInfo,
     HoldInfo,
 )
+from circulation_exceptions import *
 from core.analytics import Analytics
+from core.metadata_layer import (
+    FormatData,
+    LicenseData,
+    TimestampData,
+)
+from core.model import (
+    Collection,
+    ConfigurationSetting,
+    DataSource,
+    DeliveryMechanism,
+    Edition,
+    ExternalIntegration,
+    Hold,
+    Hyperlink,
+    LicensePool,
+    Loan,
+    MediaTypes,
+    RightsStatus,
+    Session,
+    get_one,
+    get_one_or_create,
+)
+from core.monitor import (
+    CollectionMonitor,
+)
+from core.opds_import import (
+    OPDSXMLParser,
+    OPDSImporter,
+    OPDSImportMonitor,
+)
+from core.testing import (
+    DatabaseTest,
+    MockRequestsResponse,
+)
 from core.util.http import (
     HTTP,
     BadResponseException,
     RemoteIntegrationException,
 )
-from flask import url_for
-from core.testing import (
-    DatabaseTest,
-    MockRequestsResponse,
-)
-from circulation_exceptions import *
 from shared_collection import BaseSharedCollectionAPI
+
 
 class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI):
     """ODL (Open Distribution to Libraries) is a specification that allows


### PR DESCRIPTION
## Description

Adds primary ID settings from `OPDSImporter` (currently only one) to ODL collections. 

Depends on [circulation-core PR #9](https://github.com/lyrasis/simplye-server-core/pull/9).

## Motivation and Context

`ODLImporter` is a subclass of `OPDSImporter`, but does not inherit its configuration settings because ODL configuration settings are managed by `ODLAPI`.

## How Has This Been Tested?

Ran core and circulation tests. Verified via admin API that the optional setting appears for ODL collections and that the correct value appears in the database when selected.

## Checklist:

- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
