### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         module: [Api, Core]
 
     # We want to run on external PRs, but not on our own internal PRs as they'll be run

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-![Python: 3.6,3.7,3.8,3.9](https://img.shields.io/badge/Python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9-blue)
+![Python: 3.7,3.8,3.9](https://img.shields.io/badge/Python-3.7%20%7C%203.8%20%7C%203.9-blue)
 
 This is a [The Palace Project](https://thepalaceproject.org) maintained fork of the NYPL
 [Library Simplified](http://www.librarysimplified.org/) Circulation Manager.
@@ -415,7 +415,7 @@ testing the branch, or deploying hotfixes.
 
 ## Testing
 
-The Github Actions CI service runs the unit tests against Python 3.6, 3.7, 3.8 and 3.9 automatically using
+The Github Actions CI service runs the unit tests against Python 3.7, 3.8 and 3.9 automatically using
 [tox](https://tox.readthedocs.io/en/latest/).
 
 To run `pytest` unit tests locally, install `tox`.
@@ -437,7 +437,6 @@ with service dependencies running in docker containers.
 
 | Factor      | Python Version |
 | ----------- | -------------- |
-| py36        | Python 3.6     |
 | py37        | Python 3.7     |
 | py38        | Python 3.8     |
 | py39        | Python 3.9     |

--- a/docker/simplified_app.sh
+++ b/docker/simplified_app.sh
@@ -21,11 +21,6 @@ $minimal_apt_get_install --no-upgrade \
   libxmlsec1-openssl \
   pkg-config
 
-# We should be able to drop these lines when we move to Python > 3.6
-# https://click.palletsprojects.com/en/5.x/python3/#python-3-surrogate-handling
-export LC_ALL=C.UTF-8
-export LANG=C.UTF-8
-
 # Create a user.
 useradd -ms /bin/bash -U simplified
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -426,21 +426,6 @@ perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
-name = "importlib-resources"
-version = "5.2.3"
-description = "Read resources from Python packages"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
@@ -744,7 +729,6 @@ python-versions = ">=3.6.1"
 cfgv = ">=2.0.0"
 identify = ">=1.0.0"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-importlib-resources = {version = "<5.3", markers = "python_version < \"3.7\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 toml = "*"
@@ -1268,7 +1252,6 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.2,<4"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
 platformdirs = ">=2,<3"
 six = ">=1.9.0,<2"
 
@@ -1344,8 +1327,8 @@ pg-binary = ["psycopg2-binary"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.6.1,<4"
-content-hash = "04dfd474fbc7f069e8359fff5aeae07ff3500aaf3fff6472879d145360f02831"
+python-versions = ">=3.7,<4"
+content-hash = "7578d96f301986f7b9ec5236da4dd73d334e5ce0a36eeb47228cae8becf61041"
 
 [metadata.files]
 atomicwrites = [
@@ -1550,10 +1533,6 @@ idna = [
 importlib-metadata = [
     {file = "importlib_metadata-4.8.3-py3-none-any.whl", hash = "sha256:65a9576a5b2d58ca44d133c42a241905cc45e34d2c06fd5ba2bafa221e5d7b5e"},
     {file = "importlib_metadata-4.8.3.tar.gz", hash = "sha256:766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668"},
-]
-importlib-resources = [
-    {file = "importlib_resources-5.2.3-py3-none-any.whl", hash = "sha256:ae35ed1cfe8c0d6c1a53ecd168167f01fa93b893d51a62cdf23aea044c67211b"},
-    {file = "importlib_resources-5.2.3.tar.gz", hash = "sha256:203d70dda34cfbfbb42324a8d4211196e7d3e858de21a5eb68c6d1cdd99e4e98"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ pyparsing = "3.0.7"
 pypostalcode = "0.4.1"
 pyspellchecker = "0.6.3"
 pytest = "^6"  # Can't be made a dev dep because mocks included beside prod code.
-python = ">=3.6.1,<4"
+python = ">=3.7,<4"
 python-dateutil = "2.8.2"
 python-Levenshtein = "~0.12"
 python3-saml = "1.12.0"  # python-saml is required for SAML authentication

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}-{api,core}-docker
+envlist = py{37,38,39}-{api,core}-docker
 skipsdist = true
 
 [testenv]
@@ -56,7 +56,6 @@ ports =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
## Description

This PR drops Python 3.6 support from circulation. I'm leaving it in draft for now, since we need to start building our container images using a newer version of Python before it can be merged.

## Motivation and Context

Python 3.6 is [end-of-life as of 2021-12-23](https://devguide.python.org/devcycle/#end-of-life-branches). Packages are starting to drop support for it, and we should as well.

## How Has This Been Tested?

- Ran unit tests
- Read over Readme to find references to Python 3.6

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
