### PR TITLE
Refactor Overdrive code to use new configuration API

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1725,17 +1725,19 @@ class SettingsController(AdminCirculationManagerController):
                             setting=setting.get("label"),
                         )
                     )
-        if (
-            not value
-            and setting.get("required")
-            and not "default" in list(setting.keys())
-        ):
-            return INCOMPLETE_CONFIGURATION.detailed(
-                _(
-                    "The configuration is missing a required setting: %(setting)s",
-                    setting=setting.get("label"),
+
+        value_missing = not value
+        value_required = setting.get("required")
+
+        if value_missing and value_required:
+            value_default = setting.get("default")
+            if not value_default:
+                return INCOMPLETE_CONFIGURATION.detailed(
+                    _(
+                        "The configuration is missing a required setting: %(setting)s",
+                        setting=setting.get("label"),
+                    )
                 )
-            )
 
         if isinstance(value, list):
             value = json.dumps(value)

--- a/core/connection_config.py
+++ b/core/connection_config.py
@@ -1,7 +1,7 @@
-from core.config import ConfigurationTrait
-from core.model.configuration import ConfigurationMetadata, ConfigurationAttributeType
-
 from flask_babel import lazy_gettext as _
+
+from core.config import ConfigurationTrait
+from core.model.configuration import ConfigurationAttributeType, ConfigurationMetadata
 
 
 class ConnectionConfigurationTrait(ConfigurationTrait):

--- a/core/connection_config.py
+++ b/core/connection_config.py
@@ -8,7 +8,7 @@ class ConnectionConfigurationTrait(ConfigurationTrait):
     """Configuration information for connections to external servers."""
 
     max_retry_count = ConfigurationMetadata(
-        key="max_retry_count",
+        key="connection_max_retry_count",
         label=_("Connection retry limit"),
         description=_(
             "The maximum number of times to retry a request for certain connection-related errors."

--- a/core/connection_config.py
+++ b/core/connection_config.py
@@ -1,0 +1,19 @@
+from core.config import ConfigurationTrait
+from core.model.configuration import ConfigurationMetadata, ConfigurationAttributeType
+
+from flask_babel import lazy_gettext as _
+
+
+class ConnectionConfigurationTrait(ConfigurationTrait):
+    """Configuration information for connections to external servers."""
+
+    max_retry_count = ConfigurationMetadata(
+        key="max_retry_count",
+        label=_("Connection retry limit"),
+        description=_(
+            "The maximum number of times to retry a request for certain connection-related errors."
+        ),
+        type=ConfigurationAttributeType.NUMBER,
+        required=False,
+        default=3,
+    )

--- a/core/importers.py
+++ b/core/importers.py
@@ -1,9 +1,11 @@
 from core.configuration.ignored_identifier import IgnoredIdentifierConfiguration
+from core.connection_config import ConnectionConfigurationTrait
 from core.model.formats import FormatPrioritiesConfigurationTrait
 from core.saml.wayfless import SAMLWAYFlessConfigurationTrait
 
 
 class BaseImporterConfiguration(
+    ConnectionConfigurationTrait,
     SAMLWAYFlessConfigurationTrait,
     FormatPrioritiesConfigurationTrait,
     IgnoredIdentifierConfiguration,

--- a/core/model/collection.py
+++ b/core/model/collection.py
@@ -82,6 +82,7 @@ class Collection(Base, HasSessionCache):
     # secret as the Overdrive collection, but it has a distinct
     # external_account_id.
     parent_id = Column(Integer, ForeignKey("collections.id"), index=True)
+    # SQLAlchemy will create a Collection-typed field called "parent".
     parent: "Collection"
 
     # When deleting a collection, this flag is set to True so that the deletion

--- a/core/model/collection.py
+++ b/core/model/collection.py
@@ -74,6 +74,7 @@ class Collection(Base, HasSessionCache):
     external_integration_id = Column(
         Integer, ForeignKey("externalintegrations.id"), unique=True, index=True
     )
+    _external_integration: ExternalIntegration
 
     # A Collection may specialize some other Collection. For instance,
     # an Overdrive Advantage collection is a specialization of an
@@ -81,6 +82,7 @@ class Collection(Base, HasSessionCache):
     # secret as the Overdrive collection, but it has a distinct
     # external_account_id.
     parent_id = Column(Integer, ForeignKey("collections.id"), index=True)
+    parent: "Collection"
 
     # When deleting a collection, this flag is set to True so that the deletion
     # script can take care of deleting it in the background. This is
@@ -382,7 +384,7 @@ class Collection(Base, HasSessionCache):
         return external_integration
 
     @property
-    def external_integration(self):
+    def external_integration(self) -> ExternalIntegration:
         """Find the external integration for this Collection, assuming
         it already exists.
 

--- a/core/model/resource.py
+++ b/core/model/resource.py
@@ -11,7 +11,7 @@ import time
 import traceback
 from hashlib import md5
 from io import BytesIO
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Tuple
 from urllib.parse import quote, urlparse, urlsplit
 
 import requests
@@ -1055,7 +1055,7 @@ class Representation(Base, MediaTypes):
         return json.dumps(dict(d))
 
     @classmethod
-    def simple_http_get(cls, url, headers, **kwargs) -> tuple[int, Any, Any]:
+    def simple_http_get(cls, url, headers, **kwargs) -> Tuple[int, Any, Any]:
         """The most simple HTTP-based GET."""
         if not "allow_redirects" in kwargs:
             kwargs["allow_redirects"] = True

--- a/core/model/resource.py
+++ b/core/model/resource.py
@@ -11,7 +11,7 @@ import time
 import traceback
 from hashlib import md5
 from io import BytesIO
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, urlparse, urlsplit
 
 import requests
@@ -1055,7 +1055,7 @@ class Representation(Base, MediaTypes):
         return json.dumps(dict(d))
 
     @classmethod
-    def simple_http_get(cls, url, headers, **kwargs):
+    def simple_http_get(cls, url, headers, **kwargs) -> tuple[int, Any, Any]:
         """The most simple HTTP-based GET."""
         if not "allow_redirects" in kwargs:
             kwargs["allow_redirects"] = True

--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -47,10 +47,8 @@ from .model import (
     get_one,
 )
 from .model.configuration import (
-    ConfigurationAttributeType,
     ConfigurationFactory,
     ConfigurationGrouping,
-    ConfigurationMetadata,
     ConfigurationStorage,
     ExternalIntegrationLink,
     HasExternalIntegration,
@@ -92,16 +90,7 @@ def parse_identifier(db, identifier):
 
 
 class OPDSImporterConfiguration(ConfigurationGrouping, BaseImporterConfiguration):
-    max_retry_count = ConfigurationMetadata(
-        key="max_retry_count",
-        label=_("Max retry count"),
-        description=_(
-            "The maximum number of times to retry a request for certain connection-related errors."
-        ),
-        type=ConfigurationAttributeType.NUMBER,
-        required=False,
-        default=3,
-    )
+    """The basic OPDS importer configuration"""
 
 
 class AccessNotAuthenticated(Exception):
@@ -158,7 +147,6 @@ class SimplifiedOPDSLookup(object):
 
 
 class MetadataWranglerOPDSLookup(SimplifiedOPDSLookup, HasSelfTests):
-
     PROTOCOL = ExternalIntegration.METADATA_WRANGLER
     NAME = _("Palace Collection Manager Metadata Wrangler")
     CARDINALITY = 1
@@ -480,7 +468,6 @@ class MockMetadataWranglerOPDSLookup(
 
 
 class OPDSXMLParser(XMLParser):
-
     NAMESPACES = {
         "simplified": "http://librarysimplified.org/terms/",
         "app": "http://www.w3.org/2007/app",

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import logging
 from threading import RLock
-from typing import Optional, Set
+from typing import Dict, Optional, Set, Tuple
 from urllib.parse import quote, urlsplit, urlunsplit
 
 import isbnlib
@@ -206,7 +206,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
     _configuration: OverdriveConfiguration
     _external_integration: ExternalIntegration
     _db: Session
-    _hosts: dict[str, str]
+    _hosts: Dict[str, str]
     _library_id: str
     _collection_id: int
 
@@ -259,7 +259,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
         # This is set by an access to .collection_token
         self._collection_token = None
 
-    def _determine_hosts(self, configuration: OverdriveConfiguration) -> dict[str, str]:
+    def _determine_hosts(self, configuration: OverdriveConfiguration) -> Dict[str, str]:
         # Figure out which hostnames we'll be using when constructing
         # endpoint URLs.
         server_nickname = (
@@ -426,7 +426,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
 
     def get(
         self, url: str, extra_headers, exception_on_401=False
-    ) -> tuple[int, CaseInsensitiveDict, bytes]:
+    ) -> Tuple[int, CaseInsensitiveDict, bytes]:
         """Make an HTTP GET request using the active Bearer Token."""
         request_headers = dict(Authorization="Bearer %s" % self.token)
         request_headers.update(extra_headers)
@@ -457,7 +457,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
         return "Basic " + base64.standard_b64encode(s).strip()
 
     def token_post(
-        self, url: str, payload: dict[str, str], headers={}, **kwargs
+        self, url: str, payload: Dict[str, str], headers={}, **kwargs
     ) -> Response:
         """Make an HTTP POST request for purposes of getting an OAuth token."""
         headers = dict(headers)
@@ -669,7 +669,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
     def library_id(self) -> str:
         return self._library_id
 
-    def hosts(self) -> dict[str, str]:
+    def hosts(self) -> Dict[str, str]:
         return dict(self._hosts)
 
 

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -241,9 +241,9 @@ class OverdriveCoreAPI(HasExternalIntegration):
             self.parent_library_id = None
 
         # Initialize configuration information.
-        self._configuration_storage: ConfigurationStorage = ConfigurationStorage(self)
-        self._configuration_factory: ConfigurationFactory = ConfigurationFactory()
-        self._configuration: OverdriveConfiguration = OverdriveConfiguration(
+        self._configuration_storage = ConfigurationStorage(self)
+        self._configuration_factory = ConfigurationFactory()
+        self._configuration = OverdriveConfiguration(
             configuration_storage=self._configuration_storage, db=_db
         )
 
@@ -268,7 +268,6 @@ class OverdriveCoreAPI(HasExternalIntegration):
         if server_nickname not in self.HOSTS:
             server_nickname = OverdriveConfiguration.PRODUCTION_SERVERS
 
-        # Set the hostnames we'll be using.
         return dict(self.HOSTS[server_nickname])
 
     def _migrate_configuration(

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -350,7 +350,9 @@ class OverdriveAPI:
         s = b"%s:%s" % (self.client_key, self.client_secret)
         return "Basic " + base64.standard_b64encode(s).strip()
 
-    def token_post(self, url: str, payload, headers={}, **kwargs) -> Response:
+    def token_post(
+        self, url: str, payload: dict[str, str], headers={}, **kwargs
+    ) -> Response:
         """Make an HTTP POST request for purposes of getting an OAuth token."""
         headers = dict(headers)
         headers["Authorization"] = self.token_authorization_header

--- a/tests/api/admin/controller/test_collections.py
+++ b/tests/api/admin/controller/test_collections.py
@@ -172,9 +172,9 @@ class TestCollectionSettings(SettingsControllerTest):
         )
 
         c2.external_account_id = "1234"
-        c2.external_integration.password = "b"
-        c2.external_integration.username = "user"
-        c2.external_integration.setting("website_id").value = "100"
+        c2.external_integration.setting("overdrive_client_secret").value = "b"
+        c2.external_integration.setting("overdrive_client_key").value = "user"
+        c2.external_integration.setting("overdrive_website_id").value = "100"
 
         c3 = self._collection(
             name="Collection 3",
@@ -243,7 +243,9 @@ class TestCollectionSettings(SettingsControllerTest):
             assert c3.external_account_id == settings3.get("external_account_id")
 
             assert c1.external_integration.password == settings1.get("password")
-            assert c2.external_integration.password == settings2.get("password")
+            assert c2.external_integration.setting(
+                "overdrive_client_secret"
+            ).value == settings2.get("overdrive_client_secret")
 
             assert c2.id == coll3.get("parent_id")
 
@@ -420,8 +422,8 @@ class TestCollectionSettings(SettingsControllerTest):
                     ("name", "collection1"),
                     ("protocol", "Overdrive"),
                     ("external_account_id", "1234"),
-                    ("username", "user"),
-                    ("password", "password"),
+                    ("overdrive_client_key", "user"),
+                    ("overdrive_client_secret", "password"),
                 ]
             )
             response = (
@@ -492,9 +494,9 @@ class TestCollectionSettings(SettingsControllerTest):
                         ),
                     ),
                     ("external_account_id", "acctid"),
-                    ("username", "username"),
-                    ("password", "password"),
-                    ("website_id", "1234"),
+                    ("overdrive_client_key", "username"),
+                    ("overdrive_client_secret", "password"),
+                    ("overdrive_website_id", "1234"),
                 ]
             )
             response = (
@@ -507,8 +509,14 @@ class TestCollectionSettings(SettingsControllerTest):
         assert collection.id == int(response.response[0])
         assert "New Collection" == collection.name
         assert "acctid" == collection.external_account_id
-        assert "username" == collection.external_integration.username
-        assert "password" == collection.external_integration.password
+        assert (
+            "username"
+            == collection.external_integration.setting("overdrive_client_key").value
+        )
+        assert (
+            "password"
+            == collection.external_integration.setting("overdrive_client_secret").value
+        )
 
         # Two libraries now have access to the collection.
         assert [collection] == l1.collections
@@ -516,8 +524,8 @@ class TestCollectionSettings(SettingsControllerTest):
         assert [] == l3.collections
 
         # Additional settings were set on the collection.
-        setting = collection.external_integration.setting("website_id")
-        assert "website_id" == setting.key
+        setting = collection.external_integration.setting("overdrive_website_id")
+        assert "overdrive_website_id" == setting.key
         assert "1234" == setting.value
 
         assert (
@@ -594,9 +602,9 @@ class TestCollectionSettings(SettingsControllerTest):
                     ("name", "Collection 1"),
                     ("protocol", ExternalIntegration.OVERDRIVE),
                     ("external_account_id", "1234"),
-                    ("username", "user2"),
-                    ("password", "password"),
-                    ("website_id", "1234"),
+                    ("overdrive_client_key", "user2"),
+                    ("overdrive_client_secret", "password"),
+                    ("overdrive_website_id", "1234"),
                     (
                         "libraries",
                         json.dumps([{"short_name": "L1", "ils_name": "the_ils"}]),
@@ -611,14 +619,17 @@ class TestCollectionSettings(SettingsControllerTest):
         assert collection.id == int(response.response[0])
 
         # The collection has been changed.
-        assert "user2" == collection.external_integration.username
+        assert (
+            "user2"
+            == collection.external_integration.setting("overdrive_client_key").value
+        )
 
         # A library now has access to the collection.
         assert [collection] == l1.collections
 
         # Additional settings were set on the collection.
-        setting = collection.external_integration.setting("website_id")
-        assert "website_id" == setting.key
+        setting = collection.external_integration.setting("overdrive_website_id")
+        assert "overdrive_website_id" == setting.key
         assert "1234" == setting.value
 
         assert (
@@ -635,9 +646,9 @@ class TestCollectionSettings(SettingsControllerTest):
                     ("name", "Collection 1"),
                     ("protocol", ExternalIntegration.OVERDRIVE),
                     ("external_account_id", "1234"),
-                    ("username", "user2"),
-                    ("password", "password"),
-                    ("website_id", "1234"),
+                    ("overdrive_client_key", "user2"),
+                    ("overdrive_client_secret", "password"),
+                    ("overdrive_website_id", "1234"),
                     ("libraries", json.dumps([])),
                 ]
             )
@@ -649,7 +660,10 @@ class TestCollectionSettings(SettingsControllerTest):
         assert collection.id == int(response.response[0])
 
         # The collection is the same.
-        assert "user2" == collection.external_integration.username
+        assert (
+            "user2"
+            == collection.external_integration.setting("overdrive_client_key").value
+        )
         assert ExternalIntegration.OVERDRIVE == collection.protocol
 
         # But the library has been removed.

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -46,7 +46,7 @@ class OverdriveAPITest(DatabaseTest):
         self.circulation = CirculationAPI(
             self._db, library, api_map={ExternalIntegration.OVERDRIVE: MockOverdriveAPI}
         )
-        self.api = self.circulation.api_for_collection[self.collection.id]
+        self.api: OverdriveAPI = self.circulation.api_for_collection[self.collection.id]
 
     @classmethod
     def sample_data(self, filename):
@@ -257,7 +257,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         # integration and the ILS name associated with the library
         # into the form expected by Overdrive.
         expect = "websiteid:%s authorizationname:%s" % (
-            self.api.website_id.decode("utf-8"),
+            self.api.website_id().decode("utf-8"),
             self.api.ils_name(self._default_library),
         )
         assert expect == self.api.scope_string(self._default_library)
@@ -1473,7 +1473,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         assert "https://oauth-patron.overdrive.com/patrontoken" == url
         assert "barcode" == payload["username"]
         expect_scope = "websiteid:%s authorizationname:%s" % (
-            self.api.website_id.decode("utf-8"),
+            self.api.website_id().decode("utf-8"),
             self.api.ils_name(patron.library),
         )
         assert expect_scope == payload["scope"]


### PR DESCRIPTION
## Description

This refactors the Overdrive code to use the new configuration
API and improves type safety and encapsulation everywhere.
    
* The core OverdriveAPI class was renamed to OverdriveCoreAPI in order to stop having two classes in the core and API with the same name.
* Configuration values were renamed so that all Overdrive-specific values are now called `overdrive_*` in the database. Code was added to migrate from the old configuration structure to the new structure (and the old values are set to `None` in the database).
* Many attributes were renamed to turn them into "protected" attributes, and type annotations were added. External code needing access to the attributes now has to retrieve the values through methods.

## Motivation and Context

https://www.notion.so/lyrasis/Migrate-Overdrive-integration-to-new-configuration-API-1f8d105bf6cd4c99a23bd6baead15d9e

## How Has This Been Tested?

I tried creating a new Overdrive collection and checked that the configuration settings held.
I also opened an existing Overdrive collection that was created using the old API, and checked that the settings were preserved.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
