### PR TITLE
Overdrive retry login: Use correct "allowed response codes"

### DIFF
--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -431,7 +431,9 @@ class OverdriveCoreAPI(HasExternalIntegration):
         request_headers = dict(Authorization="Bearer %s" % self.token)
         request_headers.update(extra_headers)
 
-        response: Response = self._do_get(url, request_headers)
+        response: Response = self._do_get(
+            url, request_headers, allowed_response_codes=["2xx", "3xx", "401", "404"]
+        )
         status_code: int = response.status_code
         headers: CaseInsensitiveDict = response.headers
         content: bytes = response.content
@@ -650,11 +652,15 @@ class OverdriveCoreAPI(HasExternalIntegration):
     def _do_get(self, url: str, headers, **kwargs) -> Response:
         """This method is overridden in MockOverdriveAPI."""
         url = self.endpoint(url)
+        kwargs["max_retry_count"] = self._configuration.max_retry_count
+        kwargs["timeout"] = 120
         return HTTP.get_with_timeout(url, headers=headers, **kwargs)
 
     def _do_post(self, url: str, payload, headers, **kwargs) -> Response:
         """This method is overridden in MockOverdriveAPI."""
         url = self.endpoint(url)
+        kwargs["max_retry_count"] = self._configuration.max_retry_count
+        kwargs["timeout"] = 120
         return HTTP.post_with_timeout(url, payload, headers=headers, **kwargs)
 
     def website_id(self) -> bytes:

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -425,7 +425,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
         self._token = credential.credential
 
     def get(
-        self, url: str, extra_headers, exception_on_401=False
+        self, url: str, extra_headers={}, exception_on_401=False
     ) -> Tuple[int, CaseInsensitiveDict, bytes]:
         """Make an HTTP GET request using the active Bearer Token."""
         request_headers = dict(Authorization="Bearer %s" % self.token)

--- a/tests/core/util/test_mock_web_server.py
+++ b/tests/core/util/test_mock_web_server.py
@@ -1,0 +1,241 @@
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+
+from core.util.http import HTTP, RequestNetworkException
+
+
+class MockAPIServerRequest:
+    """A request made to a server."""
+
+    headers: Dict[str, str]
+    payload: bytes
+    method: str
+    path: str
+
+    def __init__(self):
+        self.headers = {}
+        self.payload = b""
+        self.method = "GET"
+        self.path = "/"
+
+
+class MockAPIServerResponse:
+    """A response returned from a server."""
+
+    status_code: int
+    content: bytes
+    headers: Dict[str, str]
+    close_obnoxiously: bool
+
+    def __init__(self):
+        self.status_code = 200
+        self.content = "".encode("utf-8")
+        self.headers = {}
+        self.close_obnoxiously = False
+
+    def set_content(self, data: bytes):
+        """A convenience method that automatically sets the correct content length for data."""
+        self.content = data
+        self.headers["content-length"] = str(len(data))
+
+
+class MockAPIServerRequestHandler(BaseHTTPRequestHandler):
+    """Basic request handler."""
+
+    def _send_everything(self, _response: MockAPIServerResponse):
+        if _response.close_obnoxiously:
+            return
+
+        self.send_response(_response.status_code)
+        for key in _response.headers.keys():
+            _value = _response.headers.get(key)
+            if _value:
+                self.send_header(key, _value)
+
+        self.end_headers()
+        self.wfile.write(_response.content)
+        self.wfile.flush()
+
+    def _read_everything(self) -> MockAPIServerRequest:
+        _request = MockAPIServerRequest()
+        _request.method = self.command
+        for k in self.headers.keys():
+            _request.headers[k] = self.headers.get(k)
+        _request.path = self.path
+        _readable = int(self.headers.get("Content-Length") or 0)
+        if _readable > 0:
+            _request.payload = self.rfile.read(_readable)
+        return _request
+
+    def _handle_everything(self):
+        _request = self._read_everything()
+        _response = self.server.mock_api_server.dequeue_response(_request)
+        if _response is None:
+            logging.error(
+                f"failed to find a response for {_request.method} {_request.path}"
+            )
+            raise AssertionError("No available response!")
+        self._send_everything(_response)
+
+    def do_GET(self):
+        logging.info("GET")
+        self._handle_everything()
+
+    def do_POST(self):
+        logging.info("POST")
+        self._handle_everything()
+
+    def do_PUT(self):
+        logging.info("PUT")
+        self._handle_everything()
+
+    def version_string(self) -> str:
+        return ""
+
+    def date_time_string(self, timestamp: Optional[int] = 0) -> str:
+        return "Sat, 1 January 2000 00:00:00 UTC"
+
+
+class MockAPIInternalServer(HTTPServer):
+    mock_api_server: "MockAPIServer"
+
+    def __init__(self, server_address: Tuple[str, int], bind_and_activate: bool):
+        super(MockAPIInternalServer, self).__init__(
+            server_address, MockAPIServerRequestHandler, bind_and_activate
+        )
+        self.allow_reuse_address = True
+
+
+class MockAPIServer:
+    """Embedded web server."""
+
+    _address: str
+    _port: int
+    _server: HTTPServer
+    _server_thread: threading.Thread
+    _responses: Dict[str, Dict[str, List[MockAPIServerResponse]]]
+    _requests: List[MockAPIServerRequest]
+
+    def __init__(self, address: str, port: int):
+        self._address = address
+        self._port = port
+        self._server = MockAPIInternalServer(
+            (self._address, self._port), bind_and_activate=True
+        )
+        self._server.mock_api_server = self
+        self._server_thread = threading.Thread(target=self._server.serve_forever)
+        self._responses = {}
+        self._requests = []
+
+    def start(self) -> None:
+        self._server_thread.start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._server_thread.join(timeout=10)
+
+    def enqueue_response(
+        self, request_method: str, request_path: str, response: MockAPIServerResponse
+    ):
+        _by_method = self._responses.get(request_method) or {}
+        _by_path = _by_method.get(request_path) or []
+        _by_path.append(response)
+        _by_method[request_path] = _by_path
+        self._responses[request_method] = _by_method
+
+    def dequeue_response(
+        self, request: MockAPIServerRequest
+    ) -> Optional[MockAPIServerResponse]:
+        self._requests.append(request)
+        _by_method = self._responses.get(request.method) or {}
+        _by_path = _by_method.get(request.path) or []
+        if len(_by_path) > 0:
+            return _by_path.pop(0)
+        return None
+
+    def address(self) -> str:
+        return self._address
+
+    def port(self) -> int:
+        return self._port
+
+    def url(self, path: str) -> str:
+        return f"http://{self.address()}:{self.port()}{path}"
+
+    def requests(self) -> List[MockAPIServerRequest]:
+        return list(self._requests)
+
+
+@pytest.fixture
+def mock_web_server():
+    """A test fixture that yields a usable mock web server for the lifetime of the test."""
+    _server = MockAPIServer("127.0.0.1", 10256)
+    _server.start()
+    logging.info(f"starting mock web server on {_server.address()}:{_server.port()}")
+    yield _server
+    logging.info(
+        f"shutting down mock web server on {_server.address()}:{_server.port()}"
+    )
+    _server.stop()
+
+
+class TestMockAPIServer:
+    def test_server_get(self, mock_web_server: MockAPIServer):
+        mock_web_server.enqueue_response("GET", "/x/y/z", MockAPIServerResponse())
+
+        url = mock_web_server.url("/x/y/z")
+        response = HTTP.request_with_timeout("GET", url)
+        assert response.status_code == 200
+        assert response.content == "".encode("utf-8")
+
+        requests = mock_web_server.requests()
+        assert len(requests) == 1
+        assert requests[0].path == "/x/y/z"
+        assert requests[0].method == "GET"
+
+    def test_server_post(self, mock_web_server: MockAPIServer):
+        _r = MockAPIServerResponse()
+        _r.status_code = 201
+        _r.headers["Extra"] = "Thing"
+        _r.set_content(b"DATA!")
+        mock_web_server.enqueue_response("POST", "/x/y/z", _r)
+
+        url = mock_web_server.url("/x/y/z")
+        response = HTTP.request_with_timeout(
+            "POST", url, data=b"DATA!", headers={"Extra": "Thing"}
+        )
+        assert response.status_code == 201
+        assert response.content == "DATA!".encode("utf-8")
+        assert response.headers["Extra"] == "Thing"
+
+        requests = mock_web_server.requests()
+        assert len(requests) == 1
+        assert requests[0].path == "/x/y/z"
+        assert requests[0].method == "POST"
+        assert requests[0].payload == b"DATA!"
+        assert requests[0].headers["Extra"] == "Thing"
+
+    def test_server_get_no_response(self, mock_web_server: MockAPIServer):
+        url = mock_web_server.url("/x/y/z")
+        try:
+            HTTP.request_with_timeout("GET", url)
+        except RequestNetworkException:
+            return
+        raise AssertionError("Failed to fail!")
+
+    def test_server_get_dies(self, mock_web_server: MockAPIServer):
+        _r = MockAPIServerResponse()
+        _r.close_obnoxiously = True
+        mock_web_server.enqueue_response("GET", "/x/y/z", _r)
+
+        url = mock_web_server.url("/x/y/z")
+        try:
+            HTTP.request_with_timeout("GET", url)
+        except RequestNetworkException:
+            return
+        raise AssertionError("Failed to fail!")


### PR DESCRIPTION
## Description

This adds the "allowed response codes" and the connection retry count
to the internal HTTP requests to allow for retrying on Overdrive
API failures.

## Motivation and Context

Affects: https://www.notion.so/lyrasis/overdrive_new_title-import-fails-due-to-timeouts-and-500-errors-87ec0491e0f94a889a3ef37cc2f440a5

## How Has This Been Tested?

I've run three complete Overdrive imports in total, which took about an hour each. Each one presented various errors, and the import continued after retrying. In particular, the imports would have been failing with 401 errors when the authentication token expired because the retry logic that was recently added to the low-level HTTP imports meant that the Overdrive code would have seen an exception instead of a 401 error code.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
