### PR TITLE
Don't add timezone to date that already has one.

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -5,7 +5,6 @@ import urllib.parse
 
 import dateutil
 import flask
-import pytz
 from flask_babel import lazy_gettext as _
 
 from core.analytics import Analytics
@@ -1364,10 +1363,6 @@ class NewTitlesOverdriveCollectionMonitor(OverdriveCirculationMonitor):
             self.log.error("Got invalid date: %s", date_added)
             return False
 
-        # The time stored in the database is UTC, but it's stored
-        # without any time zone information. Add that information so
-        # we can compare it against the date we got from Overdrive.
-        start = pytz.utc.localize(start)
         self.log.info(
             "Date added: %s, start time: %s, result %s",
             date_added,


### PR DESCRIPTION
## Description

Fixes a crash in `overdrive_new_titles` monitor script caused by trying to add a timezone to a `datetime` that already has one.

## Motivation and Context

The monitor's `start` timestamp originates in a `timestamp with time zone` field in the `timestamps` table, so should be either `None` or a `datetime` with a time zone. It does not need to be converted.

## How Has This Been Tested?

- Manually ran the script on a local instance on which it had previously failed.
- Tested on a QA server.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.
