### PR TITLE
Make LCP's Passphrase hint and Passphrase hint URL configuration settings mandatory and add default values

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -110,6 +110,7 @@ from .lanes import (
     load_lanes,
 )
 from .odl import ODLAPI
+from .odl2 import ODL2API
 from .opds import (
     CirculationManagerAnnotator,
     LibraryAnnotator,
@@ -2359,7 +2360,7 @@ class ODLNotificationController(CirculationManagerController):
             return NO_ACTIVE_LOAN.detailed(_("No loan was found for this identifier."))
 
         collection = loan.license_pool.collection
-        if collection.protocol != ODLAPI.NAME:
+        if collection.protocol not in (ODLAPI.NAME, ODL2API.NAME):
             return INVALID_LOAN_FOR_ODL_NOTIFICATION
 
         api = self.manager.circulation_apis[library.id].api_for_license_pool(

--- a/api/odl.py
+++ b/api/odl.py
@@ -120,7 +120,7 @@ class ODLAPIConfiguration(ConfigurationGrouping):
         ),
         type=ConfigurationAttributeType.TEXT,
         required=True,
-        default=DEFAULT_PASSPHRASE_HINT
+        default=DEFAULT_PASSPHRASE_HINT,
     )
 
     passphrase_hint_url = ConfigurationMetadata(
@@ -132,7 +132,7 @@ class ODLAPIConfiguration(ConfigurationGrouping):
         type=ConfigurationAttributeType.TEXT,
         required=True,
         default=DEFAULT_PASSPHRASE_HINT_URL,
-        format="url"
+        format="url",
     )
 
     encryption_algorithm = ConfigurationMetadata(

--- a/api/odl.py
+++ b/api/odl.py
@@ -1,6 +1,5 @@
 import binascii
 import datetime
-import hashlib
 import json
 import logging
 import uuid
@@ -65,7 +64,8 @@ from .shared_collection import BaseSharedCollectionAPI
 class ODLAPIConfiguration(ConfigurationGrouping):
     """Contains LCP License Server's settings"""
 
-    DEFAULT_PASSPHRASE_HINT = "Look in the Palace app."
+    DEFAULT_PASSPHRASE_HINT = "View the help page for more information."
+    DEFAULT_PASSPHRASE_HINT_URL = "https://lyrasis.zendesk.com/"
     DEFAULT_ENCRYPTION_ALGORITHM = HashingAlgorithm.SHA256.value
 
     feed_url = ConfigurationMetadata(
@@ -119,8 +119,8 @@ class ODLAPIConfiguration(ConfigurationGrouping):
             "Hint displayed to the user when opening an LCP protected publication."
         ),
         type=ConfigurationAttributeType.TEXT,
-        required=False,
-        default=DEFAULT_PASSPHRASE_HINT,
+        required=True,
+        default=DEFAULT_PASSPHRASE_HINT
     )
 
     passphrase_hint_url = ConfigurationMetadata(
@@ -130,8 +130,9 @@ class ODLAPIConfiguration(ConfigurationGrouping):
             "Hint URL available to the user when opening an LCP protected publication."
         ),
         type=ConfigurationAttributeType.TEXT,
-        required=False,
-        format="url",
+        required=True,
+        default=DEFAULT_PASSPHRASE_HINT_URL,
+        format="url"
     )
 
     encryption_algorithm = ConfigurationMetadata(

--- a/api/odl2.py
+++ b/api/odl2.py
@@ -174,7 +174,11 @@ class ODL2Importer(OPDS2Importer, HasExternalIntegration):
             skipped_license_formats = configuration.skipped_license_formats
 
             if skipped_license_formats:
-                skipped_license_formats = set(json.loads(skipped_license_formats))
+                skipped_license_formats = (
+                    set(json.loads(skipped_license_formats))
+                    if isinstance(skipped_license_formats, str)
+                    else set(skipped_license_formats)
+                )
 
         if publication.licenses:
             for license in publication.licenses:

--- a/api/odl2.py
+++ b/api/odl2.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from contextlib2 import contextmanager
@@ -174,11 +173,7 @@ class ODL2Importer(OPDS2Importer, HasExternalIntegration):
             skipped_license_formats = configuration.skipped_license_formats
 
             if skipped_license_formats:
-                skipped_license_formats = (
-                    set(json.loads(skipped_license_formats))
-                    if isinstance(skipped_license_formats, str)
-                    else set(skipped_license_formats)
-                )
+                skipped_license_formats = set(skipped_license_formats)
 
         if publication.licenses:
             for license in publication.licenses:

--- a/api/proquest/importer.py
+++ b/api/proquest/importer.py
@@ -266,44 +266,6 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
         ) as configuration:
             yield configuration
 
-    @staticmethod
-    def _get_affiliation_attributes(configuration):
-        """Return a configured list of SAML attributes which can contain affiliation ID.
-
-        :param configuration: Configuration object
-        :type configuration: ProQuestOPDS2ImporterConfiguration
-
-        :return: Configured list of SAML attributes which can contain affiliation ID
-        :rtype: List[str]
-        """
-        affiliation_attributes = (
-            ProQuestOPDS2ImporterConfiguration.DEFAULT_AFFILIATION_ATTRIBUTES
-        )
-
-        if configuration.affiliation_attributes:
-            if isinstance(configuration.affiliation_attributes, list):
-                affiliation_attributes = configuration.affiliation_attributes
-            elif isinstance(configuration.affiliation_attributes, str):
-                affiliation_attributes = tuple(
-                    map(
-                        str.strip,
-                        str(configuration.affiliation_attributes)
-                        .replace("[", "")
-                        .replace("]", "")
-                        .replace("(", "")
-                        .replace(")", "")
-                        .replace("'", "")
-                        .replace('"', "")
-                        .split(","),
-                    )
-                )
-            else:
-                raise ValueError(
-                    "Configuration setting 'affiliation_attributes' has an incorrect format"
-                )
-
-        return affiliation_attributes
-
     def _get_patron_affiliation_id(self, patron, configuration):
         """Get a patron's affiliation ID.
 
@@ -316,9 +278,8 @@ class ProQuestOPDS2Importer(OPDS2Importer, BaseCirculationAPI, HasExternalIntegr
         :return: Patron's affiliation ID
         :rtype: Optional[str]
         """
-        affiliation_attributes = self._get_affiliation_attributes(configuration)
         affiliation_id = self._credential_manager.lookup_patron_affiliation_id(
-            self._db, patron, affiliation_attributes
+            self._db, patron, configuration.affiliation_attributes
         )
 
         self._logger.info(

--- a/api/proquest/importer.py
+++ b/api/proquest/importer.py
@@ -87,10 +87,10 @@ class ProQuestOPDS2ImporterConfiguration(ConfigurationGrouping):
 
     DEFAULT_TOKEN_EXPIRATION_TIMEOUT_SECONDS = 60 * 60
     TEST_AFFILIATION_ID = 1
-    DEFAULT_AFFILIATION_ATTRIBUTES = (
+    DEFAULT_AFFILIATION_ATTRIBUTES = [
         SAMLAttributeType.eduPersonPrincipalName.name,
         SAMLAttributeType.eduPersonScopedAffiliation.name,
-    )
+    ]
 
     data_source_name = ConfigurationMetadata(
         key=Collection.DATA_SOURCE_NAME_SETTING,

--- a/api/saml/configuration/model.py
+++ b/api/saml/configuration/model.py
@@ -242,15 +242,11 @@ class SAMLConfiguration(ConfigurationGrouping):
         if not self.federated_identity_provider_entity_ids:
             return []
 
-        federated_identity_provider_entity_ids = json.loads(
-            self.federated_identity_provider_entity_ids
-        )
-
         return (
             db.query(SAMLFederatedIdentityProvider)
             .filter(
                 SAMLFederatedIdentityProvider.entity_id.in_(
-                    federated_identity_provider_entity_ids
+                    self.federated_identity_provider_entity_ids
                 )
             )
             .all()

--- a/api/saml/provider.py
+++ b/api/saml/provider.py
@@ -85,7 +85,9 @@ class SAMLWebSSOAuthenticationProvider(
                 configuration.patron_id_use_name_id
             )
             self._patron_id_attributes = configuration.patron_id_attributes
-            self._patron_id_regular_expression = configuration.patron_id_regular_expression
+            self._patron_id_regular_expression = (
+                configuration.patron_id_regular_expression
+            )
 
     def _authentication_flow_document(self, db):
         """Creates a Authentication Flow object for use in an Authentication for OPDS document.

--- a/api/saml/provider.py
+++ b/api/saml/provider.py
@@ -84,14 +84,8 @@ class SAMLWebSSOAuthenticationProvider(
             self._patron_id_use_name_id = ConfigurationMetadata.to_bool(
                 configuration.patron_id_use_name_id
             )
-            self._patron_id_attributes = (
-                json.loads(configuration.patron_id_attributes)
-                if configuration.patron_id_attributes
-                else []
-            )
-            self._patron_id_regular_expression = (
-                configuration.patron_id_regular_expression
-            )
+            self._patron_id_attributes = configuration.patron_id_attributes
+            self._patron_id_regular_expression = configuration.patron_id_regular_expression
 
     def _authentication_flow_document(self, db):
         """Creates a Authentication Flow object for use in an Authentication for OPDS document.

--- a/tests/proquest/test_importer.py
+++ b/tests/proquest/test_importer.py
@@ -265,27 +265,6 @@ class TestProQuestOPDS2Importer(DatabaseTest):
     @parameterized.expand(
         [
             (
-                "tuple",
-                (
-                    SAMLAttributeType.mail.name,
-                    SAMLAttributeType.uid.name,
-                ),
-            ),
-            (
-                "list",
-                [
-                    SAMLAttributeType.mail.name,
-                    SAMLAttributeType.uid.name,
-                ],
-            ),
-            (
-                "tuple_string",
-                "({0}, {1})".format(
-                    SAMLAttributeType.mail.name,
-                    SAMLAttributeType.uid.name,
-                ),
-            ),
-            (
                 "list_string",
                 json.dumps(
                     [
@@ -310,10 +289,10 @@ class TestProQuestOPDS2Importer(DatabaseTest):
         affiliation_id = "12345"
         proquest_token = "1234567890"
 
-        expected_affiliation_attributes = (
+        expected_affiliation_attributes = [
             SAMLAttributeType.mail.name,
             SAMLAttributeType.uid.name,
-        )
+        ]
 
         saml_subject = SAMLSubject(
             None,

--- a/tests/saml/test_provider.py
+++ b/tests/saml/test_provider.py
@@ -377,15 +377,6 @@ class TestSAMLWebSSOAuthenticationProvider(ControllerTest):
                 "false",
             ),
             (
-                "subject_has_unique_name_id_but_use_of_name_id_is_switched_off_using_none",
-                SAMLSubject(
-                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "12345"),
-                    SAMLAttributeStatement([]),
-                ),
-                SAML_INVALID_SUBJECT.detailed("Subject does not have a unique ID"),
-                None,
-            ),
-            (
                 "subject_has_unique_name_id_and_use_of_name_id_is_switched_on_using_string_literal_true",
                 SAMLSubject(
                     SAMLNameID(SAMLNameIDFormat.UNSPECIFIED, "", "", "12345"),

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -54,7 +54,7 @@ from api.lanes import (
     create_default_lanes,
 )
 from api.novelist import MockNoveListAPI
-from api.odl import MockODLAPI, ODLAPI
+from api.odl import ODLAPI, MockODLAPI
 from api.odl2 import ODL2API
 from api.opds import (
     CirculationManagerAnnotator,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -5346,16 +5346,7 @@ class TestODLNotificationController(ControllerTest):
     when a loan's status changes."""
 
     @parameterized.expand(
-        [
-            (
-                "ODL 1.x collection",
-                ODLAPI.NAME
-            ),
-            (
-                "ODL 2.x collection",
-                ODL2API.NAME
-            )
-        ]
+        [("ODL 1.x collection", ODLAPI.NAME), ("ODL 2.x collection", ODL2API.NAME)]
     )
     def test_notify_success(self, _, protocol: str) -> None:
         collection = MockODLAPI.mock_collection(self._db, protocol)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -19,6 +19,7 @@ from flask import Response as FlaskResponse
 from flask import url_for
 from flask_sqlalchemy_session import current_session
 from mock import MagicMock, patch
+from parameterized import parameterized
 from werkzeug.datastructures import ImmutableMultiDict
 from werkzeug.exceptions import NotFound
 
@@ -53,7 +54,8 @@ from api.lanes import (
     create_default_lanes,
 )
 from api.novelist import MockNoveListAPI
-from api.odl import MockODLAPI
+from api.odl import MockODLAPI, ODLAPI
+from api.odl2 import ODL2API
 from api.opds import (
     CirculationManagerAnnotator,
     LibraryAnnotator,
@@ -5343,8 +5345,20 @@ class TestODLNotificationController(ControllerTest):
     """Test that an ODL distributor can notify the circulation manager
     when a loan's status changes."""
 
-    def test_notify_success(self):
-        collection = MockODLAPI.mock_collection(self._db)
+    @parameterized.expand(
+        [
+            (
+                "ODL 1.x collection",
+                ODLAPI.NAME
+            ),
+            (
+                "ODL 2.x collection",
+                ODL2API.NAME
+            )
+        ]
+    )
+    def test_notify_success(self, _, protocol: str) -> None:
+        collection = MockODLAPI.mock_collection(self._db, protocol)
         patron = self._patron()
         pool = self._licensepool(None, collection=collection)
         pool.licenses_owned = 10

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -95,7 +95,9 @@ class TestODLAPI(DatabaseTest, BaseODLTest):
         params = urllib.parse.parse_qs(parsed.query)
 
         assert ODLAPIConfiguration.passphrase_hint.default == params.get("hint")[0]
-        assert ODLAPIConfiguration.passphrase_hint_url.default == params.get("hint_url")[0]
+        assert (
+            ODLAPIConfiguration.passphrase_hint_url.default == params.get("hint_url")[0]
+        )
 
         assert self.license.identifier == params.get("id")[0]
 

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -17,11 +17,12 @@ from api.odl import (
     ODLAPI,
     MockODLAPI,
     MockSharedODLAPI,
+    ODLAPIConfiguration,
     ODLExpiredItemsReaper,
     ODLHoldReaper,
     ODLImporter,
     SharedODLAPI,
-    SharedODLImporter, ODLAPIConfiguration,
+    SharedODLImporter,
 )
 from core.model import (
     Collection,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR depends on https://github.com/ThePalaceProject/circulation-core/pull/35.

This PR contains quite a lot of different changes:
1. The most important change is making `Passphrase hint` and Passphrase hint URL` configuration settings mandatory and adding meaningful default values.
2. All other changes are mostly related with changes from https://github.com/ThePalaceProject/circulation-core/pull/35 and fixing some failing tests.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
