### PR TITLE
Add permissions to workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   sync_with_nypl:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
 
     steps:
       - name: Checkout repo to sync

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,13 +8,10 @@ env:
   # Push the built docker image only in the following cases:
   #  - The `NO_DOCKER_IMAGE` secret is not set. (Useful if you want to disable pushing
   #    of docker images in local forks of this repo).
-  #  - The branch name does not start with `dependabot/`. The dependabot service does not
-  #    have the proper security token to push to github packages.
   #  - The event that triggered this action was a `push`. If it was a PR the github action
   #    context will not have permissions to push the image to github packages.
   IMAGE_PUSH_ENABLED: ${{
       secrets.NO_DOCKER_IMAGE == null &&
-      !startsWith(github.ref, 'refs/heads/dependabot/') &&
       github.event_name == 'push'
     }}
 
@@ -23,6 +20,8 @@ jobs:
     name: ${{ matrix.module }} Tests (Py ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -64,6 +63,9 @@ jobs:
   build-docker-images:
     name: Build and push docker images
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs: [test]
 
     # We want to run on external PRs, but not on our own internal PRs as they'll be run


### PR DESCRIPTION
## Description

When Dependabot pushes branches, or automatically merges PRs, it currently doesn't have permissions to create docker images, causing builds to fail.

## Motivation and Context

Dependabot is by default given only read permissions on repositories, but it respects the repos `permissions` set in the workflow [[1]](https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/). In order to be able to push docker images it needs `packages: write` permission. 

You can set explicit workflow permissions by setting a permissions key in the workflows [[2]](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/). Setting these should actually be more secure then our previous configuration, as the defaults are quite permissive. 

I was worried that this might give too much permissions to PRs from forks, but we don't run the docker-build workflow on forks and from the blog post: 
> Pull requests from public forks are still considered a special case and will receive a read token regardless of these settings.

## How Has This Been Tested?

Since this is scoped to our actions workflows, the CI passing on this PR should give confidence this is working.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
