### PR TITLE
Bump admin UI to 0.0.7.

### DIFF
--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -12,7 +12,7 @@ class Configuration:
 
     APP_NAME = "Palace Collection Manager"
     PACKAGE_NAME = "@thepalaceproject/circulation-admin"
-    PACKAGE_VERSION = "0.0.6"
+    PACKAGE_VERSION = "0.0.7"
 
     STATIC_ASSETS = {
         "admin_js": "circulation-admin.js",


### PR DESCRIPTION
## Description

Bumps admin UI to version 0.0.7.

## How Has This Been Tested?

Ran locally to ensure that the new admin UI version is picked up by the browser and that the styling changes were visible.
