### PR TITLE
Order admin/libraries endpoint by Library Name

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -31,7 +31,7 @@ class LibrarySettingsController(SettingsController):
 
     def process_get(self):
         response = []
-        libraries = self._db.query(Library).all()
+        libraries = self._db.query(Library).order_by(Library.name).all()
         ConfigurationSetting.cache_warm(self._db)
 
         for library in libraries:


### PR DESCRIPTION
## Description

Small change to make sure that the `admin/libraries` endpoint is ordered by Library name. This got dropped during the optimization work in #79. 

## Motivation and Context

The Libraries in the register library screen used to be ordered by Library name. This stopped being the case after the performance optimizations that were recently done. This restores that functionality.

## How Has This Been Tested?

Load local admin interface and make sure the libraries were ordered by name.
