### PR TITLE
Feature/aws xray

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -2,17 +2,15 @@ import logging
 import os
 import urllib.parse
 
-import flask
-from flask import Flask, Response, redirect
+from flask import Flask
 from flask_babel import Babel
 from flask_sqlalchemy_session import flask_scoped_session
-from sqlalchemy.orm import sessionmaker
 
+from api.config import Configuration
+from api.util.xray import PalaceXrayUtils
 from core.log import LogConfiguration
-from core.model import ConfigurationSetting, SessionManager
+from core.model import SessionManager
 from core.util import LanguageCodes
-
-from .config import Configuration
 
 app = Flask(__name__)
 app._db = None
@@ -21,6 +19,9 @@ app.config["BABEL_DEFAULT_LOCALE"] = LanguageCodes.three_to_two[
 ]
 app.config["BABEL_TRANSLATION_DIRECTORIES"] = "../translations"
 babel = Babel(app)
+
+# Setup AWS XRay for the app
+PalaceXrayUtils.configure_app(app)
 
 
 @app.before_first_request
@@ -42,8 +43,8 @@ def initialize_database(autoinitialize=True):
     logging.getLogger().info("Application debug mode==%r" % app.debug)
 
 
-from . import routes
-from .admin import routes
+from . import routes  # noqa
+from .admin import routes  # noqa
 
 
 def run(url=None):

--- a/api/util/xray.py
+++ b/api/util/xray.py
@@ -1,0 +1,88 @@
+import logging
+import os
+from typing import Optional
+
+from aws_xray_sdk.core import AWSXRayRecorder, xray_recorder, patch as xray_patch
+from aws_xray_sdk.ext.httplib import add_ignored as httplib_add_ignored
+from aws_xray_sdk.core.models.segment import Segment
+from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
+from flask import Flask, request, Response, session
+
+from core.config import Configuration
+
+
+class PalaceXrayUtils:
+    XRAY_ENV_ENABLE = "PALACE_XRAY"
+    XRAY_ENV_NAME = "PALACE_XRAY_NAME"
+    XRAY_ENV_ANNOTATE = "PALACE_XRAY_ANNOTATE_"
+
+    @classmethod
+    def put_annotations(cls, segment: Optional[Segment], seg_type: Optional[str] = None):
+        if seg_type is not None:
+            segment.put_annotation('type', seg_type)
+
+        for env, value in os.environ.items():
+            if env.startswith(cls.XRAY_ENV_ANNOTATE):
+                name = env.replace(cls.XRAY_ENV_ANNOTATE, '').lower()
+                segment.put_annotation(name, value)
+
+        if Configuration.app_version() != Configuration.NO_APP_VERSION_FOUND:
+            segment.put_annotation('version', Configuration.app_version())
+
+    @classmethod
+    def setup_xray(cls):
+        name = os.environ.get(cls.XRAY_ENV_NAME, "Palace")
+        xray_recorder.configure(service=name, streaming_threshold=5, context_missing='LOG_ERROR', plugins=["EC2Plugin"])
+        xray_patch(('httplib', 'sqlalchemy_core', 'requests'))
+        httplib_add_ignored(hostname='logs.*.amazonaws.com')
+
+    @classmethod
+    def configure_app(cls, app: Flask):
+        enable_xray = os.environ.get(cls.XRAY_ENV_ENABLE)
+        if enable_xray and enable_xray.lower() == "true":
+            logging.getLogger().info("Configuring app with AWS XRAY.")
+            cls.setup_xray()
+            PalaceXrayMiddleware(app, xray_recorder)
+
+
+class PalaceXrayMiddleware(XRayMiddleware):
+
+    def __init__(self, app: Flask, recorder: AWSXRayRecorder):
+        super().__init__(app, recorder)
+
+        # Add an additional hook to before first request
+        self.app.before_first_request(self._before_first_request)
+
+    def _before_first_request(self):
+        self._before_request()
+        segment = self._recorder.current_segment()
+
+        # Add an annotation for the first request, since it does extra caching work.
+        segment.put_annotation("request", "first")
+        request._palace_first_request = True
+
+    def _before_request(self):
+        if getattr(request, "_palace_first_request", None) is not None:
+            # If we are in the first request this work is already done
+            return
+        super()._before_request()
+        PalaceXrayUtils.put_annotations(self._recorder.current_segment(), "web")
+
+    def _after_request(self, response: Response):
+        super()._after_request(response)
+
+        segment = self._recorder.current_segment()
+        # Add library shortname
+        if hasattr(request, 'library'):
+            segment.put_annotation('library', str(request.library.short_name))
+
+        # Add patron data
+        if hasattr(request, 'patron'):
+            segment.set_user(str(request.patron.authorization_identifier))
+            segment.put_annotation('barcode', str(request.patron.authorization_identifier))
+
+        # Add admin UI username
+        if 'admin_email' in session:
+            segment.set_user(session['admin_email'])
+
+        return response

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,4 +1,5 @@
 alabaster==0.7.12
+aws-xray-sdk<2.9
 backports.functools-lru-cache==1.6.1
 backports.ssl-match-hostname==3.7.0.1
 beautifulsoup4==4.9.1

--- a/tests/api/util/test_xray.py
+++ b/tests/api/util/test_xray.py
@@ -1,0 +1,61 @@
+from unittest.mock import call, MagicMock
+
+import aws_xray_sdk
+
+from api.util.xray import PalaceXrayMiddleware, PalaceXrayUtils
+from core.config import Configuration
+
+
+class TestPalaceXrayUtils:
+
+    def test_put_annotations_none(self):
+        # If no segment is passed in nothing is returned
+        value = PalaceXrayUtils.put_annotations(None)
+        assert value is None
+
+    def test_put_annotations(self):
+        # Type annotation set based on seg_type passed into put_annotation
+        segment = MagicMock()
+        PalaceXrayUtils.put_annotations(segment, "test")
+        segment.put_annotation.assert_called_once_with("type", "test")
+
+    def test_put_annotations_env(self, monkeypatch):
+        # Annotations are made based on environment variables
+        segment = MagicMock()
+        monkeypatch.setenv(f"{PalaceXrayUtils.XRAY_ENV_ANNOTATE}TEST", "test")
+        monkeypatch.setenv(f"{PalaceXrayUtils.XRAY_ENV_ANNOTATE}ANOTHER_TEST", "test123")
+        PalaceXrayUtils.put_annotations(segment)
+        assert segment.put_annotation.called is True
+        assert segment.put_annotation.call_count == 2
+        assert segment.put_annotation.call_args_list == [call("test", "test"), call("another_test", "test123")]
+
+    def test_put_annotations_version(self, monkeypatch):
+        # The version number is added as an annotation
+        segment = MagicMock()
+        monkeypatch.setattr(Configuration, "app_version", lambda: "foo")
+        PalaceXrayUtils.put_annotations(segment)
+        segment.put_annotation.assert_called_once_with("version", "foo")
+
+    def test_configure_app(self, monkeypatch):
+        mock_app = MagicMock()
+        mock_middleware = MagicMock()
+
+        monkeypatch.setattr(PalaceXrayUtils, "setup_xray", MagicMock())
+        monkeypatch.setattr("api.util.xray.PalaceXrayMiddleware", mock_middleware)
+
+        # Nothing happens if env isn't set
+        PalaceXrayUtils.configure_app(mock_app)
+        assert PalaceXrayUtils.setup_xray.called is False
+        assert mock_middleware.called is False
+
+        # Xray not setup is env isn't true
+        monkeypatch.setenv(PalaceXrayUtils.XRAY_ENV_ENABLE, "false")
+        PalaceXrayUtils.configure_app(mock_app)
+        assert PalaceXrayUtils.setup_xray.called is False
+        assert mock_middleware.called is False
+
+        # Xray is setup is env is true
+        monkeypatch.setenv(PalaceXrayUtils.XRAY_ENV_ENABLE, "true")
+        PalaceXrayUtils.configure_app(mock_app)
+        assert PalaceXrayUtils.setup_xray.called is True
+        assert mock_middleware.called is True

--- a/tests/api/util/test_xray.py
+++ b/tests/api/util/test_xray.py
@@ -1,4 +1,4 @@
-from unittest.mock import call, MagicMock
+from unittest.mock import MagicMock, call
 
 import aws_xray_sdk
 
@@ -7,7 +7,6 @@ from core.config import Configuration
 
 
 class TestPalaceXrayUtils:
-
     def test_put_annotations_none(self):
         # If no segment is passed in nothing is returned
         value = PalaceXrayUtils.put_annotations(None)
@@ -23,11 +22,16 @@ class TestPalaceXrayUtils:
         # Annotations are made based on environment variables
         segment = MagicMock()
         monkeypatch.setenv(f"{PalaceXrayUtils.XRAY_ENV_ANNOTATE}TEST", "test")
-        monkeypatch.setenv(f"{PalaceXrayUtils.XRAY_ENV_ANNOTATE}ANOTHER_TEST", "test123")
+        monkeypatch.setenv(
+            f"{PalaceXrayUtils.XRAY_ENV_ANNOTATE}ANOTHER_TEST", "test123"
+        )
         PalaceXrayUtils.put_annotations(segment)
         assert segment.put_annotation.called is True
         assert segment.put_annotation.call_count == 2
-        assert segment.put_annotation.call_args_list == [call("test", "test"), call("another_test", "test123")]
+        assert segment.put_annotation.call_args_list == [
+            call("test", "test"),
+            call("another_test", "test123"),
+        ]
 
     def test_put_annotations_version(self, monkeypatch):
         # The version number is added as an annotation


### PR DESCRIPTION
## Description

Adds a new optional middleware that enables AWS XRay on requests to the Palace app. 

## Motivation and Context

Should help us troubleshoot performance issues within the app.

## How Has This Been Tested?

I tested in a local environment with the xray daemon running in a docker container. 

This is the command I used to run the xray daemon: 
```
docker run -it --name xray -e AWS_REGION=us-west-2 --rm -p 2000:2000/udp -v ~/.aws/:/home/xray/.aws/:ro -e AWS_PROFILE=simplye amazon/aws-xray-daemon
```

Then I tested the app like this: 
```
PALACE_XRAY=true SIMPLIFIED_PRODUCTION_DATABASE="postgres://simplified:test@localhost:5431/circ" python app.py
```

This gave xray traces from the local app run. 
