### PR TITLE
Fix the ProQuest empty page issue

### DIFF
--- a/tests/proquest/test_client.py
+++ b/tests/proquest/test_client.py
@@ -143,6 +143,27 @@ class TestProQuestAPIClient(DatabaseTest):
                 "json_document_does_not_contain_opds_feed",
                 {"json": {ProQuestAPIClient.RESPONSE_STATUS_CODE_FIELD: 200}},
             ),
+            (
+                "json_document_contains_incorrect_opds_feed",
+                {
+                    "json": {
+                        ProQuestAPIClient.RESPONSE_STATUS_CODE_FIELD: 200,
+                        "opdsFeed": {"publications": [], "group": {"publications": []}},
+                    }
+                },
+            ),
+            (
+                "json_document_contains_empty_opds_feed",
+                {
+                    "json": {
+                        ProQuestAPIClient.RESPONSE_STATUS_CODE_FIELD: 200,
+                        "opdsFeed": {
+                            "publications": [],
+                            "groups": {"publications": []},
+                        },
+                    }
+                },
+            ),
         ]
     )
     def test_download_all_feed_pages_correctly_stops(
@@ -159,8 +180,14 @@ class TestProQuestAPIClient(DatabaseTest):
         books_catalog_service_url_3 = URLUtility.build_url(
             BOOKS_CATALOG_SERVICE_URL, {"page": 3, "hitsPerPage": page_size}
         )
-        expected_feed_1 = {"metadata": {"title": "Page 1"}}
-        expected_feed_2 = {"metadata": {"title": "Page 2"}}
+        expected_feed_1 = {
+            "metadata": {"title": "Page 1"},
+            "groups": [{"publications": [{"metadata": {"title": "Publication 1"}}]}],
+        }
+        expected_feed_2 = {
+            "metadata": {"title": "Page 2"},
+            "groups": [{"publications": [{"metadata": {"title": "Publication 2"}}]}],
+        }
         expected_response_1 = {
             ProQuestAPIClient.RESPONSE_STATUS_CODE_FIELD: 200,
             ProQuestAPIClient.RESPONSE_OPDS_FEED_FIELD: expected_feed_1,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR fixes the ProQuest empty page issue. It adds new logic that stops CM from downloading the feed when it receives an empty page.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

ProQuest used to throw a 404 or 500 error when we tried to request a non-existent page, but this behavior recently had changed. Instead of throwing an error, they return empty pages, making CM infinitely loop through them.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
