### PR TITLE
Update CM admin UI to v0.0.4

### DIFF
--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -11,7 +11,7 @@ class OperationalMode(str, Enum):
 class Configuration:
 
     PACKAGE_NAME = '@thepalaceproject/circulation-admin'
-    PACKAGE_VERSION = '0.0.3'
+    PACKAGE_VERSION = '0.0.4'
 
     STATIC_ASSETS = {
         'admin_js': 'circulation-admin.js',

--- a/api/config.py
+++ b/api/config.py
@@ -52,11 +52,11 @@ class Configuration(CoreConfiguration):
     # service for a library's inclusion in the SimplyE library
     # registry.
     CUSTOM_TOS_HREF = "tos_href"
-    DEFAULT_TOS_HREF = "https://librarysimplified.org/simplyetermsofservice2/"
+    DEFAULT_TOS_HREF = "https://thepalaceproject.org/terms-of-service/"
 
     # Custom text for the link defined in CUSTOM_TOS_LINK.
     CUSTOM_TOS_TEXT = "tos_text"
-    DEFAULT_TOS_TEXT = "Terms of Service for presenting e-reading materials through NYPL's SimplyE mobile app"
+    DEFAULT_TOS_TEXT = "Terms of Service for presenting content through the Palace client applications"
 
     # A short description of the library, used in its Authentication
     # for OPDS document.


### PR DESCRIPTION
## Description

- Updates to `circulation-admin` v0.0.4, primarily for custom list manager fix.
- Update admin UI footer terms of service (ToS) to reference Palace-specific text and link.

## Motivation and Context

- Custom list manager did not properly populate view for editing.
- ToS text and link were not appropriate for the Palace context.

## How Has This Been Tested?

Manual testing to ensure that:
- list manager appears to work properly and 
- that ToS text and link display and operate properly.

Ran all tests.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
