### PR TITLE
Add retry logic to OPDS\ODL import monitors

### DIFF
--- a/api/odl2.py
+++ b/api/odl2.py
@@ -11,18 +11,18 @@ from core.model import Edition, RightsStatus
 from core.model.configuration import (
     ConfigurationAttributeType,
     ConfigurationFactory,
-    ConfigurationGrouping,
     ConfigurationMetadata,
     ConfigurationStorage,
     ExternalIntegration,
     HasExternalIntegration,
 )
 from core.opds2_import import OPDS2Importer, OPDS2ImportMonitor, RWPMManifestParser
+from core.opds_import import ConnectionConfiguration
 from core.util import first_or_default
 from core.util.datetime_helpers import to_utc
 
 
-class ODL2APIConfiguration(ConfigurationGrouping):
+class ODL2APIConfiguration(ConnectionConfiguration):
     skipped_license_formats = ConfigurationMetadata(
         key="odl2_skipped_license_formats",
         label=_("Skipped license formats"),

--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -95,8 +95,7 @@ class ConnectionConfiguration(ConfigurationGrouping):
         key="max_retry_count",
         label=_("Max retry count"),
         description=_(
-            "Max number of times Circulation Manager will try attempt to reconnect "
-            "in the case of any connection-related errors."
+            "The maximum number of times to retry a request for certain connection-related errors."
         ),
         type=ConfigurationAttributeType.NUMBER,
         required=False,

--- a/core/util/http.py
+++ b/core/util/http.py
@@ -274,6 +274,9 @@ class HTTP(object):
             if make_request_with == sessions.Session.request:
                 with sessions.Session() as session:
                     if max_retry_count is not None:
+                        # TODO: Verify the status codes for which it retries.
+                        #  Are there any status codes for which we would NOT want to retry (e.g., 401, 403)?
+                        #  Are there some that we want to ensure get retried (e.g., 502, which we get a lot).
                         retry_strategy = Retry(total=max_retry_count)
                         adapter = HTTPAdapter(max_retries=retry_strategy)
 

--- a/tests/core/test_opds_import.py
+++ b/tests/core/test_opds_import.py
@@ -2724,7 +2724,7 @@ class TestOPDSImportMonitor(OPDSImporterTest):
         ) as configuration:
             configuration.max_retry_count = retry_count
 
-        # After we overrode the value of  configuration setting we can instantiate OPDSImportMonitor.
+        # After we overrode the value of configuration setting we can instantiate OPDSImportMonitor.
         # It'll load new "Max retry count"'s value from the database.
         monitor = OPDSImportMonitor(
             self._db, collection=self._default_collection, import_class=OPDSImporter


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds a new configuration setting `Max retry count` to ODL 2.x integration. This configuration setting determines the max number of times Circulation Manager will attempt to reconnect in the case of any connection-related errors.

Below there is an image showing how new configuration settings looks like.
![image](https://user-images.githubusercontent.com/6442436/148324004-745ec191-394f-45aa-ae9d-925ea9b57960.png)


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Sometimes the DPLA API times out and Circulation Manager is not able to download feed pages.
Adding a retry logic [similar to what we used for ProQuest](https://github.com/ThePalaceProject/circulation/pull/83) helps in this case.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

In my case locally I always had a problem with traversing the DPLA feed pages. Circulation Manager used to stuck on page 28 and get weird `Failed to establish a new connection: [Errno 60] Operation timed out'` errors. After I had applied my changes and set a retry count to 3, Circulation Manager was able to correctly traverse the whole feed and start importing the items. I didn't wait until all the items were ingested successfully because the feed is quite large but below you could see that there are quite a lot of items were successfully ingested:
![image](https://user-images.githubusercontent.com/6442436/148324207-e7b1046c-ad9d-4664-9693-3b4a022a8a35.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
