### PR TITLE
OPDS2 Accept header has been overridden from the OPDS value

### DIFF
--- a/api/admin/controller/collection_settings.py
+++ b/api/admin/controller/collection_settings.py
@@ -28,6 +28,27 @@ class CollectionSettingsController(SettingsController):
         protocols = super(CollectionSettingsController, self)._get_collection_protocols(
             self.PROVIDER_APIS
         )
+
+        # dedupe and only keep the latest SETTINGS
+        # this will allow child objects to overwrite
+        # parent settings with the same key
+        # This relies on the fact that child settings
+        # are added after parent settings as such
+        # `SETTINGS + <configuration>.to_settings()`
+        for protocol in protocols:
+            if "settings" not in protocol:
+                continue
+            _found_settings = dict()
+            for ix, setting in enumerate(protocol["settings"]):
+                _key = setting["key"]
+                _found_settings[_key] = ix
+            _settings = []
+            # Go through the dict items and only use the latest found settings
+            # for any given key
+            for _, v in _found_settings.items():
+                _settings.append(protocol["settings"][v])
+            protocol["settings"] = _settings
+
         # If there are storage integrations, add a mirror integration
         # setting to every protocol's 'settings' block.
         mirror_integration_settings = self._mirror_integration_settings()

--- a/core/opds2_import.py
+++ b/core/opds2_import.py
@@ -21,8 +21,10 @@ from webpub_manifest_parser.utils import encode, first_or_default
 from core.configuration.ignored_identifier import IgnoredIdentifierImporterMixin
 from core.mirror import MirrorUploader
 from core.model.configuration import (
+    ConfigurationAttributeType,
     ConfigurationFactory,
     ConfigurationGrouping,
+    ConfigurationMetadata,
     ConfigurationStorage,
     HasExternalIntegration,
 )
@@ -114,6 +116,19 @@ class RWPMManifestParser(object):
 class OPDS2ImporterConfiguration(ConfigurationGrouping, BaseImporterConfiguration):
     """Contains configuration settings of OPDS2Importer.
     Currently empty, but maintaining it as a base class for others"""
+
+    custom_accept_header_setting = ConfigurationMetadata(
+        key=ExternalIntegration.CUSTOM_ACCEPT_HEADER,
+        label=_("Custom accept header"),
+        description=_(
+            "Some servers expect an accept header to decide which file to send. You can use */* if the server doesn't expect anything."
+        ),
+        type=ConfigurationAttributeType.TEXT,
+        required=False,
+        default="{0}, {1};q=0.9, */*;q=0.1".format(
+            OPDS2MediaTypesRegistry.OPDS_FEED.key, "application/json"
+        ),
+    )
 
 
 class OPDS2Importer(

--- a/tests/api/admin/controller/test_collection_settings.py
+++ b/tests/api/admin/controller/test_collection_settings.py
@@ -46,3 +46,45 @@ class TestCollectionSettingsController(DatabaseTest):
         # We want to make sure that the result setting array contains a correct value in a list format.
         saved_affiliation_attributes = settings[affiliation_attributes_key]
         assert expected_affiliation_attributes == saved_affiliation_attributes
+
+    def test_duplicate_protocol_settings(self):
+        """Dedupe protocol settings using the last settings of the same value"""
+        manager = create_autospec(spec=CirculationManager)
+        manager._db = PropertyMock(return_value=self._db)
+
+        class MockProviderAPI:
+            NAME = "NAME"
+            SETTINGS = [
+                dict(key="k1", value="v1"),
+                dict(key="k2", value="v2"),  # This should get overwritten
+                dict(key="k2", value="v3"),  # Only this should remain
+            ]
+
+        controller = CollectionSettingsController(manager)
+        controller.PROVIDER_APIS = [MockProviderAPI]
+        protocols = controller._get_collection_protocols()
+
+        k2_list = list(filter(lambda x: x["key"] == "k2", protocols[0]["settings"]))
+        assert len(k2_list) == 1
+        assert k2_list[0]["value"] == "v3"
+
+        class MockProviderAPIMulti:
+            NAME = "NAME"
+            SETTINGS = [
+                dict(key="k1", value="v0"),  # This should get overwritten
+                dict(key="k1", value="v1"),  # Only this should remain
+                dict(key="k2", value="v1"),  # This should get overwritten
+                dict(key="k2", value="v2"),  # This should get overwritten
+                dict(key="k2", value="v4"),  # Only this should remain
+            ]
+
+        controller.PROVIDER_APIS = [MockProviderAPIMulti]
+        protocols = controller._get_collection_protocols()
+
+        k2_list = list(filter(lambda x: x["key"] == "k2", protocols[0]["settings"]))
+        assert len(k2_list) == 1
+        assert k2_list[0]["value"] == "v4"
+
+        k1_list = list(filter(lambda x: x["key"] == "k1", protocols[0]["settings"]))
+        assert len(k1_list) == 1
+        assert k1_list[0]["value"] == "v1"


### PR DESCRIPTION
## Description

Make a minor change in how the JSON value for settings was managed. Only the last value in the SETTINGS array will be considered.

## Motivation and Context
The OPDS2 importer needed a different Accept header than the OPDS importer. However, due to the SETTINGS being an array it is not possible to overwrite a single configuration.
Hence a duplicate setting needed to be added, and thereafter deduped in the code.
The dedupe code relies on the fact that the child class always adds its settings to the end of the SETTINGS array

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test cases were written for different scenarios
Also tested this manually with the admin panel for the OPDS2 collections page

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
