### PR TITLE
Fix test that was causing intermittant hangs in test runs.

### DIFF
--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -5803,7 +5803,7 @@ class TestScopedSession(ControllerTest):
             # When the index controller runs in the request context,
             # it doesn't store anything that's associated with the
             # scoped session.
-            flask.request.library = self._default_library
+            flask.request.library = self.library
             response = self.app.manager.index_controller()
             assert 302 == response.status_code
 
@@ -5832,7 +5832,7 @@ class TestScopedSession(ControllerTest):
             # The controller still works in the new request context -
             # nothing it needs is associated with the previous scoped
             # session.
-            flask.request.library = self._default_library
+            flask.request.library = self.library
             response = self.app.manager.index_controller()
             assert 302 == response.status_code
 


### PR DESCRIPTION
## Description

Caught a [stack trace](https://github.com/ThePalaceProject/circulation/runs/4098182955?check_suite_focus=true#step:6:178) the other day of a test hanging. It was caused by a database deadlock. I spent a bit of time looking into it, because I was worried that it wasn't just a test issue, but a potential deadlock we could see in production code. 

Still doing some investigation as to if this could happen on real servers or not.

## Motivation and Context

This seems like its a somewhat known issue, as this comment in the test code mentions it:
https://github.com/ThePalaceProject/circulation/blob/main/tests/test_controller.py#L175-L177

However despite this warning, the tests inheriting from this class do use `_default_library` in a large number of places, and this is what caused the race condition that occasionally resulted in a hang here. Some work should probably be undertaken to try to clean up these tests a bit. 

This PR focuses specifically on fixing the test that occasionally hangs and haunts 👻 our tests. 

## How Has This Been Tested?

I was able to fairly reliably reproduce this hang locally, by changing the `cooldown` parameter of [`site_configuration_has_changed`](https://github.com/ThePalaceProject/circulation-core/blob/d35bec9458e033f038e80379507a9db2a9da48e9/model/listeners.py#L26) to have a default of 0. Once I was able to make the hang happen reliably, I applied this patch and verified that the hang is no longer happening. 🎉 
