### PR TITLE
Feature/bibliotheca cloudlink reserve

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -947,6 +947,8 @@ class ErrorParser(BibliothecaParser):
     error_mapping = {
         "The patron does not have the book on hold": NotOnHold,
         "The patron has no eBooks checked out": NotCheckedOut,
+        "the patron document status was CAN_HOLD and not one of CAN_LOAN,RESERVATION": NotOnHold,
+        "the patron document status was HOLD and not one of CAN_LOAN,RESERVATION": NotOnHold,
     }
 
     def process_all(self, string):

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -49,6 +49,7 @@ from core.model import (
     get_one,
     get_one_or_create,
 )
+from core.model.configuration import ConfigurationAttributeValue
 from core.monitor import CollectionMonitor, IdentifierSweepMonitor, TimelineMonitor
 from core.scripts import RunCollectionMonitorScript
 from core.testing import DatabaseTest
@@ -98,7 +99,20 @@ class BibliothecaAPI(BaseCirculationAPI, HasSelfTests):
     ] + BaseCirculationAPI.SETTINGS
 
     LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
-        BaseCirculationAPI.DEFAULT_LOAN_DURATION_SETTING
+        BaseCirculationAPI.DEFAULT_LOAN_DURATION_SETTING,
+        {
+            "key": ExternalIntegration.DONT_DISPLAY_RESERVES,
+            "label": _("Don’t Show Titles Available to Reserve"),
+            "required": False,
+            "description": _(
+                "Titles that are only available to reserve will not be displayed in the Catalog view."
+            ),
+            "type": "select",
+            "options": [
+                {"key": ConfigurationAttributeValue.NOVALUE.value, "label": "No"},
+                {"key": ConfigurationAttributeValue.YESVALUE.value, "label": "Yes"},
+            ],
+        },
     ]
 
     MAX_AGE = timedelta(days=730).seconds

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -961,8 +961,6 @@ class ErrorParser(BibliothecaParser):
     error_mapping = {
         "The patron does not have the book on hold": NotOnHold,
         "The patron has no eBooks checked out": NotCheckedOut,
-        "the patron document status was CAN_HOLD and not one of CAN_LOAN,RESERVATION": NotOnHold,
-        "the patron document status was HOLD and not one of CAN_LOAN,RESERVATION": NotOnHold,
     }
 
     def process_all(self, string):

--- a/core/model/configuration.py
+++ b/core/model/configuration.py
@@ -289,6 +289,9 @@ class ExternalIntegration(Base):
     PRIMARY_IDENTIFIER_SOURCE = "primary_identifier_source"
     DCTERMS_IDENTIFIER = "first_dcterms_identifier"
 
+    # If the library-collection pair should display books with holds when no loans are available
+    DONT_DISPLAY_RESERVES = "dont_display_reserves"
+
     __tablename__ = "externalintegrations"
     id = Column(Integer, primary_key=True)
 
@@ -964,6 +967,13 @@ class ConfigurationAttribute(Enum):
     OPTIONS = "options"
     CATEGORY = "category"
     FORMAT = "format"
+
+
+class ConfigurationAttributeValue(Enum):
+    """Enumeration of common configuration attribute values"""
+
+    YESVALUE = "YES"
+    NOVALUE = "NO"
 
 
 class ConfigurationOption(object):

--- a/core/model/configuration.py
+++ b/core/model/configuration.py
@@ -972,8 +972,8 @@ class ConfigurationAttribute(Enum):
 class ConfigurationAttributeValue(Enum):
     """Enumeration of common configuration attribute values"""
 
-    YESVALUE = "YES"
-    NOVALUE = "NO"
+    YESVALUE = "yes"
+    NOVALUE = "no"
 
 
 class ConfigurationOption(object):

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -49,6 +49,8 @@ from core.model import (
     get_one_or_create,
     tuple_to_numericrange,
 )
+from core.model.collection import Collection
+from core.model.configuration import ConfigurationSetting, ExternalIntegration
 from core.problem_details import INVALID_INPUT
 from core.testing import DatabaseTest, EndToEndSearchTest, LogCaptureHandler
 from core.util.datetime_helpers import utc_now
@@ -2469,6 +2471,48 @@ class TestWorkList(DatabaseTest):
 
         assert [] == wl.search(self._db, query, RaisesException())
 
+    def test_worklist_for_resultset_no_holds_allowed(self):
+        wl = WorkList()
+        wl.initialize(self._default_library)
+        m = wl.works_for_resultsets
+
+        # Create two works.
+        w1: Work = self._work(with_license_pool=True)
+        w2: Work = self._work(with_license_pool=True)
+
+        w1.license_pools[0].licenses_available = 0
+        collection1: Collection = w1.license_pools[0].collection
+        cs1 = ConfigurationSetting(
+            library_id=self._default_library.id,
+            external_integration_id=collection1.external_integration_id,
+            key=ExternalIntegration.DONT_DISPLAY_RESERVES,
+            value="yes",
+        )
+        self._db.add(cs1)
+        self._db.commit()
+
+        class MockHit(object):
+            def __init__(self, work_id, has_last_update=False):
+                if isinstance(work_id, Work):
+                    self.work_id = work_id.id
+                else:
+                    self.work_id = work_id
+                self.has_last_update = has_last_update
+
+            def __contains__(self, k):
+                # Pretend to have the 'last_update' script field,
+                # if necessary.
+                return k == "last_update" and self.has_last_update
+
+        hit1 = MockHit(w1)
+        hit2 = MockHit(w2)
+
+        # For each list of hits passed in, a corresponding list of
+        # Works is returned.
+        assert [[w2]] == m(self._db, [[hit2]])
+        assert [[w2], []] == m(self._db, [[hit2], [hit1]])
+        assert [[], [w2, w2], []] == m(self._db, [[hit1, hit1], [hit2, hit2], []])
+
 
 class TestDatabaseBackedWorkList(DatabaseTest):
     def test_works_from_database(self):
@@ -2535,6 +2579,9 @@ class TestDatabaseBackedWorkList(DatabaseTest):
             def only_show_ready_deliverable_works(self, _db, qu):
                 return self._stage("only_show_ready_deliverable_works", _db, qu)
 
+            def _restrict_query_for_no_hold_collections(self, _db, qu):
+                return self._stage("_restrict_query_for_no_hold_collections", _db, qu)
+
             def bibliographic_filter_clauses(self, _db, qu):
                 # This method is a little different, so we can't use
                 # _stage().
@@ -2574,6 +2621,7 @@ class TestDatabaseBackedWorkList(DatabaseTest):
         assert [
             "base_query",
             "only_show_ready_deliverable_works",
+            "_restrict_query_for_no_hold_collections",
             "modify_database_query_hook",
         ] == result.clauses
 
@@ -2584,6 +2632,7 @@ class TestDatabaseBackedWorkList(DatabaseTest):
         assert [
             "base_query",
             "only_show_ready_deliverable_works",
+            "_restrict_query_for_no_hold_collections",
         ] == wl.bibliographic_filter_clauses_called_with.clauses
         wl.bibliographic_filter_clauses_called_with = None
 
@@ -2630,6 +2679,7 @@ class TestDatabaseBackedWorkList(DatabaseTest):
         assert [
             "base_query",
             "only_show_ready_deliverable_works",
+            "_restrict_query_for_no_hold_collections",
         ] == wl.pre_bibliographic_filter.clauses
 
         # bibliographic_filter_clauses created a brand new object,


### PR DESCRIPTION
## Description
Collection/Library associations now have a dropdown to select if unavailable works should be displayed
![image](https://user-images.githubusercontent.com/90382027/159715851-ce3f22d8-44c8-4a75-b055-b9b29b0c390d.png)

This is accomplished by adding this filter to the query all the way down at the DatabaseBackedWorkList level which affects all feeds that originate from lanes


<!--- Describe your changes -->

## Motivation and Context
https://www.notion.so/lyrasis/Add-configuration-setting-to-filter-out-titles-when-all-available-copies-have-been-loaned-f488c3fa43704ed0a59323a80ee893fb
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
