### PR TITLE
Tune codeql config

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -1,0 +1,8 @@
+disable-default-queries: true
+
+queries:
+  - uses: ./.github/codeql/queries.qls
+
+paths-ignore:
+  - tests
+  - bin

--- a/.github/codeql/queries.qls
+++ b/.github/codeql/queries.qls
@@ -1,0 +1,14 @@
+- description: Standard Code Scanning queries for Python
+
+# Documentation used to create this file:
+# https://codeql.github.com/docs/codeql-cli/creating-codeql-query-suites/
+# https://github.com/github/codeql/issues/4426
+# https://github.com/github/codeql/tree/main/python/ql/src/codeql-suites
+
+- import: codeql-suites/python-code-scanning.qls
+  from: codeql-python
+
+# This rule causes a lot of false positives in our codebase
+- exclude:
+    query filename:
+        - CleartextLogging.ql

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,11 +18,6 @@ jobs:
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'python' ]
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -42,11 +37,8 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        languages: python
+        config-file: ./.github/codeql/config.yml
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,3 +42,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
+      with:
+        category: ".github/workflows/codeql-analysis.yml:analyze/language:python"


### PR DESCRIPTION
## Description

Drop in a CodeQL config file to exclude some of the rules that are on by default. This should reduce the number of false positives we are getting from this scanning.
