### PR TITLE
Add LCP hashed passphrase to feed.

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -1321,6 +1321,11 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         return cached
 
     def lcp_key_retrieval_tags(self, active_loan):
+        # In the case of LCP we have to include a patron's hashed passphrase
+        # inside the acquisition link so client applications can use it to open the LCP license
+        # without having to ask the user to enter their password
+        # https://readium.org/lcp-specs/notes/lcp-key-retrieval.html#including-a-hashed-passphrase-in-an-opds-1-catalog
+
         db = Session.object_session(active_loan)
         lcp_credential_factory = LCPCredentialFactory()
 

--- a/api/opds.py
+++ b/api/opds.py
@@ -3,18 +3,11 @@ import logging
 import urllib.error
 import urllib.parse
 import urllib.request
-import uuid
 from collections import defaultdict
 
 from flask import url_for
-from lxml import etree
-from sqlalchemy.orm import lazyload
 
-from api.lanes import (
-    CrawlableCollectionBasedLane,
-    CrawlableCustomListBasedLane,
-    DynamicLane,
-)
+from api.lanes import DynamicLane
 from core.analytics import Analytics
 from core.app_server import cdn_url_for
 from core.cdn import cdnify
@@ -22,26 +15,22 @@ from core.classifier import Classifier
 from core.entrypoint import EverythingEntryPoint
 from core.external_search import WorkSearchResult
 from core.lane import Lane, WorkList
+from core.lcp.credential import LCPCredentialFactory
+from core.lcp.exceptions import LCPError
 from core.model import (
     CirculationEvent,
     ConfigurationSetting,
-    Credential,
-    CustomList,
-    DataSource,
     DeliveryMechanism,
     Edition,
     Hold,
-    Identifier,
     LicensePool,
     LicensePoolDeliveryMechanism,
     Loan,
     Patron,
     Session,
-    Work,
 )
 from core.opds import AcquisitionFeed, Annotator, UnfulfillableWork
 from core.util.datetime_helpers import from_timestamp
-from core.util.flask_util import OPDSFeedResponse
 from core.util.opds_writer import OPDSFeed
 
 from .adobe_vendor_id import AuthdataUtility
@@ -1227,10 +1216,10 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         children = AcquisitionFeed.license_tags(license_pool, active_loan, None)
         link_tag.extend(children)
 
-        children = self.drm_device_registration_tags(
+        drm_tags = self.drm_extension_tags(
             license_pool, active_loan, delivery_mechanism
         )
-        link_tag.extend(children)
+        link_tag.extend(drm_tags)
         return link_tag
 
     def open_access_link(self, pool, lpdm):
@@ -1245,9 +1234,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         link_tag.attrib.update(dict(href=fulfill_url))
         return link_tag
 
-    def drm_device_registration_tags(
-        self, license_pool, active_loan, delivery_mechanism
-    ):
+    def drm_extension_tags(self, license_pool, active_loan, delivery_mechanism):
         """Construct OPDS Extensions for DRM tags that explain how to
         register a device with the DRM server that manages this loan.
         :param delivery_mechanism: A DeliveryMechanism
@@ -1258,12 +1245,18 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         if delivery_mechanism.drm_scheme == DeliveryMechanism.ADOBE_DRM:
             # Get an identifier for the patron that will be registered
             # with the DRM server.
-            _db = Session.object_session(active_loan)
             patron = active_loan.patron
 
             # Generate a <drm:licensor> tag that can feed into the
             # Vendor ID service.
             return self.adobe_id_tags(patron)
+
+        if delivery_mechanism.drm_scheme == DeliveryMechanism.LCP_DRM:
+            # Generate a <lcp:hashed_passphrase> tag that can be used for the loan
+            # in the mobile apps.
+
+            return self.lcp_key_retrieval_tags(active_loan)
+
         return []
 
     def adobe_id_tags(self, patron_identifier):
@@ -1326,6 +1319,27 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         else:
             cached = copy.deepcopy(cached)
         return cached
+
+    def lcp_key_retrieval_tags(self, active_loan):
+        db = Session.object_session(active_loan)
+        lcp_credential_factory = LCPCredentialFactory()
+
+        response = []
+
+        try:
+            hashed_passphrase = lcp_credential_factory.get_hashed_passphrase(
+                db, active_loan.patron
+            )
+            hashed_passphrase_element = OPDSFeed.makeelement(
+                "{%s}hashed_passphrase" % OPDSFeed.LCP_NS
+            )
+            hashed_passphrase_element.text = hashed_passphrase
+            response.append(hashed_passphrase_element)
+        except LCPError:
+            # The patron's passphrase wasn't generated yet and not present in the database.
+            pass
+
+        return response
 
     def add_patron(self, feed_obj):
         if not self.identifies_patrons:

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -550,9 +550,7 @@ class TestLibraryAnnotator(VendorIDTest):
 
         # Setup LCP credentials
         lcp_credential_factory = LCPCredentialFactory()
-        lcp_credential_factory.set_hashed_passphrase(
-            self._db, patron, hashed_password
-        )
+        lcp_credential_factory.set_hashed_passphrase(self._db, patron, hashed_password)
 
         loan, ignore = pool.loan_to(patron, start=utc_now())
         lcp_delivery_mechanism, ignore = DeliveryMechanism.lookup(
@@ -570,10 +568,7 @@ class TestLibraryAnnotator(VendorIDTest):
         # The fulfill link for lcp DRM includes hashed_passphrase
         link = self.annotator.fulfill_link(pool, loan, lcp_delivery_mechanism)
         hashed_passphrase = link[-1]
-        assert (
-            hashed_passphrase.tag
-            == "{%s}hashed_passphrase" % OPDSFeed.LCP_NS
-        )
+        assert hashed_passphrase.tag == "{%s}hashed_passphrase" % OPDSFeed.LCP_NS
         assert hashed_passphrase.text == hashed_password
 
     def test_default_lane_url(self):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -546,10 +546,12 @@ class TestLibraryAnnotator(VendorIDTest):
         identifier = pool.identifier
         patron = self._patron()
 
+        hashed_password = "hashed password"
+
         # Setup LCP credentials
         lcp_credential_factory = LCPCredentialFactory()
         lcp_credential_factory.set_hashed_passphrase(
-            self._db, patron, "hashed password"
+            self._db, patron, hashed_password
         )
 
         loan, ignore = pool.loan_to(patron, start=utc_now())
@@ -563,16 +565,16 @@ class TestLibraryAnnotator(VendorIDTest):
         # The fulfill link for non-LCP DRM does not include the hashed_passphrase tag.
         link = self.annotator.fulfill_link(pool, loan, other_delivery_mechanism)
         for child in link:
-            assert child.tag != "{http://readium.org/lcp-specs/ns}hashed_passphrase"
+            assert child.tag != "{%s}hashed_passphrase" % OPDSFeed.LCP_NS
 
         # The fulfill link for lcp DRM includes hashed_passphrase
         link = self.annotator.fulfill_link(pool, loan, lcp_delivery_mechanism)
         hashed_passphrase = link[-1]
         assert (
             hashed_passphrase.tag
-            == "{http://readium.org/lcp-specs/ns}hashed_passphrase"
+            == "{%s}hashed_passphrase" % OPDSFeed.LCP_NS
         )
-        assert hashed_passphrase.text == "hashed password"
+        assert hashed_passphrase.text == hashed_password
 
     def test_default_lane_url(self):
         default_lane_url = self.annotator.default_lane_url()

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1,14 +1,10 @@
-import contextlib
 import datetime
 import json
-import os
 import re
 from collections import defaultdict
-from pdb import set_trace
 
 import dateutil
 import feedparser
-import jwt
 import pytest
 from lxml import etree
 from mock import create_autospec
@@ -16,7 +12,7 @@ from mock import create_autospec
 from api.adobe_vendor_id import AuthdataUtility
 from api.circulation import BaseCirculationAPI, CirculationAPI, FulfillmentInfo
 from api.config import Configuration, temp_config
-from api.lanes import ContributorLane, CrawlableCustomListBasedLane
+from api.lanes import ContributorLane
 from api.novelist import NoveListAPI
 from api.opds import (
     CirculationManagerAnnotator,
@@ -30,7 +26,8 @@ from core.analytics import Analytics
 from core.classifier import Classifier, Fantasy, Urban_Fantasy
 from core.entrypoint import AudiobooksEntryPoint, EverythingEntryPoint
 from core.external_search import MockExternalSearchIndex, WorkSearchResult
-from core.lane import FacetsWithEntryPoint, Lane, WorkList
+from core.lane import FacetsWithEntryPoint, WorkList
+from core.lcp.credential import LCPCredentialFactory
 from core.model import (
     CirculationEvent,
     ConfigurationSetting,
@@ -39,14 +36,10 @@ from core.model import (
     DeliveryMechanism,
     ExternalIntegration,
     Hyperlink,
-    Library,
     PresentationCalculationPolicy,
     Representation,
     RightsStatus,
-    SessionManager,
     Work,
-    create,
-    get_one_or_create,
 )
 from core.opds import AcquisitionFeed, TestAnnotator, UnfulfillableWork
 from core.opds_import import OPDSXMLParser
@@ -54,7 +47,6 @@ from core.testing import DatabaseTest
 from core.util.datetime_helpers import datetime_utc, utc_now
 from core.util.flask_util import OPDSEntryResponse, OPDSFeedResponse
 from core.util.opds_writer import AtomFeed, OPDSFeed
-from core.util.string_helpers import base64
 
 _strftime = AtomFeed._strftime
 
@@ -548,6 +540,39 @@ class TestLibraryAnnotator(VendorIDTest):
         )
         self._db.delete(setting)
         assert [] == self.annotator.adobe_id_tags("new identifier")
+
+    def test_lcp_acquisition_link_contains_hashed_passphrase(self):
+        [pool] = self.work.license_pools
+        identifier = pool.identifier
+        patron = self._patron()
+
+        # Setup LCP credentials
+        lcp_credential_factory = LCPCredentialFactory()
+        lcp_credential_factory.set_hashed_passphrase(
+            self._db, patron, "hashed password"
+        )
+
+        loan, ignore = pool.loan_to(patron, start=utc_now())
+        lcp_delivery_mechanism, ignore = DeliveryMechanism.lookup(
+            self._db, "text/html", DeliveryMechanism.LCP_DRM
+        )
+        other_delivery_mechanism, ignore = DeliveryMechanism.lookup(
+            self._db, "text/html", DeliveryMechanism.OVERDRIVE_DRM
+        )
+
+        # The fulfill link for non-LCP DRM does not include the hashed_passphrase tag.
+        link = self.annotator.fulfill_link(pool, loan, other_delivery_mechanism)
+        for child in link:
+            assert child.tag != "{http://readium.org/lcp-specs/ns}hashed_passphrase"
+
+        # The fulfill link for lcp DRM includes hashed_passphrase
+        link = self.annotator.fulfill_link(pool, loan, lcp_delivery_mechanism)
+        hashed_passphrase = link[-1]
+        assert (
+            hashed_passphrase.tag
+            == "{http://readium.org/lcp-specs/ns}hashed_passphrase"
+        )
+        assert hashed_passphrase.text == "hashed password"
 
     def test_default_lane_url(self):
         default_lane_url = self.annotator.default_lane_url()


### PR DESCRIPTION
## Description

Core PR here: https://github.com/ThePalaceProject/circulation-core/pull/39

Updates how we add the LCP hashed passphrase item to feed to be consistent with how we add adobe tags.

## How Has This Been Tested?

Ran locally against the CT state Palace Marketplace collection as well as running tests.
