### PR TITLE
Order queries for admin screens.

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1603,8 +1603,10 @@ class SettingsController(AdminCirculationManagerController):
             .filter(ExternalIntegration.goal == goal)
         )
         ConfigurationSetting.cache_warm(self._db, settings_query.all)
-        for service in self._db.query(ExternalIntegration).filter(
-            ExternalIntegration.goal == goal
+        for service in (
+            self._db.query(ExternalIntegration)
+            .filter(ExternalIntegration.goal == goal)
+            .order_by(ExternalIntegration.name)
         ):
             candidates = [p for p in protocols if p.get("name") == service.protocol]
             if not candidates:

--- a/api/admin/controller/individual_admin_settings.py
+++ b/api/admin/controller/individual_admin_settings.py
@@ -22,7 +22,7 @@ class IndividualAdminSettingsController(SettingsController):
 
     def process_get(self):
         admins = []
-        for admin in self._db.query(Admin):
+        for admin in self._db.query(Admin).order_by(Admin.email):
             roles = []
             for role in admin.roles:
                 if role.library:


### PR DESCRIPTION
## Description

Add some ordering to the queries used to populate some of the Admin screens. This adds in ordering that was lost in the performance upgrades, and adds in some additional ordering of elements that was requested. 

QOL improvement for the integration team.

## How Has This Been Tested?

Tested locally and used `ab` to do some basic performance testing. It doesn't seem to have any major performance impact.
