### PR TITLE
Bugfix/onix corporate contributor

### DIFF
--- a/tests/files/onix/onix_example.xml
+++ b/tests/files/onix/onix_example.xml
@@ -347,5 +347,13 @@
       <b233>MIT Press Title ID</b233>
       <b244>11245</b244>
     </productidentifier>
+    <descriptivedetail>
+      <contributor>
+        <b034>1</b034>
+        <b035>A01</b035>
+        <b047>The Test Corporation</b047>
+        <x443>Test Corporation, The</x443>
+      </contributor>
+    </descriptivedetail>
   </product>
 </ONIXmessage>

--- a/tests/test_onix.py
+++ b/tests/test_onix.py
@@ -52,6 +52,8 @@ class TestONIXExtractor(object):
 
         record = metadata_records[1]
         assert Edition.AUDIO_MEDIUM == record.medium
+        assert "The Test Corporation" == record.contributors[0].display_name
+        assert "Test Corporation, The" == record.contributors[0].sort_name
 
     @parameterized.expand([
         (


### PR DESCRIPTION
## Description

- Adds support for contributors with corporate names.
- Generalizes pub date parsing support to any ISO 8601 date.

## Motivation and Context

- Some imports were failing because they had corporate contributors.
- Generalized ISO 8601 parsing simplifies date handling and should cover more cases until we introduce more format specific handling.

## How Has This Been Tested?

- Added new tests for contributors with corporate names.
- Ran existing tests.
- Successfully imported the previously failing content.

## Checklist:

- [N/A] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
