### PR TITLE
Feaure/in memory batching

### DIFF
--- a/bin/equivalent_identifiers_refresh
+++ b/bin/equivalent_identifiers_refresh
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+"""Re-index Equivalent identifiers
+"""
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.equivalents_coverage import EquivalentIdentifiersCoverageProvider
+from core.scripts import RunCoverageProviderScript
+
+RunCoverageProviderScript(EquivalentIdentifiersCoverageProvider).run()

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -1,4 +1,3 @@
-from ast import operator
 import logging
 import traceback
 from typing import Optional, Union
@@ -6,7 +5,6 @@ from typing import Optional, Union
 from sqlalchemy.orm import Load
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.functions import func
-from sqlalchemy.orm import Load, joinedload
 
 from core.model.coverage import EquivalencyCoverageRecord
 

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -1,3 +1,4 @@
+from ast import operator
 import logging
 import traceback
 from typing import Optional, Union
@@ -5,6 +6,7 @@ from typing import Optional, Union
 from sqlalchemy.orm import Load
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.functions import func
+from sqlalchemy.orm import Load, joinedload
 
 from . import log  # This sets the appropriate log format.
 from .metadata_layer import ReplacementPolicy, TimestampData
@@ -187,6 +189,7 @@ class BaseCoverageProvider(object):
         self.cutoff_time = cutoff_time
         self.registered_only = registered_only
         self.collection_id = None
+        self._last_batch_id = None
 
     @property
     def log(self):

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -187,7 +187,6 @@ class BaseCoverageProvider(object):
         self.cutoff_time = cutoff_time
         self.registered_only = registered_only
         self.collection_id = None
-        self._last_batch_id = None
 
     @property
     def log(self):
@@ -343,14 +342,14 @@ class BaseCoverageProvider(object):
         qu = self.items_that_need_coverage(count_as_covered=count_as_covered)
 
         # Running this statement only ONCE as it adds an unbounded query, very bad for the DB cluster
-        if self._last_batch_id is None:
+        if progress.offset == 0:
             self.log.info(
                 "%d items need coverage%s", qu.count(), count_as_covered_message
             )
         else:
             self.log.info(
                 "Covering items after %d : %s",
-                self._last_batch_id,
+                progress.offset,
                 count_as_covered_message,
             )
 
@@ -359,14 +358,10 @@ class BaseCoverageProvider(object):
         # Hence we make use of the indexed id attribute for offset
         # This is only possible because the we are ordering by this attribute
         # Else it would not give us the correct batching
-        if self._last_batch_id is not None:
-            qu = qu.filter(WorkCoverageRecord.id > self._last_batch_id)
+        qu = qu.offset(progress.offset)
         batch = qu.limit(self.batch_size)
-        batch_count = batch.count()
-
         batch_results = batch.all()
-        works = [wcr.work for wcr in batch_results]
-        self._last_batch_id = batch_results[-1].id
+        batch_count = len(batch_results)
 
         if not batch_count:
             # The batch is empty. We're done.
@@ -377,7 +372,7 @@ class BaseCoverageProvider(object):
             successes,
             transient_failures,
             persistent_failures,
-        ), results = self.process_batch_and_handle_results(works)
+        ), results = self.process_batch_and_handle_results(batch_results)
 
         # Update the running totals so that the service's eventual timestamp
         # will have a useful .achievements.
@@ -1468,7 +1463,7 @@ class WorkCoverageProvider(BaseCoverageProvider):
         :param: Only Works connected with one of the given identifiers
             are chosen.
         """
-        qu = WorkCoverageRecord.missing_coverage_from(
+        qu = Work.missing_coverage_from(
             self._db,
             operation=self.operation,
             count_as_missing_before=self.cutoff_time,

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -1,11 +1,10 @@
-from ast import operator
 import logging
 import traceback
 from typing import Optional, Union
 
+from sqlalchemy.orm import Load
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.functions import func
-from sqlalchemy.orm import Load, joinedload
 
 from . import log  # This sets the appropriate log format.
 from .metadata_layer import ReplacementPolicy, TimestampData
@@ -345,11 +344,17 @@ class BaseCoverageProvider(object):
 
         # Running this statement only ONCE as it adds an unbounded query, very bad for the DB cluster
         if self._last_batch_id is None:
-            self.log.info("%d items need coverage%s", qu.count(), count_as_covered_message)
+            self.log.info(
+                "%d items need coverage%s", qu.count(), count_as_covered_message
+            )
         else:
-            self.log.info("Covering items after %d : %s", self._last_batch_id, count_as_covered_message)
+            self.log.info(
+                "Covering items after %d : %s",
+                self._last_batch_id,
+                count_as_covered_message,
+            )
 
-        # This used to be an OFFSET query, 
+        # This used to be an OFFSET query,
         # however postgresql will ALWAYS do a seq scan in this case
         # Hence we make use of the indexed id attribute for offset
         # This is only possible because the we are ordering by this attribute
@@ -1463,9 +1468,13 @@ class WorkCoverageProvider(BaseCoverageProvider):
         :param: Only Works connected with one of the given identifiers
             are chosen.
         """
-        qu = WorkCoverageRecord.missing_coverage_from(self._db, operation=self.operation, 
-                                            count_as_missing_before=self.cutoff_time, **kwargs)
-        qu = qu.options(Load(Work).lazyload('*'))
+        qu = WorkCoverageRecord.missing_coverage_from(
+            self._db,
+            operation=self.operation,
+            count_as_missing_before=self.cutoff_time,
+            **kwargs
+        )
+        qu = qu.options(Load(Work).lazyload("*"))
 
         if identifiers:
             ids = [x.id for x in identifiers]

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -1,4 +1,3 @@
-from ast import operator
 import logging
 import traceback
 from typing import Optional, Union
@@ -6,7 +5,6 @@ from typing import Optional, Union
 from sqlalchemy.orm import Load
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.functions import func
-from sqlalchemy.orm import Load, joinedload
 
 from . import log  # This sets the appropriate log format.
 from .metadata_layer import ReplacementPolicy, TimestampData

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -1,3 +1,4 @@
+from ast import operator
 import logging
 import traceback
 from typing import Optional, Union
@@ -5,6 +6,7 @@ from typing import Optional, Union
 from sqlalchemy.orm import Load
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.functions import func
+from sqlalchemy.orm import Load, joinedload
 
 from core.model.coverage import EquivalencyCoverageRecord
 
@@ -203,6 +205,7 @@ class BaseCoverageProvider(object):
         self.cutoff_time = cutoff_time
         self.registered_only = registered_only
         self.collection_id = None
+        self._last_batch_id = None
 
     @property
     def log(self):

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -203,7 +203,6 @@ class BaseCoverageProvider(object):
         self.cutoff_time = cutoff_time
         self.registered_only = registered_only
         self.collection_id = None
-        self._last_batch_id = None
 
     @property
     def log(self):

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -187,7 +187,6 @@ class BaseCoverageProvider(object):
         self.cutoff_time = cutoff_time
         self.registered_only = registered_only
         self.collection_id = None
-        self._last_batch_id = None
 
     @property
     def log(self):

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -342,14 +342,14 @@ class BaseCoverageProvider(object):
         qu = self.items_that_need_coverage(count_as_covered=count_as_covered)
 
         # Running this statement only ONCE as it adds an unbounded query, very bad for the DB cluster
-        if progress.offset == 0:
+        if progress.successes == 0:
             self.log.info(
                 "%d items need coverage%s", qu.count(), count_as_covered_message
             )
         else:
             self.log.info(
-                "Covering items after %d : %s",
-                progress.offset,
+                "Covering items after %d successes: %s",
+                progress.successes,
                 count_as_covered_message,
             )
 

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import Load
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.functions import func
 
+from core.model.coverage import EquivalencyCoverageRecord
+
 from . import log  # This sets the appropriate log format.
 from .metadata_layer import ReplacementPolicy, TimestampData
 from .model import (
@@ -71,6 +73,20 @@ class CoverageFailure(object):
     def to_work_coverage_record(self, operation):
         """Convert this failure into a WorkCoverageRecord."""
         record, ignore = WorkCoverageRecord.add_for(self.obj, operation=operation)
+        record.exception = self.exception
+        if self.transient:
+            record.status = CoverageRecord.TRANSIENT_FAILURE
+        else:
+            record.status = CoverageRecord.PERSISTENT_FAILURE
+        return record
+
+    def to_equivalency_coverage_record(
+        self, operation: str
+    ) -> EquivalencyCoverageRecord:
+        """Convert this failure into a EquivalencyCoverageRecord."""
+        record, ignore = EquivalencyCoverageRecord.add_for(
+            self.obj, operation=operation
+        )
         record.exception = self.exception
         if self.transient:
             record.status = CoverageRecord.TRANSIENT_FAILURE

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -353,11 +353,6 @@ class BaseCoverageProvider(object):
                 count_as_covered_message,
             )
 
-        # This used to be an OFFSET query,
-        # however postgresql will ALWAYS do a seq scan in this case
-        # Hence we make use of the indexed id attribute for offset
-        # This is only possible because the we are ordering by this attribute
-        # Else it would not give us the correct batching
         qu = qu.offset(progress.offset)
         batch = qu.limit(self.batch_size)
         batch_results = batch.all()

--- a/core/equivalents_coverage.py
+++ b/core/equivalents_coverage.py
@@ -1,0 +1,158 @@
+from typing import List, Set
+
+from sqlalchemy import delete
+from sqlalchemy.orm import joinedload
+
+from core.coverage import BaseCoverageProvider, CoverageFailure
+from core.model.coverage import EquivalencyCoverageRecord
+from core.model.identifier import Equivalency, Identifier, RecursiveEquivalencyCache
+
+
+class EquivalentIdentifiersCoverageProvider(BaseCoverageProvider):
+
+    SERVICE_NAME = "Equivalent identifiers coverage provider"
+
+    DEFAULT_BATCH_SIZE = 50
+
+    OPERATION = EquivalencyCoverageRecord.RECURSIVE_EQUIVALENCY_REFRESH
+
+    def __init__(
+        self, _db, batch_size=None, cutoff_time=None, registered_only=False, **kwargs
+    ):
+        # Set of identifiers covered this run of the provider
+        self._already_covered_identifiers = set()
+        super().__init__(_db, batch_size, cutoff_time, registered_only)
+
+    def run(self):
+        self.update_missing_coverage_records()
+        return super().run()
+
+    def items_that_need_coverage(self, identifiers=None, **kwargs):
+        qu = (
+            self._db.query(EquivalencyCoverageRecord)
+            .filter(EquivalencyCoverageRecord.operation == self.operation)
+            .order_by(EquivalencyCoverageRecord.id)
+            .options(joinedload(EquivalencyCoverageRecord.equivalency))
+        )
+
+        # Need this function exactly, unfortuanately its in workcoveragerecord
+        missing = EquivalencyCoverageRecord.not_covered(
+            kwargs.get("count_as_covered"), kwargs.get("count_as_missing_before")
+        )
+        qu = qu.filter(missing)
+
+        # print ([(q.id, q.status) for q in list(qu.all())[:5]])
+
+        return qu
+
+    def _identifiers_for_coverage(
+        self, records: List[EquivalencyCoverageRecord]
+    ) -> Set[int]:
+
+        equivs = [r.equivalency for r in records]
+        # process both inputs and outputs
+        identifier_ids = [eq.input_id for eq in equivs]
+        identifier_ids.extend([eq.output_id for eq in equivs])
+        identifier_ids = set(identifier_ids)
+
+        # Any identifier found, should be recalculated
+        # However we must recalculate any other chain these identifiers were part of also
+        # Since now those chains MAY contain this modified equivalency
+        other_chains = self._db.query(RecursiveEquivalencyCache).filter(
+            RecursiveEquivalencyCache.identifier_id.in_(identifier_ids)
+        )
+        for item in other_chains.all():
+            identifier_ids.add(item.parent_identifier_id)
+
+        return identifier_ids
+
+    def process_batch(self, batch):
+        # print (batch)
+        completed_identifiers = set()
+        identifier_ids = self._identifiers_for_coverage(batch)
+
+        qu = Identifier.recursively_equivalent_identifier_ids_query(Identifier.id)
+        qu = (
+            qu.select_from(Identifier)
+            .where(Identifier.id.in_(identifier_ids))
+            .column(Identifier.id)
+        )
+
+        # print (qu)
+        chained_identifiers = self._db.execute(qu).fetchall()
+        print(chained_identifiers)
+        print(len(chained_identifiers))
+
+        # We don't want to cover identifiers already looped over
+        identifier_ids.difference_update(self._already_covered_identifiers)
+
+        recursive_equivs = []
+        for link_id, parent_id in chained_identifiers:
+
+            # First time around we MUST delete any chains formed from this identifier before
+            if parent_id not in completed_identifiers:
+                delete_stmt = delete(RecursiveEquivalencyCache).where(
+                    RecursiveEquivalencyCache.parent_identifier_id == parent_id
+                )
+                self._db.execute(delete_stmt)
+
+            recursive_equivs.append(
+                RecursiveEquivalencyCache(
+                    parent_identifier_id=parent_id, identifier_id=link_id
+                )
+            )
+            completed_identifiers.add(parent_id)
+
+        self._db.add_all(recursive_equivs)
+
+        print("done")
+        # raise Exception()
+        self._already_covered_identifiers.update(completed_identifiers)
+
+        ret = [
+            b
+            for b in batch
+            if completed_identifiers.issuperset(
+                (b.equivalency.input_id, b.equivalency.output_id)
+            )
+        ]
+        print(len(ret))
+        # print ([r.id for r in ret])
+        return ret
+
+    def failure_for_ignored_item(self, equivalency):
+        """TODO: this method"""
+        print("RECORD FAILED IGNORE", equivalency)
+        return None
+
+    def record_failure_as_coverage_record(self, failure):
+        """TODO: this method"""
+        print("RECORD FAILED", failure)
+        return CoverageFailure(failure, "Did not run")
+
+    def add_coverage_record_for(self, item: EquivalencyCoverageRecord):
+        return EquivalencyCoverageRecord.add_for(
+            item.equivalency, operation=self.operation
+        )
+
+    def update_missing_coverage_records(self):
+        """
+        Register coveragerecords for all equivalents without records
+        This is required so we don't run a seq scan per loop
+        but rather ONCE at the start of the job
+        """
+        qu = (
+            self._db.query(Equivalency)
+            .outerjoin(
+                EquivalencyCoverageRecord,
+                Equivalency.id == EquivalencyCoverageRecord.equivalency_id,
+            )
+            .filter(EquivalencyCoverageRecord.id == None)
+        )
+
+        eqs_without_records = qu.all()
+        print("PRINT", len(eqs_without_records))
+
+        EquivalencyCoverageRecord.bulk_add(
+            self._db, eqs_without_records, self.operation, batch_size=500
+        )

--- a/core/equivalents_coverage.py
+++ b/core/equivalents_coverage.py
@@ -1,4 +1,4 @@
-from typing import List, Set
+from typing import List, Optional, Set
 
 from sqlalchemy import delete
 from sqlalchemy.orm import joinedload
@@ -45,13 +45,13 @@ class EquivalentIdentifiersCoverageProvider(BaseCoverageProvider):
 
     def _identifiers_for_coverage(
         self, records: List[EquivalencyCoverageRecord]
-    ) -> Set[int]:
+    ) -> Set[Optional[int]]:
 
         equivs = [r.equivalency for r in records]
         # process both inputs and outputs
-        identifier_ids = [eq.input_id for eq in equivs]
-        identifier_ids.extend([eq.output_id for eq in equivs])
-        identifier_ids = set(identifier_ids)
+        identifier_ids_list: List[Optional[int]] = [eq.input_id for eq in equivs]
+        identifier_ids_list.extend([eq.output_id for eq in equivs])
+        identifier_ids: Set[Optional[int]] = set(identifier_ids_list)
 
         # Any identifier found, should be recalculated
         # However we must recalculate any other chain these identifiers were part of also

--- a/core/equivalents_coverage.py
+++ b/core/equivalents_coverage.py
@@ -41,8 +41,6 @@ class EquivalentIdentifiersCoverageProvider(BaseCoverageProvider):
         )
         qu = qu.filter(missing)
 
-        # print ([(q.id, q.status) for q in list(qu.all())[:5]])
-
         return qu
 
     def _identifiers_for_coverage(
@@ -67,7 +65,6 @@ class EquivalentIdentifiersCoverageProvider(BaseCoverageProvider):
         return identifier_ids
 
     def process_batch(self, batch):
-        # print (batch)
         completed_identifiers = set()
         identifier_ids = self._identifiers_for_coverage(batch)
 
@@ -78,10 +75,7 @@ class EquivalentIdentifiersCoverageProvider(BaseCoverageProvider):
             .column(Identifier.id)
         )
 
-        # print (qu)
         chained_identifiers = self._db.execute(qu).fetchall()
-        print(chained_identifiers)
-        print(len(chained_identifiers))
 
         # We don't want to cover identifiers already looped over
         identifier_ids.difference_update(self._already_covered_identifiers)
@@ -105,8 +99,6 @@ class EquivalentIdentifiersCoverageProvider(BaseCoverageProvider):
 
         self._db.add_all(recursive_equivs)
 
-        print("done")
-        # raise Exception()
         self._already_covered_identifiers.update(completed_identifiers)
 
         ret = [
@@ -116,8 +108,6 @@ class EquivalentIdentifiersCoverageProvider(BaseCoverageProvider):
                 (b.equivalency.input_id, b.equivalency.output_id)
             )
         ]
-        print(len(ret))
-        # print ([r.id for r in ret])
         return ret
 
     def failure_for_ignored_item(self, equivalency):
@@ -151,7 +141,6 @@ class EquivalentIdentifiersCoverageProvider(BaseCoverageProvider):
         )
 
         eqs_without_records = qu.all()
-        print("PRINT", len(eqs_without_records))
 
         EquivalencyCoverageRecord.bulk_add(
             self._db, eqs_without_records, self.operation, batch_size=500

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -564,7 +564,7 @@ class ExternalSearchIndex(HasSelfTests):
             needs_add.append(work)
 
         # Add/update any works that need adding/updating.
-        docs = Work.to_search_documents(needs_add)
+        docs = Work.to_search_documents_in_app(needs_add)
 
         for doc in docs:
             doc["_index"] = self.works_index

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -476,6 +476,42 @@ def production_session(initialize_data=True):
     return _db
 
 
+class SessionBulkOperation:
+    """Bulk insert/update/operate on a session"""
+
+    def __init__(
+        self,
+        session,
+        batch_size,
+        bulk_method: str = "bulk_save_objects",
+        bulk_method_kwargs=None,
+    ) -> None:
+        self.session = session
+        self.bulk_method = bulk_method
+        self.bulk_method_kwargs = bulk_method_kwargs or {}
+        self.batch_size = batch_size
+        self._objects = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self._bulk_operation()
+
+    def add(self, object):
+        self._objects.append(object)
+        if len(self._objects) == self.batch_size:
+            self._bulk_operation()
+
+    def _bulk_operation(self):
+        self.bulk_method, getattr(
+            self.session,
+            self.bulk_method,
+        )(self._objects, **self.bulk_method_kwargs)
+        self.session.commit()
+        self._objects = []
+
+
 from .admin import Admin, AdminRole
 from .cachedfeed import CachedFeed, CachedMARCFile, WillNotGenerateExpensiveFeed
 from .circulationevent import CirculationEvent

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import warnings
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING, Dict, List
 
 from psycopg2.extensions import adapt as sqlescape
 from psycopg2.extras import NumericRange
@@ -490,7 +490,7 @@ class SessionBulkOperation:
         self.bulk_method = bulk_method
         self.bulk_method_kwargs = bulk_method_kwargs or {}
         self.batch_size = batch_size
-        self._objects = []
+        self._objects: List[Base] = []
 
     def __enter__(self):
         return self

--- a/core/model/coverage.py
+++ b/core/model/coverage.py
@@ -1,5 +1,7 @@
 # encoding: utf-8
 # BaseCoverageRecord, Timestamp, CoverageRecord, WorkCoverageRecord
+from typing import TYPE_CHECKING
+
 from sqlalchemy import (
     Column,
     DateTime,
@@ -17,6 +19,9 @@ from sqlalchemy.sql.expression import and_, literal, literal_column, or_
 
 from ..util.datetime_helpers import utc_now
 from . import Base, get_one, get_one_or_create
+
+if TYPE_CHECKING:
+    pass
 
 
 class BaseCoverageRecord(object):

--- a/core/model/coverage.py
+++ b/core/model/coverage.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
 from sqlalchemy.orm import joinedload
+from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_, literal, literal_column, or_
 
 from ..util.datetime_helpers import utc_now
@@ -724,9 +725,11 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
             new_records,
         )
         _db.execute(insert)
-    
+
     @classmethod
-    def missing_coverage_from(cls, _db, count_as_missing_before=None, operation=None, **kwargs):
+    def missing_coverage_from(
+        cls, _db, count_as_missing_before=None, operation=None, **kwargs
+    ):
         qu = (
             _db.query(WorkCoverageRecord)
             .filter(WorkCoverageRecord.operation == operation)

--- a/core/model/coverage.py
+++ b/core/model/coverage.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     Unicode,
     UniqueConstraint,
 )
-from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_, literal, literal_column, or_
 
@@ -717,24 +716,6 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
             new_records,
         )
         _db.execute(insert)
-
-    @classmethod
-    def missing_coverage_from(
-        cls, _db, count_as_missing_before=None, operation=None, **kwargs
-    ):
-        qu = (
-            _db.query(WorkCoverageRecord)
-            .filter(WorkCoverageRecord.operation == operation)
-            .join(WorkCoverageRecord.work)
-            .order_by(WorkCoverageRecord.id)
-            .options(joinedload(WorkCoverageRecord.work))
-        )
-        missing = WorkCoverageRecord.not_covered(
-            kwargs.get("count_as_covered"), count_as_missing_before
-        )
-        qu = qu.filter(missing)
-
-        return qu
 
 
 Index(

--- a/core/model/coverage.py
+++ b/core/model/coverage.py
@@ -741,7 +741,9 @@ class EquivalencyCoverageRecord(Base, BaseCoverageRecord):
 
     id = Column(Integer, primary_key=True)
 
-    equivalency_id = Column(Integer, ForeignKey("equivalents.id"), index=True)
+    equivalency_id = Column(
+        Integer, ForeignKey("equivalents.id", ondelete="CASCADE"), index=True
+    )
     equivalency = relationship("Equivalency", foreign_keys=equivalency_id)
 
     operation = Column(String(255), index=True, default=None)

--- a/core/model/coverage.py
+++ b/core/model/coverage.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.expression import and_, literal, literal_column, or_
 
 from ..util.datetime_helpers import utc_now
@@ -723,6 +724,22 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
             new_records,
         )
         _db.execute(insert)
+    
+    @classmethod
+    def missing_coverage_from(cls, _db, count_as_missing_before=None, operation=None, **kwargs):
+        qu = (
+            _db.query(WorkCoverageRecord)
+            .filter(WorkCoverageRecord.operation == operation)
+            .join(WorkCoverageRecord.work)
+            .order_by(WorkCoverageRecord.id)
+            .options(joinedload(WorkCoverageRecord.work))
+        )
+        missing = WorkCoverageRecord.not_covered(
+            kwargs.get("count_as_covered"), count_as_missing_before
+        )
+        qu = qu.filter(missing)
+
+        return qu
 
 
 Index(

--- a/core/model/coverage.py
+++ b/core/model/coverage.py
@@ -21,7 +21,7 @@ from ..util.datetime_helpers import utc_now
 from . import Base, get_one, get_one_or_create
 
 if TYPE_CHECKING:
-    pass
+    from . import Equivalency  # noqa
 
 
 class BaseCoverageRecord(object):

--- a/core/model/coverage.py
+++ b/core/model/coverage.py
@@ -11,8 +11,8 @@ from sqlalchemy import (
     Unicode,
     UniqueConstraint,
 )
-from sqlalchemy.orm.session import Session
 from sqlalchemy.orm import joinedload
+from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_, literal, literal_column, or_
 
 from ..util.datetime_helpers import utc_now
@@ -717,9 +717,11 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
             new_records,
         )
         _db.execute(insert)
-    
+
     @classmethod
-    def missing_coverage_from(cls, _db, count_as_missing_before=None, operation=None, **kwargs):
+    def missing_coverage_from(
+        cls, _db, count_as_missing_before=None, operation=None, **kwargs
+    ):
         qu = (
             _db.query(WorkCoverageRecord)
             .filter(WorkCoverageRecord.operation == operation)

--- a/core/model/coverage.py
+++ b/core/model/coverage.py
@@ -15,8 +15,6 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
-from sqlalchemy.orm import joinedload
-from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_, literal, literal_column, or_
 
 from ..util.datetime_helpers import utc_now
@@ -725,24 +723,6 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
             new_records,
         )
         _db.execute(insert)
-
-    @classmethod
-    def missing_coverage_from(
-        cls, _db, count_as_missing_before=None, operation=None, **kwargs
-    ):
-        qu = (
-            _db.query(WorkCoverageRecord)
-            .filter(WorkCoverageRecord.operation == operation)
-            .join(WorkCoverageRecord.work)
-            .order_by(WorkCoverageRecord.id)
-            .options(joinedload(WorkCoverageRecord.work))
-        )
-        missing = WorkCoverageRecord.not_covered(
-            kwargs.get("count_as_covered"), count_as_missing_before
-        )
-        qu = qu.filter(missing)
-
-        return qu
 
 
 Index(

--- a/core/model/identifier.py
+++ b/core/model/identifier.py
@@ -972,9 +972,9 @@ class Equivalency(Base):
 
     def __repr__(self):
         r = "[%s ->\n %s\n source=%s strength=%.2f votes=%d)]" % (
-            repr(self.input).decode("utf8"),
-            repr(self.output).decode("utf8"),
-            self.data_source.name,
+            repr(self.input),
+            repr(self.output),
+            self.data_source_id and self.data_source.name,
             self.strength,
             self.votes,
         )

--- a/core/model/identifier.py
+++ b/core/model/identifier.py
@@ -860,9 +860,6 @@ class Identifier(Base, IdentifierConstants):
         if identifiers:
             qu = qu.filter(Identifier.id.in_([x.id for x in identifiers]))
 
-        # Using an offset must have an order by
-        qu = qu.order_by(Identifier.id)
-
         return qu
 
     def opds_entry(self):

--- a/core/model/identifier.py
+++ b/core/model/identifier.py
@@ -13,6 +13,7 @@ import isbnlib
 from sqlalchemy import (
     Boolean,
     Column,
+    Computed,
     Float,
     ForeignKey,
     Integer,
@@ -999,3 +1000,33 @@ class Equivalency(Base):
         if exclude_ids:
             q = q.filter(~Equivalency.id.in_(exclude_ids))
         return q
+
+
+class RecursiveEquivalencyCache(Base):
+    """A chain of identifiers linked to a starting "parent" identifier
+    From equivalents if there exists (10,12),(12,19)
+    then for parent 10 there should exist rows
+    (10,12,order_no=1), (10,19,order_no=2)
+    This allows for simple querying during different jobs
+    rather than doing on-the-go dynamic recursive_equivalents
+    """
+
+    __tablename__ = "recursiveequivalentscache"
+
+    id = Column(Integer, primary_key=True)
+
+    # The "parent" or the start of the chain
+    parent_identifier_id = Column(
+        Integer, ForeignKey("identifiers.id", ondelete="CASCADE")
+    )
+    parent_identifier = relationship("Identifier", foreign_keys=parent_identifier_id)
+
+    # The identifier chained to the parent
+    identifier_id = Column(Integer, ForeignKey("identifiers.id", ondelete="CASCADE"))
+    identifier = relationship("Identifier", foreign_keys=identifier_id)
+
+    # Its always important to query for the parent id chain to self first
+    # this can be easily accomplished by ORDER BY parent_identifier,is_parent DESC
+    is_parent = Column(Boolean, Computed("parent_identifier_id = identifier_id"))
+
+    __table_args__ = (UniqueConstraint(parent_identifier_id, identifier_id),)

--- a/core/model/identifier.py
+++ b/core/model/identifier.py
@@ -10,10 +10,10 @@ from typing import TYPE_CHECKING, Optional, Tuple
 from urllib.parse import quote, unquote
 
 import isbnlib
+from sqlalchemy import Computed  # type: ignore
 from sqlalchemy import (
     Boolean,
     Column,
-    Computed,
     Float,
     ForeignKey,
     Integer,

--- a/core/model/identifier.py
+++ b/core/model/identifier.py
@@ -860,6 +860,9 @@ class Identifier(Base, IdentifierConstants):
         if identifiers:
             qu = qu.filter(Identifier.id.in_([x.id for x in identifiers]))
 
+        # Using an offset must have an order by
+        qu = qu.order_by(Identifier.id)
+
         return qu
 
     def opds_entry(self):

--- a/core/model/listeners.py
+++ b/core/model/listeners.py
@@ -253,8 +253,10 @@ def equivalency_coverage_reset_on_equivalency_delete(mapper, _db, target: Equiva
     TODO: This is a deprecated feature of listeners, we cannot write to the DB anymore
     However we are doing this until we have a solution, ala queues
     """
+
+    session = Session(bind=_db)
     EquivalencyCoverageQueries.add_coverage_for_identifiers_chain(
-        [target.input, target.output]
+        [target.input, target.output], _db=session
     )
 
 

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -19,10 +19,9 @@ from sqlalchemy import (
     String,
     Unicode,
 )
-from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import INT4RANGE
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm import contains_eager, joinedload, relationship, lazyload
+from sqlalchemy.orm import contains_eager, joinedload, relationship
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_, case, join, literal_column, or_, select
 from sqlalchemy.sql.functions import func
@@ -1654,14 +1653,15 @@ class Work(Base):
             )
 
         target_age = doc.target_age
-        result["target_age"] = {
-            "lower": None,
-            "upper": None
-        }
+        result["target_age"] = {"lower": None, "upper": None}
         if target_age and target_age.lower is not None:
-            result["target_age"]["lower"] = target_age.lower + (0 if target_age.lower_inc else 1)
+            result["target_age"]["lower"] = target_age.lower + (
+                0 if target_age.lower_inc else 1
+            )
         if target_age and target_age.upper is not None:
-            result["target_age"]["upper"] = target_age.upper - (0 if target_age.upper_inc else 1)
+            result["target_age"]["upper"] = target_age.upper - (
+                0 if target_age.upper_inc else 1
+            )
 
         _set_value(doc.presentation_edition, "edition", result)
 

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -19,9 +19,10 @@ from sqlalchemy import (
     String,
     Unicode,
 )
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import INT4RANGE
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm import contains_eager, joinedload, relationship
+from sqlalchemy.orm import contains_eager, joinedload, relationship, lazyload
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_, case, join, literal_column, or_, select
 from sqlalchemy.sql.functions import func

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -3,10 +3,9 @@
 
 import logging
 from collections import Counter
-from typing import TYPE_CHECKING, Optional
 from datetime import datetime
 from decimal import Decimal
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from sqlalchemy import (
     Boolean,

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1620,7 +1620,7 @@ class Work(Base):
             elif isinstance(value, datetime):
                 return value.timestamp()
             return value
-        
+
         def _set_value(parent, key, target):
             for c in columns[key]:
                 val = getattr(parent, c)
@@ -1651,6 +1651,16 @@ class Work(Base):
             result["target_age"]["upper"] = target_age.upper - (
                 0 if target_age.upper_inc else 1
             )
+
+        target_age = doc.target_age
+        result["target_age"] = {
+            "lower": None,
+            "upper": None
+        }
+        if target_age and target_age.lower is not None:
+            result["target_age"]["lower"] = target_age.lower + (0 if target_age.lower_inc else 1)
+        if target_age and target_age.upper is not None:
+            result["target_age"]["upper"] = target_age.upper - (0 if target_age.upper_inc else 1)
 
         _set_value(doc.presentation_edition, "edition", result)
 
@@ -1687,12 +1697,24 @@ class Work(Base):
                 "weight": item.affinity,
             }
             result["genres"].append(genre)
-        
+
         result["identifiers"] = []
         for item in doc.identifiers:
             identifier = {}
             _set_value(item, "identifiers", identifier)
             result["identifiers"].append(identifier)
+        
+        result["classifications"] = []
+        for item in doc.classifications:
+            classification = {}
+            _set_value(item, "classifications", classification)
+            result["classifications"].append(classification)
+
+        result["customlists"] = []
+        for item in doc.custom_list_entries:
+            customlist = {}
+            _set_value(item, "custom_list_entries", customlist)
+            result["customlists"].append(customlist)
 
         result["identifiers"] = []
         for item in doc.identifiers:

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -19,10 +19,9 @@ from sqlalchemy import (
     String,
     Unicode,
 )
-from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import INT4RANGE
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm import contains_eager, joinedload, relationship, lazyload
+from sqlalchemy.orm import contains_eager, joinedload, relationship
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_, case, join, literal_column, or_, select
 from sqlalchemy.sql.functions import func

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1631,11 +1631,6 @@ class Work(Base):
                 val = getattr(parent, c)
                 target[c] = _convert(val)
 
-        def _set_value(parent, key, target):
-            for c in columns[key]:
-                val = getattr(parent, c)
-                target[c] = _convert(val)
-
         _set_value(doc, "work", result)
         result["_id"] = getattr(doc, "id")
         result["work_id"] = getattr(doc, "id")
@@ -1645,17 +1640,6 @@ class Work(Base):
         )
         if result["audience"]:
             result["audience"] = result["audience"].replace(" ", "")
-
-        target_age = doc.target_age
-        result["target_age"] = {"lower": None, "upper": None}
-        if target_age and target_age.lower is not None:
-            result["target_age"]["lower"] = target_age.lower + (
-                0 if target_age.lower_inc else 1
-            )
-        if target_age and target_age.upper is not None:
-            result["target_age"]["upper"] = target_age.upper - (
-                0 if target_age.upper_inc else 1
-            )
 
         target_age = doc.target_age
         result["target_age"] = {"lower": None, "upper": None}
@@ -1703,24 +1687,6 @@ class Work(Base):
                 "weight": item.affinity,
             }
             result["genres"].append(genre)
-
-        result["identifiers"] = []
-        for item in doc.identifiers:  # type: ignore
-            identifier: Dict = {}
-            _set_value(item, "identifiers", identifier)
-            result["identifiers"].append(identifier)
-
-        result["classifications"] = []
-        for item in doc.classifications:  # type: ignore
-            classification: Dict = {}
-            _set_value(item, "classifications", classification)
-            result["classifications"].append(classification)
-
-        result["customlists"] = []
-        for item in doc.custom_list_entries:  # type: ignore
-            customlist: Dict = {}
-            _set_value(item, "custom_list_entries", customlist)
-            result["customlists"].append(customlist)
 
         result["identifiers"] = []
         for item in doc.identifiers:

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -19,9 +19,10 @@ from sqlalchemy import (
     String,
     Unicode,
 )
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import INT4RANGE
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.orm import contains_eager, joinedload, relationship
+from sqlalchemy.orm import contains_eager, joinedload, relationship, lazyload
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import and_, case, join, literal_column, or_, select
 from sqlalchemy.sql.functions import func
@@ -1703,7 +1704,7 @@ class Work(Base):
             identifier = {}
             _set_value(item, "identifiers", identifier)
             result["identifiers"].append(identifier)
-        
+
         result["classifications"] = []
         for item in doc.classifications:
             classification = {}

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1689,20 +1689,20 @@ class Work(Base):
             result["genres"].append(genre)
 
         result["identifiers"] = []
-        for item in doc.identifiers:
-            identifier = {}
+        for item in doc.identifiers:  # type: ignore
+            identifier: Dict = {}
             _set_value(item, "identifiers", identifier)
             result["identifiers"].append(identifier)
 
         result["classifications"] = []
-        for item in doc.classifications:
-            classification = {}
+        for item in doc.classifications:  # type: ignore
+            classification: Dict = {}
             _set_value(item, "classifications", classification)
             result["classifications"].append(classification)
 
         result["customlists"] = []
-        for item in doc.custom_list_entries:
-            customlist = {}
+        for item in doc.custom_list_entries:  # type: ignore
+            customlist: Dict = {}
             _set_value(item, "custom_list_entries", customlist)
             result["customlists"].append(customlist)
 

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1620,6 +1620,7 @@ class Work(Base):
             elif isinstance(value, datetime):
                 return value.timestamp()
             return value
+        
 
         def _set_value(parent, key, target):
             for c in columns[key]:
@@ -1682,6 +1683,14 @@ class Work(Base):
                 "weight": item.affinity,
             }
             result["genres"].append(genre)
+        
+        result["identifiers"] = []
+        for item in doc.identifiers:
+            identifier = {}
+            for c in columns["identifiers"]:
+                val = getattr(item, c)
+                identifier[c] = _convert(val)
+            result["identifiers"].append(identifier)
 
         result["identifiers"] = []
         for item in doc.identifiers:

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1621,6 +1621,10 @@ class Work(Base):
                 return value.timestamp()
             return value
         
+        def _set_value(parent, key, target):
+            for c in columns[key]:
+                val = getattr(parent, c)
+                target[c] = _convert(val)
 
         def _set_value(parent, key, target):
             for c in columns[key]:
@@ -1687,9 +1691,7 @@ class Work(Base):
         result["identifiers"] = []
         for item in doc.identifiers:
             identifier = {}
-            for c in columns["identifiers"]:
-                val = getattr(item, c)
-                identifier[c] = _convert(val)
+            _set_value(item, "identifiers", identifier)
             result["identifiers"].append(identifier)
 
         result["identifiers"] = []

--- a/core/query/coverage.py
+++ b/core/query/coverage.py
@@ -1,0 +1,41 @@
+from typing import List
+
+from sqlalchemy.orm.session import Session
+
+from core.model.coverage import EquivalencyCoverageRecord
+from core.model.identifier import Equivalency, Identifier, RecursiveEquivalencyCache
+
+
+class EquivalencyCoverageQueries:
+    @classmethod
+    def add_coverage_for_identifiers_chain(
+        cls, identifiers: List[Identifier]
+    ) -> List[EquivalencyCoverageRecord]:
+        """Hunt down any recursive identifiers that may be touched by these identifiers
+        set all the possible coverages to reset and recompute the chain
+        """
+        if not len(identifiers):
+            return []
+
+        _db = Session.object_session(identifiers[0])
+        ids = list((idn.id for idn in identifiers))
+
+        # Any parent ids that touch these identifiers
+        parent_ids = (
+            _db.query(RecursiveEquivalencyCache.parent_identifier_id)
+            .filter(RecursiveEquivalencyCache.identifier_id.in_(ids))
+            .all()
+        )
+
+        # Need to be reset
+        equivs = Equivalency.for_identifiers(_db, (p[0] for p in parent_ids))
+        records = []
+        for equiv in equivs:
+            record, is_new = EquivalencyCoverageRecord.add_for(
+                equiv,
+                EquivalencyCoverageRecord.RECURSIVE_EQUIVALENCY_REFRESH,
+                status=EquivalencyCoverageRecord.REGISTERED,
+            )
+            records.append(record)
+
+        return records

--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -11,11 +11,12 @@ HOME=/var/www/circulation
 
 # These scripts update internal caches.
 #
-*/5 * * * * root core/bin/run cache_opds_blocks >> /var/log/cron.log 2>&1
-*/6 * * * * root core/bin/run search_index_refresh >> /var/log/cron.log 2>&1
+*/30 * * * * root core/bin/run cache_opds_blocks >> /var/log/cron.log 2>&1
+20/30 * * * * root core/bin/run -d 9 search_index_refresh >> /var/log/cron.log 2>&1
 10 0 * * * root core/bin/run search_index_clear >> /var/log/cron.log 2>&1
 0 0 * * * root core/bin/run update_custom_list_size >> /var/log/cron.log 2>&1
 0 10 * * * root core/bin/run update_lane_size >> /var/log/cron.log 2>&1
+10/30 * * * * root core/bin/run -d 5 equivalent_identifiers_refresh >> /var/log/cron.log 2>&1
 
 # These scripts improve the bibliographic information associated with
 # the collections.

--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -12,11 +12,11 @@ HOME=/var/www/circulation
 # These scripts update internal caches.
 #
 */30 * * * * root core/bin/run cache_opds_blocks >> /var/log/cron.log 2>&1
-20/30 * * * * root core/bin/run -d 9 search_index_refresh >> /var/log/cron.log 2>&1
+*/30 * * * * root core/bin/run -d 15 search_index_refresh >> /var/log/cron.log 2>&1
 10 0 * * * root core/bin/run search_index_clear >> /var/log/cron.log 2>&1
 0 0 * * * root core/bin/run update_custom_list_size >> /var/log/cron.log 2>&1
 0 10 * * * root core/bin/run update_lane_size >> /var/log/cron.log 2>&1
-10/30 * * * * root core/bin/run -d 5 equivalent_identifiers_refresh >> /var/log/cron.log 2>&1
+*/30 * * * * root core/bin/run -d 5 equivalent_identifiers_refresh >> /var/log/cron.log 2>&1
 
 # These scripts improve the bibliographic information associated with
 # the collections.

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -1394,6 +1394,9 @@ class TestCustomListsController(AdminControllerTest):
         # regardless of filter, since that's what the mock search engine's count_works does.
         assert lane.size == 350
 
+        # Test fails without expiring the ORM cache
+        self._db.expire_all()
+
         with self.request_context_with_library_and_admin("/", method="POST"):
             flask.request.form = MultiDict(
                 [

--- a/tests/core/models/test_coverage.py
+++ b/tests/core/models/test_coverage.py
@@ -594,3 +594,22 @@ class TestEquivalencyCoverageRecord(DatabaseTest):
         assert set([r.equivalency_id for r in all_records]) == set(
             [e.id for e in self.equivalencies]
         )
+
+    def test_delete_identifier(self):
+        for eq in self.equivalencies:
+            record, is_new = EquivalencyCoverageRecord.add_for(
+                eq,
+                EquivalencyCoverageRecord.RECURSIVE_EQUIVALENCY_REFRESH,
+                status=CoverageRecord.REGISTERED,
+            )
+        self._db.commit()
+
+        all_equivs = self._db.query(EquivalencyCoverageRecord).all()
+        assert len(all_equivs) == 3
+
+        self._db.delete(self.idens[0])
+        self._db.commit()
+
+        all_equivs = self._db.query(EquivalencyCoverageRecord).all()
+
+        assert len(all_equivs) == 1

--- a/tests/core/test_equivalent_coverage.py
+++ b/tests/core/test_equivalent_coverage.py
@@ -1,0 +1,166 @@
+from core.equivalents_coverage import EquivalentIdentifiersCoverageProvider
+from core.model.coverage import EquivalencyCoverageRecord
+from core.model.identifier import Equivalency, RecursiveEquivalencyCache
+from core.testing import DatabaseTest
+
+
+class TestEquivalentCoverage(DatabaseTest):
+    def setup_method(self):
+        super().setup_method()
+        self.idens = [
+            self._identifier(),
+            self._identifier(),
+            self._identifier(),
+            self._identifier(),
+        ]
+        idn = self.idens
+        self.equivalencies = [
+            Equivalency(input_id=idn[0].id, output_id=idn[1].id, strength=1),
+            Equivalency(input_id=idn[1].id, output_id=idn[2].id, strength=1),
+            Equivalency(input_id=idn[1].id, output_id=idn[0].id, strength=1),
+        ]
+        self._db.add_all(self.equivalencies)
+        self._db.commit()
+        self.provider = EquivalentIdentifiersCoverageProvider(self._db)
+
+    def test_update_missing_coverage_records(self):
+        assert self._db.query(EquivalencyCoverageRecord).count() == 0
+
+        self.provider.update_missing_coverage_records()
+
+        assert self._db.query(EquivalencyCoverageRecord).count() == 3
+
+        records = self._db.query(EquivalencyCoverageRecord).all()
+        assert [r.equivalency_id for r in records] == [r.id for r in self.equivalencies]
+        assert [r.input_id for r in records] == [r.input_id for r in self.equivalencies]
+        assert [r.output_id for r in records] == [
+            r.output_id for r in self.equivalencies
+        ]
+        assert (
+            len(
+                list(
+                    filter(
+                        lambda x: x.operation
+                        == EquivalencyCoverageRecord.RECURSIVE_EQUIVALENCY_REFRESH,
+                        records,
+                    )
+                )
+            )
+            == 3
+        )
+        assert (
+            len(
+                list(
+                    filter(
+                        lambda x: x.status == EquivalencyCoverageRecord.REGISTERED,
+                        records,
+                    )
+                )
+            )
+            == 3
+        )
+
+    def test_items_that_need_coverage(self):
+        qu = self.provider.items_that_need_coverage()
+        records = qu.all()
+        assert len(records) == 0
+
+        self.provider.update_missing_coverage_records()
+        qu = self.provider.items_that_need_coverage()
+        records = qu.all()
+        assert len(records) == 3
+
+    def test_items_that_need_coverage_few(self):
+        qu = self.provider.items_that_need_coverage()
+        records = qu.all()
+        assert len(records) == 0
+
+        eq, inew = EquivalencyCoverageRecord.add_for(
+            self.equivalencies[0],
+            EquivalencyCoverageRecord.RECURSIVE_EQUIVALENCY_REFRESH,
+            status=EquivalencyCoverageRecord.REGISTERED,
+        )
+
+        qu = self.provider.items_that_need_coverage()
+        records = qu.all()
+        assert len(records) == 1
+
+        eq, inew = EquivalencyCoverageRecord.add_for(
+            self.equivalencies[0],
+            EquivalencyCoverageRecord.RECURSIVE_EQUIVALENCY_REFRESH,
+            status=EquivalencyCoverageRecord.SUCCESS,
+        )
+
+        qu = self.provider.items_that_need_coverage()
+        records = qu.all()
+        assert len(records) == 0
+
+        eq, inew = EquivalencyCoverageRecord.add_for(
+            self.equivalencies[0],
+            EquivalencyCoverageRecord.RECURSIVE_EQUIVALENCY_REFRESH,
+            status=EquivalencyCoverageRecord.PERSISTENT_FAILURE,
+        )
+
+        qu = self.provider.items_that_need_coverage(
+            count_as_covered=[
+                EquivalencyCoverageRecord.SUCCESS,
+                EquivalencyCoverageRecord.TRANSIENT_FAILURE,
+            ]
+        )
+        records = qu.all()
+        assert len(records) == 1
+
+    def test_identifiers_for_coverage(self):
+        self.provider.update_missing_coverage_records()
+        items = self.provider.items_that_need_coverage().all()
+        identifier_ids = self.provider._identifiers_for_coverage(items)
+
+        assert len(items) == 3
+        assert len(identifier_ids) == 3
+
+        rec = RecursiveEquivalencyCache(
+            parent_identifier_id=self.idens[1].id, identifier_id=self.idens[2].id
+        )
+        self._db.add(rec)
+
+        eq = Equivalency(
+            input_id=self.idens[2].id, output_id=self.idens[3].id, strength=1
+        )
+        self._db.add(eq)
+
+        record, is_new = EquivalencyCoverageRecord.add_for(
+            eq, EquivalencyCoverageRecord.RECURSIVE_EQUIVALENCY_REFRESH
+        )
+
+        identifier_ids = self.provider._identifiers_for_coverage([record])
+
+        assert len(identifier_ids) == 3
+        assert identifier_ids == {self.idens[1].id, self.idens[2].id, self.idens[3].id}
+
+    def test_process_batch(self):
+        self.provider.update_missing_coverage_records()
+        batch = self.provider.items_that_need_coverage().all()
+
+        assert len(self.provider._already_covered_identifiers) == 0
+
+        return_batch = self.provider.process_batch(batch)
+
+        assert len(batch) == 3
+        assert len(return_batch) == 3
+
+        # still in the registered mode
+        assert {b.status for b in return_batch} == {
+            EquivalencyCoverageRecord.REGISTERED,
+        }
+        assert len(self.provider._already_covered_identifiers) == 3
+
+    def test_process_batch_on_delete(self):
+        self.provider.update_missing_coverage_records()
+
+        # An identifier was deleted thereafter
+        self._db.delete(self.idens[0])
+        self._db.commit()
+
+        batch = self.provider.items_that_need_coverage().all()
+        assert len(batch) == 3
+        self.provider.process_batch(batch)

--- a/tests/core/test_equivalent_coverage.py
+++ b/tests/core/test_equivalent_coverage.py
@@ -234,3 +234,22 @@ class TestEquivalentCoverage(DatabaseTest):
             assert r.status == r.REGISTERED
             # identity 1 is connected only to identitity 2
             assert self.idens[1].id in (r.equivalency.input_id, r.equivalency.output_id)
+
+    def test_update_identity_recursive_equivalents(self):
+        self.provider.update_missing_coverage_records()
+        batch = self.provider.items_that_need_coverage()
+        self.provider.process_batch(batch)
+
+        missing = self.provider.update_identity_recursive_equivalents()
+
+        assert len(missing) == 1
+        assert missing[0].id == self.idens[3].id
+
+        recursives = (
+            self._db.query(RecursiveEquivalencyCache)
+            .filter(RecursiveEquivalencyCache.parent_identifier_id == self.idens[3].id)
+            .all()
+        )
+
+        assert len(recursives) == 1
+        assert recursives[0].is_parent == True

--- a/tests/core/test_equivalent_coverage.py
+++ b/tests/core/test_equivalent_coverage.py
@@ -133,6 +133,7 @@ class TestEquivalentCoverage(DatabaseTest):
             input_id=self.idens[2].id, output_id=self.idens[3].id, strength=1
         )
         self._db.add(eq)
+        self._db.commit()
 
         record, is_new = EquivalencyCoverageRecord.add_for(
             eq, EquivalencyCoverageRecord.RECURSIVE_EQUIVALENCY_REFRESH

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -4537,8 +4537,8 @@ class TestSearchIndexCoverageProvider(DatabaseTest):
         # Do not be 100x performance
         assert t2.execution_time < t1.execution_time * 5
 
-        # 3 queries per work only
-        assert new_counter.get_count() < len(works) * 3 + 1
+        # 4 queries per batch only
+        assert new_counter.get_count() == 4
 
     def test_success(self):
         work = self._work()

--- a/tests/core/utils.py
+++ b/tests/core/utils.py
@@ -1,0 +1,59 @@
+import time
+
+import sqlalchemy
+
+
+class DBStatementCounter:
+    """
+    Use as a context manager to count the number of execute()'s performed
+    against the given sqlalchemy connection.
+
+    Usage:
+        with DBStatementCounter(conn) as ctr:
+            conn.execute("SELECT 1")
+            conn.execute("SELECT 1")
+        assert ctr.get_count() == 2
+    """
+
+    def __init__(self, conn):
+        self.conn = conn
+        self.count = 0
+        # Will have to rely on this since sqlalchemy 0.8 does not support
+        # removing event listeners
+        self.do_count = False
+        sqlalchemy.event.listen(conn, "after_execute", self.callback)
+
+    def __enter__(self):
+        self.do_count = True
+        return self
+
+    def __exit__(self, *_):
+        self.do_count = False
+
+    def get_count(self):
+        return self.count
+
+    def callback(self, *_):
+        if self.do_count:
+            self.count += 1
+
+
+class PerfTimer:
+    """Performance timer to wrap around blocks of code
+
+    Usage:
+        <code we don't want timed>
+        ....
+        with PerfTimer() as pt:
+            <do code we need to time>
+            ....
+        print ("Time taken:", pt.execution_time)
+    """
+
+    def __enter__(self):
+        self.start = time.perf_counter()
+        self.execution_time = 0
+        return self
+
+    def __exit__(self, *args):
+        self.execution_time = time.perf_counter() - self.start


### PR DESCRIPTION
## Description
Notion: https://www.notion.so/lyrasis/Implement-proposed-solution-for-search_index_refresh-085989c0bd504f3f8e65eca8993066b7

* Remove unbounded counts on every job loop
* Remove the pressure of JSON serializing from the clster, and adds it to the application server

## Motivation and Context

The search_index_refresh job runs every 6 minutes on the Production systems.
This is a necessary script (maybe not with frequency) and puts a lot of CPU pressure on the RDS cluster

The refactoring here reduces the CPU usage of the script.
What could not be done is changing the `SELECT works JOIN workcoveragerecords` into a `SELECT workcoveragerecords JOIN works` query
This is because the job depends on the fact that there may be works WITHOUT a corresponding workcoveragerecords entry, which would imply a work needing coverage
This can be changed but will need an architectural change of how workcoveragerecords are created

## How Has This Been Tested?

All unit tests are passing
New unit tests are written
Real world data was used to compare results manually

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
