### PR TITLE
Fix admin static package asset path.

### DIFF
--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -26,7 +26,7 @@ class Configuration:
             'asset_rel_url': 'dist/{filename}'
         },
         OperationalMode.development: {
-            'package_url': '/',
+            'package_url': '/admin/',
             'asset_rel_url': 'static/{filename}',
         },
     }

--- a/tests/admin/test_config.py
+++ b/tests/admin/test_config.py
@@ -53,13 +53,13 @@ class TestAdminUI(object):
     @pytest.mark.parametrize(
         'asset_key, operational_mode, expected_result',
         [
-            ['admin_css', OperationalMode.development, '/static/circulation-admin.css'],
+            ['admin_css', OperationalMode.development, '/admin/static/circulation-admin.css'],
             ['admin_css', OperationalMode.production,
              'https://cdn.jsdelivr.net/npm/known-package-name@1.0.0/dist/circulation-admin.css'],
-            ['admin_js', OperationalMode.development, '/static/circulation-admin.js'],
+            ['admin_js', OperationalMode.development, '/admin/static/circulation-admin.js'],
             ['admin_js', OperationalMode.production,
              'https://cdn.jsdelivr.net/npm/known-package-name@1.0.0/dist/circulation-admin.js'],
-            ['another-asset.jpg', OperationalMode.development, '/static/another-asset.jpg'],
+            ['another-asset.jpg', OperationalMode.development, '/admin/static/another-asset.jpg'],
             ['another-asset.jpg', OperationalMode.production,
              'https://cdn.jsdelivr.net/npm/known-package-name@1.0.0/dist/another-asset.jpg'],
         ]


### PR DESCRIPTION
## Description

Fixes static package path for local copy of admin UI.

This problem affected only those test environments in which the `circulation-admin` client was locally installed or linked.

## Motivation and Context

The local package URL allows package assets to pulled from local static files on the CM server, rather than pulling from a CDN, as is normal.

## How Has This Been Tested?

Manually tested to verify that the assets were retrievable. Adjusted existing tests for the correct path.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
