### PR TITLE
Remove references to six

### DIFF
--- a/api/saml/auth.py
+++ b/api/saml/auth.py
@@ -1,7 +1,6 @@
 import logging
 from urllib.parse import urlparse
 
-import six
 from flask import request
 from flask_babel import lazy_gettext as _
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
@@ -176,7 +175,7 @@ class SAMLAuthenticationManager(object):
                 "An unexpected error occurred during filtering {0}".format(subject)
             )
 
-            return SAML_GENERIC_ERROR.detailed(six.ensure_text(str(exception)))
+            return SAML_GENERIC_ERROR.detailed(str(exception))
 
     @property
     def configuration(self):
@@ -229,7 +228,7 @@ class SAMLAuthenticationManager(object):
                 "Unexpected exception occurred while initiating authentication workflow"
             )
 
-            return SAML_GENERIC_ERROR.detailed(six.ensure_text(str(exception)))
+            return SAML_GENERIC_ERROR.detailed(str(exception))
 
     def finish_authentication(self, db, idp_entity_id):
         """Finish the SAML authentication workflow by validating AuthnResponse and extracting a SAML assertion from it.

--- a/api/saml/configuration/validator.py
+++ b/api/saml/configuration/validator.py
@@ -2,7 +2,6 @@ import logging
 import re
 from enum import Enum
 
-import six
 from flask_babel import lazy_gettext as _
 
 from api.admin.problem_details import INCOMPLETE_CONFIGURATION
@@ -140,13 +139,13 @@ class SAMLSettingsValidator(Validator):
             if provider_type == ProviderType.ServiceProvider:
                 message = (
                     "Service Provider's metadata has incorrect format: {0}".format(
-                        six.ensure_text(str(exception))
+                        str(exception)
                     )
                 )
             else:
                 message = (
                     "Identity Provider's metadata has incorrect format: {0}".format(
-                        six.ensure_text(str(exception))
+                        str(exception)
                     )
                 )
 
@@ -276,7 +275,7 @@ class SAMLSettingsValidator(Validator):
                 return SAML_INCORRECT_FILTRATION_EXPRESSION.detailed(
                     _(
                         "SAML filtration expression has an incorrect format: {0}".format(
-                            six.ensure_text(str(exception))
+                            str(exception)
                         )
                     )
                 )
@@ -316,16 +315,14 @@ class SAMLSettingsValidator(Validator):
                     return SAML_INCORRECT_PATRON_ID_REGULAR_EXPRESSION.detailed(
                         _(
                             "SAML patron ID regular expression '{0}' does not have mandatory named group '{1}'".format(
-                                six.ensure_text(patron_id_regular_expression),
-                                six.ensure_text(
-                                    SAMLSubjectPatronIDExtractor.PATRON_ID_REGULAR_EXPRESSION_NAMED_GROUP
-                                ),
+                                patron_id_regular_expression,
+                                SAMLSubjectPatronIDExtractor.PATRON_ID_REGULAR_EXPRESSION_NAMED_GROUP,
                             )
                         )
                     )
             except re.error as exception:
                 error_message = "SAML patron ID regular expression '{0}' has an incorrect format: {1}".format(
-                    six.ensure_text(patron_id_regular_expression), exception
+                    patron_id_regular_expression, exception
                 )
 
                 self._logger.exception(error_message)

--- a/api/saml/metadata/federations/validator.py
+++ b/api/saml/metadata/federations/validator.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 from abc import ABCMeta
 
-import six
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from onelogin.saml2.xmlparser import fromstring
 
@@ -14,8 +13,7 @@ class SAMLFederatedMetadataValidationError(BaseError):
     """Raised in the case of any errors happened during SAML metadata validation."""
 
 
-@six.add_metaclass(ABCMeta)
-class SAMLFederatedMetadataValidator(object):
+class SAMLFederatedMetadataValidator(metaclass=ABCMeta):
     """Base class for all validators checking correctness of SAML federated metadata."""
 
     def validate(self, federation, metadata):
@@ -182,9 +180,7 @@ class SAMLMetadataSignatureValidator(SAMLFederatedMetadataValidator):
                 metadata, federation.certificate, raise_exceptions=True
             )
         except Exception as exception:
-            raise SAMLFederatedMetadataValidationError(
-                six.ensure_text(str(exception)), exception
-            )
+            raise SAMLFederatedMetadataValidationError(str(exception), exception)
 
         self._logger.info(
             "Finished verifying the validity of the metadata's signature belonging to {0}".format(

--- a/api/saml/metadata/model.py
+++ b/api/saml/metadata/model.py
@@ -5,7 +5,6 @@ from enum import Enum
 from json import JSONDecoder, JSONEncoder
 from json.decoder import WHITESPACE
 
-import six
 from onelogin.saml2.constants import OneLogin_Saml2_Constants
 
 from core.util.datetime_helpers import from_timestamp, utc_now
@@ -1352,9 +1351,7 @@ class SAMLSubjectPatronIDExtractor(object):
         :rtype: Optional[str]
         """
         self._logger.info(
-            "Trying to extract a unique patron ID from {0}".format(
-                six.ensure_text(repr(subject))
-            )
+            "Trying to extract a unique patron ID from {0}".format(repr(subject))
         )
 
         patron_id = None
@@ -1380,8 +1377,8 @@ class SAMLSubjectPatronIDExtractor(object):
 
         self._logger.info(
             "Extracted a unique patron ID from {0}: {1}".format(
-                six.ensure_text(repr(subject)),
-                six.ensure_text(patron_id) if patron_id else "",
+                repr(subject),
+                patron_id if patron_id else "",
             )
         )
 


### PR DESCRIPTION
## Description

Even though we don't have the `six` package in our dependencies, it appears we import and call a few functions from six in our code 😅 .

## Motivation and Context

Remove unnecessary references to `six` still present in the codebase.

## How Has This Been Tested?

Ran unit tests.
