### PR TITLE
Show diff on pre-commit lint failure

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,4 +30,4 @@ jobs:
           restore-keys: pre-commit-${{ runner.os }}-py${{ env.PYTHON_VERSION }}
 
       - name: Lint
-        run: pre-commit run --all-files
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
     rev: v0.19.0
     hooks:
       - id: toml-sort
-        args: [-aiI]
+        args: [--all, --in-place, --ignore-case]
         files: pyproject.toml
 
   - repo: https://github.com/jackdewinter/pymarkdown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
     hooks:
       - id: toml-sort
         args: [-aiI]
+        files: pyproject.toml
 
   - repo: https://github.com/jackdewinter/pymarkdown
     rev: v0.9.3


### PR DESCRIPTION
## Description

Seeing some strange behavior where lints are failing in our repo, adding `--show-diff-on-failure` since this will help troubleshoot whats going on, and is nice to have in general.
