### PR TITLE
Pin minio docker tag to prevent test failure

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ ports =
     9006:9200/tcp
 
 [docker:minio-circ]
-image = bitnami/minio:latest
+image = bitnami/minio:2022.3
 environment =
     MINIO_ACCESS_KEY=simplified
     MINIO_SECRET_KEY=12345678901234567890

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ ports =
     9006:9200/tcp
 
 [docker:minio-circ]
-image = bitnami/minio:2022.3
+image = bitnami/minio:2022.3.3
 environment =
     MINIO_ACCESS_KEY=simplified
     MINIO_SECRET_KEY=12345678901234567890


### PR DESCRIPTION
## Description

Pins `minio` docker container tag to `2022.3.3` -- a version known to work before tests began failing.

## Motivation and Context

Using `latest` tag for `minio` resulted in test failures in the `Core Test`s.  with this error message:
```
  _ ERROR at teardown of TestS3UploaderIntegration.test_mirror_0_using_s3_uploader_and_open_access_bucket _
  
  self = <tests.core.test_s3.TestS3UploaderIntegration object at 0x7febac83b450>
  
      def teardown_method(self):
          """Deinitializes the test suite by removing all the buckets from MinIO"""
          super(S3UploaderTest, self).teardown_method()
      
  >       response = self.minio_s3_client.list_buckets()
```
...
```
  E           botocore.exceptions.ClientError: An error occurred (InvalidAccessKeyId) when calling the CreateBucket operation: The Access Key Id you provided does not exist in our records.
```

## How Has This Been Tested?

Automated tests ran successfully.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
