### PR TITLE
Bugfix/subject with missing name and identifier

### DIFF
--- a/core/metadata_layer.py
+++ b/core/metadata_layer.py
@@ -1931,14 +1931,19 @@ class Metadata(MetaToModelUtility):
 
         # Apply all new subjects to the identifier.
         for subject in list(new_subjects.values()):
-            identifier.classify(
-                data_source,
-                subject.type,
-                subject.identifier,
-                subject.name,
-                weight=subject.weight,
-            )
-            work_requires_full_recalculation = True
+            try:
+                identifier.classify(
+                    data_source,
+                    subject.type,
+                    subject.identifier,
+                    subject.name,
+                    weight=subject.weight,
+                )
+                work_requires_full_recalculation = True
+            except ValueError as e:
+                self.log.error(
+                    f"Error classifying subject: {subject} for identifier {identifier}: {e}"
+                )
 
         # Associate all links with the primary identifier.
         if replace.links and self.links is not None:


### PR DESCRIPTION
## Description

Log an error for some errors during subject classification in `Metadata.apply(), rather than treating them as fatal errors. Specifically, a subject with no name and no identifier will result in NO new classification and a logged error, rather than an exception and potential crash.

## Motivation and Context

Overdrive Format Sweep sweep crashes when a subject is missing both name and identifier.

Notion issue: [overdrive_format_sweep crashes](https://www.notion.so/lyrasis/overdrive_format_sweep-crashes-e89a69a907ec4704ade3871744a470b0)

## How Has This Been Tested?

- Added test for subject missing both `name` and `identifier`.
- All new and existing tests ran successfully.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
