### PR TITLE
Clean up most pytest warnings

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1896,7 +1896,7 @@ class SettingsController(AdminCirculationManagerController):
             message = _("Exception getting self-test results for %s %s: %s")
             error_message = str(e)
             args = (self.type, item.name, error_message)
-            logging.warn(message, *args, exc_info=error_message)
+            logging.warning(message, *args, exc_info=error_message)
             self_test_results = dict(exception=message % args)
 
         return self_test_results

--- a/api/axis.py
+++ b/api/axis.py
@@ -896,7 +896,7 @@ class BibliographicParser(Axis360Parser):
 
     # Axis authors with a special role have an abbreviation after their names,
     # e.g. "San Ruby (FRW)"
-    role_abbreviation = re.compile("\(([A-Z][A-Z][A-Z])\)$")
+    role_abbreviation = re.compile(r"\(([A-Z][A-Z][A-Z])\)$")
     generic_author = object()
     role_abbreviation_to_role = dict(
         INT=Contributor.INTRODUCTION_ROLE,

--- a/api/axis.py
+++ b/api/axis.py
@@ -541,7 +541,7 @@ class Axis360API(
         collection = self.collection
         pool = identifier.licensed_through_collection(collection)
         if not pool:
-            self.log.warn(
+            self.log.warning(
                 "Was about to reap %r but no local license pool in this collection.",
                 identifier,
             )
@@ -1094,7 +1094,7 @@ class BibliographicParser(Axis360Parser):
                 continue
 
             if informal_name not in self.DELIVERY_DATA_FOR_AXIS_FORMAT:
-                self.log.warn(
+                self.log.warning(
                     "Unrecognized Axis format name for %s: %s"
                     % (identifier, informal_name)
                 )

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1120,7 +1120,7 @@ class CirculationAPI(object):
         :param delivery_mechanism: A DeliveryMechanism.
         """
         if isinstance(delivery_mechanism, LicensePoolDeliveryMechanism):
-            self.log.warn(
+            self.log.warning(
                 "LicensePoolDeliveryMechanism passed into fulfill_open_access, should be DeliveryMechanism."
             )
             delivery_mechanism = delivery_mechanism.delivery_mechanism

--- a/api/controller.py
+++ b/api/controller.py
@@ -491,14 +491,14 @@ class CirculationManager(object):
             node_value = adobe.password
             if vendor_id and node_value:
                 if new_adobe_vendor_id:
-                    self.log.warn(
+                    self.log.warning(
                         "Multiple libraries define an Adobe Vendor ID integration. This is not supported and the last library seen will take precedence."
                     )
                 new_adobe_vendor_id = AdobeVendorIDController(
                     _db, library, vendor_id, node_value, self.auth
                 )
             else:
-                self.log.warn(
+                self.log.warning(
                     "Adobe Vendor ID controller is disabled due to missing or incomplete configuration. This is probably nothing to worry about."
                 )
         if new_adobe_vendor_id:

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -859,7 +859,7 @@ def create_lane_for_small_collection(_db, library, parent, languages, priority=0
     try:
         language_identifier = LanguageCodes.name_for_languageset(languages)
     except ValueError as e:
-        logging.getLogger().warn(
+        logging.getLogger().warning(
             "Could not create a lane for small collection with languages %s", languages
         )
         return 0
@@ -931,7 +931,7 @@ def create_lane_for_tiny_collection(_db, library, parent, languages, priority=0)
     try:
         name = LanguageCodes.name_for_languageset(languages)
     except ValueError as e:
-        logging.getLogger().warn(
+        logging.getLogger().warning(
             "Could not create a lane for tiny collection with languages %s", languages
         )
         return 0

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -388,7 +388,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
                 try:
                     fines = MoneyUtility.parse(v)
                 except ValueError:
-                    self.log.warn(
+                    self.log.warning(
                         'Malformed fine amount for patron: "%s". Treating as no fines.'
                     )
                     fines = Money("0", "USD")
@@ -404,7 +404,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
                     expires_local = expires_local.date()
                     authorization_expires = expires_local
                 except ValueError:
-                    self.log.warn(
+                    self.log.warning(
                         'Malformed expiration date for patron: "%s". Treating as unexpirable.',
                         v,
                     )
@@ -482,7 +482,7 @@ class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
             kv = line[:-4]
             if not "=" in kv:
                 # This shouldn't happen, but there's no need to crash.
-                self.log.warn("Unexpected line in patron dump: %s", line)
+                self.log.warning("Unexpected line in patron dump: %s", line)
                 continue
             yield kv.split("=", 1)
 

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -154,7 +154,7 @@ class NoveListAPI(object):
             ]
 
         if not isbns:
-            self.log.warn(
+            self.log.warning(
                 (
                     "Identifiers without an ISBN equivalent can't"
                     "be looked up with NoveList: %r"
@@ -171,7 +171,7 @@ class NoveListAPI(object):
                 lookup_metadata.append(metadata)
 
         if not lookup_metadata:
-            self.log.warn(
+            self.log.warning(
                 (
                     "No NoveList metadata found for Identifiers without an ISBN"
                     "equivalent can't be looked up with NoveList: %r"
@@ -185,7 +185,7 @@ class NoveListAPI(object):
         )
         if best_metadata:
             if round(confidence, 2) < 0.5:
-                self.log.warn(self.NO_ISBN_EQUIVALENCY, identifier)
+                self.log.warning(self.NO_ISBN_EQUIVALENCY, identifier)
                 return None
             return metadata
 
@@ -211,7 +211,7 @@ class NoveListAPI(object):
             return metadata_objects[0], confidence
 
         # One or more of the equivalents did not return the same NoveList work
-        self.log.warn("%r has inaccurate ISBN equivalents", identifier)
+        self.log.warning("%r has inaccurate ISBN equivalents", identifier)
         counter = Counter()
         for metadata in metadata_objects:
             counter[metadata.primary_identifier] += 1
@@ -221,7 +221,7 @@ class NoveListAPI(object):
         )
         if most_amount == secondmost:
             # The counts are the same, and neither can be trusted.
-            self.log.warn(self.NO_ISBN_EQUIVALENCY, identifier)
+            self.log.warning(self.NO_ISBN_EQUIVALENCY, identifier)
             return None, None
         confidence = most_amount / float(len(metadata_objects))
         target_metadata = [

--- a/api/opds.py
+++ b/api/opds.py
@@ -1193,7 +1193,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         if not self.identifies_patrons and rel != OPDSFeed.OPEN_ACCESS_REL:
             return
         if isinstance(delivery_mechanism, LicensePoolDeliveryMechanism):
-            logging.warn(
+            logging.warning(
                 "LicensePoolDeliveryMechanism passed into fulfill_link instead of DeliveryMechanism!"
             )
             delivery_mechanism = delivery_mechanism.delivery_mechanism

--- a/core/app_server.py
+++ b/core/app_server.py
@@ -244,7 +244,7 @@ class ErrorHandler(object):
                 # service. It's a serious problem, but probably not
                 # indicative of a bug in our software. Log it at log level
                 # WARN.
-                log_method = logging.warn
+                log_method = logging.warning
             response = make_response(document.response)
         else:
             # There's no way to turn this exception into a problem

--- a/core/classifier/__init__.py
+++ b/core/classifier/__init__.py
@@ -357,15 +357,16 @@ class GradeLevelClassifier(Classifier):
 
     # Regular expressions that match common ways of expressing grade
     # levels.
+    # TODO: Is this code duplicated in core/classifier/age.py?
     grade_res = [
         re.compile(x, re.I)
         for x in [
             "grades? ([kp0-9]+) to ([kp0-9]+)?",
             "grades? ([kp0-9]+) ?-? ?([kp0-9]+)?",
-            "gr\.? ([kp0-9]+) ?-? ?([kp0-9]+)?",
+            r"gr\.? ([kp0-9]+) ?-? ?([kp0-9]+)?",
             "grades?: ([kp0-9]+) to ([kp0-9]+)",
             "grades?: ([kp0-9]+) ?-? ?([kp0-9]+)?",
-            "gr\.? ([kp0-9]+)",
+            r"gr\.? ([kp0-9]+)",
             "([0-9]+)[tnsr][hdt] grade",
             "([a-z]+) grade",
             r"\b(kindergarten|preschool)\b",

--- a/core/classifier/age.py
+++ b/core/classifier/age.py
@@ -45,15 +45,16 @@ class GradeLevelClassifier(Classifier):
 
     # Regular expressions that match common ways of expressing grade
     # levels.
+    # TODO: Is this code duplicated in core/classifier/__init__.py?
     grade_res = [
         re.compile(x, re.I)
         for x in [
             "grades? ([kp0-9]+) to ([kp0-9]+)?",
             "grades? ([kp0-9]+) ?-? ?([kp0-9]+)?",
-            "gr\.? ([kp0-9]+) ?-? ?([kp0-9]+)?",
+            r"gr\.? ([kp0-9]+) ?-? ?([kp0-9]+)?",
             "grades?: ([kp0-9]+) to ([kp0-9]+)",
             "grades?: ([kp0-9]+) ?-? ?([kp0-9]+)?",
-            "gr\.? ([kp0-9]+)",
+            r"gr\.? ([kp0-9]+)",
             "([0-9]+)[tnsr][hdt] grade",
             "([a-z]+) grade",
             r"\b(kindergarten|preschool)\b",

--- a/core/classifier/bisac.py
+++ b/core/classifier/bisac.py
@@ -654,7 +654,7 @@ class BISACClassifier(Classifier):
 
     # A BISAC name copied from the BISAC website may end with this
     # human-readable note, which is not part of the official name.
-    see_also = re.compile("\(see also .*")
+    see_also = re.compile(r"\(see also .*")
 
     @classmethod
     def scrub_identifier(cls, identifier):

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -412,7 +412,7 @@ class BaseCoverageProvider(object):
                     unhandled_items.remove(item.obj)
                 record = self.record_failure_as_coverage_record(item)
                 if item.transient:
-                    self.log.warn(
+                    self.log.warning(
                         "Transient failure covering %r: %s", item.obj, item.exception
                     )
                     record.status = BaseCoverageRecord.TRANSIENT_FAILURE
@@ -438,7 +438,7 @@ class BaseCoverageProvider(object):
         # Perhaps some records were ignored--they neither succeeded nor
         # failed. Treat them as transient failures.
         for item in unhandled_items:
-            self.log.warn(
+            self.log.warning(
                 "%r was ignored by a coverage provider that was supposed to cover it.",
                 item,
             )
@@ -972,7 +972,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
                 replace=self.replacement_policy,
             )
         except Exception as e:
-            self.log.warn(
+            self.log.warning(
                 "Error applying metadata to edition %d: %s", edition.id, e, exc_info=e
             )
             return self.failure(identifier, repr(e), transient=True)
@@ -1332,7 +1332,7 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
                 collection_name = " to collection %s" % self.collection.name
             else:
                 collection_name = ""
-            self.log.warn(
+            self.log.warning(
                 "Error applying circulationdata%s: %s", collection_name, e, exc_info=e
             )
             return self.failure(identifier, repr(e), transient=True)

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -932,18 +932,18 @@ class CurrentMapping(Mapping):
     for name, pattern, replacement in [
         # The special author name "[Unknown]" should sort after everything
         # else. REPLACEMENT CHARACTER is the final valid Unicode character.
-        ("unknown_author", "\[Unknown\]", "\N{REPLACEMENT CHARACTER}"),
+        ("unknown_author", r"\[Unknown\]", "\N{REPLACEMENT CHARACTER}"),
         # Works by a given primary author should be secondarily sorted
         # by title, not by the other contributors.
-        ("primary_author_only", "\s+;.*", ""),
+        ("primary_author_only", r"\s+;.*", ""),
         # Remove parentheticals (e.g. the full name of someone who
         # goes by initials).
-        ("strip_parentheticals", "\s+\([^)]+\)", ""),
+        ("strip_parentheticals", r"\s+\([^)]+\)", ""),
         # Remove periods from consideration.
-        ("strip_periods", "\.", ""),
+        ("strip_periods", r"\.", ""),
         # Collapse spaces for people whose sort names end with initials.
-        ("collapse_three_initials", " ([A-Z]) ([A-Z]) ([A-Z])$", " $1$2$3"),
-        ("collapse_two_initials", " ([A-Z]) ([A-Z])$", " $1$2"),
+        ("collapse_three_initials", r" ([A-Z]) ([A-Z]) ([A-Z])$", " $1$2$3"),
+        ("collapse_two_initials", r" ([A-Z]) ([A-Z])$", " $1$2"),
     ]:
         normalizer = dict(
             type="pattern_replace", pattern=pattern, replacement=replacement

--- a/core/metadata_layer.py
+++ b/core/metadata_layer.py
@@ -2501,10 +2501,10 @@ class MARCExtractor(object):
     # Common things found in a MARC record after the name of the author
     # which we sould like to remove.
     END_OF_AUTHOR_NAME_RES = [
-        re.compile(",\s+[0-9]+-"),  # Birth year
-        re.compile(",\s+active "),
-        re.compile(",\s+graf,"),
-        re.compile(",\s+author."),
+        re.compile(r",\s+[0-9]+-"),  # Birth year
+        re.compile(r",\s+active "),
+        re.compile(r",\s+graf,"),
+        re.compile(r",\s+author."),
     ]
 
     @classmethod

--- a/core/metadata_layer.py
+++ b/core/metadata_layer.py
@@ -463,7 +463,7 @@ class ContributorData(object):
                     sort_name,
                 )
             else:
-                log.warn(
+                log.warning(
                     "Canonicalizer could not find sort name for %r/%s",
                     identifier_obj,
                     self.display_name,
@@ -838,7 +838,7 @@ class MetaToModelUtility(object):
             link_obj.identifier and identifier != link_obj.identifier
         ):
             # insanity found
-            self.log.warn(
+            self.log.warning(
                 "Tried to mirror a link with an invalid identifier %r" % identifier
             )
             return
@@ -2366,7 +2366,7 @@ class CSVMetadataImporter(object):
         language = self._field(row, self.language_field, self.default_language)
         medium = self._field(row, self.medium_field, self.default_medium)
         if medium not in list(Edition.medium_to_additional_type.keys()):
-            self.log.warn("Ignored unrecognized medium %s" % medium)
+            self.log.warning("Ignored unrecognized medium %s" % medium)
             medium = Edition.BOOK_MEDIUM
         series = self._field(row, self.series_field)
         publisher = self._field(row, self.publisher_field)
@@ -2486,7 +2486,7 @@ class CSVMetadataImporter(object):
             try:
                 value = to_utc(parse(value))
             except ValueError:
-                self.log.warn('Could not parse date "%s"' % value)
+                self.log.warning('Could not parse date "%s"' % value)
                 value = None
         return value
 

--- a/core/model/configuration.py
+++ b/core/model/configuration.py
@@ -377,7 +377,9 @@ class ExternalIntegration(Base):
 
         integrations = integrations.all()
         if len(integrations) > 1:
-            logging.warn("Multiple integrations found for '%s'/'%s'" % (protocol, goal))
+            logging.warning(
+                "Multiple integrations found for '%s'/'%s'" % (protocol, goal)
+            )
 
         if [i for i in integrations if i.libraries] and not library:
             raise ValueError(

--- a/core/model/contributor.py
+++ b/core/model/contributor.py
@@ -361,17 +361,20 @@ class Contributor(Base):
         _db.commit()
 
     # Regular expressions used by default_names().
-    PARENTHETICAL = re.compile("\([^)]*\)")
+    PARENTHETICAL = re.compile(r"\([^)]*\)")
     ALPHABETIC = re.compile("[a-zA-z]")
     NUMBERS = re.compile("[0-9]")
 
     DATE_RES = [
-        re.compile("\(?" + x + "\)?")
+        # TODO: This doesn't seem quite right. The second paren should be present
+        #  only if the first is present (i.e., both or neither).
+        re.compile(r"\(?" + x + r"\)?")
         for x in (
             "[0-9?]+-",
             "[0-9]+st cent",
             "[0-9]+nd cent",
             "[0-9]+th cent",
+            # TODO: Probably meant to be "blank" `space`, rather than a `backspace`.
             "\bcirca",
         )
     ]

--- a/core/model/edition.py
+++ b/core/model/edition.py
@@ -720,14 +720,14 @@ class Edition(Base, EditionConstants):
 
             if best_cover:
                 if not best_cover.representation:
-                    logging.warn(
+                    logging.warning(
                         "Best cover for %r has no representation!",
                         self.primary_identifier,
                     )
                 else:
                     rep = best_cover.representation
                     if not rep.thumbnails:
-                        logging.warn(
+                        logging.warning(
                             "Best cover for %r (%s) was never thumbnailed!",
                             self.primary_identifier,
                             rep.public_url,
@@ -760,7 +760,7 @@ class Edition(Base, EditionConstants):
                 )
                 if best_thumbnail:
                     if not best_thumbnail.representation:
-                        logging.warn(
+                        logging.warning(
                             "Best thumbnail for %r has no representation!",
                             self.primary_identifier,
                         )

--- a/core/model/library.py
+++ b/core/model/library.py
@@ -168,7 +168,7 @@ class Library(Base, HasSessionCache):
                 # There are no libraries in the system, so no default.
                 return None
             [default_library] = libraries
-            logging.warn(
+            logging.warning(
                 "No default library, setting %s as default."
                 % (default_library.short_name)
             )
@@ -177,7 +177,7 @@ class Library(Base, HasSessionCache):
             # race condition. Fix it by arbitrarily designating one
             # of the libraries as the default.
             default_library = defaults[0]
-            logging.warn(
+            logging.warning(
                 "Multiple default libraries, setting %s as default."
                 % (default_library.short_name)
             )

--- a/core/model/licensing.py
+++ b/core/model/licensing.py
@@ -1191,7 +1191,7 @@ class LicensePool(Base):
         if not presentation_edition:
             # We don't have any information about the identifier
             # associated with this LicensePool, so we can't create a work.
-            logging.warn(
+            logging.warning(
                 "NO EDITION for %s, cowardly refusing to create work.", self.identifier
             )
 
@@ -1205,7 +1205,7 @@ class LicensePool(Base):
 
         if not presentation_edition.title and not even_if_no_title:
             if presentation_edition.work:
-                logging.warn(
+                logging.warning(
                     "Edition %r has no title but has a Work assigned. This will not stand.",
                     presentation_edition,
                 )
@@ -1257,7 +1257,7 @@ class LicensePool(Base):
         # All LicensePools with a given Identifier must share a work.
         existing_works = set([x.work for x in self.identifier.licensed_through])
         if len(existing_works) > 1:
-            logging.warn(
+            logging.warning(
                 "LicensePools for %r have more than one Work between them. Removing them all and starting over.",
                 self.identifier,
             )

--- a/core/model/resource.py
+++ b/core/model/resource.py
@@ -1208,7 +1208,9 @@ class Representation(Base, MediaTypes):
         # Known extensions can be followed by a version number (.epub3)
         # or an additional extension (.epub.noimages)
         known_extensions = "|".join(list(self.FILE_EXTENSIONS.values()))
-        known_extension_re = re.compile("\.(%s)\d?\.?[\w\d]*$" % known_extensions, re.I)
+        known_extension_re = re.compile(
+            r"\.(%s)\d?\.?[\w\d]*$" % known_extensions, re.I
+        )
 
         known_match = known_extension_re.search(url_path)
 
@@ -1216,7 +1218,7 @@ class Representation(Base, MediaTypes):
             return known_match.group()
 
         else:
-            any_extension_re = re.compile("\.[\w\d]*$", re.I)
+            any_extension_re = re.compile(r"\.[\w\d]*$", re.I)
 
             any_match = any_extension_re.search(url_path)
 

--- a/core/model/resource.py
+++ b/core/model/resource.py
@@ -213,7 +213,7 @@ class Resource(Base):
 
         # Humans have voted positively on this Resource, and now it's
         # being rejected regardless.
-        logging.warn("Rejecting Resource with positive votes: %r", self)
+        logging.warning("Rejecting Resource with positive votes: %r", self)
 
         # Make the voted_quality negative without impacting the weight
         # of existing votes so the value can be restored relatively

--- a/core/model/resource.py
+++ b/core/model/resource.py
@@ -16,12 +16,12 @@ from urllib.parse import quote, urlparse, urlsplit
 import requests
 from PIL import Image
 from sqlalchemy import (
-    Binary,
     Column,
     DateTime,
     Float,
     ForeignKey,
     Integer,
+    LargeBinary,
     Unicode,
     UniqueConstraint,
 )
@@ -567,7 +567,7 @@ class Representation(Base, MediaTypes):
     image_width = Column(Integer, index=True)
 
     # The content of the representation itself.
-    content = Column(Binary)
+    content = Column(LargeBinary)
 
     # Instead of being stored in the database, the content of the
     # representation may be stored on a local file relative to the

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -40,6 +40,7 @@ class CollectionMonitorLogger(logging.LoggerAdapter):
         self.extra = extra
         collection = self.extra.get("collection", None)
         self.log_prefix = "[{}] ".format(collection.name) if collection else ""
+        # TODO: Remove the next line once all uses have adopted `warning`.
         self.warn = self.warning
 
     def process(self, msg, kwargs):

--- a/core/opds.py
+++ b/core/opds.py
@@ -1267,11 +1267,11 @@ class AcquisitionFeed(OPDSFeed):
 
         # There's no reason to present a book that has no active license pool.
         if not identifier:
-            logging.warn("%r HAS NO IDENTIFIER", work)
+            logging.warning("%r HAS NO IDENTIFIER", work)
             return None
 
         if not active_license_pool and not even_if_no_license_pool:
-            logging.warn("NO ACTIVE LICENSE POOL FOR %r", work)
+            logging.warning("NO ACTIVE LICENSE POOL FOR %r", work)
             return self.error_message(
                 identifier,
                 403,
@@ -1279,7 +1279,7 @@ class AcquisitionFeed(OPDSFeed):
             )
 
         if not active_edition:
-            logging.warn("NO ACTIVE EDITION FOR %r", active_license_pool)
+            logging.warning("NO ACTIVE EDITION FOR %r", active_license_pool)
             return self.error_message(
                 identifier,
                 403,
@@ -1418,7 +1418,7 @@ class AcquisitionFeed(OPDSFeed):
         if edition.medium:
             additional_type = Edition.medium_to_additional_type.get(edition.medium)
             if not additional_type:
-                logging.warn("No additionalType for medium %s", edition.medium)
+                logging.warning("No additionalType for medium %s", edition.medium)
             additional_type_field = AtomFeed.schema_("additionalType")
             kw[additional_type_field] = additional_type
 

--- a/core/opds.py
+++ b/core/opds.py
@@ -1968,7 +1968,7 @@ class NavigationFeed(OPDSFeed):
 # Mock annotators for use in unit tests.
 
 
-class TestAnnotator(Annotator):
+class MockAnnotator(Annotator):
     def __init__(self):
         self.lanes_by_work = defaultdict(list)
 
@@ -2047,7 +2047,7 @@ class TestAnnotator(Annotator):
         return "Test Top Level Title"
 
 
-class TestAnnotatorWithGroup(TestAnnotator):
+class MockAnnotatorWithGroup(MockAnnotator):
     def group_uri(self, work, license_pool, identifier):
         lanes = self.lanes_by_work.get(work, None)
 
@@ -2071,7 +2071,7 @@ class TestAnnotatorWithGroup(TestAnnotator):
         return "Test Top Level Title"
 
 
-class TestUnfulfillableAnnotator(TestAnnotator):
+class MockUnfulfillableAnnotator(MockAnnotator):
     """Raise an UnfulfillableWork exception when asked to annotate an entry."""
 
     def annotate_work_entry(self, *args, **kwargs):

--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -1662,7 +1662,7 @@ class OPDSImporter(object):
         :param entry_tag: A <atom:entry> tag.
         :param default: The value to use if nothing is found.
         """
-        if not entry_tag:
+        if entry_tag is None:
             return default
 
         medium = None

--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -647,7 +647,7 @@ class OPDSImporter(object):
             )
         except CannotLoadConfiguration:
             # The Metadata Wrangler isn't configured, but we can import without it.
-            self.log.warn(
+            self.log.warning(
                 "Metadata Wrangler integration couldn't be loaded, importing without it."
             )
             self.metadata_client = None

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -664,7 +664,7 @@ class OverdriveRepresentationExtractor(object):
         products = book_list["products"]
         for product in products:
             if not "id" in product:
-                cls.log.warn("No ID found in %r", product)
+                cls.log.warning("No ID found in %r", product)
                 continue
             book_id = product["id"]
             data = dict(
@@ -682,7 +682,7 @@ class OverdriveRepresentationExtractor(object):
                 link = links["availability"]["href"]
                 data["availability_link"] = OverdriveAPI.make_link_safe(link)
             else:
-                logging.getLogger("Overdrive API").warn(
+                logging.getLogger("Overdrive API").warning(
                     "No availability link for %s", book_id
                 )
             l.append(data)

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -214,7 +214,7 @@ class RunMonitorScript(Script):
         if self.monitor:
             self.monitor.run()
         elif self.collection_monitor:
-            logging.warn(
+            logging.warning(
                 "Running a CollectionMonitor by delegating to RunCollectionMonitorScript. "
                 "It would be better if you used RunCollectionMonitorScript directly."
             )
@@ -534,7 +534,7 @@ class IdentifierInputScript(InputScript):
                     _db, identifier_type, arg, autocreate=autocreate
                 )
             if not identifier:
-                logging.warn("Could not load identifier %s/%s", identifier_type, arg)
+                logging.warning("Could not load identifier %s/%s", identifier_type, arg)
             if identifier:
                 identifiers.append(identifier)
         return identifiers
@@ -609,7 +609,7 @@ class LibraryInputScript(InputScript):
                     libraries.append(library)
                     break
             else:
-                logging.warn("Could not find library %s", arg)
+                logging.warning("Could not find library %s", arg)
         return libraries
 
     def do_run(self, *args, **kwargs):
@@ -704,7 +704,7 @@ class PatronInputScript(LibraryInputScript):
                     patrons.append(patron)
                     break
             else:
-                logging.warn("Could not find patron %s", arg)
+                logging.warning("Could not find patron %s", arg)
         return patrons
 
     def do_run(self, *args, **kwargs):
@@ -1503,7 +1503,7 @@ class AddClassificationScript(IdentifierInputScript):
                 if work:
                     work.calculate_presentation(policy=policy)
         else:
-            self.log.warn("Could not locate subject, doing nothing.")
+            self.log.warning("Could not locate subject, doing nothing.")
 
 
 class WorkProcessingScript(IdentifierInputScript):
@@ -2000,7 +2000,7 @@ class MirrorResourcesScript(CollectionInputScript):
         )
         if not license_pool:
             # This shouldn't happen.
-            self.log.warn(
+            self.log.warning(
                 "Could not find LicensePool for %r, skipping it rather than mirroring something we shouldn't."
             )
             return
@@ -2009,7 +2009,7 @@ class MirrorResourcesScript(CollectionInputScript):
         if link_obj.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD:
             rights_status = self.derive_rights_status(license_pool, resource)
             if not rights_status:
-                self.log.warn(
+                self.log.warning(
                     "Could not unambiguously determine rights status for %r, skipping.",
                     link_obj,
                 )
@@ -2660,7 +2660,7 @@ class DatabaseMigrationInitializationScript(DatabaseMigrationScript):
             # A Timestamp exists and it has a .finish, so it wasn't created
             # by TimestampInfo.find.
             if parsed.force:
-                self.log.warn(
+                self.log.warning(
                     "Overwriting existing %s timestamp: %r",
                     self.name,
                     existing_timestamp,

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -2050,7 +2050,7 @@ class DatabaseMigrationScript(Script):
     SERVICE_NAME = "Database Migration"
     PY_TIMESTAMP_SERVICE_NAME = SERVICE_NAME + " - Python"
 
-    MIGRATION_WITH_COUNTER = re.compile("\d{8}-(\d+)-(.)+\.(py|sql)")
+    MIGRATION_WITH_COUNTER = re.compile(r"\d{8}-(\d+)-(.)+\.(py|sql)")
 
     # There are some SQL commands that can't be run inside a transaction.
     TRANSACTIONLESS_COMMANDS = ["alter type"]

--- a/core/testing.py
+++ b/core/testing.py
@@ -169,7 +169,7 @@ class DatabaseTest(object):
             shutil.rmtree(cls.tmp_data_dir)
 
         else:
-            logging.warn(
+            logging.warning(
                 "Cowardly refusing to remove 'temporary' directory %s"
                 % cls.tmp_data_dir
             )
@@ -877,7 +877,7 @@ class DatabaseTest(object):
         """
         if not "TESTING" in os.environ:
             # we are on production, abort, abort!
-            logging.warn(
+            logging.warning(
                 "Forgot to remove call to testing.py:DatabaseTest.print_database_instance() before pushing to production."
             )
             return
@@ -913,7 +913,7 @@ class DatabaseTest(object):
         """
         if not "TESTING" in os.environ:
             # we are on production, abort, abort!
-            logging.warn(
+            logging.warning(
                 "Forgot to remove call to testing.py:DatabaseTest.print_database_class() before pushing to production."
             )
             return

--- a/core/util/__init__.py
+++ b/core/util/__init__.py
@@ -59,7 +59,7 @@ def slugify(text, length_limit=None):
     >>> slugify('Happy birthday!', length_limit=4)
     happ
     """
-    slug = re.sub("[.!@#'$,?\(\)]", "", text.lower())
+    slug = re.sub(r"[.!@#'$,?\(\)]", "", text.lower())
     slug = re.sub("&", " and ", slug)
     slug = re.sub(" {2,}", " ", slug)
 
@@ -75,7 +75,7 @@ def slugify(text, length_limit=None):
 class MetadataSimilarity(object):
     """Estimate how similar two bits of metadata are."""
 
-    SEPARATOR = re.compile("\W")
+    SEPARATOR = re.compile(r"\W")
 
     @classmethod
     def _wordbag(cls, s):

--- a/core/util/languages.py
+++ b/core/util/languages.py
@@ -632,7 +632,7 @@ class LanguageNames(object):
     ignore = set(["No linguistic content", "Not applicable", "Uncoded"])
 
     number = re.compile("[0-9]")
-    parentheses = re.compile("\([^)]+\)")
+    parentheses = re.compile(r"\([^)]+\)")
 
     @classmethod
     def _process(cls, human_readable_name, alpha):

--- a/core/util/permanent_work_id.py
+++ b/core/util/permanent_work_id.py
@@ -180,7 +180,15 @@ class WorkIDCalculator(object):
         return groupingAuthor
 
     commonSubtitlesPattern = re.compile(
-        "^(.*?)((a|una)\\s(.*)novel(a|la)?|a(.*)memoir|a(.*)mystery|a(.*)thriller|by\\s(.+)|a novel of .*|stories|an autobiography|a biography|a memoir in books|\\d+\S*\s*ed(ition)?|\\d+\S*\s*update|1st\\s+ed.*|an? .* story|a .*\\s?book|poems|the movie|[\\w\\s]+series book \\d+|[\\w\\s]+trilogy book \\d+|large print|graphic novel|magazine|audio cd)$",
+        ("^"
+         r"(.*?)"
+         r"((a|una)\s(.*)novel(a|la)?|a(.*)memoir|a(.*)mystery|a(.*)thriller|by\s(.+)"
+         r"|a novel of .*|stories|an autobiography|a biography|a memoir in books"
+         r"|\d+\S*\s*ed(ition)?|\d+\S*\s*update|1st\s+ed.*"
+         r"|an? .* story|a .*\s?book|poems|the movie"
+         r"|[\w\s]+series book \d+|[\w\s]+trilogy book \d+"
+         r"|large print|graphic novel|magazine|audio cd)"
+         "$"),
         re.U,
     )
 

--- a/core/util/permanent_work_id.py
+++ b/core/util/permanent_work_id.py
@@ -180,15 +180,17 @@ class WorkIDCalculator(object):
         return groupingAuthor
 
     commonSubtitlesPattern = re.compile(
-        ("^"
-         r"(.*?)"
-         r"((a|una)\s(.*)novel(a|la)?|a(.*)memoir|a(.*)mystery|a(.*)thriller|by\s(.+)"
-         r"|a novel of .*|stories|an autobiography|a biography|a memoir in books"
-         r"|\d+\S*\s*ed(ition)?|\d+\S*\s*update|1st\s+ed.*"
-         r"|an? .* story|a .*\s?book|poems|the movie"
-         r"|[\w\s]+series book \d+|[\w\s]+trilogy book \d+"
-         r"|large print|graphic novel|magazine|audio cd)"
-         "$"),
+        (
+            "^"
+            r"(.*?)"
+            r"((a|una)\s(.*)novel(a|la)?|a(.*)memoir|a(.*)mystery|a(.*)thriller|by\s(.+)"
+            r"|a novel of .*|stories|an autobiography|a biography|a memoir in books"
+            r"|\d+\S*\s*ed(ition)?|\d+\S*\s*update|1st\s+ed.*"
+            r"|an? .* story|a .*\s?book|poems|the movie"
+            r"|[\w\s]+series book \d+|[\w\s]+trilogy book \d+"
+            r"|large print|graphic novel|magazine|audio cd)"
+            "$"
+        ),
         re.U,
     )
 

--- a/core/util/personal_names.py
+++ b/core/util/personal_names.py
@@ -9,12 +9,12 @@ from .permanent_work_id import WorkIDCalculator
 
 """Fallback algorithms for dealing with personal names when VIAF fails us."""
 
-phdFix = re.compile("((. +)|(, ?))P(h|H)\.? *(D|d)(\.| |$){1}")
-mdFix = re.compile("((. +)|(, ?))M\.? *D(\.| |$){1}")
+phdFix = re.compile(r"((. +)|(, ?))P(h|H)\.? *(D|d)(\.| |$){1}")
+mdFix = re.compile(r"((. +)|(, ?))M\.? *D(\.| |$){1}")
 # omit exclamation point in case it can be part of stage name
 # only match punctuation that's not part of name initials or title.
 # so "Bitshifter, B." is OK, "Bitshifter, Bob Jr.", but "Bitshifter, Robert." is not.
-trailingPunctuation = re.compile("(.*)(\w{4,})([?:.,;]*?)\Z")
+trailingPunctuation = re.compile(r"(.*)(\w{4,})([?:.,;]*?)\Z")
 
 
 def _replace_md(match):

--- a/core/util/problem_detail.py
+++ b/core/util/problem_detail.py
@@ -73,9 +73,9 @@ class ProblemDetail(object):
         # Title and detail must be LazyStrings from Flask-Babel that are
         # localized when they are first used as strings.
         if title and not isinstance(title, LazyString):
-            logging.warn('"%s" has not been internationalized' % title)
+            logging.warning('"%s" has not been internationalized' % title)
         if detail and not isinstance(detail, LazyString):
-            logging.warn('"%s" has not been internationalized' % detail)
+            logging.warning('"%s" has not been internationalized' % detail)
 
         return ProblemDetail(
             self.uri,

--- a/scripts.py
+++ b/scripts.py
@@ -357,7 +357,7 @@ class CacheRepresentationPerLane(TimestampScript, LaneSweeperScript):
                 if alpha:
                     self.languages.append(alpha)
                 else:
-                    self.log.warn("Ignored unrecognized language code %s", alpha)
+                    self.log.warning("Ignored unrecognized language code %s", alpha)
         self.max_depth = parsed.max_depth
         self.min_depth = parsed.min_depth
 
@@ -573,24 +573,24 @@ class CacheFacetListsPerLane(CacheRepresentationPerLane):
         for entrypoint_name in chosen_entrypoints:
             entrypoint = EntryPoint.BY_INTERNAL_NAME.get(entrypoint_name)
             if not entrypoint:
-                logging.warn("Ignoring unknown entry point %s" % entrypoint_name)
+                logging.warning("Ignoring unknown entry point %s" % entrypoint_name)
                 continue
             if not entrypoint_name in allowed_entrypoint_names:
-                logging.warn("Ignoring disabled entry point %s" % entrypoint_name)
+                logging.warning("Ignoring disabled entry point %s" % entrypoint_name)
                 continue
             for order in chosen_orders:
                 if order not in allowed_orders:
-                    logging.warn("Ignoring unsupported ordering %s" % order)
+                    logging.warning("Ignoring unsupported ordering %s" % order)
                     continue
                 for availability in chosen_availabilities:
                     if availability not in allowed_availabilities:
-                        logging.warn(
+                        logging.warning(
                             "Ignoring unsupported availability %s" % availability
                         )
                         continue
                     for collection in chosen_collections:
                         if collection not in allowed_collections:
-                            logging.warn(
+                            logging.warning(
                                 "Ignoring unsupported collection %s" % collection
                             )
                             continue
@@ -1395,7 +1395,7 @@ class DirectoryImportScript(TimestampScript):
         default_medium_type=None,
     ):
         if dry_run:
-            self.log.warn(
+            self.log.warning(
                 "This is a dry run. No files will be uploaded and nothing will change in the database."
             )
 
@@ -1829,7 +1829,7 @@ class DirectoryImportScript(TimestampScript):
 
         # If we went through that whole loop without returning,
         # we have failed.
-        logging.warn(
+        logging.warning(
             "Could not find %s for %s. Looked in: %s",
             file_type,
             base_filename,

--- a/tests/api/sip/test_authentication_provider.py
+++ b/tests/api/sip/test_authentication_provider.py
@@ -489,7 +489,6 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         assert isinstance(results[1].exception, IOError)
         assert results[1].exception.args == ("Error logging in",)
 
-
         # Set the log in username and password
         integration.username = "user1"
         integration.password = "pass1"
@@ -511,7 +510,9 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         assert results[2].name == "Authenticating test patron"
         assert results[2].success == False
         assert isinstance(results[2].exception, CannotLoadConfiguration)
-        assert results[2].exception.args == ("No test patron identifier is configured.",)
+        assert results[2].exception.args == (
+            "No test patron identifier is configured.",
+        )
 
         # Now add the test patron credentials into the mocked client and SIP2 authenticator provider
         patronDataClient = MockSIPLogin(login_user_id="user1", login_password="pass1")

--- a/tests/api/sip/test_authentication_provider.py
+++ b/tests/api/sip/test_authentication_provider.py
@@ -472,7 +472,8 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
         assert len(results) == 1
         assert results[0].name == "Test Connection"
         assert results[0].success == False
-        assert (results[0].exception, IOError("Could not connect"))
+        assert isinstance(results[0].exception, IOError)
+        assert results[0].exception.args == ("Could not connect",)
 
         auth = SIP2AuthenticationProvider(
             self._default_library, integration, client=MockSIPLogin
@@ -485,7 +486,9 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
 
         assert results[1].name == "Test Login with username 'None' and password 'None'"
         assert results[1].success == False
-        assert (results[1].exception, IOError("Error logging in"))
+        assert isinstance(results[1].exception, IOError)
+        assert results[1].exception.args == ("Error logging in",)
+
 
         # Set the log in username and password
         integration.username = "user1"
@@ -507,10 +510,8 @@ class TestSIP2AuthenticationProvider(DatabaseTest):
 
         assert results[2].name == "Authenticating test patron"
         assert results[2].success == False
-        assert (
-            results[2].exception,
-            CannotLoadConfiguration("No test patron identifier is configured."),
-        )
+        assert isinstance(results[2].exception, CannotLoadConfiguration)
+        assert results[2].exception.args == ("No test patron identifier is configured.",)
 
         # Now add the test patron credentials into the mocked client and SIP2 authenticator provider
         patronDataClient = MockSIPLogin(login_user_id="user1", login_password="pass1")

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -1197,7 +1197,7 @@ class TestLibraryAnnotator(VendorIDTest):
 
         feed = AcquisitionFeed(self._db, "title", "url", [work], self.annotator)
         u = str(feed)
-        holds_re = re.compile('<opds:holds\W+total="25"\W*/>', re.S)
+        holds_re = re.compile(r'<opds:holds\W+total="25"\W*/>', re.S)
         assert holds_re.search(u) is not None
 
         copies_re = re.compile('<opds:copies[^>]+available="50"', re.S)

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -41,7 +41,7 @@ from core.model import (
     RightsStatus,
     Work,
 )
-from core.opds import AcquisitionFeed, TestAnnotator, UnfulfillableWork
+from core.opds import AcquisitionFeed, MockAnnotator, UnfulfillableWork
 from core.opds_import import OPDSXMLParser
 from core.testing import DatabaseTest
 from core.util.datetime_helpers import datetime_utc, utc_now
@@ -224,7 +224,7 @@ class TestCirculationManagerAnnotator(DatabaseTest):
         # Test the case where we accept the defaults.
         work = self._work()
         url = self._url
-        annotator = TestAnnotator()
+        annotator = MockAnnotator()
         response = m(self._db, work, annotator, url)
         assert isinstance(response, OPDSEntryResponse)
         assert "<title>%s</title>" % work.title in response.get_data(as_text=True)

--- a/tests/core/models/test_configuration.py
+++ b/tests/core/models/test_configuration.py
@@ -787,7 +787,7 @@ SETTING4_DEFAULT = None
 SETTING4_CATEGORY = "Settings"
 
 
-class TestConfiguration(ConfigurationGrouping):
+class MockConfiguration(ConfigurationGrouping):
     setting1 = ConfigurationMetadata(
         key=SETTING1_KEY,
         label=SETTING1_LABEL,
@@ -847,7 +847,7 @@ class ConfigurationWithBooleanProperty(ConfigurationGrouping):
     )
 
 
-class TestConfiguration2(ConfigurationGrouping):
+class MockConfiguration2(ConfigurationGrouping):
     setting1 = ConfigurationMetadata(
         key="setting1",
         label=SETTING1_LABEL,
@@ -911,7 +911,7 @@ class TestConfigurationGrouping(object):
         configuration_storage = create_autospec(spec=ConfigurationStorage)
         configuration_storage.load = MagicMock(return_value=expected_value)
         db = create_autospec(spec=sqlalchemy.orm.session.Session)
-        configuration = TestConfiguration(configuration_storage, db)
+        configuration = MockConfiguration(configuration_storage, db)
 
         # Act
         setting_value = getattr(configuration, setting_name)
@@ -924,33 +924,33 @@ class TestConfigurationGrouping(object):
         [
             (
                 "default_menu_value",
-                TestConfiguration.setting3.key,
+                MockConfiguration.setting3.key,
                 None,
-                TestConfiguration.setting3.default,
+                MockConfiguration.setting3.default,
             ),
             (
                 "menu_value",
-                TestConfiguration.setting3.key,
+                MockConfiguration.setting3.key,
                 json.dumps(
                     [
-                        TestConfiguration.setting3.options[0].key,
-                        TestConfiguration.setting3.options[1].key,
+                        MockConfiguration.setting3.options[0].key,
+                        MockConfiguration.setting3.options[1].key,
                     ]
                 ),
                 [
-                    TestConfiguration.setting3.options[0].key,
-                    TestConfiguration.setting3.options[1].key,
+                    MockConfiguration.setting3.options[0].key,
+                    MockConfiguration.setting3.options[1].key,
                 ],
             ),
             (
                 "default_list_value",
-                TestConfiguration.setting4.key,
+                MockConfiguration.setting4.key,
                 None,
-                TestConfiguration.setting4.default,
+                MockConfiguration.setting4.default,
             ),
             (
                 "menu_value",
-                TestConfiguration.setting4.key,
+                MockConfiguration.setting4.key,
                 json.dumps(["value1", "value2"]),
                 ["value1", "value2"],
             ),
@@ -961,7 +961,7 @@ class TestConfigurationGrouping(object):
         configuration_storage = create_autospec(spec=ConfigurationStorage)
         configuration_storage.load = MagicMock(return_value=db_value)
         db = create_autospec(spec=sqlalchemy.orm.session.Session)
-        configuration = TestConfiguration(configuration_storage, db)
+        configuration = MockConfiguration(configuration_storage, db)
 
         # Act
         setting_value = getattr(configuration, setting_name)
@@ -975,7 +975,7 @@ class TestConfigurationGrouping(object):
         configuration_storage = create_autospec(spec=ConfigurationStorage)
         configuration_storage.load = MagicMock(return_value=None)
         db = create_autospec(spec=sqlalchemy.orm.session.Session)
-        configuration = TestConfiguration(configuration_storage, db)
+        configuration = MockConfiguration(configuration_storage, db)
 
         # Act
         setting_value = configuration.setting1
@@ -991,7 +991,7 @@ class TestConfigurationGrouping(object):
         configuration_storage = create_autospec(spec=ConfigurationStorage)
         configuration_storage.save = MagicMock(return_value=expected_value)
         db = create_autospec(spec=sqlalchemy.orm.session.Session)
-        configuration = TestConfiguration(configuration_storage, db)
+        configuration = MockConfiguration(configuration_storage, db)
 
         # Act
         setattr(configuration, setting_name, expected_value)
@@ -1003,7 +1003,7 @@ class TestConfigurationGrouping(object):
 
     def test_to_settings_considers_default_indices(self):
         # Act
-        settings = TestConfiguration.to_settings()
+        settings = MockConfiguration.to_settings()
 
         # Assert
         assert len(settings) == 4
@@ -1060,7 +1060,7 @@ class TestConfigurationGrouping(object):
 
     def test_to_settings_considers_explicit_indices(self):
         # Act
-        settings = TestConfiguration2.to_settings()
+        settings = MockConfiguration2.to_settings()
 
         # Assert
         assert len(settings) == 2

--- a/tests/core/test_app_server.py
+++ b/tests/core/test_app_server.py
@@ -23,7 +23,7 @@ from core.entrypoint import AudiobooksEntryPoint, EbooksEntryPoint, EntryPoint
 from core.lane import Facets, Pagination, SearchFacets, WorkList
 from core.log import LogConfiguration
 from core.model import ConfigurationSetting, Identifier
-from core.opds import TestAnnotator
+from core.opds import MockAnnotator
 from core.problem_details import INVALID_INPUT, INVALID_URN
 from core.testing import DatabaseTest
 from core.util.opds_writer import OPDSFeed, OPDSMessage
@@ -164,7 +164,7 @@ class TestURNLookupController(DatabaseTest):
     def test_work_lookup(self):
         work = self._work(with_license_pool=True)
         identifier = work.license_pools[0].identifier
-        annotator = TestAnnotator()
+        annotator = MockAnnotator()
         # NOTE: We run this test twice to verify that the controller
         # doesn't keep any state between requests. At one point there
         # was a bug which would have caused a book to show up twice on
@@ -198,7 +198,7 @@ class TestURNLookupController(DatabaseTest):
         work = self._work(with_license_pool=True)
         work.license_pools[0].open_access = False
         identifier = work.license_pools[0].identifier
-        annotator = TestAnnotator()
+        annotator = MockAnnotator()
         with self.app.test_request_context("/?urn=%s" % identifier.urn):
             response = self.controller.permalink(identifier.urn, annotator)
 

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -45,11 +45,11 @@ from core.opds import (
     AcquisitionFeed,
     Annotator,
     LookupAcquisitionFeed,
-    NavigationFacets,
-    NavigationFeed,
     MockAnnotator,
     MockAnnotatorWithGroup,
     MockUnfulfillableAnnotator,
+    NavigationFacets,
+    NavigationFeed,
     VerboseAnnotator,
 )
 from core.opds_import import OPDSXMLParser
@@ -956,8 +956,8 @@ class TestOPDS(DatabaseTest):
 
         [next_link] = self.links(parsed, "next")
         assert (
-                MockAnnotator.feed_url(lane, facets, pagination.next_page)
-                == next_link["href"]
+            MockAnnotator.feed_url(lane, facets, pagination.next_page)
+            == next_link["href"]
         )
 
         # This was the first page, so no previous link.
@@ -1023,8 +1023,8 @@ class TestOPDS(DatabaseTest):
 
         [next_link] = self.links(parsed, "next")
         assert (
-                MockAnnotator.feed_url(lane, facets, pagination.next_page)
-                == next_link["href"]
+            MockAnnotator.feed_url(lane, facets, pagination.next_page)
+            == next_link["href"]
         )
 
         # This was the first page, so no previous link.
@@ -1101,8 +1101,8 @@ class TestOPDS(DatabaseTest):
 
         [next_link] = self.links(parsed, "next")
         assert (
-                MockAnnotator.feed_url(worklist, pagination=pagination.next_page)
-                == next_link["href"]
+            MockAnnotator.feed_url(worklist, pagination=pagination.next_page)
+            == next_link["href"]
         )
 
         # This was the first page, so no previous link.
@@ -1113,8 +1113,8 @@ class TestOPDS(DatabaseTest):
         parsed = feedparser.parse(str(works))
         [previous_link] = self.links(parsed, "previous")
         assert (
-                MockAnnotator.feed_url(worklist, pagination=pagination.previous_page)
-                == previous_link["href"]
+            MockAnnotator.feed_url(worklist, pagination=pagination.previous_page)
+            == previous_link["href"]
         )
         assert 1 == len(parsed["entries"])
         assert [] == self.links(parsed, "next")

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -2236,7 +2236,7 @@ class TestLookupAcquisitionFeed(DatabaseTest):
         entry = feed.create_entry((identifier, work))
         if isinstance(entry, OPDSMessage):
             return feed, entry
-        if entry:
+        if entry is not None:
             entry = etree.tounicode(entry)
         return feed, entry
 

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -47,9 +47,9 @@ from core.opds import (
     LookupAcquisitionFeed,
     NavigationFacets,
     NavigationFeed,
-    TestAnnotator,
-    TestAnnotatorWithGroup,
-    TestUnfulfillableAnnotator,
+    MockAnnotator,
+    MockAnnotatorWithGroup,
+    MockUnfulfillableAnnotator,
     VerboseAnnotator,
 )
 from core.opds_import import OPDSXMLParser
@@ -485,7 +485,7 @@ class TestOPDS(DatabaseTest):
         work = self._work(with_open_access_download=True, authors="Alice")
         [lp] = work.license_pools
 
-        annotator = TestAnnotatorWithGroup()
+        annotator = MockAnnotatorWithGroup()
         feed = AcquisitionFeed(
             self._db, "test", "http://the-url.com/", [work], annotator
         )
@@ -550,7 +550,7 @@ class TestOPDS(DatabaseTest):
         facets = Facets.default(self._default_library)
 
         cached_feed = AcquisitionFeed.page(
-            self._db, "title", "http://the-url.com/", lane, TestAnnotator, facets=facets
+            self._db, "title", "http://the-url.com/", lane, MockAnnotator, facets=facets
         )
 
         u = str(cached_feed)
@@ -631,7 +631,7 @@ class TestOPDS(DatabaseTest):
 
         self._db.commit()
         works = self._db.query(Work)
-        with_times = AcquisitionFeed(self._db, "test", "url", works, TestAnnotator)
+        with_times = AcquisitionFeed(self._db, "test", "url", works, MockAnnotator)
         u = str(with_times)
         assert "dcterms:issued" in u
 
@@ -678,7 +678,7 @@ class TestOPDS(DatabaseTest):
             w.calculate_opds_entries(verbose=False)
 
         works = self._db.query(Work)
-        with_publisher = AcquisitionFeed(self._db, "test", "url", works, TestAnnotator)
+        with_publisher = AcquisitionFeed(self._db, "test", "url", works, MockAnnotator)
         with_publisher = feedparser.parse(str(with_publisher))
         entries = sorted(with_publisher["entries"], key=lambda x: x["title"])
         assert "The Publisher" == entries[0]["dcterms_publisher"]
@@ -936,7 +936,7 @@ class TestOPDS(DatabaseTest):
                 "test",
                 self._url,
                 lane,
-                TestAnnotator,
+                MockAnnotator,
                 pagination=pagination,
                 search_engine=search_engine,
             )
@@ -947,17 +947,17 @@ class TestOPDS(DatabaseTest):
 
         # Make sure the links are in place.
         [up_link] = self.links(parsed, "up")
-        assert TestAnnotator.groups_url(lane.parent) == up_link["href"]
+        assert MockAnnotator.groups_url(lane.parent) == up_link["href"]
         assert lane.parent.display_name == up_link["title"]
 
         [start] = self.links(parsed, "start")
-        assert TestAnnotator.groups_url(None) == start["href"]
-        assert TestAnnotator.top_level_title() == start["title"]
+        assert MockAnnotator.groups_url(None) == start["href"]
+        assert MockAnnotator.top_level_title() == start["title"]
 
         [next_link] = self.links(parsed, "next")
         assert (
-            TestAnnotator.feed_url(lane, facets, pagination.next_page)
-            == next_link["href"]
+                MockAnnotator.feed_url(lane, facets, pagination.next_page)
+                == next_link["href"]
         )
 
         # This was the first page, so no previous link.
@@ -967,7 +967,7 @@ class TestOPDS(DatabaseTest):
         cached_works = str(make_page(pagination.next_page))
         parsed = feedparser.parse(cached_works)
         [previous] = self.links(parsed, "previous")
-        assert TestAnnotator.feed_url(lane, facets, pagination) == previous["href"]
+        assert MockAnnotator.feed_url(lane, facets, pagination) == previous["href"]
         assert work2.title == parsed["entries"][0]["title"]
 
         # The feed has breadcrumb links
@@ -979,11 +979,11 @@ class TestOPDS(DatabaseTest):
         # There's one breadcrumb link for each parent Lane, plus one for
         # the top-level.
         assert len(parentage) + 1 == len(links)
-        assert TestAnnotator.top_level_title() == links[0].get("title")
-        assert TestAnnotator.default_lane_url() == links[0].get("href")
+        assert MockAnnotator.top_level_title() == links[0].get("title")
+        assert MockAnnotator.default_lane_url() == links[0].get("href")
         for i, lane in enumerate(parentage):
             assert lane.display_name == links[i + 1].get("title")
-            assert TestAnnotator.lane_url(lane) == links[i + 1].get("href")
+            assert MockAnnotator.lane_url(lane) == links[i + 1].get("href")
 
     def test_page_feed_for_worklist(self):
         # Test the ability to create a paginated feed of works for a
@@ -1004,7 +1004,7 @@ class TestOPDS(DatabaseTest):
                 "test",
                 self._url,
                 lane,
-                TestAnnotator,
+                MockAnnotator,
                 pagination=pagination,
                 search_engine=search_engine,
             )
@@ -1018,13 +1018,13 @@ class TestOPDS(DatabaseTest):
         assert [] == self.links(parsed, "up")
 
         [start] = self.links(parsed, "start")
-        assert TestAnnotator.groups_url(None) == start["href"]
-        assert TestAnnotator.top_level_title() == start["title"]
+        assert MockAnnotator.groups_url(None) == start["href"]
+        assert MockAnnotator.top_level_title() == start["title"]
 
         [next_link] = self.links(parsed, "next")
         assert (
-            TestAnnotator.feed_url(lane, facets, pagination.next_page)
-            == next_link["href"]
+                MockAnnotator.feed_url(lane, facets, pagination.next_page)
+                == next_link["href"]
         )
 
         # This was the first page, so no previous link.
@@ -1034,7 +1034,7 @@ class TestOPDS(DatabaseTest):
         cached_works = str(make_page(pagination.next_page))
         parsed = feedparser.parse(cached_works)
         [previous] = self.links(parsed, "previous")
-        assert TestAnnotator.feed_url(lane, facets, pagination) == previous["href"]
+        assert MockAnnotator.feed_url(lane, facets, pagination) == previous["href"]
         assert work2.title == parsed["entries"][0]["title"]
 
         # The feed has no parents, so no breadcrumbs.
@@ -1091,7 +1091,7 @@ class TestOPDS(DatabaseTest):
                 "url",
                 pagination,
                 url_fn,
-                TestAnnotator,
+                MockAnnotator,
             )
 
         works = from_query(pagination)
@@ -1101,8 +1101,8 @@ class TestOPDS(DatabaseTest):
 
         [next_link] = self.links(parsed, "next")
         assert (
-            TestAnnotator.feed_url(worklist, pagination=pagination.next_page)
-            == next_link["href"]
+                MockAnnotator.feed_url(worklist, pagination=pagination.next_page)
+                == next_link["href"]
         )
 
         # This was the first page, so no previous link.
@@ -1113,8 +1113,8 @@ class TestOPDS(DatabaseTest):
         parsed = feedparser.parse(str(works))
         [previous_link] = self.links(parsed, "previous")
         assert (
-            TestAnnotator.feed_url(worklist, pagination=pagination.previous_page)
-            == previous_link["href"]
+                MockAnnotator.feed_url(worklist, pagination=pagination.previous_page)
+                == previous_link["href"]
         )
         assert 1 == len(parsed["entries"])
         assert [] == self.links(parsed, "next")
@@ -1144,7 +1144,7 @@ class TestOPDS(DatabaseTest):
             "Urban Fantasy", parent=self.fantasy, genres=["Urban Fantasy"]
         )
 
-        annotator = TestAnnotatorWithGroup()
+        annotator = MockAnnotatorWithGroup()
         private = object()
         cached_groups = AcquisitionFeed.groups(
             self._db,
@@ -1216,7 +1216,7 @@ class TestOPDS(DatabaseTest):
         # Mock search index and Annotator.
         search_engine = MockExternalSearchIndex()
 
-        class Mock(TestAnnotator):
+        class Mock(MockAnnotator):
             def annotate_feed(self, feed, worklist):
                 self.called = True
 
@@ -1269,7 +1269,7 @@ class TestOPDS(DatabaseTest):
                 "fantasy",
                 pagination=pagination,
                 facets=facets,
-                annotator=TestAnnotator,
+                annotator=MockAnnotator,
                 private=private,
             )
 
@@ -1284,11 +1284,11 @@ class TestOPDS(DatabaseTest):
 
         # Make sure the links are in place.
         [start] = self.links(parsed, "start")
-        assert TestAnnotator.groups_url(None) == start["href"]
-        assert TestAnnotator.top_level_title() == start["title"]
+        assert MockAnnotator.groups_url(None) == start["href"]
+        assert MockAnnotator.top_level_title() == start["title"]
 
         [next_link] = self.links(parsed, "next")
-        expect = TestAnnotator.search_url(
+        expect = MockAnnotator.search_url(
             fantasy_lane, "test", pagination.next_page, facets=facets
         )
         assert expect == next_link["href"]
@@ -1303,7 +1303,7 @@ class TestOPDS(DatabaseTest):
 
         # Make sure there's an "up" link to the lane that was searched
         [up_link] = self.links(parsed, "up")
-        uplink_url = TestAnnotator.lane_url(fantasy_lane)
+        uplink_url = MockAnnotator.lane_url(fantasy_lane)
         assert uplink_url == up_link["href"]
         assert fantasy_lane.display_name == up_link["title"]
 
@@ -1311,7 +1311,7 @@ class TestOPDS(DatabaseTest):
         feed = str(make_page(pagination.next_page))
         parsed = feedparser.parse(feed)
         [previous] = self.links(parsed, "previous")
-        expect = TestAnnotator.search_url(
+        expect = MockAnnotator.search_url(
             fantasy_lane, "test", pagination, facets=facets
         )
         assert expect == previous["href"]
@@ -1344,7 +1344,7 @@ class TestOPDS(DatabaseTest):
                 "test",
                 self._url,
                 fantasy_lane,
-                TestAnnotator,
+                MockAnnotator,
                 pagination=Pagination.default(),
                 search_engine=search_engine,
             )
@@ -1387,7 +1387,7 @@ class TestAcquisitionFeed(DatabaseTest):
             "feed title",
             "url",
             wl,
-            TestAnnotator,
+            MockAnnotator,
             max_age=10,
             private=private,
         )
@@ -1403,7 +1403,7 @@ class TestAcquisitionFeed(DatabaseTest):
     def test_as_response(self):
         # Verify the ability to convert an AcquisitionFeed object to an
         # OPDSFeedResponse containing the feed.
-        feed = AcquisitionFeed(self._db, "feed title", "http://url/", [], TestAnnotator)
+        feed = AcquisitionFeed(self._db, "feed title", "http://url/", [], MockAnnotator)
 
         # Some other piece of code set expectations for how this feed should
         # be cached.
@@ -1422,7 +1422,7 @@ class TestAcquisitionFeed(DatabaseTest):
     def test_as_error_response(self):
         # Verify the ability to convert an AcquisitionFeed object to an
         # OPDSFeedResponse that is to be treated as an error message.
-        feed = AcquisitionFeed(self._db, "feed title", "http://url/", [], TestAnnotator)
+        feed = AcquisitionFeed(self._db, "feed title", "http://url/", [], MockAnnotator)
 
         # Some other piece of code set expectations for how this feed should
         # be cached.
@@ -1674,7 +1674,7 @@ class TestAcquisitionFeed(DatabaseTest):
         # this Work.
         private = object()
         entry = AcquisitionFeed.single_entry(
-            self._db, work, TestAnnotator, private=private
+            self._db, work, MockAnnotator, private=private
         )
         assert isinstance(entry, OPDSEntryResponse)
 
@@ -1694,7 +1694,7 @@ class TestAcquisitionFeed(DatabaseTest):
         five_hundred_years = datetime.timedelta(days=(500 * 365))
         work.presentation_edition.issued = utc_now() - five_hundred_years
 
-        entry = AcquisitionFeed.single_entry(self._db, work, TestAnnotator)
+        entry = AcquisitionFeed.single_entry(self._db, work, MockAnnotator)
 
         expected = str(work.presentation_edition.issued.date())
         assert expected in str(entry)
@@ -1740,7 +1740,7 @@ class TestAcquisitionFeed(DatabaseTest):
 
         # But now the annotator is set up to insert a tag with that
         # namespace.
-        class AddDRMTagAnnotator(TestAnnotator):
+        class AddDRMTagAnnotator(MockAnnotator):
             @classmethod
             def annotate_work_entry(
                 cls, work, license_pool, edition, identifier, feed, entry
@@ -1762,7 +1762,7 @@ class TestAcquisitionFeed(DatabaseTest):
         work = self._work(title="Hello, World!", with_license_pool=True)
         work.license_pools[0].identifier = None
         work.presentation_edition.primary_identifier = None
-        entry = AcquisitionFeed.single_entry(self._db, work, TestAnnotator)
+        entry = AcquisitionFeed.single_entry(self._db, work, MockAnnotator)
         assert entry == None
 
     def test_error_when_work_has_no_licensepool(self):
@@ -1852,7 +1852,7 @@ class TestAcquisitionFeed(DatabaseTest):
         response = AcquisitionFeed.single_entry(
             self._db,
             work,
-            TestUnfulfillableAnnotator,
+            MockUnfulfillableAnnotator,
         )
         assert isinstance(response, Response)
         expect = AcquisitionFeed.error_message(
@@ -1921,7 +1921,7 @@ class TestAcquisitionFeed(DatabaseTest):
         class MockFeed(AcquisitionFeed):
             def __init__(self):
                 super(MockFeed, self).__init__(
-                    _db, "", "", [], annotator=TestAnnotator()
+                    _db, "", "", [], annotator=MockAnnotator()
                 )
                 self.feed = []
 
@@ -1943,7 +1943,7 @@ class TestAcquisitionFeed(DatabaseTest):
             # For easier reading, all assertions in this test are
             # written as calls to this function.
             feed = MockFeed()
-            annotator = TestAnnotator()
+            annotator = MockAnnotator()
 
             entrypoint = add_breadcrumbs_kwargs.get("entrypoint", None)
             include_lane = add_breadcrumbs_kwargs.get("include_lane", False)
@@ -2107,7 +2107,7 @@ class TestAcquisitionFeed(DatabaseTest):
             def show_current_entrypoint(self, entrypoint):
                 self.current_entrypoint = entrypoint
 
-        annotator = TestAnnotator
+        annotator = MockAnnotator
         feed = MockFeed(self._db, "title", "url", [], annotator=annotator)
 
         lane = self._lane()
@@ -2312,7 +2312,7 @@ class TestLookupAcquisitionFeed(DatabaseTest):
     def test_unfilfullable_work(self):
         work = self._work(with_open_access_download=True)
         [pool] = work.license_pools
-        feed, entry = self.entry(pool.identifier, work, TestUnfulfillableAnnotator)
+        feed, entry = self.entry(pool.identifier, work, MockUnfulfillableAnnotator)
         expect = AcquisitionFeed.error_message(
             pool.identifier,
             403,
@@ -2414,7 +2414,7 @@ class TestEntrypointLinkInsertion(DatabaseTest):
         self.no_eps.works = works
         self.wl.works = works
 
-        self.annotator = TestAnnotator
+        self.annotator = MockAnnotator
         self.old_add_entrypoint_links = AcquisitionFeed.add_entrypoint_links
         AcquisitionFeed.add_entrypoint_links = self.mock.add_entrypoint_links
 
@@ -2618,7 +2618,7 @@ class TestNavigationFeed(DatabaseTest):
             "Navigation",
             "http://navigation",
             self.fiction,
-            TestAnnotator,
+            MockAnnotator,
             max_age=42,
             private=private,
         )
@@ -2663,7 +2663,7 @@ class TestNavigationFeed(DatabaseTest):
 
     def test_navigation_without_sublanes(self):
         feed = NavigationFeed.navigation(
-            self._db, "Navigation", "http://navigation", self.fantasy, TestAnnotator
+            self._db, "Navigation", "http://navigation", self.fantasy, MockAnnotator
         )
         parsed = feedparser.parse(str(feed))
         assert "Navigation" == parsed["feed"]["title"]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     core: pytest {posargs:--disable-warnings tests/core}
 passenv = SIMPLIFIED_* CI
 setenv =
-    docker: SIMPLIFIED_TEST_DATABASE=postgres://simplified_test:test@localhost:9005/simplified_circulation_test
+    docker: SIMPLIFIED_TEST_DATABASE=postgresql://simplified_test:test@localhost:9005/simplified_circulation_test
     docker: SIMPLIFIED_TEST_ELASTICSEARCH=http://localhost:9006
     core-docker: SIMPLIFIED_TEST_MINIO_ENDPOINT_URL=http://localhost:9004
     core-docker: SIMPLIFIED_TEST_MINIO_USER=simplified

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ commands_pre =
     docker: docker restart es-circ
     python -m textblob.download_corpora
 commands =
-    api: pytest {posargs:--disable-warnings tests/api}
-    core: pytest {posargs:--disable-warnings tests/core}
+    api: pytest {posargs:tests/api}
+    core: pytest {posargs:tests/core}
 passenv = SIMPLIFIED_* CI
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgresql://simplified_test:test@localhost:9005/simplified_circulation_test


### PR DESCRIPTION
## Description

This branch resolves a bunch of warnings seen when running tests. Some highlights:
- Use logging's `warning`, rather than deprecated `warn`.
- Use SQLAlchemy's `LargeBinary`, instead of deprecated `Binary`.
- Don't start non-test class names with "Test".
- Use raw strings for regex patterns with escape sequences.
- Use "postgresql" as DB dialect, instead of deprecated "postgres".
- Fix some broken tests with inert assertions.
- Be more explicit in some falsy tests.
- Warning messages enabled by default.

## Motivation and Context

- Resolve deprecated approaches and move to current ones.
- Reduce cognitive load from unhelpful messages when running tests.

## How Has This Been Tested?

Fixed broken tests. Ran all tests.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
