### PR TITLE
Centralize our configuration in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,10 @@
 build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core>=1.0.0"]
 
+[tool.isort]
+known_first_party = ["core", "api"]
+profile = "black"
+
 [tool.poetry]
 authors = ["The Palace Project <info@thepalaceproject.org>"]
 description = "The Palace Project Manager Application"
@@ -89,3 +93,7 @@ requests-mock = "1.8.0"
 docs = ["alabaster", "docutils", "Pygments", "Sphinx", "sphinxcontrib-websupport"]
 pg = ["psycopg2"]
 pg-binary = ["psycopg2-binary"]
+
+[tool.pytest.ini_options]
+timeout = "600"
+timeout_method = "thread"

--- a/tox.ini
+++ b/tox.ini
@@ -65,15 +65,3 @@ python =
 MODULE =
     Core: core
     Api: api
-
-[pytest]
-timeout_method = thread
-timeout = 600
-
-[flake8]
-max-line-length = 120
-extend-ignore = E203, E501, E711, E712
-
-[isort]
-profile = black
-known_first_party = core,api


### PR DESCRIPTION
## Description

Move our tool configuration to the more standard `pyproject.toml` file, from the tox.ini file. And remove the unused flake8 configuration from tox.ini.

## Motivation and Context

Same configuration settings different file.
