### PR TITLE
Make sure Onix ISO8601 dates containe timezone information.

### DIFF
--- a/api/onix.py
+++ b/api/onix.py
@@ -1,4 +1,5 @@
 import logging
+import pytz
 
 import dateutil.parser
 from enum import Enum
@@ -224,6 +225,12 @@ class ONIXExtractor(object):
             issued = None
             if publishing_date:
                 issued = dateutil.parser.isoparse(publishing_date)
+                if issued.tzinfo is None:
+                    cls._logger.warning(
+                        "Publishing date {} does not contain timezone information. Assuming UTC."
+                        .format(publishing_date)
+                    )
+                    issued = issued.replace(tzinfo=pytz.UTC)
 
             identifier_tags = parser._xpath(record, 'productidentifier')
             identifiers = []

--- a/api/onix.py
+++ b/api/onix.py
@@ -1,5 +1,4 @@
 import logging
-import pytz
 
 import dateutil.parser
 from enum import Enum

--- a/api/onix.py
+++ b/api/onix.py
@@ -21,7 +21,7 @@ from core.model import (
     Representation,
     Subject,
     LicensePool, EditionConstants)
-from core.util.datetime_helpers import strptime_utc
+from core.util.datetime_helpers import to_utc
 from core.util.xmlparser import XMLParser
 
 
@@ -230,7 +230,7 @@ class ONIXExtractor(object):
                         "Publishing date {} does not contain timezone information. Assuming UTC."
                         .format(publishing_date)
                     )
-                    issued = issued.replace(tzinfo=pytz.UTC)
+                issued = to_utc(issued)
 
             identifier_tags = parser._xpath(record, 'productidentifier')
             identifiers = []


### PR DESCRIPTION
## Description

Tests on the `main` branch are failing because merging `python3` and `main` brought in two sets of changes. 

1. https://github.com/ThePalaceProject/circulation/pull/23
    Which changed the ONIX parser to use `dateutil.parser.isoparse`
2. https://github.com/NYPL-Simplified/circulation/pull/1589
    Which changed all the dates in the `python3` branch to be timezone aware

## Motivation and Context

The tests are failing because we are trying to compare a timezone aware date with a non-timezone aware date in the ONIX parser tests. This PR updates the ONIX parser to default to UTC if no timezone info is given, with a warning that his is happening.
