### PR TITLE
Pin golang container tag to 1.17 for lcpencrypt install.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 ## lcpencrypt
 ###############################################################################
 
-FROM golang AS builder
+FROM golang:1.17 AS builder
 
 LABEL maintainer="The Palace Project <info@thepalaceproject.org>"
 


### PR DESCRIPTION
## Description

Pins `golang` Docker container tag to version 1.17 for installing `lcpencrypt` into the Docker containers .

## Motivation and Context

Beginning with version 1.18, 'go get' is no longer supported outside a module.

## How Has This Been Tested?

- Verified that containers built successfully after all tests passed.
- Verified that all GitHub workflows ran successfully.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
