### PR TITLE
Allow returns when API on licensepool is None

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1018,7 +1018,7 @@ class CirculationAPI(object):
         )
         if loan:
             api = self.api_for_license_pool(licensepool)
-            if api is not None:
+            if not (api is None or licensepool.open_access or licensepool.self_hosted):
                 try:
                     api.checkin(patron, pin, licensepool)
                 except NotCheckedOut, e:

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1017,8 +1017,8 @@ class CirculationAPI(object):
             on_multiple='interchangeable'
         )
         if loan:
-            if not licensepool.open_access and not licensepool.self_hosted:
-                api = self.api_for_license_pool(licensepool)
+            api = self.api_for_license_pool(licensepool)
+            if api is not None:
                 try:
                     api.checkin(patron, pin, licensepool)
                 except NotCheckedOut, e:

--- a/tests/test_circulationapi.py
+++ b/tests/test_circulationapi.py
@@ -960,7 +960,8 @@ class TestCirculationAPI(DatabaseTest):
 
     @parameterized.expand([
         ('open_access', True, False),
-        ('self_hosted', False, True)
+        ('self_hosted', False, True),
+        ('neither', False, False),
     ])
     def test_revoke_loan(self, _, open_access=False, self_hosted=False):
         self.pool.open_access = open_access


### PR DESCRIPTION
## Description

In the case where we are pulling in ACSM files for Adobe testing, they are not open access, but they also have no API associated. When we try to return these titles we get: 
```
{"host": "b2b3404f5062", "name": "root", "level": "ERROR", "timestamp": "2021-07-26T18:34:31.537640", "app": "simplified", "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/env/lib/python2.7/site-packages/flask/app.py\", line 1950, in full_dispatch_request\n    rv = self.dispatch_request()\n  File \"/var/www/circulation/env/lib/python2.7/site-packages/flask/app.py\", line 1936, in dispatch_request\n    return self.view_functions[rule.endpoint](**req.view_args)\n  File \"/var/www/circulation/api/routes.py\", line 152, in decorated\n    return f(*args, **kwargs)\n  File \"/var/www/circulation/api/routes.py\", line 116, in wrapped_function\n    resp = make_response(f(*args, **kwargs))\n  File \"/var/www/circulation/api/routes.py\", line 77, in decorated\n    return f(*args, **kwargs)\n  File \"/var/www/circulation/core/app_server.py\", line 106, in decorated\n    v = f(*args, **kwargs)\n  File \"/var/www/circulation/api/routes.py\", line 465, in revoke_loan_or_hold\n    return app.manager.loans.revoke(license_pool_id)\n  File \"/var/www/circulation/api/controller.py\", line 1740, in revoke\n    self.circulation.revoke_loan(patron, credential, pool)\n  File \"/var/www/circulation/api/circulation.py\", line 1023, in revoke_loan\n    api.checkin(patron, pin, licensepool)\nAttributeError: 'NoneType' object has no attribute 'checkin'", "message": "Exception in web app: 'NoneType' object has no attribute 'checkin'", "filename": "app_server.py"}
```

## Motivation and Context

I think we can just be checking if there is an associated API, instead of specifically if its OA or self hosted. This simplifies this check and allows us to return books borrowed from ACSM files.

## How Has This Been Tested?

Tested by returning ACSM file borrowed on demo.
