### PR TITLE
Update timeout method to stop hung tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ commands_pre =
     docker: docker restart es-circ
     python -m textblob.download_corpora
 commands =
-    pytest {posargs:--timeout=600 --disable-warnings tests}
+    pytest {posargs:--disable-warnings}
 passenv = SIMPLIFIED_* CI
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test
@@ -43,3 +43,8 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+
+[pytest]
+timeout_method = signal
+timeout = 600
+testpaths = tests

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,6 @@ python =
     3.9: py39
 
 [pytest]
-timeout_method = signal
+timeout_method = thread
 timeout = 600
 testpaths = tests


### PR DESCRIPTION
## Description

Update `tox.ini` with pytest [config options](https://docs.pytest.org/en/latest/reference/reference.html#configuration-options). This lets us centralize out pytest config. 

Update `pytest-timeout` to use the [`thread` method](https://pypi.org/project/pytest-timeout/) for timing out the test suite. It seems that the signal method is not working, since [this run](https://github.com/ThePalaceProject/circulation/runs/4047051977?check_suite_focus=true#step:6:173) spent 50 minutes on a single test and never timed out. 

Hopefully the thread method will actually timeout the tests and help us get an understanding of what is failing when the tests hang. 