### PR TITLE
Update vulnerable dependency

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -36,7 +36,7 @@ pypostalcode==0.3.6
 pyOpenSSL==19.1.0
 # TODO: python-Levenshtein is supposedly required for author name
 # matching, but is not a core requirement; perhaps it can be removed.
-python-Levenshtein==0.12.0
+python-Levenshtein<0.13
 # python-saml is required for SAML authentication
 python3-saml==1.12.0
 # requests-mock is used for unit tests.


### PR DESCRIPTION
## Description

Update to a newer dependency version.

## Motivation and Context

When doing a pip install we are getting the security warning: 

```
  WARNING: The candidate selected for download or install is a yanked version: 'python-levenshtein' candidate (version 0.12.0 at https://files.pythonhosted.org/packages/42/a9/d1785c85ebf9b7dfacd08938dd028209c34a0ea3b1bcdb895208bd40a67d/python-Levenshtein-0.12.0.tar.gz#sha256=033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1 (from https://pypi.org/simple/python-levenshtein/))
  Reason for being yanked: Insecure, upgrade to 0.12.1
```
