### PR TITLE
OverdriveAPI fulfillment credentials through patronauth

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -642,7 +642,7 @@ class OverdriveAPI(
                     patron,
                     pin,
                     is_fulfillment=True,
-                )
+                ).credential
                 return OverdriveManifestFulfillmentInfo(
                     self.collection,
                     download_link,

--- a/core/config.py
+++ b/core/config.py
@@ -3,6 +3,7 @@ import copy
 import json
 import logging
 import os
+from typing import Dict
 
 from flask_babel import lazy_gettext as _
 from sqlalchemy.engine.url import make_url
@@ -505,10 +506,9 @@ class Configuration(ConfigurationConstants):
         return url
 
     @classmethod
-    def overdrive_fulfillment_keys(cls):
-        test = os.environ.get("TESTING", False)
+    def overdrive_fulfillment_keys(cls, testing=False) -> Dict[str, str]:
         prefix = (
-            cls.OD_PREFIX_TESTING_PREFIX if test else cls.OD_PREFIX_PRODUCTION_PREFIX
+            cls.OD_PREFIX_TESTING_PREFIX if testing else cls.OD_PREFIX_PRODUCTION_PREFIX
         )
         return {
             "key": os.environ.get(f"{prefix}_{cls.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}"),

--- a/core/config.py
+++ b/core/config.py
@@ -510,12 +510,11 @@ class Configuration(ConfigurationConstants):
         prefix = (
             cls.OD_PREFIX_TESTING_PREFIX if testing else cls.OD_PREFIX_PRODUCTION_PREFIX
         )
-        return {
-            "key": os.environ.get(f"{prefix}_{cls.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}"),
-            "secret": os.environ.get(
-                f"{prefix}_{cls.OD_FULFILLMENT_CLIENT_SECRET_SUFFIX}"
-            ),
-        }
+        key = os.environ.get(f"{prefix}_{cls.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}")
+        secret = os.environ.get(f"{prefix}_{cls.OD_FULFILLMENT_CLIENT_SECRET_SUFFIX}")
+        if key is None or secret is None:
+            raise CannotLoadConfiguration("Invalid fulfillment credentials.")
+        return {"key": key, "secret": secret}
 
     @classmethod
     def app_version(cls):

--- a/core/config.py
+++ b/core/config.py
@@ -79,6 +79,12 @@ class Configuration(ConfigurationConstants):
     DATABASE_TEST_ENVIRONMENT_VARIABLE = "SIMPLIFIED_TEST_DATABASE"
     DATABASE_PRODUCTION_ENVIRONMENT_VARIABLE = "SIMPLIFIED_PRODUCTION_DATABASE"
 
+    # Environment variable for Overdrive fulfillment keys
+    OD_PREFIX_PRODUCTION_PREFIX = "SIMPLIFIED"
+    OD_PREFIX_TESTING_PREFIX = "SIMPLIFIED_TESTING"
+    OD_FULFILLMENT_CLIENT_KEY_SUFFIX = "OVERDRIVE_FULFILLMENT_CLIENT_KEY"
+    OD_FULFILLMENT_CLIENT_SECRET_SUFFIX = "OVERDRIVE_FULFILLMENT_CLIENT_SECRET"
+
     # The version of the app.
     APP_VERSION = "app_version"
     VERSION_FILENAME = ".version"
@@ -497,6 +503,19 @@ class Configuration(ConfigurationConstants):
         # Calling __to_string__ will hide the password.
         logging.info("Connecting to database: %s" % url_obj.__to_string__())
         return url
+
+    @classmethod
+    def overdrive_fulfillment_keys(cls):
+        test = os.environ.get("TESTING", False)
+        prefix = (
+            cls.OD_PREFIX_TESTING_PREFIX if test else cls.OD_PREFIX_PRODUCTION_PREFIX
+        )
+        return {
+            "key": os.environ.get(f"{prefix}_{cls.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}"),
+            "secret": os.environ.get(
+                f"{prefix}_{cls.OD_FULFILLMENT_CLIENT_SECRET_SUFFIX}"
+            ),
+        }
 
     @classmethod
     def app_version(cls):

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -460,8 +460,11 @@ class OverdriveCoreAPI(HasExternalIntegration):
 
     @property
     def fulfillment_authorization_header(self) -> str:
-        keys = Configuration.overdrive_fulfillment_keys()
-        s = b"%s:%s" % (keys["key"].encode(), keys["secret"].encode())
+        client_credentials = Configuration.overdrive_fulfillment_keys()
+        s = b"%s:%s" % (
+            client_credentials["key"].encode(),
+            client_credentials["secret"].encode(),
+        )
         return "Basic " + base64.standard_b64encode(s).strip()
 
     def token_post(

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -250,6 +250,10 @@ class OverdriveCoreAPI(HasExternalIntegration):
         self._migrate_configuration(
             collection=collection, configuration=self._configuration
         )
+        self._server_nickname = (
+            self._configuration.server_nickname
+            or OverdriveConfiguration.PRODUCTION_SERVERS
+        )
         self._hosts = self._determine_hosts(configuration=self._configuration)
 
         # This is set by an access to .token, or by a call to
@@ -460,7 +464,14 @@ class OverdriveCoreAPI(HasExternalIntegration):
 
     @property
     def fulfillment_authorization_header(self) -> str:
-        client_credentials = Configuration.overdrive_fulfillment_keys()
+        is_test_mode = (
+            True
+            if self._server_nickname == OverdriveConfiguration.TESTING_SERVERS
+            else False
+        )
+        client_credentials = Configuration.overdrive_fulfillment_keys(
+            testing=is_test_mode
+        )
         s = b"%s:%s" % (
             client_credentials["key"].encode(),
             client_credentials["secret"].encode(),

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1553,7 +1553,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         exc = pytest.raises(
             CannotFulfill,
             od_api.get_fulfillment_link,
-            *(patron, "pin", "odid", "audiobook-overdrive-manifest")
+            *(patron, "pin", "odid", "audiobook-overdrive-manifest"),
         )
         assert exc.match("No download link for")
 
@@ -1563,7 +1563,6 @@ class TestOverdriveAPI(OverdriveAPITest):
         )
         with pytest.raises(CannotFulfill):
             od_api.fulfillment_authorization_header
-        
 
 
 class TestOverdriveAPICredentials(OverdriveAPITest):
@@ -1933,17 +1932,14 @@ class TestSyncBookshelf(OverdriveAPITest):
         # We have created previously unknown LicensePools and
         # Identifiers.
         identifiers = [loan.license_pool.identifier.identifier for loan in loans]
-        assert (
-            sorted(
-                [
-                    "a5a3d737-34d4-4d69-aad8-eba4e46019a3",
-                    "99409f99-45a5-4238-9e10-98d1435cde04",
-                    "993e4b33-823c-40af-8f61-cac54e1cba5d",
-                    "a2ec6f3a-ebfe-4c95-9638-2cb13be8de5a",
-                ]
-            )
-            == sorted(identifiers)
-        )
+        assert sorted(
+            [
+                "a5a3d737-34d4-4d69-aad8-eba4e46019a3",
+                "99409f99-45a5-4238-9e10-98d1435cde04",
+                "993e4b33-823c-40af-8f61-cac54e1cba5d",
+                "a2ec6f3a-ebfe-4c95-9638-2cb13be8de5a",
+            ]
+        ) == sorted(identifiers)
 
         # We have recorded a new DeliveryMechanism associated with
         # each loan.

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1048,8 +1048,8 @@ class TestOverdriveAPI(OverdriveAPITest):
         loan_info = {"isFormatLockedIn": False}
 
         class MockAPI(MockOverdriveAPI):
-            def get_loan(self, patron, pin, overdrive_id):
-                self.get_loan_called_with = (patron, pin, overdrive_id)
+            def get_loan(self, patron, pin, overdrive_id, is_fulfillment=False):
+                self.get_loan_called_with = (patron, pin, overdrive_id, is_fulfillment)
                 return loan_info
 
             def get_download_link(self, loan, format_type, error_url):
@@ -1081,7 +1081,12 @@ class TestOverdriveAPI(OverdriveAPITest):
         # let's see how we got there.
 
         # First, our mocked get_loan() was called.
-        assert (patron, "1234", "http://download-link") == api.get_loan_called_with
+        assert (
+            patron,
+            "1234",
+            "http://download-link",
+            True,
+        ) == api.get_loan_called_with
 
         # It returned a dictionary that contained no information
         # except isFormatLockedIn: false.
@@ -1854,14 +1859,17 @@ class TestSyncBookshelf(OverdriveAPITest):
         # We have created previously unknown LicensePools and
         # Identifiers.
         identifiers = [loan.license_pool.identifier.identifier for loan in loans]
-        assert sorted(
-            [
-                "a5a3d737-34d4-4d69-aad8-eba4e46019a3",
-                "99409f99-45a5-4238-9e10-98d1435cde04",
-                "993e4b33-823c-40af-8f61-cac54e1cba5d",
-                "a2ec6f3a-ebfe-4c95-9638-2cb13be8de5a",
-            ]
-        ) == sorted(identifiers)
+        assert (
+            sorted(
+                [
+                    "a5a3d737-34d4-4d69-aad8-eba4e46019a3",
+                    "99409f99-45a5-4238-9e10-98d1435cde04",
+                    "993e4b33-823c-40af-8f61-cac54e1cba5d",
+                    "a2ec6f3a-ebfe-4c95-9638-2cb13be8de5a",
+                ]
+            )
+            == sorted(identifiers)
+        )
 
         # We have recorded a new DeliveryMechanism associated with
         # each loan.

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1859,17 +1859,14 @@ class TestSyncBookshelf(OverdriveAPITest):
         # We have created previously unknown LicensePools and
         # Identifiers.
         identifiers = [loan.license_pool.identifier.identifier for loan in loans]
-        assert (
-            sorted(
-                [
-                    "a5a3d737-34d4-4d69-aad8-eba4e46019a3",
-                    "99409f99-45a5-4238-9e10-98d1435cde04",
-                    "993e4b33-823c-40af-8f61-cac54e1cba5d",
-                    "a2ec6f3a-ebfe-4c95-9638-2cb13be8de5a",
-                ]
-            )
-            == sorted(identifiers)
-        )
+        assert sorted(
+            [
+                "a5a3d737-34d4-4d69-aad8-eba4e46019a3",
+                "99409f99-45a5-4238-9e10-98d1435cde04",
+                "993e4b33-823c-40af-8f61-cac54e1cba5d",
+                "a2ec6f3a-ebfe-4c95-9638-2cb13be8de5a",
+            ]
+        ) == sorted(identifiers)
 
         # We have recorded a new DeliveryMechanism associated with
         # each loan.


### PR DESCRIPTION
using overdrive fulfillment key-secret on the backend we now
create an access token for the clients to use rather than
have them store the key-secret locally

Backend storage of key-secret is done via environment variables
for maximum security

## Description
The Configuration object now looks for SIMPLIFIED_OVERDRIVE_FULFILLMENT_CLIENT_{KEY,SECRET} environment variables
While returning an `OverdriveManifestFulfillmentInfo` we add into it the `X-Overdrive-Patron-Authentication` header with the fulfillment bearer token
The `OverdriveManifestFulfillmentInfo` object is the only object that returns the `X-Overdrive-Scope` header, so it is logically the only place we need to add this additional header
<!--- Describe your changes -->

## Motivation and Context

The Overdrive security review stated the fulfilment key-secrets being stored on the mobile clients needed to be moved to the backend.
To this end, we now create fulfilment access tokens for the mobile clients during the fulfilment API requests and return them as an `X-Overdrive-Patron-Authentication` header

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
