### PR TITLE
Change button/link color to Palace dark blue on admin login page.

### DIFF
--- a/api/admin/template_styles.py
+++ b/api/admin/template_styles.py
@@ -40,7 +40,7 @@ section_style = """
     align-items: center;
 """
 button_style = """
-    background: #7177C8;
+    background: #242DAB;
     border-color: transparent;
     border-radius: .25em;
     color: #fff;
@@ -54,10 +54,10 @@ button_style = """
 """
 
 link_style = """
-    background: #7177C8;
+    background: #242DAB;
     text-align: center;
     text-decoration: none;
-    border-color: #7177C8;
+    border-color: #242DAB;
     border-radius: .25em;
     color: #fff;
     padding: 10px;


### PR DESCRIPTION
## Description

This changes the button and link color on the admin login page to Palace dark blue. Previously, the button color was a lighter shade of Palace dark blue.

This goes with https://github.com/ThePalaceProject/circulation-admin/pull/16, but they don't need to be merged in any particular order.

In the future I really want to make this page load a stylesheet from the circulation-admin package so we don't need to make changes in both places, but this is just a quick fix.

## Motivation and Context

This was requested to make the styling better match the Palace style guide.

See comments in this Notion ticket: https://www.notion.so/lyrasis/Update-CM-with-Brand-guidance-88976ea09252447998779b4bbeb2fdeb

## How Has This Been Tested?

I opened the admin login page (/admin/sign_in), and verified that the Sign In button is Palace dark blue. I entered invalid credentials, and verified that the Try Again link is also Palace dark blue.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
