### PR TITLE
Modify tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,23 +5,23 @@ skipsdist = true
 [testenv]
 deps = -r requirements-dev.txt
 commands_pre =
-    docker: docker exec es elasticsearch-plugin -s install analysis-icu
-    docker: docker restart es
+    docker: docker exec es-circ elasticsearch-plugin -s install analysis-icu
+    docker: docker restart es-circ
     python -m textblob.download_corpora
 commands =
-    pytest {posargs:--disable-warnings -v tests}
+    pytest {posargs:--disable-warnings tests}
 passenv = SIMPLIFIED_*
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test
     docker: SIMPLIFIED_TEST_ELASTICSEARCH=http://localhost:9006
 docker =
-    docker: es
-    docker: db
+    docker: es-circ
+    docker: db-circ
 allowlist_externals =
     docker: docker
     python
 
-[docker:db]
+[docker:db-circ]
 image = postgres:12
 environment =
     POSTGRES_USER=simplified_test
@@ -30,7 +30,7 @@ environment =
 ports =
     9005:5432/tcp
 
-[docker:es]
+[docker:es-circ]
 image = elasticsearch:6.8.6
 environment =
     discovery.type=single-node

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands_pre =
     python -m textblob.download_corpora
 commands =
     pytest {posargs:--disable-warnings tests}
-passenv = SIMPLIFIED_*
+passenv = SIMPLIFIED_* CI
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test
     docker: SIMPLIFIED_TEST_ELASTICSEARCH=http://localhost:9006


### PR DESCRIPTION
## Description

Change the ports and container names in the tox config to allow both the circulation and core to run tox on the same machine at the same time. 

Same changes implemented in core:
https://github.com/ThePalaceProject/circulation-core/pull/11

Also make a couple more small changes to the default tox config:
- Pass the CI environment variable though from tox into the testing process. Pytest looks to see if this environment variable is set and doesn't truncate error output if it is. Github actions sets the CI env variable by default.
- Remove the `-v` flag from the test output, since we don't need verbose output, it just makes the test logs in github actions hard to read.

## Motivation and Context

This is helpful in development, so you can be running both sets of tests simultaneously.

## How Has This Been Tested?

Ran tox locally against circ and core at the same time.
