### PR TITLE
Add saml_migrate script allowing to update SAML patrons' unique IDs

### DIFF
--- a/api/saml/metadata/model.py
+++ b/api/saml/metadata/model.py
@@ -1288,6 +1288,33 @@ class SAMLSubjectPatronIDExtractor(object):
 
     PATRON_ID_REGULAR_EXPRESSION_NAMED_GROUP = "patron_id"
 
+    @property
+    def use_name_id(self):
+        """Return the boolean value indicating whether NameID should be searched for a unique patron ID.
+
+        :return: Boolean value indicating whether NameID should be searched for a unique patron ID
+        :rtype: bool
+        """
+        return self._use_name_id
+
+    @property
+    def patron_id_attributes(self):
+        """Return the list of SAML attributes which should be searched for a unique patron ID.
+
+        :return: List of SAML attributes which should be searched for a unique patron ID
+        :rtype: List[str]
+        """
+        return self._patron_id_attributes
+
+    @property
+    def patron_id_regular_expression(self):
+        """Return the regular expression used to extract a unique patron ID from SAML attributes.
+
+        :return: Regular expression used to extract a unique patron ID from SAML attributes
+        :rtype: str
+        """
+        return self._patron_id_regular_expression
+
     def __init__(self, use_name_id=True, attributes=None, regular_expression=None):
         """Initialize a new instance of SAMLSubjectPatronIDExtractor class.
 
@@ -1295,10 +1322,10 @@ class SAMLSubjectPatronIDExtractor(object):
         :type use_name_id: bool
 
         :param attributes: List of SAML attributes which should be searched for a unique patron ID
-        :type attributes: List[SAMLAttributeType]
+        :type attributes: Optional[List[str]]
 
         :param regular_expression: Regular expression used to extract a unique patron ID from SAML attributes
-        :type regular_expression: str
+        :type regular_expression: Optional[str]
         """
         # To keep backward compatibility, we assume that use_name_id is True by default.
         self._use_name_id = bool(use_name_id) if use_name_id is not None else True
@@ -1363,10 +1390,10 @@ class SAMLSubjectPatronIDExtractor(object):
         patron_id = None
 
         if subject.attribute_statement:
-            for patron_id_attribute in self._patron_id_attributes:
-                if patron_id_attribute in subject.attribute_statement.attributes:
+            for patron_id_attribute_name in self._patron_id_attributes:
+                if patron_id_attribute_name in subject.attribute_statement.attributes:
                     patron_id_attribute = subject.attribute_statement.attributes[
-                        patron_id_attribute
+                        patron_id_attribute_name
                     ]
 
                     # NOTE: It takes the first value.

--- a/api/saml/migration.py
+++ b/api/saml/migration.py
@@ -1,0 +1,265 @@
+import argparse
+import json
+import logging
+from json import JSONDecoder
+
+from api.authenticator import BaseSAMLAuthenticationProvider, PatronData
+from api.saml.configuration.model import SAMLConfiguration, SAMLConfigurationFactory
+from api.saml.metadata.model import SAMLSubjectJSONDecoder, SAMLSubjectPatronIDExtractor
+from api.saml.metadata.parser import SAMLMetadataParser
+from api.saml.provider import SAMLWebSSOAuthenticationProvider
+from core.model import Credential, Patron, Session
+from core.model.configuration import (
+    ConfigurationMetadata,
+    ConfigurationStorage,
+    ExternalIntegration,
+)
+from core.scripts import LibraryInputScript
+from core.util.string_helpers import is_string
+
+
+class SAMLMigrationManager(object):
+    """Allows to change unique IDs of SAML patrons."""
+
+    def __init__(self, saml_subject_json_decoder, patron_id_extractor):
+        """Initialize a new instance of SAMLMigrationManager class.
+
+        :param saml_subject_json_decoder: JSONDecoder instance used to extract a JSON-serialized SAML subject
+            from Credential object stored in the database
+        :type saml_subject_json_decoder: JSONDecoder
+
+        :param patron_id_extractor: SAMLSubjectPatronIDExtractor instance used to extract a unique patron ID
+            from the SAML subject
+        :type patron_id_extractor: SAMLSubjectPatronIDExtractor
+        """
+        if not isinstance(saml_subject_json_decoder, JSONDecoder):
+            raise ValueError(
+                "'saml_subject_json_decoder' argument must be an instance of {0} class".format(
+                    JSONDecoder.__class__
+                )
+            )
+        if not isinstance(patron_id_extractor, SAMLSubjectPatronIDExtractor):
+            raise ValueError(
+                "'patron_id_extractor' argument must be an instance of {0} class".format(
+                    SAMLSubjectPatronIDExtractor.__class__
+                )
+            )
+
+        self._patron_id_extractor = patron_id_extractor
+        self._saml_subject_json_decoder = saml_subject_json_decoder
+        self._logger = logging.getLogger(__name__)
+
+    def migrate(self, db, library_id):
+        """Migrate all the SAML patrons in the database:
+        - find existing SAML patrons
+        - update their unique IDs according to the settings in `self._patron_id_extractor`.
+
+        :param db: Database session
+        :type db: sqlalchemy.orm.session.Session
+
+        :param library_id: ID of the library patrons belong to
+        :type library_id: int
+        """
+        self._logger.info(
+            "Started migrating SAML patrons using the following settings: "
+            "use NameID={0}, SAML attributes={1}, regular expression={2}".format(
+                self._patron_id_extractor.use_name_id,
+                ", ".join(self._patron_id_extractor.patron_id_attributes)
+                if self._patron_id_extractor.patron_id_attributes
+                else "[]",
+                str(self._patron_id_extractor.patron_id_regular_expression),
+            )
+        )
+
+        saml_credentials = (
+            db.query(Credential)
+            .join(Patron)
+            .filter(Credential.type == BaseSAMLAuthenticationProvider.TOKEN_TYPE)
+            .filter(Patron.library_id == library_id)
+        )
+
+        transaction = db.begin_nested()
+
+        try:
+            for saml_credential in saml_credentials:
+                saml_subject = self._saml_subject_json_decoder.decode(
+                    saml_credential.credential
+                )
+                patron_id = self._patron_id_extractor.extract(saml_subject)
+
+                if not patron_id:
+                    self._logger.warning(
+                        "Could not find a unique patron ID in {0} for patron {1}".format(
+                            saml_credential,
+                            saml_credential.patron
+                        )
+                    )
+
+                patron_data = PatronData(
+                    permanent_id=patron_id,
+                    authorization_identifier=patron_id,
+                    external_type="A",
+                    complete=True,
+                )
+
+                patron_data.apply(saml_credential.patron)
+
+            transaction.commit()
+            db.commit()
+        except:
+            self._logger.exception(
+                "An unexpected exception occurred during migration of SAML patrons"
+            )
+
+            transaction.rollback()
+            raise
+
+        self._logger.info("Finished migrating SAML patrons")
+
+
+class SAMLMigrationManagerFactory(object):
+    """Used to create SAMLMigrationManager instances.
+
+    This class simplifies creation of SAMLMigrationManager instances and allows to unit-test it.
+    """
+
+    def create(
+        self,
+        use_name_id=True,
+        patron_id_attributes=None,
+        patron_id_regular_expression=None,
+    ):
+        """Create a new instance of SAMLMigrationManager class.
+
+        :param use_name_id: Boolean value indicating whether NameID should be searched for a unique patron ID
+        :type use_name_id: bool
+
+        :param patron_id_attributes: List of SAML attributes which should be searched for a unique patron ID
+        :type patron_id_attributes: Optional[List[str]]
+
+        :param patron_id_regular_expression: Regular expression used to extract a unique patron ID from SAML attributes
+        :type patron_id_regular_expression: Optional[str]
+
+        :return: SAMLMigrationManager object
+        :rtype: SAMLMigrationManager
+        """
+        if not isinstance(use_name_id, bool):
+            raise ValueError("'use_name_id' must be boolean")
+        if patron_id_attributes is not None and not isinstance(patron_id_attributes, list):
+            raise ValueError("'patron_id_attributes' must be a list")
+        if patron_id_regular_expression is not None and not is_string(patron_id_regular_expression):
+            raise ValueError("'patron_id_regular_expression' must be a string")
+
+        saml_subject_json_decoder = SAMLSubjectJSONDecoder()
+        patron_id_extractor = SAMLSubjectPatronIDExtractor(
+            use_name_id, patron_id_attributes, patron_id_regular_expression
+        )
+        migration_manager = SAMLMigrationManager(
+            saml_subject_json_decoder, patron_id_extractor
+        )
+
+        return migration_manager
+
+
+class SAMLMigrationScript(LibraryInputScript):
+    """Script running SAML patron ID migration logic."""
+
+    def __init__(self, saml_migration_manager_factory, db=None, *args, **kwargs):
+        """Initialize a new instance of SAMLMigrationScript class.
+
+        :param db: Database session
+        :type db: sqlalchemy.orm.session.Session
+        """
+        super(SAMLMigrationScript, self).__init__(db, *args, **kwargs)
+
+        if not isinstance(saml_migration_manager_factory, SAMLMigrationManagerFactory):
+            raise ValueError(
+                "'saml_migration_manager_factory' argument must be an instance of {0} class".format(
+                    SAMLMigrationManagerFactory.__name__
+                )
+            )
+
+        self._saml_migration_manager_factory = saml_migration_manager_factory
+
+    def _parse_command_line(self, library, *args, **kwargs):
+        parsed = self.parse_command_line(self._db, *args, **kwargs)
+
+        if (
+            not hasattr(parsed, "use_name_id")
+            or not hasattr(parsed, "patron_id_attributes")
+            or not hasattr(parsed, "patron_id_regex")
+        ):
+            db = Session.object_session(library)
+            saml_authentication_provider_external_integration = (
+                ExternalIntegration.lookup(
+                    db,
+                    "api.saml.provider",
+                    ExternalIntegration.PATRON_AUTH_GOAL,
+                    library,
+                )
+            )
+            saml_authentication_provider = SAMLWebSSOAuthenticationProvider(
+                library, saml_authentication_provider_external_integration
+            )
+            saml_configuration_storage = ConfigurationStorage(
+                saml_authentication_provider
+            )
+            saml_configuration_factory = SAMLConfigurationFactory(SAMLMetadataParser())
+
+            with saml_configuration_factory.create(
+                saml_configuration_storage, self._db, SAMLConfiguration
+            ) as configuration:
+                if not hasattr(parsed, "use_name_id"):
+                    parsed.use_name_id = ConfigurationMetadata.to_bool(
+                        configuration.patron_id_use_name_id
+                    )
+                if not hasattr(parsed, "patron_id_attributes"):
+                    parsed.patron_id_attributes = (
+                        json.loads(configuration.patron_id_attributes)
+                        if configuration.patron_id_attributes
+                        else []
+                    )
+                if not hasattr(parsed, "patron_id_regex"):
+                    parsed.patron_id_regex = configuration.patron_id_regular_expression
+
+        # Make sure that `use_name_id` is always boolean.
+        parsed.use_name_id = ConfigurationMetadata.to_bool(parsed.use_name_id)
+
+        return parsed
+
+    @classmethod
+    def arg_parser(cls, db, multiple_libraries=True):
+        parser = LibraryInputScript.arg_parser(db, multiple_libraries)
+        parser.add_argument(
+            "--use-name-id",
+            dest="use_name_id",
+            default=argparse.SUPPRESS,
+            help="Boolean value indicating whether NameID should be searched for a unique patron ID. "
+            "If the value is omitted, configuration setting Patron ID: SAML NameID will be used instead.",
+            action="store",
+            choices=[str(True), str(False)],
+        )
+        parser.add_argument(
+            "--patron-id-attributes",
+            dest="patron_id_attributes",
+            default=argparse.SUPPRESS,
+            help="List of SAML attributes which should be searched for a unique patron ID. "
+            "If the value is omitted, configuration setting Patron ID: SAML Attributes will be used instead.",
+            nargs="*",
+        )
+        parser.add_argument(
+            "--patron-id-regex",
+            dest="patron_id_regex",
+            default=argparse.SUPPRESS,
+            help="Regular expression used to extract a unique patron ID from SAML attributes. "
+            "If the value is omitted, configuration setting Patron ID: Regular expression will be used instead.",
+        )
+        return parser
+
+    def process_library(self, library, *args, **kwargs):
+        parsed = self._parse_command_line(library, *args, **kwargs)
+        migration_manager = self._saml_migration_manager_factory.create(
+            parsed.use_name_id, parsed.patron_id_attributes, parsed.patron_id_regex
+        )
+
+        migration_manager.migrate(self._db, library.id)

--- a/api/saml/provider.py
+++ b/api/saml/provider.py
@@ -471,7 +471,9 @@ class SAMLWebSSOAuthenticationProvider(
             return patron_data
 
         # Convert the PatronData into a Patron object
-        patron, is_new = patron_data.get_or_create_patron(db, self.library_id, self.analytics)
+        patron, is_new = patron_data.get_or_create_patron(
+            db, self.library_id, self.analytics
+        )
 
         # Create a credential for the Patron
         with self.get_configuration(db) as configuration:

--- a/bin/saml_migrate
+++ b/bin/saml_migrate
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+"""Allows to change unique IDs of SAML patrons."""
+
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from api.saml.migration import SAMLMigrationScript, SAMLMigrationManagerFactory
+
+
+saml_migration_manager_factory = SAMLMigrationManagerFactory()
+saml_migration_script = SAMLMigrationScript(saml_migration_manager_factory)
+saml_migration_script.run()

--- a/tests/saml/database_test.py
+++ b/tests/saml/database_test.py
@@ -8,9 +8,15 @@ class DatabaseTest(BaseDatabaseTest):
         super(DatabaseTest, self).setup_method()
 
         self._integration = self._external_integration(
-            protocol=SAMLWebSSOAuthenticationProvider.NAME,
+            protocol="api.saml.provider",
             goal=ExternalIntegration.PATRON_AUTH_GOAL,
+            libraries=self._default_library
         )
+
+        # We have to make sure that the external integration has an ID
+        # because it's used in AuthenticationProvider's constructor.
+        self._db.commit()
+
         self._authentication_provider = SAMLWebSSOAuthenticationProvider(
             self._default_library, self._integration
         )

--- a/tests/saml/test_migration.py
+++ b/tests/saml/test_migration.py
@@ -1,0 +1,355 @@
+import json
+import sys
+
+from api.saml.configuration.model import SAMLConfiguration, SAMLConfigurationFactory
+from api.saml.metadata.model import (
+    SAMLAttribute,
+    SAMLAttributeStatement,
+    SAMLAttributeType,
+    SAMLNameID,
+    SAMLNameIDFormat,
+    SAMLSubject,
+)
+from api.saml.metadata.parser import SAMLMetadataParser
+from api.saml.migration import SAMLMigrationManagerFactory, SAMLMigrationScript
+from api.saml.provider import SAMLWebSSOAuthenticationProvider
+from core.model.configuration import ConfigurationStorage
+from mock import MagicMock
+from parameterized import parameterized
+from tests.saml import fixtures
+from tests.saml.database_test import DatabaseTest
+
+
+class TestSAMLMigrationManager(DatabaseTest):
+    def setup_method(self, _db=None, set_up_circulation_manager=True):
+        super(TestSAMLMigrationManager, self).setup_method()
+
+        metadata_parser = SAMLMetadataParser()
+
+        self._configuration_storage = ConfigurationStorage(
+            self._authentication_provider
+        )
+        self._configuration_factory = SAMLConfigurationFactory(metadata_parser)
+
+    def test_migrate_migrates_patrons_with_old_ids(self):
+        """Ensure that migration logic works correctly. This test case emulates the following scenario:
+        1. The administrator set up the SAML authentication provider and left "Patron ID" configuration settings
+        untouched making Circulation Manager use the default ("old") patron ID extraction algorithm.
+        2. Patrons authenticated using SAML.
+        3. Circulation Manager used the default ("old") patron ID extraction algorithm,
+        extracted "old" ID from the SAML NameID and created Patron objects.
+        4. Patrons checked out some books and had some books on hold that were associated with their Patron objects.
+        5. The administrator updated the "Patron ID" configuration settings:
+        5.1. Overrode the list of SAML attributes and added eduPersonPrincipalName attribute.
+        5.2. Set up a custom regular expression to extract a patron ID from eduPersonPrincipalName.
+        6. The administrator ran saml_migrate script to update IDs of the SAML patrons and set it to the value
+        containing in the eduPersonPrincipalName attribute.
+        7. SAML session expired.
+        8. The same patrons reauthenticated using SAML.
+        9. Circulation Manager using the new patron ID extraction settings, extracted patron IDs from
+        eduPersonPrincipalName SAML attribute's and found the existing patrons in the database,
+        the same patrons that were created in 3 and updated in 6 and who have the holds and loans.
+        """
+        # Arrange
+        patron_1_old_id = "patron_1_old_id"
+        patron_1_new_id = "patron_1_new_id"
+
+        patron_2_old_id = "patron_2_old_id"
+        patron_2_new_id = "patron_2_new_id"
+
+        patron_1_subject = SAMLSubject(
+            SAMLNameID(SAMLNameIDFormat.UNSPECIFIED.value, "", "", patron_1_old_id),
+            SAMLAttributeStatement(
+                [
+                    SAMLAttribute(
+                        name=SAMLAttributeType.eduPersonPrincipalName.name,
+                        values=["{0}@university.org".format(patron_1_new_id)],
+                    )
+                ]
+            ),
+        )
+        patron_2_subject = SAMLSubject(
+            SAMLNameID(SAMLNameIDFormat.UNSPECIFIED.value, "", "", patron_2_old_id),
+            SAMLAttributeStatement(
+                [
+                    SAMLAttribute(
+                        name=SAMLAttributeType.eduPersonPrincipalName.name,
+                        values=["{0}@university.org".format(patron_2_new_id)],
+                    )
+                ]
+            ),
+        )
+
+        edition, licensepool = self._edition(
+            with_license_pool=True,
+            with_open_access_download=False,
+        )
+
+        # Act, assert
+
+        # 1. The administrator set up the SAML authentication provider
+        # using the default "Patron ID" configuration settings.
+        with self._configuration_factory.create(
+            self._configuration_storage, self._db, SAMLConfiguration
+        ) as configuration:
+            configuration.patron_id_use_name_id = str(True)
+
+        provider = SAMLWebSSOAuthenticationProvider(
+            self._default_library, self._integration
+        )
+
+        # 2. Patrons authenticated using SAML.
+        # 3. Circulation Manager extracted the "old" patron ID.
+        _, patron_1_old_object, patron_1_old_data = provider.saml_callback(
+            self._db, patron_1_subject
+        )
+
+        assert patron_1_old_id == patron_1_old_object.authorization_identifier
+        assert patron_1_old_id == patron_1_old_object.external_identifier
+
+        _, patron_2_old_object, patron_2_old_data = provider.saml_callback(
+            self._db, patron_2_subject
+        )
+
+        assert patron_2_old_id == patron_2_old_object.authorization_identifier
+        assert patron_2_old_id == patron_2_old_object.external_identifier
+
+        # 4. The patrons checked out some books and had some books on hold.
+        patron_1_hold, _ = licensepool.loan_to(patron_1_old_object)
+        patron_1_hold, _ = licensepool.on_hold_to(patron_1_old_object)
+
+        patron_2_hold, _ = licensepool.loan_to(patron_2_old_object)
+        patron_2_hold, _ = licensepool.on_hold_to(patron_2_old_object)
+
+        # 5. The administrator updated the "Patron ID" configuration settings.
+        with self._configuration_factory.create(
+            self._configuration_storage, self._db, SAMLConfiguration
+        ) as configuration:
+            configuration.patron_id_attributes = json.dumps(
+                [SAMLAttributeType.eduPersonPrincipalName.name]
+            )
+            configuration.patron_id_regular_expression = (
+                fixtures.PATRON_ID_REGULAR_EXPRESSION_ORG
+            )
+
+        # 6. The administrator ran saml_migrate script.
+        saml_migration_manager_factory = SAMLMigrationManagerFactory()
+        migration_script = SAMLMigrationScript(saml_migration_manager_factory, self._db)
+
+        sys.argv = ["saml_migrate", self._default_library.short_name]
+        migration_script.run()
+
+        # 7. SAML session expired.
+
+        provider = SAMLWebSSOAuthenticationProvider(
+            self._default_library, self._integration
+        )
+
+        # 8. The same patrons reauthenticated using SAML.
+        # 9. Circulation Manager using the new patron ID extraction settings, extracted patron IDs from
+        # eduPersonPrincipalName SAML attribute and found the existing patrons in the database,
+        # the same patrons that were created in 3 and who have the holds and loans.
+        _, patron_1_new_object, patron_1_new_data = provider.saml_callback(
+            self._db, patron_1_subject
+        )
+        _, patron_2_new_object, patron_2_new_data = provider.saml_callback(
+            self._db, patron_2_subject
+        )
+
+        # Assert
+        # Ensure that all the holds and loans were successfully transferred.
+        assert patron_1_new_object == patron_1_hold.patron
+        assert patron_1_new_object == patron_1_hold.patron
+
+        assert patron_2_new_object == patron_2_hold.patron
+        assert patron_2_new_object == patron_2_hold.patron
+
+        # Ensure that patron has the "new" ID (value of the eduPersonPrincipalName SAML attribute).
+        assert patron_1_new_id == patron_1_new_object.authorization_identifier
+        assert patron_1_new_id == patron_1_new_object.external_identifier
+
+        assert patron_2_new_id == patron_2_new_object.authorization_identifier
+        assert patron_2_new_id == patron_2_new_object.external_identifier
+
+
+class TestSAMLMigrationScript(DatabaseTest):
+    def setup_method(self, _db=None, set_up_circulation_manager=True):
+        super(TestSAMLMigrationScript, self).setup_method()
+
+        metadata_parser = SAMLMetadataParser()
+
+        self._configuration_storage = ConfigurationStorage(
+            self._authentication_provider
+        )
+        self._configuration_factory = SAMLConfigurationFactory(metadata_parser)
+
+    @parameterized.expand(
+        [
+            (
+                "default_database_settings",
+                None,
+                None,
+                None,
+                SAMLConfiguration.patron_id_use_name_id.default,
+                json.dumps(SAMLConfiguration.patron_id_attributes.default),
+                SAMLConfiguration.patron_id_regular_expression.default,
+                True,
+                SAMLConfiguration.patron_id_attributes.default,
+                SAMLConfiguration.patron_id_regular_expression.default,
+            ),
+            (
+                "use_name_id_passed_as_command_line_argument",
+                False,
+                None,
+                None,
+                SAMLConfiguration.patron_id_use_name_id.default,
+                json.dumps(SAMLConfiguration.patron_id_attributes.default),
+                SAMLConfiguration.patron_id_regular_expression.default,
+                False,
+                SAMLConfiguration.patron_id_attributes.default,
+                SAMLConfiguration.patron_id_regular_expression.default,
+            ),
+            (
+                "use_name_id_and_attributes_passed_as_command_line_argument",
+                False,
+                [
+                    SAMLAttributeType.givenName.name,
+                    SAMLAttributeType.surname.name,
+                    SAMLAttributeType.displayName.name,
+                ],
+                None,
+                SAMLConfiguration.patron_id_use_name_id.default,
+                json.dumps(SAMLConfiguration.patron_id_attributes.default),
+                SAMLConfiguration.patron_id_regular_expression.default,
+                False,
+                [
+                    SAMLAttributeType.givenName.name,
+                    SAMLAttributeType.surname.name,
+                    SAMLAttributeType.displayName.name,
+                ],
+                SAMLConfiguration.patron_id_regular_expression.default,
+            ),
+            (
+                "use_name_id_attributes_and_regex_passed_as_command_line_argument",
+                False,
+                [
+                    SAMLAttributeType.givenName.name,
+                    SAMLAttributeType.surname.name,
+                    SAMLAttributeType.displayName.name,
+                ],
+                fixtures.PATRON_ID_REGULAR_EXPRESSION_ORG,
+                SAMLConfiguration.patron_id_use_name_id.default,
+                json.dumps(SAMLConfiguration.patron_id_attributes.default),
+                SAMLConfiguration.patron_id_regular_expression.default,
+                False,
+                [
+                    SAMLAttributeType.givenName.name,
+                    SAMLAttributeType.surname.name,
+                    SAMLAttributeType.displayName.name,
+                ],
+                fixtures.PATRON_ID_REGULAR_EXPRESSION_ORG,
+            ),
+        ]
+    )
+    def test(
+        self,
+        _,
+        command_line_use_name_id,
+        command_line_patron_id_attributes,
+        command_line_patron_id_regex,
+        database_use_name_id,
+        database_patron_id_attributes,
+        database_patron_id_regex,
+        expected_use_name_id,
+        expected_patron_id_attributes,
+        expected_patron_id_regex,
+    ):
+        """Ensure that SAMLMigrationScript correctly parses command-line arguments and
+        substitutes them with database values if they're missing.
+
+        This test tries different combinations of explicit command-line arguments and database configuration settings
+        and makes sure that the SAML patron migration process is always launched using correct parameters.
+
+        :param command_line_use_name_id: Command-line argument containing
+            a boolean value indicating whether NameID should be searched for a unique patron ID.
+            NOTE: It should be boolean, it will be converted into string in the test body.
+        :type command_line_use_name_id: bool
+
+        :param command_line_patron_id_attributes: Command-line argument containing
+            a list of SAML attributes which should be searched for a unique patron ID
+        :type command_line_patron_id_attributes: List[str]
+
+        :param command_line_patron_id_regex: Command-line argument containing
+            regular expression used to extract a unique patron ID from SAML attributes
+        :type command_line_patron_id_regex: str
+
+        :param database_use_name_id: Value of Patron ID: SAML NameID configuration setting
+        :type database_use_name_id: bool
+
+        :param database_patron_id_attributes: Value of Patron ID: SAML Attributes configuration setting
+        :type database_patron_id_attributes: List[str]
+
+        :param database_patron_id_regex: Value of Patron ID: Regular expression configuration setting
+        :type database_patron_id_regex: str
+
+        :param expected_use_name_id: Expected value of Use SAML Name ID setting
+            that will be used by SAMLSubjectPatronIDExtractor
+        :type expected_use_name_id: bool
+
+        :param expected_patron_id_attributes: Expected value of SAML Patron ID Attributes setting
+            that will be used by SAMLSubjectPatronIDExtractor
+        :type expected_patron_id_attributes: List[str]
+
+        :param expected_patron_id_regex: Expected value of SAML Patron ID Regular Expression setting
+            that will be used by SAMLSubjectPatronIDExtractor
+        :type expected_patron_id_regex: str
+        """
+        # Arrange
+        command_line_arguments = ["saml_migrate"]
+
+        if command_line_use_name_id is not None:
+            command_line_arguments.extend(
+                ["--use-name-id", str(command_line_use_name_id)]
+            )
+        if command_line_patron_id_attributes is not None:
+            command_line_arguments.append("--patron-id-attributes")
+            command_line_arguments.extend(command_line_patron_id_attributes)
+        if command_line_patron_id_regex is not None:
+            command_line_arguments.extend(
+                ["--patron-id-regex", command_line_patron_id_regex]
+            )
+
+        if (
+            database_use_name_id
+            or database_patron_id_attributes
+            or database_patron_id_regex
+        ):
+            with self._configuration_factory.create(
+                self._configuration_storage, self._db, SAMLConfiguration
+            ) as configuration:
+                if database_use_name_id:
+                    configuration.patron_id_use_name_id = database_use_name_id
+                if database_patron_id_attributes:
+                    configuration.patron_id_attributes = database_patron_id_attributes
+                if database_patron_id_regex:
+                    configuration.patron_id_regular_expression = (
+                        database_patron_id_regex
+                    )
+
+        sys.argv = command_line_arguments
+        saml_migration_manager_factory = SAMLMigrationManagerFactory()
+        saml_migration_manager_factory.create = MagicMock(
+            side_effect=saml_migration_manager_factory.create
+        )
+
+        migration_script = SAMLMigrationScript(saml_migration_manager_factory, self._db)
+
+        # Act
+        migration_script.run()
+
+        # Assert
+        saml_migration_manager_factory.create.assert_called_once_with(
+            expected_use_name_id,
+            expected_patron_id_attributes,
+            expected_patron_id_regex,
+        )


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

NOTE: Migrated from https://github.com/lyrasis/simplye-circulation/pull/6.

This PR adds `saml_migrate` script allowing to update SAML patrons' unique IDs.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[PR # 1572](https://github.com/NYPL-Simplified/circulation/pull/1572) added an ability to override patron ID extraction settings but changing them might lead to existing patrons losing their holds and loans: Circulation Manager will be using new ID extraction settings and won't be able to find "old" `Patron` objects.

[TestSAMLMigrationManager.test_migrate_migrates_patrons_with_old_ids](https://github.com/lyrasis/simplye-circulation/pull/6/files#diff-bb0f411c0d4c4a15948714ccd218d1476b11bf89f581eed996d1b5f74cb5822aR35) shows how the migration workflow looks like.

We assume that usually `saml_migrate` is launched after changing patron ID extraction settings. Without explicitly specified command-line arguments `saml_migrate` will be using SAML auth provider's`Patron ID` configuration settings and will be updating patron IDs according to their values.
However, if you want to override this behaviour you can explicitly specify arguments while running `saml_migrate`. For example:
- `saml_migrate TEST_LIBRARY --use-name-id True --patron-id-attributes "" --patron-id-regex ""` will update IDs of SAML patrons belonging to the library with the `TEST_LIBRARY` short name. `saml_migrate` will try to extract a new patron ID from SAML NameIDs and won't be looking at SAML attributes.
- `saml_migrate TEST_LIBRARY --use-name-id False --patron-id-attributes eduPersonTargetedID givenName --patron-id-regex ""` will update IDs of SAML patrons belonging to `TEST_LIBRARY` with values from `eduPersonTargetedID`, `givenName` SAML attributes.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested the script using [the SAML testbed ](https://github.com/vbessonov/circulation-saml-test):
1. Update `CM_ACS`, `CM_AUTHENTICATION_DOCUMENT_URL`, and `CM_GROUPS_URL` values in [.env file](https://github.com/vbessonov/circulation-saml-test/blob/master/.env) with the URL of your local Circulation Manager (for example, `http://localhost:6500`).
2. Set up the local Circulation Manager as it's described in the SAML testbed's [README file](https://github.com/vbessonov/circulation-saml-test).
3. Export environment variables from [.env file](https://github.com/vbessonov/circulation-saml-test/blob/master/.env).
4. Run `cm-test` locally:
```
FLASK_APP = circulation-test/circulation_test/__init__.py
FLASK_ENV = development
FLASK_DEBUG = 0
flask run
```
5. Authenticate using different credentials from [a list of built-in users](https://github.com/vbessonov/circulation-saml-test/blob/master/ldap/confd/templates/init-users.ldif.tmpl).
6. Check patrons' IDs in the database:
```
select * from patrons;
```
7. Run `saml_migrate` using the commands above and check how patrons' `external_identifier` and `authorization_identifier` changing.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.