### PR TITLE
Fix the DPLA audiobook download issue

### DIFF
--- a/api/odl.py
+++ b/api/odl.py
@@ -2,7 +2,6 @@ import binascii
 import datetime
 import json
 import logging
-import re
 import uuid
 from io import StringIO
 from typing import Callable, Dict, List, Optional, Tuple, Union
@@ -20,7 +19,7 @@ from uritemplate import URITemplate
 from core import util
 from core.analytics import Analytics
 from core.lcp.credential import LCPCredentialFactory
-from core.metadata_layer import CirculationData, FormatData, LicenseData, TimestampData
+from core.metadata_layer import FormatData, LicenseData, TimestampData
 from core.model import (
     Collection,
     ConfigurationSetting,
@@ -50,7 +49,7 @@ from core.model.configuration import (
     HasExternalIntegration,
 )
 from core.model.licensing import LicenseStatus
-from core.monitor import CollectionMonitor, IdentifierSweepMonitor
+from core.monitor import CollectionMonitor
 from core.opds_import import OPDSImporter, OPDSImportMonitor, OPDSXMLParser
 from core.testing import DatabaseTest, MockRequestsResponse
 from core.util.datetime_helpers import to_utc, utc_now

--- a/api/odl.py
+++ b/api/odl.py
@@ -575,7 +575,7 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
         if not drm_scheme:
             # If we don't have a requested DRM scheme, so we use the first one.
             # TODO: Can this just be dropped?
-            return next(candidates)
+            return candidates[0]
 
         return next(filter(lambda x: x[1] == drm_scheme, candidates), (None, None))
 

--- a/api/odl.py
+++ b/api/odl.py
@@ -1057,7 +1057,7 @@ class ODLImporter(OPDSImporter):
             checkouts_available=available,
             status=status,
             terms_concurrency=concurrency,
-            content_types=content_types
+            content_types=content_types,
         )
 
     @classmethod

--- a/api/odl.py
+++ b/api/odl.py
@@ -541,29 +541,7 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
         return self._fulfill(loan, internal_format)
 
     @staticmethod
-    def _is_audiobook(
-        delivery_mechanism: Union[Optional[str], Optional[LicensePoolDeliveryMechanism]]
-    ) -> bool:
-        """Check whether a particular delivery mechanism delivers an audiobook.
-
-        :param delivery_mechanism: Selected delivery mechanism
-
-        :return: Boolean value showing whether a particular delivery mechanism delivers an audiobook
-        """
-        if not delivery_mechanism:
-            return False
-        elif isinstance(delivery_mechanism, str):
-            return delivery_mechanism == MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE
-        elif isinstance(delivery_mechanism, LicensePoolDeliveryMechanism):
-            return (
-                delivery_mechanism.delivery_mechanism.content_type
-                == MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE
-            )
-        else:
-            return False
-
     def _find_content_link_and_type(
-        self,
         links: List[Dict],
         delivery_mechanism: Union[
             Optional[str], Optional[LicensePoolDeliveryMechanism]
@@ -650,7 +628,7 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
         if (
             not content_link
             and not content_type
-            and self._is_audiobook(delivery_mechanism)
+            and licensepool.presentation_edition.medium == Edition.AUDIO_MEDIUM
         ):
             # DPLA's ODL feed doesn't always mention a DRM type of audiobooks.
             # It means that DPLA audiobooks get imported without any DRM information

--- a/api/odl.py
+++ b/api/odl.py
@@ -999,6 +999,7 @@ class ODLImporter(OPDSImporter):
         document_terms = license_info_document.get("terms", {})
         document_expires = document_terms.get("expires")
         document_concurrency = document_terms.get("concurrency")
+        document_format = license_info_document.get("format")
 
         if identifier is None:
             logging.error("License info document has no identifier.")
@@ -1040,6 +1041,13 @@ class ODLImporter(OPDSImporter):
         if document_concurrency is not None:
             concurrency = int(document_concurrency)
 
+        content_types = None
+        if document_format is not None:
+            if isinstance(document_format, str):
+                content_types = [document_format]
+            elif isinstance(document_format, list):
+                content_types = document_format
+
         return LicenseData(
             identifier=identifier,
             checkout_url=checkout_link,
@@ -1049,6 +1057,7 @@ class ODLImporter(OPDSImporter):
             checkouts_available=available,
             status=status,
             terms_concurrency=concurrency,
+            content_types=content_types
         )
 
     @classmethod
@@ -1180,7 +1189,6 @@ class ODLImporter(OPDSImporter):
                     break
 
             expires = None
-            total_checkouts = None
             concurrent_checkouts = None
 
             terms = parser._xpath(odl_license_tag, "odl:terms")

--- a/api/odl2.py
+++ b/api/odl2.py
@@ -49,21 +49,6 @@ class ODL2Importer(OPDS2Importer, HasExternalIntegration):
 
     NAME = ODL2API.NAME
 
-    FEEDBOOKS_AUDIO = "{0}; protection={1}".format(
-        MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
-        DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM,
-    )
-
-    CONTENT_TYPE = "content-type"
-    DRM_SCHEME = "drm-scheme"
-
-    LICENSE_FORMATS = {
-        FEEDBOOKS_AUDIO: {
-            CONTENT_TYPE: MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
-            DRM_SCHEME: DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM,
-        }
-    }
-
     def __init__(
         self,
         db,
@@ -242,12 +227,12 @@ class ODL2Importer(OPDS2Importer, HasExternalIntegration):
                             if MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE in content_type:
                                 license_format = content_type
 
-                    if license_format in self.LICENSE_FORMATS:
-                        drm_scheme = self.LICENSE_FORMATS[license_format][
-                            self.DRM_SCHEME
+                    if license_format in ODLImporter.LICENSE_FORMATS:
+                        drm_scheme = ODLImporter.LICENSE_FORMATS[license_format][
+                            ODLImporter.DRM_SCHEME
                         ]
-                        license_format = self.LICENSE_FORMATS[license_format][
-                            self.CONTENT_TYPE
+                        license_format = ODLImporter.LICENSE_FORMATS[license_format][
+                            ODLImporter.CONTENT_TYPE
                         ]
 
                         drm_schemes.append(drm_scheme)

--- a/api/odl2.py
+++ b/api/odl2.py
@@ -7,7 +7,7 @@ from webpub_manifest_parser.opds2.registry import OPDS2LinkRelationsRegistry
 
 from api.odl import ODLAPI, ODLImporter
 from core.metadata_layer import FormatData
-from core.model import DeliveryMechanism, Edition, MediaTypes, RightsStatus
+from core.model import Edition, RightsStatus
 from core.model.configuration import (
     ConfigurationAttributeType,
     ConfigurationFactory,

--- a/api/odl2.py
+++ b/api/odl2.py
@@ -235,7 +235,8 @@ class ODL2Importer(OPDS2Importer, HasExternalIntegration):
                     # We want to try to extract that information from the License Info Document it's present there.
                     if (
                         license_format == MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE
-                        and parsed_license and parsed_license.content_types
+                        and parsed_license
+                        and parsed_license.content_types
                     ):
                         for content_type in parsed_license.content_types:
                             if MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE in content_type:

--- a/tests/files/odl2/feed-audiobook.json
+++ b/tests/files/odl2/feed-audiobook.json
@@ -1,0 +1,153 @@
+{
+  "metadata": {
+    "title": "Test",
+    "itemsPerPage": 10,
+    "currentPage": 1,
+    "numberOfItems": 100
+  },
+  "links": [
+    {
+      "type": "application/opds+json",
+      "rel": "self",
+      "href": "https://market.feedbooks.com/api/libraries/harvest.json"
+    }
+  ],
+  "publications": [
+    {
+      "metadata": {
+        "@type": "http://schema.org/Book",
+        "title": "Past Imperfect",
+        "language": "en",
+        "modified": "2021-04-17T11:23:38Z",
+        "published": "2009-09-10T00:00:00Z",
+        "identifier": "urn:ISBN:9780792766919",
+        "author": [
+          {
+            "name": "Julian Fellowes",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/store/browse/recent.json?author_id=161600&lang=en"
+              }
+            ]
+          }
+        ],
+        "narrator": [
+          {
+            "name": "Richard Morant",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/store/browse/recent.json?contributor_id=1235819&lang=en"
+              }
+            ]
+          }
+        ],
+        "publisher": {
+          "name": "Blackstone Publishing",
+          "links": [
+            {
+              "type": "application/opds+json",
+              "href": "https://market.feedbooks.com/store/browse/recent.json?lang=en&publisher=Blackstone+Publishing"
+            }
+          ]
+        },
+        "description": "<p>Damian Baxter is hugely wealthy and dying. He lives alone in a big house in Surrey, England, looked after by a chauffeur, butler, cook, and housemaid. He has but one concern?his fortune in excess of five hundred million and who should inherit it on his death. <i>Past Imperfect</i> is the story of a quest. Damian Baxter wishes to know if he has a living heir. By the time he married in his late thirties he was sterile (the result of adult mumps), but what about before that unfortunate illness? Had he sired a child? He sets himself (and others) to the task of finding his heir.</p>",
+        "subject": [
+          {
+            "code": "FBFIC000000",
+            "name": "Fiction",
+            "scheme": "http://www.feedbooks.com/categories",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/category/FBFIC000000.json?lang=en"
+              }
+            ]
+          },
+          {
+            "code": "FBFIC019000",
+            "name": "Literary",
+            "scheme": "http://www.feedbooks.com/categories",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/category/FBFIC019000.json?lang=en"
+              }
+            ]
+          },
+          {
+            "code": "READ0000",
+            "scheme": "http://schema.org/Audience",
+            "name": "Adult",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/top.json?age=READ0000&lang=en"
+              }
+            ]
+          }
+        ]
+      },
+      "images": [
+        {
+          "href": "https://covers.feedbooks.net/item/3270952.jpg?size=large&t=1603092006",
+          "type": "image/jpeg",
+          "width": 260,
+          "height": 420
+        },
+        {
+          "href": "https://covers.feedbooks.net/item/3270952.jpg?t=1603092006",
+          "type": "image/jpeg",
+          "width": 100,
+          "height": 180
+        }
+      ],
+      "licenses": [
+        {
+          "metadata": {
+            "identifier": "urn:uuid:a44b9e96-7ad6-42b5-a86d-786563f32b12",
+            "format": [
+              "application/audiobook+lcp",
+              "text/html"
+            ],
+            "created": "2021-10-07T22:23:45+02:00",
+            "source": "http://www.cantook.net/",
+            "price": {
+              "currency": "USD",
+              "value": 69.95
+            },
+            "terms": {
+              "concurrency": 1,
+              "length": 5097600
+            },
+            "protection": {
+              "format": [
+                "application/vnd.readium.lcp.license.v1.0+json"
+              ],
+              "devices": 6
+            },
+            "order": {
+              "name": "Palace Marketplace Test Cart - Tara & Carissa",
+              "identifier": "202110-718-013938",
+              "href": "https://market.feedbooks.com/carts/13938"
+            }
+          },
+          "links": [
+            {
+              "rel": "http://opds-spec.org/acquisition/borrow",
+              "href": "https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}",
+              "type": "application/vnd.readium.license.status.v1.0+json",
+              "templated": true
+            },
+            {
+              "rel": "self",
+              "href": "https://license.feedbooks.net/copy/status/?uuid=a44b9e96-7ad6-42b5-a86d-786563f32b12",
+              "type": "application/vnd.odl.info+json"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/files/odl2/feed.json
+++ b/tests/files/odl2/feed.json
@@ -65,8 +65,7 @@
             "identifier": "urn:uuid:f7847120-fc6f-11e3-8158-56847afe9799",
             "format": [
               "application/epub+zip",
-              "text/html",
-              "application/audiobook+json"
+              "text/html"
             ],
             "price": {
               "currency": "USD",

--- a/tests/files/odl2/feed.json
+++ b/tests/files/odl2/feed.json
@@ -66,7 +66,7 @@
             "format": [
               "application/epub+zip",
               "text/html",
-              "application/audiobook+json; protection=http://www.feedbooks.com/audiobooks/access-restriction"
+              "application/audiobook+json"
             ],
             "price": {
               "currency": "USD",

--- a/tests/files/odl2/license-audiobook.json
+++ b/tests/files/odl2/license-audiobook.json
@@ -1,0 +1,17 @@
+{
+ "identifier": "urn:uuid:a44b9e96-7ad6-42b5-a86d-786563f32b12",
+ "status": "available",
+ "created": "2021-10-07T20:23:45Z",
+ "format": "application/audiobook+json; protection=http://www.feedbooks.com/audiobooks/access-restriction",
+ "price": {
+  "value": 69.95,
+  "currency": "usd"
+ },
+ "terms": {
+  "concurrency": 1,
+  "length": 5097600
+ },
+ "checkouts": {
+  "available": 1
+ }
+}

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -81,12 +81,16 @@ class LicenseInfoHelper:
         available: int,
         status: str = "available",
         left: Optional[int] = None,
+        content_types: Optional[Union[str, List[str]]] = None,
+        drm_schemes: Optional[Union[str, List[str]]] = None,
     ) -> None:
         """Initialize a new instance of LicenseInfoHelper class."""
         self.license: LicenseHelper = license
         self.status: str = status
         self.left: int = left
         self.available: int = available
+        self.content_types = content_types
+        self.drm_schemes = drm_schemes
 
     def __str__(self) -> str:
         """Return a JSON representation of a part of the License Info Document."""
@@ -104,6 +108,12 @@ class LicenseInfoHelper:
             output["terms"]["expires"] = self.license.expires
         if self.left is not None:
             output["checkouts"]["left"] = self.left
+        if self.content_types is not None:
+            output["format"] = self.content_types
+        if self.drm_schemes is not None:
+            output["protection"] = {
+                "format": self.drm_schemes
+            }
         return json.dumps(output)
 
 

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -811,6 +811,9 @@ class TestODLAPI(DatabaseTest, BaseODLAPITest):
         feed_drm_scheme,
         type_in_license,
     ):
+        # We need to override the medium and set it to 'Audio'.
+        pool.presentation_edition.medium = Edition.AUDIO_MEDIUM
+
         # Fulfill a loan in a way that gives access to a manifest file.
         license.setup(concurrency=1, available=1)
         checkout()

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -111,9 +111,7 @@ class LicenseInfoHelper:
         if self.content_types is not None:
             output["format"] = self.content_types
         if self.drm_schemes is not None:
-            output["protection"] = {
-                "format": self.drm_schemes
-            }
+            output["protection"] = {"format": self.drm_schemes}
         return json.dumps(output)
 
 

--- a/tests/test_odl.py
+++ b/tests/test_odl.py
@@ -284,11 +284,6 @@ class BaseODLAPITest(BaseODLTest):
 
 
 class TestODLAPI(DatabaseTest, BaseODLAPITest):
-    AUDIO_BOOK_WITH_FEEDBOOKS_DRM = (
-        f"{MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE}; "
-        f"protection=http://www.feedbooks.com/audiobooks/access-restriction"
-    )
-
     def test_get_license_status_document_success(self, license, patron, api, library):
         # With a new loan.
         loan, _ = license.loan_to(patron)
@@ -796,13 +791,8 @@ class TestODLAPI(DatabaseTest, BaseODLAPITest):
             ),
             (
                 MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
-                DeliveryMechanism.NO_DRM,
-                AUDIO_BOOK_WITH_FEEDBOOKS_DRM,
-            ),
-            (
-                MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
                 DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM,
-                AUDIO_BOOK_WITH_FEEDBOOKS_DRM,
+                ODLImporter.FEEDBOOKS_AUDIO,
             ),
         ],
     )

--- a/tests/test_odl2.py
+++ b/tests/test_odl2.py
@@ -10,7 +10,6 @@ from webpub_manifest_parser.odl.semantic import (
     ODL_PUBLICATION_MUST_CONTAIN_EITHER_LICENSES_OR_OA_ACQUISITION_LINK_ERROR,
 )
 
-from api.odl import ODLImporter
 from api.odl2 import ODL2API, ODL2APIConfiguration, ODL2Importer
 from core.coverage import CoverageFailure
 from core.model import (
@@ -93,7 +92,6 @@ class TestODL2Importer(TestODLImporter):
             ),
             left=30,
             available=10,
-            content_types=[ODLImporter.FEEDBOOKS_AUDIO],
         )
 
         mock_get.add(moby_dick_license)
@@ -163,7 +161,7 @@ class TestODL2Importer(TestODLImporter):
         assert 30 == moby_dick_license_pool.licenses_owned
         assert 10 == moby_dick_license_pool.licenses_available
 
-        assert 5 == len(moby_dick_license_pool.delivery_mechanisms)
+        assert 2 == len(moby_dick_license_pool.delivery_mechanisms)
 
         moby_dick_epub_adobe_drm_delivery_mechanism = (
             self._get_delivery_mechanism_by_drm_scheme_and_content_type(
@@ -182,33 +180,6 @@ class TestODL2Importer(TestODLImporter):
             )
         )
         assert moby_dick_epub_lcp_drm_delivery_mechanism is not None
-
-        moby_dick_audio_book_adobe_drm_delivery_mechanism = (
-            self._get_delivery_mechanism_by_drm_scheme_and_content_type(
-                moby_dick_license_pool.delivery_mechanisms,
-                MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
-                DeliveryMechanism.ADOBE_DRM,
-            )
-        )
-        assert moby_dick_audio_book_adobe_drm_delivery_mechanism is not None
-
-        moby_dick_audio_book_lcp_drm_delivery_mechanism = (
-            self._get_delivery_mechanism_by_drm_scheme_and_content_type(
-                moby_dick_license_pool.delivery_mechanisms,
-                MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
-                DeliveryMechanism.LCP_DRM,
-            )
-        )
-        assert moby_dick_audio_book_lcp_drm_delivery_mechanism is not None
-
-        moby_dick_audio_book_feedbooks_drm_delivery_mechanism = (
-            self._get_delivery_mechanism_by_drm_scheme_and_content_type(
-                moby_dick_license_pool.delivery_mechanisms,
-                MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
-                DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM,
-            )
-        )
-        assert moby_dick_audio_book_feedbooks_drm_delivery_mechanism is not None
 
         assert 1 == len(moby_dick_license_pool.licenses)
         [moby_dick_license] = moby_dick_license_pool.licenses

--- a/tests/test_odl2.py
+++ b/tests/test_odl2.py
@@ -92,7 +92,7 @@ class TestODL2Importer(TestODLImporter):
             ),
             left=30,
             available=10,
-            content_types=[ODL2Importer.FEEDBOOKS_AUDIO]
+            content_types=[ODL2Importer.FEEDBOOKS_AUDIO],
         )
 
         mock_get.add(moby_dick_license)

--- a/tests/test_odl2.py
+++ b/tests/test_odl2.py
@@ -10,6 +10,7 @@ from webpub_manifest_parser.odl.semantic import (
     ODL_PUBLICATION_MUST_CONTAIN_EITHER_LICENSES_OR_OA_ACQUISITION_LINK_ERROR,
 )
 
+from api.odl import ODLImporter
 from api.odl2 import ODL2API, ODL2APIConfiguration, ODL2Importer
 from core.coverage import CoverageFailure
 from core.model import (
@@ -92,7 +93,7 @@ class TestODL2Importer(TestODLImporter):
             ),
             left=30,
             available=10,
-            content_types=[ODL2Importer.FEEDBOOKS_AUDIO],
+            content_types=[ODLImporter.FEEDBOOKS_AUDIO],
         )
 
         mock_get.add(moby_dick_license)

--- a/tests/test_odl2.py
+++ b/tests/test_odl2.py
@@ -92,6 +92,7 @@ class TestODL2Importer(TestODLImporter):
             ),
             left=30,
             available=10,
+            content_types=[ODL2Importer.FEEDBOOKS_AUDIO]
         )
 
         mock_get.add(moby_dick_license)


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

## Motivation and Context

This PR depends on https://github.com/ThePalaceProject/circulation-core/pull/40.

This PR fixes the DPLA audiobook download issue.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

I tested the changes I made locally:
1. Imported the DPLA ODL+OPDS2 feed.
2. Set up a basic authentication provider.
3. Successfully downloaded `Secret Language of Sisters`  audiobook.
4. Successfully downloaded `They Both Die at the End` Adobe DRM-protected ebook.
5. Successfully downloaded LCP-protected book `Light From Uncommon Stars` (it has both, Adobe and LCP versions).

Below is the screenshot showing the CM's response when I downloaded an Feedbooks DRM-protected audiobook:
![image](https://user-images.githubusercontent.com/6442436/143909391-929865ab-1863-4ec7-bcf2-a0cffd75d67a.png)

- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
