### PR TITLE
Fix Marketplace Audiobooks

### DIFF
--- a/api/odl.py
+++ b/api/odl.py
@@ -559,12 +559,6 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
                 continue
             href = link.get("href")
             type = link.get("type")
-
-            # For DeMarque audiobook content, we need to translate the type property
-            # to reflect what we have stored in our delivery mechanisms.
-            if type in ODLImporter.LICENSE_FORMATS:
-                type = ODLImporter.LICENSE_FORMATS[type][ODLImporter.DRM_SCHEME]
-
             candidates.append((href, type))
 
         if len(candidates) == 0:
@@ -575,6 +569,11 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
             # If we don't have a requested DRM scheme, so we use the first one.
             # TODO: Can this just be dropped?
             return candidates[0]
+
+        # For DeMarque audiobook content, we need to translate the type property
+        # to reflect what we have stored in our delivery mechanisms.
+        if drm_scheme == DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM:
+            drm_scheme = ODLImporter.FEEDBOOKS_AUDIO
 
         return next(filter(lambda x: x[1] == drm_scheme, candidates), (None, None))
 

--- a/tests/api/test_odl.py
+++ b/tests/api/test_odl.py
@@ -741,9 +741,10 @@ class TestODLAPI(DatabaseTest, BaseODLAPITest):
         assert 0 == db.query(Loan).count()
 
     @pytest.mark.parametrize(
-        "delivery_mechanism, correct_link, links",
+        "delivery_mechanism, correct_type, correct_link, links",
         [
             (
+                DeliveryMechanism.ADOBE_DRM,
                 DeliveryMechanism.ADOBE_DRM,
                 "http://acsm",
                 [
@@ -756,6 +757,7 @@ class TestODLAPI(DatabaseTest, BaseODLAPITest):
             ),
             (
                 MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
+                MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE,
                 "http://manifest",
                 [
                     {
@@ -767,6 +769,7 @@ class TestODLAPI(DatabaseTest, BaseODLAPITest):
             ),
             (
                 DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM,
+                ODLImporter.FEEDBOOKS_AUDIO,
                 "http://correct",
                 [
                     {
@@ -793,6 +796,7 @@ class TestODLAPI(DatabaseTest, BaseODLAPITest):
         collection,
         db,
         delivery_mechanism,
+        correct_type,
         correct_link,
         links,
     ):
@@ -817,7 +821,7 @@ class TestODLAPI(DatabaseTest, BaseODLAPITest):
         assert pool.identifier.identifier == fulfillment.identifier
         assert datetime_utc(2017, 10, 21, 11, 12, 13) == fulfillment.content_expires
         assert correct_link == fulfillment.content_link
-        assert delivery_mechanism == fulfillment.content_type
+        assert correct_type == fulfillment.content_type
 
     def test_fulfill_cannot_fulfill(self, license, checkout, db, api, patron, pool):
         license.setup(concurrency=7, available=7)


### PR DESCRIPTION
## Description

Return a valid content type when we are getting manifests for Marketplace audiobooks.

## Motivation and Context

I don't really love the fix here, but I think it will solve the issue we are seeing with marketplace audiobooks.

## How Has This Been Tested?

It largely hasn't, once CI passes, we can test out the built container with the app and see if it works.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
