### PR TITLE
Troubleshoot docker builds

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: image=moby/buildkit:v0.9.1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -146,6 +148,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: image=moby/buildkit:v0.9.1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -224,6 +228,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: image=moby/buildkit:v0.9.1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1


### PR DESCRIPTION
## Description

I've been seeing a lot of our docker builds failing recently. It looks like its related to these issues:

https://github.com/docker/build-push-action/issues/498#issuecomment-967773178
https://github.com/docker/buildx/issues/834
https://github.com/moby/buildkit/pull/2461

Looks like a fix is merged into buildkit, but we won't get it until there is a new release, so this pins the version we are using to an older version temporarily.
