### PR TITLE
Feature/use recursive equivalents

### DIFF
--- a/core/external_search.py
+++ b/core/external_search.py
@@ -564,7 +564,7 @@ class ExternalSearchIndex(HasSelfTests):
             needs_add.append(work)
 
         # Add/update any works that need adding/updating.
-        docs = Work.to_search_documents_in_app(needs_add)
+        docs = Work.to_search_documents(needs_add)
 
         for doc in docs:
             doc["_index"] = self.works_index

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -46,7 +46,7 @@ from .contributor import Contribution, Contributor
 from .coverage import CoverageRecord, WorkCoverageRecord
 from .datasource import DataSource
 from .edition import Edition
-from .identifier import Identifier
+from .identifier import Identifier, RecursiveEquivalencyCache
 from .measurement import Measurement
 
 # Import related models when doing type checking
@@ -1437,10 +1437,12 @@ class Work(Base):
 
     @classmethod
     def to_search_documents(
-        cls: Type[WorkTypevar], works: List[WorkTypevar], policy=None
+        cls: Type[WorkTypevar], works: List[WorkTypevar]
     ) -> List[Dict]:
         """In app to search documents needed to ease off the burden
         of complex queries from the DB cluster
+        No recursive identifier policy is taken here as using the
+        RecursiveEquivalentsCache implicitly has that set
         """
         _db = Session.object_session(works[0])
 
@@ -1463,30 +1465,20 @@ class Work(Base):
         ## The same nonsense will be required for classifications
         ## TODO: move this equivalence code into another job based on its required frequency
         ## Add it to another table so it becomes faster to just query the pre-computed table
-        works_alias = (
-            select(
-                [
-                    Work.id.label("work_id"),
-                    Edition.id.label("edition_id"),
-                    Edition.primary_identifier_id.label("identifier_id"),
-                ],
-                Work.id.in_((w.id for w in works)),
-            )
-            .select_from(
-                join(Work, Edition, Work.presentation_edition_id == Edition.id)  # type: ignore
-            )
-            .alias("works_alias")
-        )
 
         equivalent_identifiers = (
-            Identifier.recursively_equivalent_identifier_ids_query(
-                literal_column(
-                    str(works_alias.name) + "." + works_alias.c.identifier_id.name
-                ),
-                policy=policy,
+            _db.query(RecursiveEquivalencyCache)
+            .join(
+                Edition,
+                Edition.primary_identifier_id
+                == RecursiveEquivalencyCache.parent_identifier_id,
             )
-            .column(works_alias.c.work_id)
-            .select_from(works_alias)
+            .join(Work, Work.presentation_edition_id == Edition.id)
+            .filter(Work.id.in_((w.id for w in works)))
+            .with_entities(
+                Work.id.label("work_id"),
+                RecursiveEquivalencyCache.identifier_id.label("equivalent_id"),
+            )
             .cte("equivalent_cte")
         )
 
@@ -1499,10 +1491,7 @@ class Work(Base):
                 ]
             )
             .select_from(Identifier)  # type: ignore
-            .where(
-                Identifier.id
-                == literal_column("equivalent_cte.fn_recursive_equivalents_1")
-            )
+            .where(Identifier.id == literal_column("equivalent_cte.equivalent_id"))
         )
 
         identifiers = list(_db.execute(identifiers_query))
@@ -1551,7 +1540,7 @@ class Work(Base):
             .group_by(scheme_column, term_column, equivalent_identifiers.c.work_id)
             .where(
                 Classification.identifier_id
-                == literal_column("equivalent_cte.fn_recursive_equivalents_1")
+                == literal_column("equivalent_cte.equivalent_id")
             )
             .select_from(
                 join(Classification, Subject, Classification.subject_id == Subject.id)  # type: ignore

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -4477,8 +4477,8 @@ class TestSearchIndexCoverageProvider(DatabaseTest):
 
         # works.extend([self._work() for i in range(500)])
 
-        result = Work.to_search_documents(works)
-        inapp = Work.to_search_documents_in_app(works)
+        result = Work.to_search_documents__DONOTUSE(works)
+        inapp = Work.to_search_documents(works)
 
         # Top level keys should be the same
         assert len(result) == len(inapp)
@@ -4522,26 +4522,26 @@ class TestSearchIndexCoverageProvider(DatabaseTest):
 
         with DBStatementCounter(self.connection) as new_counter:
             with PerfTimer() as t2:
-                inapp = Work.to_search_documents_in_app(works)
+                inapp = Work.to_search_documents(works)
 
         # Do not be 100x performance
         assert t2.execution_time < t1.execution_time * 5
 
         # 4 queries per batch only
-        assert new_counter.get_count() == 4
+        assert new_counter.get_count() <= 4
 
     def test_to_search_documents_with_missing_data(self):
         # Missing edition relationship
         work: Work = self._work(with_license_pool=True)
         work.presentation_edition_id = None
-        [result] = Work.to_search_documents_in_app([work])
+        [result] = Work.to_search_documents([work])
         assert result["identifiers"] == None
 
         # Missing just some attributes
         work: Work = self._work(with_license_pool=True)
         work.presentation_edition.title = None
         work.target_age = None
-        [result] = Work.to_search_documents_in_app([work])
+        [result] = Work.to_search_documents([work])
         assert result["title"] == None
         assert result["target_age"]["lower"] == None
 


### PR DESCRIPTION
## Description
Work.to_search_documents now uses the RecursiveEquivalentsCache table
The old to_search_documents has been appended with a __DONOTUSE statement, but not deleted.
Lest we forget the lessons of the past    

There was also a bug discovered where licensepools were not filtered out correctly in the method.
This has been fixed.
<!--- Describe your changes -->

## Motivation and Context

This further reduces the CPU load on the DB cluster by avoiding the use of the recursive SQL procedure.
Only the to_search_documents function uses this table as of now since the other methods depend on a Policy that may change.
To_search_documents also took an optional Policy, but since the method is only used in one place it could be ignored

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit test cases already cover the entirety of this functionality
They only had to be modified to prime the recursive equivalents cache before running

This was also manually tested with a sanitized NJ database
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
