### PR TITLE
Adopt Analytics singleton

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -212,7 +212,7 @@ class CirculationManager(object):
         interface.
         """
         LogConfiguration.initialize(self._db)
-        self.analytics = Analytics(self._db)
+        self.analytics = Analytics(self._db, refresh=True)
         self.auth = Authenticator(self._db, self.analytics)
 
         self.setup_external_search()

--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -151,4 +151,5 @@ class GoogleAnalyticsProvider(object):
         response = HTTP.post_with_timeout(url, params)
 
 
+# The Analytics class looks for the name "Provider".
 Provider = GoogleAnalyticsProvider

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -5131,7 +5131,10 @@ class TestAnalyticsController(CirculationControllerTest):
         integration.setting(
             LocalAnalyticsProvider.LOCATION_SOURCE
         ).value = LocalAnalyticsProvider.LOCATION_SOURCE_NEIGHBORHOOD
-        self.manager.analytics = Analytics(self._db)
+
+        # The Analytics singleton will have already been instantiated,
+        # so here we simulate a reload of its configuration with `refresh`.
+        self.manager.analytics = Analytics(self._db, refresh=True)
 
         with self.request_context_with_library("/"):
             response = self.manager.analytics_controller.track_event(


### PR DESCRIPTION
## Description

- Adopts `Analytics` singleton class from [circulation-core #43](https://github.com/ThePalaceProject/circulation-core/pull/43).
- Fixes a test to reload the `Analytics` configuration. 

## Motivation and Context

Improve `Analytics` load performance by using a shared singleton instance.

## How Has This Been Tested?

- Manually testing.
- Existing tests pass (one needed a small nudge).

## Checklist:

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
