### PR TITLE
Fix issue with xray

### DIFF
--- a/api/util/xray.py
+++ b/api/util/xray.py
@@ -60,7 +60,7 @@ class PalaceXrayUtils:
 
     @classmethod
     def include_barcode(cls):
-        include_barcode = os.environ.get(cls.XRAY_ENV_ENABLE, "true")
+        include_barcode = os.environ.get(cls.XRAY_ENV_PATRON_BARCODE, "true")
         return include_barcode.lower() == "true"
 
 


### PR DESCRIPTION
## Description

Two changes here:
- Add a new environment variable that disables adding patron barcodes to xray traces.
- Double check that the properties we are trying to add to xray requests exist.

## Motivation and Context

Once this was deployed on CT I was seeing in the logs:
```
{"host": "76e8b3fbecb2", "app": "simplified", "name": "api.app", "level": "ERROR", "filename": "app.py", "message": "Request finalizing failed with an error while handling an error", "timestamp": "2021-12-01T22:23:41.221742+00:00", "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/env/lib/python3.6/site-packages/flask/app.py\", line 2447, in wsgi_app\n    response = self.full_dispatch_request()\n  File \"/var/www/circulation/env/lib/python3.6/site-packages/flask/app.py\", line 1953, in full_dispatch_request\n    return self.finalize_request(rv)\n  File \"/var/www/circulation/env/lib/python3.6/site-packages/flask/app.py\", line 1970, in finalize_request\n    response = self.process_response(response)\n  File \"/var/www/circulation/env/lib/python3.6/site-packages/flask/app.py\", line 2267, in process_response\n    response = handler(response)\n  File \"/var/www/circulation/api/util/xray.py\", line 89, in _after_request\n    segment.set_user(str(request.patron.authorization_identifier))\nAttributeError: 'NoneType' object has no attribute 'authorization_identifier'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/var/www/circulation/env/lib/python3.6/site-packages/flask/app.py\", line 1970, in finalize_request\n    response = self.process_response(response)\n  File \"/var/www/circulation/env/lib/python3.6/site-packages/flask/app.py\", line 2267, in process_response\n    response = handler(response)\n  File \"/var/www/circulation/api/util/xray.py\", line 89, in _after_request\n    segment.set_user(str(request.patron.authorization_identifier))\nAttributeError: 'NoneType' object has no attribute 'authorization_identifier'"}
```

## How Has This Been Tested?

I tested this fix locally.
