### PR TITLE
Make ProQuestOPDS2Importer's and ODL2Importer's parser argument optional

### DIFF
--- a/api/odl2.py
+++ b/api/odl2.py
@@ -3,6 +3,7 @@ import logging
 
 from contextlib2 import contextmanager
 from flask_babel import lazy_gettext as _
+from webpub_manifest_parser.odl import ODLFeedParserFactory
 from webpub_manifest_parser.opds2.registry import OPDS2LinkRelationsRegistry
 
 from api.odl import ODLAPI, ODLExpiredItemsReaper
@@ -17,7 +18,7 @@ from core.model.configuration import (
     ConfigurationStorage,
     HasExternalIntegration,
 )
-from core.opds2_import import OPDS2Importer, OPDS2ImportMonitor
+from core.opds2_import import OPDS2Importer, OPDS2ImportMonitor, RWPMManifestParser
 from core.util import first_or_default
 
 
@@ -65,7 +66,7 @@ class ODL2Importer(OPDS2Importer, HasExternalIntegration):
         self,
         db,
         collection,
-        parser,
+        parser=None,
         data_source_name=None,
         identifier_mapping=None,
         http_get=None,
@@ -113,7 +114,7 @@ class ODL2Importer(OPDS2Importer, HasExternalIntegration):
         super(ODL2Importer, self).__init__(
             db,
             collection,
-            parser,
+            parser if parser else RWPMManifestParser(ODLFeedParserFactory()),
             data_source_name,
             identifier_mapping,
             http_get,

--- a/api/proquest/importer.py
+++ b/api/proquest/importer.py
@@ -10,6 +10,7 @@ import webpub_manifest_parser.opds2.ast as opds2_ast
 from flask_babel import lazy_gettext as _
 from requests import HTTPError
 from sqlalchemy import or_
+from webpub_manifest_parser.opds2 import OPDS2FeedParserFactory
 from webpub_manifest_parser.utils import encode
 
 from api.circulation import BaseCirculationAPI, FulfillmentInfo, LoanInfo
@@ -182,7 +183,7 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
         self,
         db,
         collection,
-        parser,
+        parser=None,
         data_source_name=None,
         identifier_mapping=None,
         http_get=None,
@@ -230,7 +231,7 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
         super(ProQuestOPDS2Importer, self).__init__(
             db,
             collection,
-            parser,
+            parser if parser else RWPMManifestParser(OPDS2FeedParserFactory()),
             data_source_name,
             identifier_mapping,
             http_get,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes the following error occurring when there is a ProQuest\ODL 2.x integration set up in Circulation Manager:
```
{"host": "d9cdc81fe392", "app": "simplified", "name": "root", "level": "INFO", "filename": "config.py", "message": "Connecting to database: postgres://demo:***@se-test-db-alpha.lyrtech.org/demo_simplye", "timestamp": "2021-09-02T13:08:55.305443+00:00"}
Traceback (most recent call last):
  File "/var/www/circulation/env/lib/python3.6/site-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/var/www/circulation/env/lib/python3.6/site-packages/flask/app.py", line 1945, in full_dispatch_request
    self.try_trigger_before_first_request_functions()
  File "/var/www/circulation/env/lib/python3.6/site-packages/flask/app.py", line 1993, in try_trigger_before_first_request_functions
    func()
  File "/var/www/circulation/api/routes.py", line 42, in initialize_circulation_manager
    app.manager = CirculationManager(app._db)
  File "/var/www/circulation/api/controller.py", line 165, in __init__
    self.load_settings()
  File "/var/www/circulation/api/controller.py", line 258, in load_settings
    library, self.analytics
  File "/var/www/circulation/api/controller.py", line 401, in setup_circulation
    return cls(self._db, library, analytics)
  File "/var/www/circulation/api/circulation.py", line 412, in __init__
    api = api_map[collection.protocol](_db, collection)
TypeError: __init__() missing 1 required positional argument: 'parser'
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
