### PR TITLE
Update uwsgi configuration

### DIFF
--- a/docker/services/nginx.conf
+++ b/docker/services/nginx.conf
@@ -9,6 +9,6 @@ server {
     location @circulation {
         include uwsgi_params;
         uwsgi_read_timeout 120;
-        uwsgi_pass unix:/var/www/circulation/uwsgi.sock;
+        uwsgi_pass unix:/var/run/uwsgi/uwsgi.sock;
     }
 }

--- a/docker/services/uwsgi.d/40_log.ini
+++ b/docker/services/uwsgi.d/40_log.ini
@@ -1,0 +1,4 @@
+[uwsgi]
+# location of log files
+logto = /var/log/uwsgi/uwsgi.log
+log-format = %(var.HTTP_X_FORWARDED_FOR) (%(addr)) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)

--- a/docker/services/uwsgi.d/50_palace.ini
+++ b/docker/services/uwsgi.d/50_palace.ini
@@ -1,0 +1,9 @@
+[uwsgi]
+# application's base folder
+base = /var/www/circulation
+home = %(base)/env
+pythonpath = %(base)
+
+# python module to import
+module = api.app
+callable = app

--- a/docker/services/uwsgi.d/60_processes.ini
+++ b/docker/services/uwsgi.d/60_processes.ini
@@ -1,0 +1,4 @@
+[uwsgi]
+# Default number of processes and threads for the app
+processes = 3
+threads = 2

--- a/docker/services/uwsgi.d/70_reload.ini
+++ b/docker/services/uwsgi.d/70_reload.ini
@@ -1,0 +1,3 @@
+[uwsgi]
+# reload based on memory usage
+reload-on-rss = 425

--- a/docker/services/uwsgi.ini
+++ b/docker/services/uwsgi.ini
@@ -1,46 +1,19 @@
 [uwsgi]
-# application's base folder
-base = /var/www/circulation
-home = %(base)/env
-pythonpath = %(base)
-
-# python module to import
-module = api.app
-callable = app
-
 # make sure docker can properly shutdown uwsgi
 die-on-term = true
 
 # location and permissions of socket file
-socket = /var/www/circulation/%n.sock
+socket = /var/run/uwsgi/uwsgi.sock
 chmod-socket = 666
 
-# location of log files
-logto = /var/log/uwsgi/%n.log
-log-format = %(var.HTTP_X_FORWARDED_FOR) (%(addr)) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
-
-# The uWSGI processes and threads to use should be set as environment
-# variables in `docker-compose.yml` or in the command line when running
-# the `Dockerfile.webapp` image. The default processes used is 3 and
-# the default threads used is 2.
-if-env = UWSGI_PROCESSES
-processes = $(UWSGI_PROCESSES)
-endif =
-if-not-env = UWSGI_PROCESSES
-processes = 3
-endif =
-
-if-env = UWSGI_THREADS
-threads = $(UWSGI_THREADS)
-endif =
-if-not-env = UWSGI_THREADS
-threads = 2
-endif =
+# reload if this files changes
+touch-reload = /etc/uwsgi.ini
 
 harakiri = 300
 lazy-apps = true
-touch-reload = %(base)/uwsgi.ini
 buffer-size = 131072
 
-# reload based on memory usage
-reload-on-rss = 425
+# load any additional config
+for-glob = /etc/uwsgi.d/*
+include = %(_)
+endfor =

--- a/docker/services/uwsgi.ini
+++ b/docker/services/uwsgi.ini
@@ -8,23 +8,26 @@ pythonpath = %(base)
 module = api.app
 callable = app
 
+# make sure docker can properly shutdown uwsgi
+die-on-term = true
+
 # location and permissions of socket file
 socket = /var/www/circulation/%n.sock
 chmod-socket = 666
 
 # location of log files
 logto = /var/log/uwsgi/%n.log
-log-format = %(addr) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
+log-format = %(var.HTTP_X_FORWARDED_FOR) (%(addr)) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
 
 # The uWSGI processes and threads to use should be set as environment
 # variables in `docker-compose.yml` or in the command line when running
-# the `Dockerfile.webapp` image. The default processes used is 6 and
+# the `Dockerfile.webapp` image. The default processes used is 3 and
 # the default threads used is 2.
 if-env = UWSGI_PROCESSES
 processes = $(UWSGI_PROCESSES)
 endif =
 if-not-env = UWSGI_PROCESSES
-processes = 6
+processes = 3
 endif =
 
 if-env = UWSGI_THREADS
@@ -38,3 +41,6 @@ harakiri = 300
 lazy-apps = true
 touch-reload = %(base)/uwsgi.ini
 buffer-size = 131072
+
+# reload based on memory usage
+reload-on-rss = 425

--- a/docker/services/uwsgi.runit
+++ b/docker/services/uwsgi.runit
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-/var/www/circulation/env/bin/uwsgi --ini ~/circulation/uwsgi.ini
+exec /var/www/circulation/env/bin/uwsgi --ini /etc/uwsgi.ini

--- a/docker/services/uwsgi.runit
+++ b/docker/services/uwsgi.runit
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-source ~/circulation/env/bin/activate && uwsgi --ini ~/circulation/uwsgi.ini
+/var/www/circulation/env/bin/uwsgi --ini ~/circulation/uwsgi.ini

--- a/docker/uwsgi.sh
+++ b/docker/uwsgi.sh
@@ -2,8 +2,8 @@
 set -ex
 
 # Configure uwsgi.
-cp /ls_build/services/uwsgi.ini /var/www/circulation/uwsgi.ini
-chown simplified:simplified /var/www/circulation/uwsgi.ini
+cp /ls_build/services/uwsgi.ini /etc/uwsgi.ini
+cp -R /ls_build/services/uwsgi.d /etc/uwsgi.d
 mkdir /var/log/uwsgi
 chown -R simplified:simplified /var/log/uwsgi
 
@@ -17,7 +17,6 @@ mkdir -p $app_home/service/uwsgi
 cp /ls_build/services/uwsgi.runit $app_home/service/uwsgi/run
 chown -R simplified:simplified $app_home/service
 
-# Create an alias to restart the application.
-touch $app_home/.bash_aliases
-echo "alias restart_app=\`touch ~/circulation/uwsgi.ini\`" >> $app_home/.bash_aliases
-chown -R simplified:simplified $app_home/.bash_aliases
+# Create socket folder with correct permissions.
+mkdir /var/run/uwsgi
+chown simplified:simplified /var/run/uwsgi


### PR DESCRIPTION
## Description

Add an additional configuration option to UWSGI `die-on-term` that causes UWSGI to respect `sigterm` that happens on docker shutdown.

This PR also updates the UWSGI configuration settings included in the container to match what we are setting in the playbook. Once this is merged, we can drop our custom uwsgi configuration in the playbook.


## Motivation and Context

In the current configuration, this causes a reload, so when we shutdown the docker container, UWSGI reloads, docker waits for it to stop, then eventually times out and forcibly shuts it down. This will speed up our docker shutdown process.

Also centralize the management of the uwsgi.ini file to this repo, instead of having it overridden in the playbook.

## How Has This Been Tested?

Started, stopped the docker container. Looked at logs. Made sure that UWSGI is restarting as expected instead of timing out as it was before.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
