### PR TITLE
Tweak styling of login page.

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -455,7 +455,7 @@ class SignInController(AdminController):
 <meta charset="utf8">
 <title>{app_name}</title>
 <style>
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap');
 </style>
 </head>
 """.format(app_name=AdminClientConfig.APP_NAME)

--- a/api/admin/template_styles.py
+++ b/api/admin/template_styles.py
@@ -42,6 +42,7 @@ button_style = """
     border-radius: .25em;
     color: #fff;
     padding: 10px;
+    font-family: 'Open Sans',Helvetica,Arial,sans-serif;
     font-size: 1rem;
     cursor: pointer;
     display: block;


### PR DESCRIPTION
## Description

This fixes a couple small issues with the styling of the login page done in #52.

- The Email and Password labels call for a font weight of 700 (bold), but this weight was not included in the Open Sans download, so it wasn't properly bold.
- The Sign In button was not appearing in Open Sans (because buttons notoriously don't inherit the font of the body). 

## Motivation and Context

This makes the styling more consistent.

Original Notion ticket: https://www.notion.so/lyrasis/Update-CM-with-Brand-guidance-88976ea09252447998779b4bbeb2fdeb

## How Has This Been Tested?

@ray-lee verified that the Email and Password labels are properly bold, and that the Sign In button has the correct font.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
