### PR TITLE
Force DirectoryImport._locate_file read books and covers as binary files

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -1747,7 +1747,7 @@ class DirectoryImportScript(TimestampScript):
                         ext.lower()
                     )
                     content = None
-                    with open_f(path) as fh:
+                    with open_f(path, "rb") as fh:
                         content = fh.read()
                     return filename, media_type, content
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1365,7 +1365,7 @@ class TestDirectoryImportScript(DatabaseTest):
             return path in mock_filesystem
 
         @contextlib.contextmanager
-        def mock_open(path):
+        def mock_open(path, mode="r"):
             yield StringIO(mock_filesystem[path])
         mock_filesystem_operations = mock_exists, mock_open
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds changes forcing `DirectoryImport._locate_file` read books and covers as binary files.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently `DirectoryImport._locate_file` tries to open and decode books and covers as UTF-8 text files which is wrong.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
