### PR TITLE
Fix logo "data" URL creation.

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -332,19 +332,23 @@ class LibrarySettingsController(SettingsController):
         return json.dumps([_f for _f in value if _f])
 
     @staticmethod
-    def _data_url_for_image(image: Image) -> Optional[str]:
+    def _data_url_for_image(image: Image, _format="PNG") -> Optional[str]:
         """Produce the `data` URL for the setting's uploaded image file.
 
-        :param setting: A setting object.
+        :param image: A Pillow Image object.
+        :param _format: A valid Pillow image format.
         :return: The `data` URL if an image file was uploaded, else None.
         """
         buffer = BytesIO()
-        image.save(buffer, format="PNG")
+        image.save(buffer, format=_format)
         b64 = base64.b64encode(buffer.getvalue())
         return "data:image/png;base64,%s" % b64.decode('utf-8')
 
-    def image_setting(self, setting: Dict[str, Any], max_dimension=135) -> str:
+    def image_setting(self, setting: Dict[str, Any], max_dimension=Configuration.LOGO_MAX_DIMENSION) -> str:
         """Retrieve an uploaded image file for the setting and return its data URL.
+
+        If the image is too large, scale it down to the `max_dimension`
+        while retaining its aspect ratio.
 
         :param image: A Python Image Library image object.
         :return: The `data` URL if an image file was uploaded, else None.

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -335,9 +335,9 @@ class LibrarySettingsController(SettingsController):
     def _data_url_for_image(image: Image, _format="PNG") -> Optional[str]:
         """Produce the `data` URL for the setting's uploaded image file.
 
-        :param image: A Pillow Image object.
+        :param image: A Pillow Image.
         :param _format: A valid Pillow image format.
-        :return: The `data` URL if an image file was uploaded, else None.
+        :return: The `data` URL for the image.
         """
         buffer = BytesIO()
         image.save(buffer, format=_format)
@@ -351,7 +351,7 @@ class LibrarySettingsController(SettingsController):
         while retaining its aspect ratio.
 
         :param image: A Python Image Library image object.
-        :return: The `data` URL if an image file was uploaded, else None.
+        :return: The `data` URL for the image file, if it was uploaded, else None.
         """
         image_file = flask.request.files.get(setting.get("key"))
         if not image_file:

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -1,36 +1,29 @@
 import base64
+from io import BytesIO
+import json
+import uuid
+
 import flask
 from flask import Response
 from flask_babel import lazy_gettext as _
-import json
-from pypostalcode import PostalCodeDatabase
-import re
-from io import BytesIO
-import urllib.request, urllib.parse, urllib.error
-import uszipcode
-import uuid
+from PIL import Image
 import wcag_contrast_ratio
 
 from . import SettingsController
+from api.admin.announcement_list_validator import AnnouncementListValidator
 from api.config import Configuration
 from api.lanes import create_default_lanes
+from api.admin.geographic_validator import GeographicValidator
+from api.admin.problem_details import *
 from core.model import (
     ConfigurationSetting,
     create,
-    ExternalIntegration,
     get_one,
     Library,
-    Representation,
 )
-from core.util.http import HTTP
-from PIL import Image
-from api.admin.exceptions import *
-from api.admin.problem_details import *
-from api.admin.geographic_validator import GeographicValidator
-from api.admin.announcement_list_validator import AnnouncementListValidator
 from core.util.problem_detail import ProblemDetail
 from core.util import LanguageCodes
-from api.registry import RemoteRegistry
+
 
 class LibrarySettingsController(SettingsController):
 

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -332,7 +332,7 @@ class LibrarySettingsController(SettingsController):
         return json.dumps([_f for _f in value if _f])
 
     @staticmethod
-    def _data_url_for_image(image: Image, _format="PNG") -> Optional[str]:
+    def _data_url_for_image(image: Image, _format="PNG") -> str:
         """Produce the `data` URL for the setting's uploaded image file.
 
         :param image: A Pillow Image.
@@ -344,7 +344,7 @@ class LibrarySettingsController(SettingsController):
         b64 = base64.b64encode(buffer.getvalue())
         return "data:image/png;base64,%s" % b64.decode('utf-8')
 
-    def image_setting(self, setting: Dict[str, Any], max_dimension=Configuration.LOGO_MAX_DIMENSION) -> str:
+    def image_setting(self, setting: Dict[str, Any], max_dimension=Configuration.LOGO_MAX_DIMENSION) -> Optional[str]:
         """Retrieve an uploaded image file for the setting and return its data URL.
 
         If the image is too large, scale it down to the `max_dimension`

--- a/api/config.py
+++ b/api/config.py
@@ -126,6 +126,8 @@ class Configuration(CoreConfiguration):
 
     # The library-wide logo setting.
     LOGO = "logo"
+    # Maximum height and width for the saved logo image
+    LOGO_MAX_DIMENSION = 135
 
     # Settings for geographic areas associated with the library.
     LIBRARY_FOCUS_AREA = "focus_area"
@@ -367,7 +369,13 @@ class Configuration(CoreConfiguration):
             "key": LOGO,
             "label": _("Logo image"),
             "type": "image",
-            "description": _("The image must be in GIF, PNG, or JPG format, approximately square, no larger than 135x135 pixels, and look good on a white background."),
+            "description": _(
+                "The image should be in GIF, PNG, or JPG format, approximately square, no larger than "
+                f"{LOGO_MAX_DIMENSION}x{LOGO_MAX_DIMENSION} pixels, "
+                "and look good on a light or dark mode background. "
+                "Larger images will be accepted, but scaled down (maintaining aspect ratio) such that "
+                f"the longest dimension does not excede {LOGO_MAX_DIMENSION} pixels."
+            ),
             "category": "Client Interface Customization",
             "level": CoreConfiguration.ALL_ACCESS
         },

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -1,39 +1,33 @@
-import pytest
-
 import base64
 import datetime
-import flask
-import json
-import urllib.request, urllib.parse, urllib.error
 from io import BytesIO
-from werkzeug.datastructures import ImmutableMultiDict, MultiDict
+import json
+
+import flask
+import pytest
+from werkzeug.datastructures import MultiDict
+
+from .test_controller import SettingsControllerTest
+from api.admin.announcement_list_validator import AnnouncementListValidator
+from api.admin.controller.library_settings import LibrarySettingsController
 from api.admin.exceptions import *
-from api.config import Configuration
-from api.registry import (
-    Registration,
-    RemoteRegistry,
-)
-from core.facets import FacetConstants
-from core.model import (
-    AdminRole,
-    ConfigurationSetting,
-    create,
-    ExternalIntegration,
-    get_one,
-    get_one_or_create,
-    Library,
-)
-from core.testing import MockRequestsResponse
-from core.util.problem_detail import ProblemDetail
+from api.admin.geographic_validator import GeographicValidator
 from api.announcements import (
     Announcements,
     Announcement,
 )
-from api.admin.controller.library_settings import LibrarySettingsController
-from api.admin.announcement_list_validator import AnnouncementListValidator
-from api.admin.geographic_validator import GeographicValidator
+from api.config import Configuration
 from api.testing import AnnouncementTest
-from .test_controller import SettingsControllerTest
+from core.facets import FacetConstants
+from core.model import (
+    AdminRole,
+    ConfigurationSetting,
+    get_one,
+    get_one_or_create,
+    Library,
+)
+from core.util.problem_detail import ProblemDetail
+
 
 class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
 

--- a/tests/admin/controller/test_library.py
+++ b/tests/admin/controller/test_library.py
@@ -33,7 +33,7 @@ from core.util.problem_detail import ProblemDetail
 class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
 
     @pytest.fixture()
-    def image_info(self):
+    def logo_properties(self):
         image_data_raw = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x01\x03\x00\x00\x00%\xdbV\xca\x00\x00\x00\x06PLTE\xffM\x00\x01\x01\x01\x8e\x1e\xe5\x1b\x00\x00\x00\x01tRNS\xcc\xd24V\xfd\x00\x00\x00\nIDATx\x9cc`\x00\x00\x00\x02\x00\x01H\xaf\xa4q\x00\x00\x00\x00IEND\xaeB`\x82'
         image_data_b64_bytes = base64.b64encode(image_data_raw)
         image_data_b64_unicode = image_data_b64_bytes.decode("utf-8")
@@ -243,24 +243,27 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
             response = self.manager.admin_library_settings_controller.process_post()
             assert response.uri == INVALID_CONFIGURATION_OPTION.uri
 
-    def test__data_url_for_image(self, image_info):
+    def test__data_url_for_image(self, logo_properties):
         """"""
-        image, expected_data_url = [image_info[key] for key in (
+        image, expected_data_url = [logo_properties[key] for key in (
             "image", "data_url"
         )]
         data_url = LibrarySettingsController._data_url_for_image(image)
         assert expected_data_url == data_url
 
-    def test_libraries_post_create(self, image_info):
+    def test_libraries_post_create(self, logo_properties):
+
         class TestFileUpload(BytesIO):
             headers = { "Content-Type": "image/png" }
 
-        image_data, expected_image_data_url, image = [image_info[key] for key in (
+        # Pull needed properties from logo fixture
+        image_data, expected_logo_data_url, image = [logo_properties[key] for key in (
             "raw_bytes", "data_url", "image"
         )]
-        # The data URL will not correspond to the image data, unless
-        # neither dimension of the image is greater than 135 pixels.
-        assert max(*image.size) <= 135
+        # LibrarySettingsController scales down images that are too large,
+        # so we fail here if our test fixture image is large enough to cause
+        # a mismatch between the expected data URL and the one configured.
+        assert max(*image.size) <= Configuration.LOGO_MAX_DIMENSION
 
         original_geographic_validate = GeographicValidator().validate_geographic_areas
         class MockGeographicValidator(GeographicValidator):
@@ -323,7 +326,7 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
             ConfigurationSetting.for_library(
                 Configuration.ENABLED_FACETS_KEY_PREFIX + FacetConstants.ORDER_FACET_GROUP_NAME,
                 library).value)
-        assert (expected_image_data_url == ConfigurationSetting.for_library(Configuration.LOGO, library).value)
+        assert (expected_logo_data_url == ConfigurationSetting.for_library(Configuration.LOGO, library).value)
         assert geographic_validator.was_called == True
         assert ('{"US": ["06759", "everywhere", "MD", "Boston, MA"], "CA": []}' ==
             ConfigurationSetting.for_library(Configuration.LIBRARY_SERVICE_AREA, library).value)


### PR DESCRIPTION
## Description

- Fixes `data` URLs for logo images so that they don't contain bytes literal notation.
- Adds fixture for test image.
- Split image data URL calculation into helper method.
- Parameterize logo max dimension.

## Motivation and Context
 
The move to Python 3 resulted in logo data URL values with embedded bytes literals (`b'...'`) like
- `data:image/png;base64,b'{base64_image_data}'`

rather than the expected values that look like
- `data:image/png;base64,{base64_image_data}`

Converting the Base64 encoded image data to Unicode strings eliminates the bytes literal notation.

## How Has This Been Tested?

- Manually verified that the resulting logo data URLs render properly in the client apps.
- Updated tests for Python 3.
- New test for data URL helper.
- Ensure that test fixture image properties are appropriate for logo-related tests.

## Checklist:

- [ N/A] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
