### PR TITLE
Refactor DRM/Content type handling to allow for preferring schemes/types

### DIFF
--- a/api/odl.py
+++ b/api/odl.py
@@ -153,8 +153,14 @@ class ODLAPIConfiguration(ConfigurationGrouping):
             "A list of DRM schemes that will be prioritized when OPDS links are generated. "
             "DRM schemes specified earlier in the list will be prioritized over schemes specified later. "
             f"Example schemes include <tt>{DeliveryMechanism.LCP_DRM}</tt> for LCP, and <tt>{DeliveryMechanism.ADOBE_DRM}</tt> "
-            f"for Adobe DRM. "
-            "An empty list here specifies backwards-compatible behaviour where no schemes are prioritized."
+            "for Adobe DRM. "
+            "An empty list here specifies backwards-compatible behavior where no schemes are prioritized."
+            "<br/>"
+            "<br/>"
+            "<b>Note:</b> Adding any DRM scheme will cause acquisition links to be reordered into a predictable "
+            "order that prioritizes DRM-free content over content with DRM. If a book exists with <i>both</i> DRM-free "
+            "<i>and</i> DRM-encumbered formats, the DRM-free version will become preferred, which might not be how your "
+            "collection originally behaved."
         ),
         type=ConfigurationAttributeType.LIST,
         required=False,
@@ -168,8 +174,14 @@ class ODLAPIConfiguration(ConfigurationGrouping):
             "A list of content types that will be prioritized when OPDS links are generated. "
             "Content types specified earlier in the list will be prioritized over types specified later. "
             f"Example types include <tt>{MediaTypes.EPUB_MEDIA_TYPE}</tt> for EPUB, and <tt>{MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE}</tt> "
-            f"for audiobook manifests. "
-            "An empty list here specifies backwards-compatible behaviour where no types are prioritized."
+            "for audiobook manifests. "
+            "An empty list here specifies backwards-compatible behavior where no types are prioritized."
+            "<br/>"
+            "<br/>"
+            "<b>Note:</b> Adding any content type here will cause acquisition links to be reordered into a predictable "
+            "order that prioritizes DRM-free content over content with DRM. If a book exists with <i>both</i> DRM-free "
+            "<i>and</i> DRM-encumbered formats, the DRM-free version will become preferred, which might not be how your "
+            "collection originally behaved."
         ),
         type=ConfigurationAttributeType.LIST,
         required=False,

--- a/api/odl.py
+++ b/api/odl.py
@@ -48,7 +48,7 @@ from core.model.configuration import (
     ConfigurationStorage,
     HasExternalIntegration,
 )
-from core.model.licensing import LicenseStatus
+from core.model.licensing import FormatPriorities, LicenseStatus
 from core.monitor import CollectionMonitor
 from core.opds_import import OPDSImporter, OPDSImportMonitor, OPDSXMLParser
 from core.testing import DatabaseTest, MockRequestsResponse
@@ -144,6 +144,36 @@ class ODLAPIConfiguration(ConfigurationGrouping):
         required=False,
         default=DEFAULT_ENCRYPTION_ALGORITHM,
         options=ConfigurationOption.from_enum(HashingAlgorithm),
+    )
+
+    prioritized_drm_schemes = ConfigurationMetadata(
+        key=FormatPriorities.PRIORITIZED_DRM_SCHEMES_KEY,
+        label=_("Prioritized DRM schemes"),
+        description=_(
+            "A list of DRM schemes that will be prioritized when OPDS links are generated. "
+            "DRM schemes specified earlier in the list will be prioritized over schemes specified later. "
+            f"Example schemes include <tt>{DeliveryMechanism.LCP_DRM}</tt> for LCP, and <tt>{DeliveryMechanism.ADOBE_DRM}</tt> "
+            f"for Adobe DRM. "
+            "An empty list here specifies backwards-compatible behaviour where no schemes are prioritized."
+        ),
+        type=ConfigurationAttributeType.LIST,
+        required=False,
+        default=[],
+    )
+
+    prioritized_content_types = ConfigurationMetadata(
+        key=FormatPriorities.PRIORITIZED_CONTENT_TYPES_KEY,
+        label=_("Prioritized content types"),
+        description=_(
+            "A list of content types that will be prioritized when OPDS links are generated. "
+            "Content types specified earlier in the list will be prioritized over types specified later. "
+            f"Example types include <tt>{MediaTypes.EPUB_MEDIA_TYPE}</tt> for EPUB, and <tt>{MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE}</tt> "
+            f"for audiobook manifests. "
+            "An empty list here specifies backwards-compatible behaviour where no types are prioritized."
+        ),
+        type=ConfigurationAttributeType.LIST,
+        required=False,
+        default=[],
     )
 
 

--- a/api/opds.py
+++ b/api/opds.py
@@ -195,25 +195,19 @@ class CirculationManagerAnnotator(Annotator):
         # information _might_ contain a set of prioritized DRM schemes and
         # content types.
 
-        prioritized_drm_schemes: List[str]
         drm_setting: ConfigurationSetting = (
             ConfigurationSetting.for_externalintegration(
                 FormatPriorities.PRIORITIZED_DRM_SCHEMES_KEY, external
             )
         )
-        prioritized_drm_schemes = drm_setting.json_value
-        if not prioritized_drm_schemes:
-            prioritized_drm_schemes = []
+        prioritized_drm_schemes: List[str] = drm_setting.json_value or []
 
-        prioritized_content_types: List[str]
         content_setting: ConfigurationSetting = (
             ConfigurationSetting.for_externalintegration(
                 FormatPriorities.PRIORITIZED_CONTENT_TYPES_KEY, external
             )
         )
-        prioritized_content_types = content_setting.json_value
-        if not prioritized_content_types:
-            prioritized_content_types = []
+        prioritized_content_types: List[str] = content_setting.json_value or []
 
         return prioritized_drm_schemes, prioritized_content_types
 

--- a/core/model/licensing.py
+++ b/core/model/licensing.py
@@ -2068,6 +2068,9 @@ class RightsStatus(Base):
 class FormatPriorities:
     """Functions for prioritizing delivery mechanisms based on content type and DRM scheme."""
 
+    PRIORITIZED_DRM_SCHEMES_KEY: str = "prioritized_drm_schemes"
+    PRIORITIZED_CONTENT_TYPES_KEY: str = "prioritized_content_types"
+
     _prioritized_drm_schemes: Mapping[str, int]
     _prioritized_content_types: Mapping[str, int]
     _hidden_content_types: List[str]
@@ -2101,17 +2104,13 @@ class FormatPriorities:
         self._hidden_content_types = hidden_content_types
 
     def prioritize_for_pool(
-        self, pool: Optional[LicensePool]
+        self, pool: LicensePool
     ) -> List[LicensePoolDeliveryMechanism]:
         """
         Filter and prioritize the delivery mechanisms in the given pool.
         :param pool: The license pool
         :return: A list of suitable delivery mechanisms in priority order, highest priority first
         """
-        # Evidently some consumers want to call this method
-        # without a usable license pool.
-        if not pool:
-            return []
         return self.prioritize_mechanisms(pool.delivery_mechanisms)
 
     def prioritize_mechanisms(

--- a/core/model/licensing.py
+++ b/core/model/licensing.py
@@ -2090,16 +2090,12 @@ class FormatPriorities:
         # Assign priorities to each content type and DRM scheme based on their position
         # in the given lists. Higher priorities are assigned to items that appear earlier.
         self._prioritized_content_types = {}
-        _priority = 1
-        for content_type in reversed(prioritized_content_types):
-            self._prioritized_content_types[content_type] = _priority
-            _priority = _priority + 1
+        for index, content_type in enumerate(reversed(prioritized_content_types)):
+            self._prioritized_content_types[content_type] = index + 1
 
         self._prioritized_drm_schemes = {}
-        _priority = 1
-        for drm_scheme in reversed(prioritized_drm_schemes):
-            self._prioritized_drm_schemes[drm_scheme] = _priority
-            _priority = _priority + 1
+        for index, drm_scheme in enumerate(reversed(prioritized_drm_schemes)):
+            self._prioritized_drm_schemes[drm_scheme] = index + 1
 
         self._hidden_content_types = hidden_content_types
 

--- a/core/model/licensing.py
+++ b/core/model/licensing.py
@@ -2138,24 +2138,19 @@ class FormatPriorities:
 
         return mechanisms_filtered
 
-    def _drm_scheme_priority(self, drm_scheme: str) -> int:
+    def _drm_scheme_priority(self, drm_scheme: Optional[str]) -> int:
         """Determine the priority of a DRM scheme. A lack of DRM is always
         prioritized over having DRM, and prioritized schemes are always
         higher priority than non-prioritized schemes."""
 
         if not drm_scheme:
             return sys.maxsize
-        if drm_scheme in self._prioritized_drm_schemes:
-            return self._prioritized_drm_schemes[drm_scheme]
-        return 0
+        return self._prioritized_drm_schemes.get(drm_scheme, 0)
 
     def _content_type_priority(self, content_type: str) -> int:
         """Determine the priority of a content type. Prioritized content
         types are always of a higher priority than non-prioritized types."""
-
-        if content_type in self._prioritized_content_types:
-            return self._prioritized_content_types[content_type]
-        return 0
+        return self._prioritized_content_types.get(content_type, 0)
 
     @staticmethod
     def _compare_int(x: int, y: int) -> int:

--- a/core/testing.py
+++ b/core/testing.py
@@ -7,6 +7,7 @@ import time
 import uuid
 from datetime import timedelta
 from pathlib import Path
+from typing import Optional
 from unittest import mock
 
 import pytest
@@ -1659,3 +1660,45 @@ def pytest_configure(config):
         "markers", "elasticsearch: mark test as requiring elasticsearch"
     )
     config.addinivalue_line("markers", "minio: mark test as requiring minio")
+
+
+class MockDeliveryMechanism:
+    """Mocks the DeliveryMechanism class."""
+
+    drm_scheme: Optional[str]
+    content_type: Optional[str]
+
+    def __repr__(self):
+        return f"MockDeliveryMechanism(drm_scheme={self.drm_scheme}, content_type={self.content_type})"
+
+    def __eq__(self, other):
+        return (
+            self.drm_scheme == other.drm_scheme
+            and self.content_type == other.content_type
+        )
+
+    def __init__(self):
+        self.drm_scheme = None
+        self.content_type = "application/epub+zip"
+
+
+class MockLicensePoolDeliveryMechanism:
+    """Mocks the LicensePoolDeliveryMechanism."""
+
+    delivery_mechanism: MockDeliveryMechanism
+
+    def __repr__(self):
+        return f"MockLicensePoolDeliveryMechanism(delivery_mechanism={self.delivery_mechanism})"
+
+    def __eq__(self, other):
+        return self.delivery_mechanism == other.delivery_mechanism
+
+    def __init__(self):
+        self.delivery_mechanism = MockDeliveryMechanism()
+
+    @staticmethod
+    def mechanism_of(drm_scheme: Optional[str], content_type: Optional[str]):
+        _mechanism = MockLicensePoolDeliveryMechanism()
+        _mechanism.delivery_mechanism.drm_scheme = drm_scheme
+        _mechanism.delivery_mechanism.content_type = content_type
+        return _mechanism

--- a/core/testing.py
+++ b/core/testing.py
@@ -7,7 +7,6 @@ import time
 import uuid
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional
 from unittest import mock
 
 import pytest
@@ -1660,45 +1659,3 @@ def pytest_configure(config):
         "markers", "elasticsearch: mark test as requiring elasticsearch"
     )
     config.addinivalue_line("markers", "minio: mark test as requiring minio")
-
-
-class MockDeliveryMechanism:
-    """Mocks the DeliveryMechanism class."""
-
-    drm_scheme: Optional[str]
-    content_type: Optional[str]
-
-    def __repr__(self):
-        return f"MockDeliveryMechanism(drm_scheme={self.drm_scheme}, content_type={self.content_type})"
-
-    def __eq__(self, other):
-        return (
-            self.drm_scheme == other.drm_scheme
-            and self.content_type == other.content_type
-        )
-
-    def __init__(self):
-        self.drm_scheme = None
-        self.content_type = "application/epub+zip"
-
-
-class MockLicensePoolDeliveryMechanism:
-    """Mocks the LicensePoolDeliveryMechanism."""
-
-    delivery_mechanism: MockDeliveryMechanism
-
-    def __repr__(self):
-        return f"MockLicensePoolDeliveryMechanism(delivery_mechanism={self.delivery_mechanism})"
-
-    def __eq__(self, other):
-        return self.delivery_mechanism == other.delivery_mechanism
-
-    def __init__(self):
-        self.delivery_mechanism = MockDeliveryMechanism()
-
-    @staticmethod
-    def mechanism_of(drm_scheme: Optional[str], content_type: Optional[str]):
-        _mechanism = MockLicensePoolDeliveryMechanism()
-        _mechanism.delivery_mechanism.drm_scheme = drm_scheme
-        _mechanism.delivery_mechanism.content_type = content_type
-        return _mechanism

--- a/tests/core/models/test_licensing.py
+++ b/tests/core/models/test_licensing.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 import datetime
 import json
-from typing import Optional
+from typing import Callable, Optional
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
@@ -1575,45 +1575,95 @@ class TestLicensePoolDeliveryMechanism(DatabaseTest):
 
 class TestFormatPriorities:
     @pytest.fixture
-    def sample_data_0(self):
+    def mock_delivery(
+        self,
+    ) -> Callable[[Optional[str], Optional[str]], DeliveryMechanism]:
+        def delivery_mechanism(
+            drm_scheme: Optional[str] = None,
+            content_type: Optional[str] = "application/epub+zip",
+        ) -> DeliveryMechanism:
+            def _delivery_eq(self, other):
+                return (
+                    self.drm_scheme == other.drm_scheme
+                    and self.content_type == other.content_type
+                )
+
+            def _delivery_repr(self):
+                return f"DeliveryMechanism(drm_scheme={self.drm_scheme}, content_type={self.content_type})"
+
+            _delivery = MagicMock(spec=DeliveryMechanism)
+            _delivery.drm_scheme = drm_scheme
+            _delivery.content_type = content_type
+            _delivery.__eq__ = _delivery_eq
+            _delivery.__repr__ = _delivery_repr
+
+            return _delivery
+
+        return delivery_mechanism
+
+    @pytest.fixture
+    def mock_mechanism(
+        self, mock_delivery
+    ) -> Callable[[Optional[str], Optional[str]], LicensePoolDeliveryMechanism]:
+        def mechanism(
+            drm_scheme: Optional[str] = None,
+            content_type: Optional[str] = "application/epub+zip",
+        ) -> LicensePoolDeliveryMechanism:
+            def _mechanism_eq(self, other):
+                return self.delivery_mechanism == other.delivery_mechanism
+
+            def _mechanism_repr(self):
+                return f"LicensePoolDeliveryMechanism(delivery_mechanism={self.delivery_mechanism})"
+
+            _mechanism = MagicMock(spec=LicensePoolDeliveryMechanism)
+            _mechanism.delivery_mechanism = mock_delivery(drm_scheme, content_type)
+            _mechanism.__eq__ = _mechanism_eq
+            _mechanism.__repr__ = _mechanism_repr
+            return _mechanism
+
+        return mechanism
+
+    @pytest.fixture
+    def sample_data_0(self, mock_mechanism):
         """An arrangement of delivery mechanisms taken from a working database."""
-        make = TestFormatPriorities.mechanism_of
         return [
-            make("application/vnd.adobe.adept+xml", "application/epub+zip"),
-            make(
+            mock_mechanism("application/vnd.adobe.adept+xml", "application/epub+zip"),
+            mock_mechanism(
                 "Libby DRM",
                 "application/vnd.overdrive.circulation.api+json;profile=audiobook",
             ),
-            make(None, "application/audiobook+json"),
-            make(
+            mock_mechanism(None, "application/audiobook+json"),
+            mock_mechanism(
                 "application/vnd.librarysimplified.bearer-token+json", "application/pdf"
             ),
-            make(
+            mock_mechanism(
                 "application/vnd.librarysimplified.bearer-token+json",
                 "application/epub+zip",
             ),
-            make(None, "application/epub+zip"),
-            make(None, "application/pdf"),
-            make("application/vnd.librarysimplified.findaway.license+json", None),
-            make(
+            mock_mechanism(None, "application/epub+zip"),
+            mock_mechanism(None, "application/pdf"),
+            mock_mechanism(
+                "application/vnd.librarysimplified.findaway.license+json", None
+            ),
+            mock_mechanism(
                 "application/vnd.librarysimplified.bearer-token+json",
                 "application/audiobook+json",
             ),
-            make(None, "application/kepub+zip"),
-            make(None, "application/x-mobipocket-ebook"),
-            make(None, "application/x-mobi8-ebook"),
-            make(None, "text/plain; charset=utf-8"),
-            make(None, "application/octet-stream"),
-            make(None, "text/html; charset=utf-8"),
-            make(
+            mock_mechanism(None, "application/kepub+zip"),
+            mock_mechanism(None, "application/x-mobipocket-ebook"),
+            mock_mechanism(None, "application/x-mobi8-ebook"),
+            mock_mechanism(None, "text/plain; charset=utf-8"),
+            mock_mechanism(None, "application/octet-stream"),
+            mock_mechanism(None, "text/html; charset=utf-8"),
+            mock_mechanism(
                 "http://www.feedbooks.com/audiobooks/access-restriction",
                 "application/audiobook+json",
             ),
-            make(
+            mock_mechanism(
                 "application/vnd.readium.lcp.license.v1.0+json",
                 "application/audiobook+lcp",
             ),
-            make(
+            mock_mechanism(
                 "application/vnd.readium.lcp.license.v1.0+json", "application/epub+zip"
             ),
         ]
@@ -1626,22 +1676,22 @@ class TestFormatPriorities:
         )
         assert [] == priorities.prioritize_mechanisms([])
 
-    def test_identity_one(self):
+    def test_identity_one(self, mock_mechanism):
         priorities = FormatPriorities(
             prioritized_drm_schemes=[],
             prioritized_content_types=[],
             hidden_content_types=[],
         )
-        mechanism_0 = TestFormatPriorities.mechanism_of()
+        mechanism_0 = mock_mechanism()
         assert [mechanism_0] == priorities.prioritize_mechanisms([mechanism_0])
 
-    def test_hidden_types_excluded(self):
+    def test_hidden_types_excluded(self, mock_mechanism):
         priorities = FormatPriorities(
             prioritized_drm_schemes=[],
             prioritized_content_types=[],
             hidden_content_types=["application/epub+zip"],
         )
-        mechanism_0 = TestFormatPriorities.mechanism_of()
+        mechanism_0 = mock_mechanism()
         assert [] == priorities.prioritize_mechanisms([mechanism_0])
 
     def test_non_prioritized_drm_0(self, sample_data_0):
@@ -1653,52 +1703,54 @@ class TestFormatPriorities:
         expected = sample_data_0.copy()
         assert expected == priorities.prioritize_mechanisms(sample_data_0)
 
-    def test_prioritized_content_type_0(self, sample_data_0):
+    def test_prioritized_content_type_0(self, mock_mechanism, sample_data_0):
         """A simple configuration where an unusual content type is prioritized."""
         priorities = FormatPriorities(
             prioritized_drm_schemes=[],
             prioritized_content_types=["application/x-mobi8-ebook"],
             hidden_content_types=[],
         )
-        make = TestFormatPriorities.mechanism_of
+
         # We expect the mobi8-ebook format to be pushed to the front of the list.
         # All other non-DRM formats are moved to the start of the list in a more or less arbitrary order.
         expected = [
-            make(None, "application/x-mobi8-ebook"),
-            make(None, "application/audiobook+json"),
-            make(None, "application/epub+zip"),
-            make(None, "application/pdf"),
-            make(None, "application/kepub+zip"),
-            make(None, "application/x-mobipocket-ebook"),
-            make(None, "text/plain; charset=utf-8"),
-            make(None, "application/octet-stream"),
-            make(None, "text/html; charset=utf-8"),
-            make("application/vnd.adobe.adept+xml", "application/epub+zip"),
-            make(
+            mock_mechanism(None, "application/x-mobi8-ebook"),
+            mock_mechanism(None, "application/audiobook+json"),
+            mock_mechanism(None, "application/epub+zip"),
+            mock_mechanism(None, "application/pdf"),
+            mock_mechanism(None, "application/kepub+zip"),
+            mock_mechanism(None, "application/x-mobipocket-ebook"),
+            mock_mechanism(None, "text/plain; charset=utf-8"),
+            mock_mechanism(None, "application/octet-stream"),
+            mock_mechanism(None, "text/html; charset=utf-8"),
+            mock_mechanism("application/vnd.adobe.adept+xml", "application/epub+zip"),
+            mock_mechanism(
                 "Libby DRM",
                 "application/vnd.overdrive.circulation.api+json;profile=audiobook",
             ),
-            make(
+            mock_mechanism(
                 "application/vnd.librarysimplified.bearer-token+json", "application/pdf"
             ),
-            make(
+            mock_mechanism(
                 "application/vnd.librarysimplified.bearer-token+json",
                 "application/epub+zip",
             ),
-            make("application/vnd.librarysimplified.findaway.license+json", None),
-            make(
+            mock_mechanism(
+                "application/vnd.librarysimplified.findaway.license+json", None
+            ),
+            mock_mechanism(
                 "application/vnd.librarysimplified.bearer-token+json",
                 "application/audiobook+json",
             ),
-            make(
+            mock_mechanism(
                 "http://www.feedbooks.com/audiobooks/access-restriction",
                 "application/audiobook+json",
             ),
-            make(
+            mock_mechanism(
                 "application/vnd.readium.lcp.license.v1.0+json",
                 "application/audiobook+lcp",
             ),
-            make(
+            mock_mechanism(
                 "application/vnd.readium.lcp.license.v1.0+json", "application/epub+zip"
             ),
         ]
@@ -1707,7 +1759,7 @@ class TestFormatPriorities:
         assert expected == received
         assert len(sample_data_0) == len(received)
 
-    def test_prioritized_content_type_1(self, sample_data_0):
+    def test_prioritized_content_type_1(self, mock_mechanism, sample_data_0):
         """A test of a more aggressive configuration where multiple content types
         and DRM schemes are prioritized."""
         priorities = FormatPriorities(
@@ -1730,39 +1782,40 @@ class TestFormatPriorities:
                 "text/html; charset=utf-8",
             ],
         )
-        make = TestFormatPriorities.mechanism_of
         expected = [
-            make(None, "application/epub+zip"),
-            make(None, "application/audiobook+json"),
-            make(None, "application/pdf"),
-            make(
+            mock_mechanism(None, "application/epub+zip"),
+            mock_mechanism(None, "application/audiobook+json"),
+            mock_mechanism(None, "application/pdf"),
+            mock_mechanism(
                 "application/vnd.readium.lcp.license.v1.0+json", "application/epub+zip"
             ),
-            make(
+            mock_mechanism(
                 "application/vnd.readium.lcp.license.v1.0+json",
                 "application/audiobook+lcp",
             ),
-            make(
+            mock_mechanism(
                 "application/vnd.librarysimplified.bearer-token+json",
                 "application/epub+zip",
             ),
-            make(
+            mock_mechanism(
                 "application/vnd.librarysimplified.bearer-token+json",
                 "application/audiobook+json",
             ),
-            make(
+            mock_mechanism(
                 "application/vnd.librarysimplified.bearer-token+json", "application/pdf"
             ),
-            make("application/vnd.adobe.adept+xml", "application/epub+zip"),
-            make(
+            mock_mechanism("application/vnd.adobe.adept+xml", "application/epub+zip"),
+            mock_mechanism(
                 "http://www.feedbooks.com/audiobooks/access-restriction",
                 "application/audiobook+json",
             ),
-            make(
+            mock_mechanism(
                 "Libby DRM",
                 "application/vnd.overdrive.circulation.api+json;profile=audiobook",
             ),
-            make("application/vnd.librarysimplified.findaway.license+json", None),
+            mock_mechanism(
+                "application/vnd.librarysimplified.findaway.license+json", None
+            ),
         ]
         received = priorities.prioritize_mechanisms(sample_data_0)
         assert expected == received
@@ -1778,35 +1831,3 @@ class TestFormatPriorities:
                 item["type"] = mechanism.delivery_mechanism.content_type
             output.append(item)
         print(json.dumps(output, indent=2))
-
-    @staticmethod
-    def mechanism_of(
-        drm_scheme: Optional[str] = None,
-        content_type: Optional[str] = "application/epub+zip",
-    ):
-        def _delivery_eq(self, other):
-            return (
-                self.drm_scheme == other.drm_scheme
-                and self.content_type == other.content_type
-            )
-
-        def _delivery_repr(self):
-            return f"DeliveryMechanism(drm_scheme={self.drm_scheme}, content_type={self.content_type})"
-
-        _delivery = MagicMock(spec=DeliveryMechanism)
-        _delivery.drm_scheme = drm_scheme
-        _delivery.content_type = content_type
-        _delivery.__eq__ = _delivery_eq
-        _delivery.__repr__ = _delivery_repr
-
-        def _mechanism_eq(self, other):
-            return self.delivery_mechanism == other.delivery_mechanism
-
-        def _mechanism_repr(self):
-            return f"LicensePoolDeliveryMechanism(delivery_mechanism={self.delivery_mechanism})"
-
-        _mechanism = MagicMock(spec=LicensePoolDeliveryMechanism)
-        _mechanism.delivery_mechanism = _delivery
-        _mechanism.__eq__ = _mechanism_eq
-        _mechanism.__repr__ = _mechanism_repr
-        return _mechanism

--- a/tests/core/models/test_licensing.py
+++ b/tests/core/models/test_licensing.py
@@ -1573,44 +1573,49 @@ class TestLicensePoolDeliveryMechanism(DatabaseTest):
 
 
 class TestFormatPriorities:
-
-    make = MockLicensePoolDeliveryMechanism.mechanism_of
-
-    """An arrangement of delivery mechanisms taken from a working database."""
-    sample_data_0 = [
-        make("application/vnd.adobe.adept+xml", "application/epub+zip"),
-        make(
-            "Libby DRM",
-            "application/vnd.overdrive.circulation.api+json;profile=audiobook",
-        ),
-        make(None, "application/audiobook+json"),
-        make("application/vnd.librarysimplified.bearer-token+json", "application/pdf"),
-        make(
-            "application/vnd.librarysimplified.bearer-token+json",
-            "application/epub+zip",
-        ),
-        make(None, "application/epub+zip"),
-        make(None, "application/pdf"),
-        make("application/vnd.librarysimplified.findaway.license+json", None),
-        make(
-            "application/vnd.librarysimplified.bearer-token+json",
-            "application/audiobook+json",
-        ),
-        make(None, "application/kepub+zip"),
-        make(None, "application/x-mobipocket-ebook"),
-        make(None, "application/x-mobi8-ebook"),
-        make(None, "text/plain; charset=utf-8"),
-        make(None, "application/octet-stream"),
-        make(None, "text/html; charset=utf-8"),
-        make(
-            "http://www.feedbooks.com/audiobooks/access-restriction",
-            "application/audiobook+json",
-        ),
-        make(
-            "application/vnd.readium.lcp.license.v1.0+json", "application/audiobook+lcp"
-        ),
-        make("application/vnd.readium.lcp.license.v1.0+json", "application/epub+zip"),
-    ]
+    @pytest.fixture
+    def sample_data_0(self):
+        """An arrangement of delivery mechanisms taken from a working database."""
+        make = MockLicensePoolDeliveryMechanism.mechanism_of
+        return [
+            make("application/vnd.adobe.adept+xml", "application/epub+zip"),
+            make(
+                "Libby DRM",
+                "application/vnd.overdrive.circulation.api+json;profile=audiobook",
+            ),
+            make(None, "application/audiobook+json"),
+            make(
+                "application/vnd.librarysimplified.bearer-token+json", "application/pdf"
+            ),
+            make(
+                "application/vnd.librarysimplified.bearer-token+json",
+                "application/epub+zip",
+            ),
+            make(None, "application/epub+zip"),
+            make(None, "application/pdf"),
+            make("application/vnd.librarysimplified.findaway.license+json", None),
+            make(
+                "application/vnd.librarysimplified.bearer-token+json",
+                "application/audiobook+json",
+            ),
+            make(None, "application/kepub+zip"),
+            make(None, "application/x-mobipocket-ebook"),
+            make(None, "application/x-mobi8-ebook"),
+            make(None, "text/plain; charset=utf-8"),
+            make(None, "application/octet-stream"),
+            make(None, "text/html; charset=utf-8"),
+            make(
+                "http://www.feedbooks.com/audiobooks/access-restriction",
+                "application/audiobook+json",
+            ),
+            make(
+                "application/vnd.readium.lcp.license.v1.0+json",
+                "application/audiobook+lcp",
+            ),
+            make(
+                "application/vnd.readium.lcp.license.v1.0+json", "application/epub+zip"
+            ),
+        ]
 
     def test_identity_empty(self):
         priorities = FormatPriorities(
@@ -1638,16 +1643,16 @@ class TestFormatPriorities:
         mechanism_0 = MockLicensePoolDeliveryMechanism()
         assert [] == priorities.prioritize_mechanisms([mechanism_0])
 
-    def test_non_prioritized_drm_0(self):
+    def test_non_prioritized_drm_0(self, sample_data_0):
         priorities = FormatPriorities(
             prioritized_drm_schemes=[],
             prioritized_content_types=[],
             hidden_content_types=[],
         )
-        expected = self.sample_data_0.copy()
-        assert expected == priorities.prioritize_mechanisms(self.sample_data_0)
+        expected = sample_data_0.copy()
+        assert expected == priorities.prioritize_mechanisms(sample_data_0)
 
-    def test_prioritized_content_type_0(self):
+    def test_prioritized_content_type_0(self, sample_data_0):
         """A simple configuration where an unusual content type is prioritized."""
         priorities = FormatPriorities(
             prioritized_drm_schemes=[],
@@ -1697,11 +1702,11 @@ class TestFormatPriorities:
             ),
         ]
 
-        received = priorities.prioritize_mechanisms(self.sample_data_0)
+        received = priorities.prioritize_mechanisms(sample_data_0)
         assert expected == received
-        assert len(self.sample_data_0) == len(received)
+        assert len(sample_data_0) == len(received)
 
-    def test_prioritized_content_type_1(self):
+    def test_prioritized_content_type_1(self, sample_data_0):
         """A test of a more aggressive configuration where multiple content types
         and DRM schemes are prioritized."""
         priorities = FormatPriorities(
@@ -1758,7 +1763,7 @@ class TestFormatPriorities:
             ),
             make("application/vnd.librarysimplified.findaway.license+json", None),
         ]
-        received = priorities.prioritize_mechanisms(self.sample_data_0)
+        received = priorities.prioritize_mechanisms(sample_data_0)
         assert expected == received
 
     @staticmethod


### PR DESCRIPTION
## Description

This implements a couple of changes that allow for preferring LCP over Adobe DRM, and also make book content type selection deterministic instead of being based on whatever arbitrary order rows appear in the database. This is broken up into three parts:

* This introduces a new class, `FormatPriorities`, which is used to filter and sort the delivery mechanisms available from a license pool by DRM scheme and content type. This is used when producing acquisition links for OPDS entries. When not provided with any kind of configuration information, the `FormatPriorities` class is designed to give behaviour equivalent to the old (arbitrary) behaviour of iterating over delivery mechanisms in database order. When provided with at least one DRM scheme or content type, links with those schemes/types appear first. DRM-free formats are prioritized over DRM encumbered formats if both happen to be available for a given book.
    
* The OPDS generation code has been adjusted to examine the configuration settings of the collection underlying the given `LicensePool`. Two keys are consulted: `prioritized_drm_schemes` and `prioritized_content_types`. These are parsed as JSON lists and passed to the `FormatPriorities` class when an OPDS entry is generated. By default, these configuration settings will be treated as empty lists when not configured, and so the `FormatPriorities` class keeps the existing acquisition link ordering behaviour.

* The ODL (and ODL2) external integrations have been updated with the `prioritized_drm_schemes` and `prioritized_content_types` fields that allow for setting DRM schemes and content types to be prioritized.

All new code has been written with type annotations, and I've generally introduced annotations to any code I've had to modify.

Before, the book `The Pocket Guide to Scandals in the Aristocracy` was served with these acquisitions:

```
    <link type="application/atom+xml;type=entry;profile=opds-catalog" rel="http://opds-spec.org/acquisition/borrow" href="http://localhost:6500/HAZELNUT/works/ISBN/9781844687503/borrow">
      <opds:indirectAcquisition type="application/vnd.adobe.adept+xml">
        <opds:indirectAcquisition type="application/epub+zip"/>
      </opds:indirectAcquisition>
      <opds:indirectAcquisition type="application/vnd.readium.lcp.license.v1.0+json">
        <opds:indirectAcquisition type="application/epub+zip"/>
      </opds:indirectAcquisition>
      <opds:availability status="available"/>
      <opds:holds total="0"/>
      <opds:copies total="40" available="10"/>
    </link>
```

After setting this configuration option:

![lcp](https://user-images.githubusercontent.com/612494/152394598-ee87906f-8314-45e7-8ac4-0a01fcd6e1f4.png)

The book is now served with these acquisitions instead:

```
    <link type="application/atom+xml;type=entry;profile=opds-catalog" rel="http://opds-spec.org/acquisition/borrow" href="http://localhost:6500/HAZELNUT/works/ISBN/9781844687503/borrow">
      <opds:indirectAcquisition type="application/vnd.readium.lcp.license.v1.0+json">
        <opds:indirectAcquisition type="application/epub+zip"/>
      </opds:indirectAcquisition>
      <opds:indirectAcquisition type="application/vnd.adobe.adept+xml">
        <opds:indirectAcquisition type="application/epub+zip"/>
      </opds:indirectAcquisition>
      <opds:availability status="available"/>
      <opds:holds total="0"/>
      <opds:copies total="40" available="10"/>
    </link>
```

## Motivation and Context

https://www.notion.so/lyrasis/Create-configuration-setting-to-prefer-LCP-DRM-47eb9356474f43a780fbaca9d5b29722

## How Has This Been Tested?

New tests were written to check the new behaviour is correct.
Existing tests were left unmodified to ensure that the new code is backwards compatible.
I tested locally against a "TEST Palace Marketplace" database.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
