### PR TITLE
Update to admin UI v0.0.5 for list/lane manager fixes.

### DIFF
--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -11,7 +11,7 @@ class OperationalMode(str, Enum):
 class Configuration:
 
     PACKAGE_NAME = '@thepalaceproject/circulation-admin'
-    PACKAGE_VERSION = '0.0.4'
+    PACKAGE_VERSION = '0.0.5'
 
     STATIC_ASSETS = {
         'admin_js': 'circulation-admin.js',


### PR DESCRIPTION
## Description

Update to admin UI v0.0.5 to prevent list and lanes manager columns collapsing when other columns contain long names/titles.

## Motivation and Context

This is affecting the custom list manager for several of our libraries.

## How Has This Been Tested?

Manual testing by modifying values in the browser developer tools.

## Checklist:

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.