### PR TITLE
Bugfix/upgrade black to stop exception

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
         name: Run black

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -232,11 +232,14 @@ class FulfillmentInfo(CirculationInfo):
             blength = len(self.content)
         else:
             blength = 0
-        return "<FulfillmentInfo: content_link: %r, content_type: %r, content: %d bytes, expires: %r>" % (
-            self.content_link,
-            self.content_type,
-            blength,
-            self.fd(self.content_expires),
+        return (
+            "<FulfillmentInfo: content_link: %r, content_type: %r, content: %d bytes, expires: %r>"
+            % (
+                self.content_link,
+                self.content_type,
+                blength,
+                self.fd(self.content_expires),
+            )
         )
 
     @property

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -2766,7 +2766,7 @@ class Filter(SearchBase):
         """
 
         exponent = 2
-        cutoff = self.minimum_featured_quality ** exponent
+        cutoff = self.minimum_featured_quality**exponent
         script = self.FEATURABLE_SCRIPT % dict(cutoff=cutoff, exponent=exponent)
         quality_field = SF("script_score", script=dict(source=script))
 

--- a/core/metadata_layer.py
+++ b/core/metadata_layer.py
@@ -204,14 +204,17 @@ class ContributorData(object):
         # TODO:  consider if it's time for ContributorData to connect back to Contributions
 
     def __repr__(self):
-        return '<ContributorData sort="%s" display="%s" family="%s" wiki="%s" roles=%r lc=%s viaf=%s>' % (
-            self.sort_name,
-            self.display_name,
-            self.family_name,
-            self.wikipedia_name,
-            self.roles,
-            self.lc,
-            self.viaf,
+        return (
+            '<ContributorData sort="%s" display="%s" family="%s" wiki="%s" roles=%r lc=%s viaf=%s>'
+            % (
+                self.sort_name,
+                self.display_name,
+                self.family_name,
+                self.wikipedia_name,
+                self.roles,
+                self.lc,
+                self.viaf,
+            )
         )
 
     @classmethod

--- a/core/util/summary.py
+++ b/core/util/summary.py
@@ -152,7 +152,7 @@ class SummaryEvaluator(object):
             off_from_optimal = 1.5
         if off_from_optimal:
             # This summary is too long or too short.
-            score /= off_from_optimal ** 1.5
+            score /= off_from_optimal**1.5
 
         bad_phrases = 0
         l = summary.lower()
@@ -167,7 +167,7 @@ class SummaryEvaluator(object):
         if l.count(" -- ") > 3:
             bad_phrases += l.count(" -- ") - 3
 
-        score *= 0.5 ** bad_phrases
+        score *= 0.5**bad_phrases
 
         if apply_language_penalty:
             language_difference = english_bigrams.difference_from(

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -361,28 +361,22 @@ class TestSignInController(AdminControllerTest):
             pw_admin, ignore = create(self._db, Admin, email="pw@nypl.org")
             pw_admin.password = "password"
             assert 2 == len(ctrl.admin_auth_providers)
-            assert (
-                set(
-                    [
-                        GoogleOAuthAdminAuthenticationProvider.NAME,
-                        PasswordAdminAuthenticationProvider.NAME,
-                    ]
-                )
-                == set([provider.NAME for provider in ctrl.admin_auth_providers])
-            )
+            assert set(
+                [
+                    GoogleOAuthAdminAuthenticationProvider.NAME,
+                    PasswordAdminAuthenticationProvider.NAME,
+                ]
+            ) == set([provider.NAME for provider in ctrl.admin_auth_providers])
 
             # Only an admin with a password.
             self._db.delete(self.admin)
             assert 2 == len(ctrl.admin_auth_providers)
-            assert (
-                set(
-                    [
-                        GoogleOAuthAdminAuthenticationProvider.NAME,
-                        PasswordAdminAuthenticationProvider.NAME,
-                    ]
-                )
-                == set([provider.NAME for provider in ctrl.admin_auth_providers])
-            )
+            assert set(
+                [
+                    GoogleOAuthAdminAuthenticationProvider.NAME,
+                    PasswordAdminAuthenticationProvider.NAME,
+                ]
+            ) == set([provider.NAME for provider in ctrl.admin_auth_providers])
 
             # No admins. Someone new could still log in with google if domains are
             # configured.

--- a/tests/api/admin/controller/test_individual_admins.py
+++ b/tests/api/admin/controller/test_individual_admins.py
@@ -40,55 +40,52 @@ class TestIndividualAdmins(SettingsControllerTest):
                 self.manager.admin_individual_admin_settings_controller.process_get()
             )
             admins = response.get("individualAdmins")
-            assert (
-                sorted(
-                    [
-                        {
-                            "email": "admin1@nypl.org",
-                            "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
-                        },
-                        {
-                            "email": "admin2@nypl.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARY_MANAGER,
-                                    "library": self._default_library.short_name,
-                                },
-                                {"role": AdminRole.SITEWIDE_LIBRARIAN},
-                            ],
-                        },
-                        {
-                            "email": "admin3@nypl.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARIAN,
-                                    "library": self._default_library.short_name,
-                                }
-                            ],
-                        },
-                        {
-                            "email": "admin4@l2.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARY_MANAGER,
-                                    "library": library2.short_name,
-                                }
-                            ],
-                        },
-                        {
-                            "email": "admin5@l2.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARIAN,
-                                    "library": library2.short_name,
-                                }
-                            ],
-                        },
-                    ],
-                    key=lambda x: x["email"],
-                )
-                == sorted(admins, key=lambda x: x["email"])
-            )
+            assert sorted(
+                [
+                    {
+                        "email": "admin1@nypl.org",
+                        "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
+                    },
+                    {
+                        "email": "admin2@nypl.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARY_MANAGER,
+                                "library": self._default_library.short_name,
+                            },
+                            {"role": AdminRole.SITEWIDE_LIBRARIAN},
+                        ],
+                    },
+                    {
+                        "email": "admin3@nypl.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARIAN,
+                                "library": self._default_library.short_name,
+                            }
+                        ],
+                    },
+                    {
+                        "email": "admin4@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARY_MANAGER,
+                                "library": library2.short_name,
+                            }
+                        ],
+                    },
+                    {
+                        "email": "admin5@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARIAN,
+                                "library": library2.short_name,
+                            }
+                        ],
+                    },
+                ],
+                key=lambda x: x["email"],
+            ) == sorted(admins, key=lambda x: x["email"])
 
         with self.request_context_with_admin("/", admin=admin2):
             # A sitewide librarian or library manager can also see all admins' roles.
@@ -96,55 +93,52 @@ class TestIndividualAdmins(SettingsControllerTest):
                 self.manager.admin_individual_admin_settings_controller.process_get()
             )
             admins = response.get("individualAdmins")
-            assert (
-                sorted(
-                    [
-                        {
-                            "email": "admin1@nypl.org",
-                            "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
-                        },
-                        {
-                            "email": "admin2@nypl.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARY_MANAGER,
-                                    "library": self._default_library.short_name,
-                                },
-                                {"role": AdminRole.SITEWIDE_LIBRARIAN},
-                            ],
-                        },
-                        {
-                            "email": "admin3@nypl.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARIAN,
-                                    "library": self._default_library.short_name,
-                                }
-                            ],
-                        },
-                        {
-                            "email": "admin4@l2.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARY_MANAGER,
-                                    "library": library2.short_name,
-                                }
-                            ],
-                        },
-                        {
-                            "email": "admin5@l2.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARIAN,
-                                    "library": library2.short_name,
-                                }
-                            ],
-                        },
-                    ],
-                    key=lambda x: x["email"],
-                )
-                == sorted(admins, key=lambda x: x["email"])
-            )
+            assert sorted(
+                [
+                    {
+                        "email": "admin1@nypl.org",
+                        "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
+                    },
+                    {
+                        "email": "admin2@nypl.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARY_MANAGER,
+                                "library": self._default_library.short_name,
+                            },
+                            {"role": AdminRole.SITEWIDE_LIBRARIAN},
+                        ],
+                    },
+                    {
+                        "email": "admin3@nypl.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARIAN,
+                                "library": self._default_library.short_name,
+                            }
+                        ],
+                    },
+                    {
+                        "email": "admin4@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARY_MANAGER,
+                                "library": library2.short_name,
+                            }
+                        ],
+                    },
+                    {
+                        "email": "admin5@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARIAN,
+                                "library": library2.short_name,
+                            }
+                        ],
+                    },
+                ],
+                key=lambda x: x["email"],
+            ) == sorted(admins, key=lambda x: x["email"])
 
         with self.request_context_with_admin("/", admin=admin3):
             # A librarian or library manager of a specific library can see all admins, but only
@@ -153,121 +147,112 @@ class TestIndividualAdmins(SettingsControllerTest):
                 self.manager.admin_individual_admin_settings_controller.process_get()
             )
             admins = response.get("individualAdmins")
-            assert (
-                sorted(
-                    [
-                        {
-                            "email": "admin1@nypl.org",
-                            "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
-                        },
-                        {
-                            "email": "admin2@nypl.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARY_MANAGER,
-                                    "library": self._default_library.short_name,
-                                },
-                                {"role": AdminRole.SITEWIDE_LIBRARIAN},
-                            ],
-                        },
-                        {
-                            "email": "admin3@nypl.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARIAN,
-                                    "library": self._default_library.short_name,
-                                }
-                            ],
-                        },
-                        {"email": "admin4@l2.org", "roles": []},
-                        {"email": "admin5@l2.org", "roles": []},
-                    ],
-                    key=lambda x: x["email"],
-                )
-                == sorted(admins, key=lambda x: x["email"])
-            )
+            assert sorted(
+                [
+                    {
+                        "email": "admin1@nypl.org",
+                        "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
+                    },
+                    {
+                        "email": "admin2@nypl.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARY_MANAGER,
+                                "library": self._default_library.short_name,
+                            },
+                            {"role": AdminRole.SITEWIDE_LIBRARIAN},
+                        ],
+                    },
+                    {
+                        "email": "admin3@nypl.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARIAN,
+                                "library": self._default_library.short_name,
+                            }
+                        ],
+                    },
+                    {"email": "admin4@l2.org", "roles": []},
+                    {"email": "admin5@l2.org", "roles": []},
+                ],
+                key=lambda x: x["email"],
+            ) == sorted(admins, key=lambda x: x["email"])
 
         with self.request_context_with_admin("/", admin=admin4):
             response = (
                 self.manager.admin_individual_admin_settings_controller.process_get()
             )
             admins = response.get("individualAdmins")
-            assert (
-                sorted(
-                    [
-                        {
-                            "email": "admin1@nypl.org",
-                            "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
-                        },
-                        {
-                            "email": "admin2@nypl.org",
-                            "roles": [{"role": AdminRole.SITEWIDE_LIBRARIAN}],
-                        },
-                        {"email": "admin3@nypl.org", "roles": []},
-                        {
-                            "email": "admin4@l2.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARY_MANAGER,
-                                    "library": library2.short_name,
-                                }
-                            ],
-                        },
-                        {
-                            "email": "admin5@l2.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARIAN,
-                                    "library": library2.short_name,
-                                }
-                            ],
-                        },
-                    ],
-                    key=lambda x: x["email"],
-                )
-                == sorted(admins, key=lambda x: x["email"])
-            )
+            assert sorted(
+                [
+                    {
+                        "email": "admin1@nypl.org",
+                        "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
+                    },
+                    {
+                        "email": "admin2@nypl.org",
+                        "roles": [{"role": AdminRole.SITEWIDE_LIBRARIAN}],
+                    },
+                    {"email": "admin3@nypl.org", "roles": []},
+                    {
+                        "email": "admin4@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARY_MANAGER,
+                                "library": library2.short_name,
+                            }
+                        ],
+                    },
+                    {
+                        "email": "admin5@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARIAN,
+                                "library": library2.short_name,
+                            }
+                        ],
+                    },
+                ],
+                key=lambda x: x["email"],
+            ) == sorted(admins, key=lambda x: x["email"])
 
         with self.request_context_with_admin("/", admin=admin5):
             response = (
                 self.manager.admin_individual_admin_settings_controller.process_get()
             )
             admins = response.get("individualAdmins")
-            assert (
-                sorted(
-                    [
-                        {
-                            "email": "admin1@nypl.org",
-                            "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
-                        },
-                        {
-                            "email": "admin2@nypl.org",
-                            "roles": [{"role": AdminRole.SITEWIDE_LIBRARIAN}],
-                        },
-                        {"email": "admin3@nypl.org", "roles": []},
-                        {
-                            "email": "admin4@l2.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARY_MANAGER,
-                                    "library": library2.short_name,
-                                }
-                            ],
-                        },
-                        {
-                            "email": "admin5@l2.org",
-                            "roles": [
-                                {
-                                    "role": AdminRole.LIBRARIAN,
-                                    "library": library2.short_name,
-                                }
-                            ],
-                        },
-                    ],
-                    key=lambda x: x["email"],
-                )
-                == sorted(admins, key=lambda x: x["email"])
-            )
+            assert sorted(
+                [
+                    {
+                        "email": "admin1@nypl.org",
+                        "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
+                    },
+                    {
+                        "email": "admin2@nypl.org",
+                        "roles": [{"role": AdminRole.SITEWIDE_LIBRARIAN}],
+                    },
+                    {"email": "admin3@nypl.org", "roles": []},
+                    {
+                        "email": "admin4@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARY_MANAGER,
+                                "library": library2.short_name,
+                            }
+                        ],
+                    },
+                    {
+                        "email": "admin5@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARIAN,
+                                "library": library2.short_name,
+                            }
+                        ],
+                    },
+                ],
+                key=lambda x: x["email"],
+            ) == sorted(admins, key=lambda x: x["email"])
 
     def test_individual_admins_post_errors(self):
         with self.request_context_with_admin("/", method="POST"):

--- a/tests/api/test_bibliotheca.py
+++ b/tests/api/test_bibliotheca.py
@@ -1640,13 +1640,13 @@ class TestItemListParser(BibliothecaAPITest):
         # So, we'll test zero and one escapings here.
         authors = list(
             ItemListParser.contributors_from_string(
-                u"Raji Codell, Esmé; Raji Codell, Esm&#233;"
+                "Raji Codell, Esmé; Raji Codell, Esm&#233;"
             )
         )
         author_names = [a.sort_name for a in authors]
         assert len(authors) == 2
         assert len(set(author_names)) == 1
-        assert all(u"Raji Codell, Esmé" == name for name in author_names)
+        assert all("Raji Codell, Esmé" == name for name in author_names)
 
         # It's possible to specify some role other than AUTHOR_ROLE.
         narrators = list(
@@ -1745,17 +1745,14 @@ class TestItemListParser(BibliothecaAPITest):
             names_and_roles.append((c.sort_name, role))
 
         # We found one author and three narrators.
-        assert (
-            sorted(
-                [
-                    ("Riggs, Ransom", "Author"),
-                    ("Callow, Simon", "Narrator"),
-                    ("Mann, Bruce", "Narrator"),
-                    ("Hagon, Garrick", "Narrator"),
-                ]
-            )
-            == sorted(names_and_roles)
-        )
+        assert sorted(
+            [
+                ("Riggs, Ransom", "Author"),
+                ("Callow, Simon", "Narrator"),
+                ("Mann, Bruce", "Narrator"),
+                ("Hagon, Garrick", "Narrator"),
+            ]
+        ) == sorted(names_and_roles)
 
 
 class TestBibliographicCoverageProvider(TestBibliothecaAPI):

--- a/tests/api/test_lanes.py
+++ b/tests/api/test_lanes.py
@@ -284,19 +284,16 @@ class TestLaneCreation(DatabaseTest):
         # We have five top-level lanes for the large collection,
         # a top-level lane for each small collection, and a lane
         # for everything left over.
-        assert (
-            set(
-                [
-                    "Fiction",
-                    "Nonfiction",
-                    "Young Adult Fiction",
-                    "Young Adult Nonfiction",
-                    "Children and Middle Grade",
-                    "World Languages",
-                ]
-            )
-            == set([x.display_name for x in lanes])
-        )
+        assert set(
+            [
+                "Fiction",
+                "Nonfiction",
+                "Young Adult Fiction",
+                "Young Adult Nonfiction",
+                "Children and Middle Grade",
+                "World Languages",
+            ]
+        ) == set([x.display_name for x in lanes])
 
         [english_fiction_lane] = [x for x in lanes if x.display_name == "Fiction"]
         assert 0 == english_fiction_lane.priority

--- a/tests/api/test_metadata_wrangler.py
+++ b/tests/api/test_metadata_wrangler.py
@@ -476,17 +476,14 @@ class TestBaseMetadataWranglerCoverageProvider(MetadataWranglerCoverageProviderT
         """Verify all the different types of identifiers we send
         to the metadata wrangler.
         """
-        assert (
-            set(
-                [
-                    Identifier.OVERDRIVE_ID,
-                    Identifier.BIBLIOTHECA_ID,
-                    Identifier.AXIS_360_ID,
-                    Identifier.URI,
-                ]
-            )
-            == set(BaseMetadataWranglerCoverageProvider.INPUT_IDENTIFIER_TYPES)
-        )
+        assert set(
+            [
+                Identifier.OVERDRIVE_ID,
+                Identifier.BIBLIOTHECA_ID,
+                Identifier.AXIS_360_ID,
+                Identifier.URI,
+            ]
+        ) == set(BaseMetadataWranglerCoverageProvider.INPUT_IDENTIFIER_TYPES)
 
     def test_create_identifier_mapping(self):
         # Most identifiers map to themselves.

--- a/tests/api/test_odilo.py
+++ b/tests/api/test_odilo.py
@@ -748,21 +748,18 @@ class TestOdiloBibliographicCoverageProvider(OdiloAPITest):
         assert 1 == pool.licenses_reserved
 
         names = [x.delivery_mechanism.name for x in pool.delivery_mechanisms]
-        assert (
-            sorted(
-                [
-                    Representation.EPUB_MEDIA_TYPE
-                    + " ("
-                    + DeliveryMechanism.ADOBE_DRM
-                    + ")",
-                    Representation.TEXT_HTML_MEDIA_TYPE
-                    + " ("
-                    + DeliveryMechanism.STREAMING_TEXT_CONTENT_TYPE
-                    + ")",
-                ]
-            )
-            == sorted(names)
-        )
+        assert sorted(
+            [
+                Representation.EPUB_MEDIA_TYPE
+                + " ("
+                + DeliveryMechanism.ADOBE_DRM
+                + ")",
+                Representation.TEXT_HTML_MEDIA_TYPE
+                + " ("
+                + DeliveryMechanism.STREAMING_TEXT_CONTENT_TYPE
+                + ")",
+            ]
+        ) == sorted(names)
 
         # Check that handle_success was called --> A Work was created and made presentation ready.
         assert True == pool.work.presentation_ready

--- a/tests/api/test_odl2.py
+++ b/tests/api/test_odl2.py
@@ -121,17 +121,17 @@ class TestODL2Importer(TestODLImporter):
         assert moby_dick_edition.primary_identifier.identifier == "978-3-16-148410-0"
         assert moby_dick_edition.primary_identifier.type == "ISBN"
 
-        assert u"Moby-Dick" == moby_dick_edition.title
-        assert u"eng" == moby_dick_edition.language
-        assert u"eng" == moby_dick_edition.language
+        assert "Moby-Dick" == moby_dick_edition.title
+        assert "eng" == moby_dick_edition.language
+        assert "eng" == moby_dick_edition.language
         assert EditionConstants.BOOK_MEDIUM == moby_dick_edition.medium
-        assert u"Herman Melville" == moby_dick_edition.author
+        assert "Herman Melville" == moby_dick_edition.author
 
         assert 1 == len(moby_dick_edition.author_contributors)
         [moby_dick_author] = moby_dick_edition.author_contributors
         assert isinstance(moby_dick_author, Contributor)
-        assert u"Herman Melville" == moby_dick_author.display_name
-        assert u"Melville, Herman" == moby_dick_author.sort_name
+        assert "Herman Melville" == moby_dick_author.display_name
+        assert "Melville, Herman" == moby_dick_author.sort_name
 
         assert 1 == len(moby_dick_author.contributions)
         [moby_dick_author_author_contribution] = moby_dick_author.contributions
@@ -142,12 +142,12 @@ class TestODL2Importer(TestODLImporter):
 
         assert datasource == moby_dick_edition.data_source
 
-        assert u"Test Publisher" == moby_dick_edition.publisher
+        assert "Test Publisher" == moby_dick_edition.publisher
         assert datetime.date(2015, 9, 29) == moby_dick_edition.published
 
-        assert u"http://example.org/cover.jpg" == moby_dick_edition.cover_full_url
+        assert "http://example.org/cover.jpg" == moby_dick_edition.cover_full_url
         assert (
-            u"http://example.org/cover-small.jpg"
+            "http://example.org/cover-small.jpg"
             == moby_dick_edition.cover_thumbnail_url
         )
 

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -1311,16 +1311,13 @@ class TestLibraryAnnotator(VendorIDTest):
         ]
         assert 3 == len(fulfill_links)
 
-        assert (
-            set(
-                [
-                    mech1.delivery_mechanism.drm_scheme_media_type,
-                    mech2.delivery_mechanism.drm_scheme_media_type,
-                    OPDSFeed.ENTRY_TYPE,
-                ]
-            )
-            == set([link["type"] for link in fulfill_links])
-        )
+        assert set(
+            [
+                mech1.delivery_mechanism.drm_scheme_media_type,
+                mech2.delivery_mechanism.drm_scheme_media_type,
+                OPDSFeed.ENTRY_TYPE,
+            ]
+        ) == set([link["type"] for link in fulfill_links])
 
         # If one of the content types is hidden, the corresponding
         # delivery mechanism does not have a link.

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1809,17 +1809,14 @@ class TestSyncBookshelf(OverdriveAPITest):
         # We have created previously unknown LicensePools and
         # Identifiers.
         identifiers = [loan.license_pool.identifier.identifier for loan in loans]
-        assert (
-            sorted(
-                [
-                    "a5a3d737-34d4-4d69-aad8-eba4e46019a3",
-                    "99409f99-45a5-4238-9e10-98d1435cde04",
-                    "993e4b33-823c-40af-8f61-cac54e1cba5d",
-                    "a2ec6f3a-ebfe-4c95-9638-2cb13be8de5a",
-                ]
-            )
-            == sorted(identifiers)
-        )
+        assert sorted(
+            [
+                "a5a3d737-34d4-4d69-aad8-eba4e46019a3",
+                "99409f99-45a5-4238-9e10-98d1435cde04",
+                "993e4b33-823c-40af-8f61-cac54e1cba5d",
+                "a2ec6f3a-ebfe-4c95-9638-2cb13be8de5a",
+            ]
+        ) == sorted(identifiers)
 
         # We have recorded a new DeliveryMechanism associated with
         # each loan.

--- a/tests/core/classifiers/test_classifier.py
+++ b/tests/core/classifiers/test_classifier.py
@@ -186,17 +186,14 @@ class TestNestedSubgenres(object):
         #  - Epic Fantasy
         #  - Historical Fantasy
         #  - Urban Fantasy
-        assert (
-            set(
-                [
-                    classifier.Fantasy,
-                    classifier.Epic_Fantasy,
-                    classifier.Historical_Fantasy,
-                    classifier.Urban_Fantasy,
-                ]
-            )
-            == set(list(classifier.Fantasy.self_and_subgenres))
-        )
+        assert set(
+            [
+                classifier.Fantasy,
+                classifier.Epic_Fantasy,
+                classifier.Historical_Fantasy,
+                classifier.Urban_Fantasy,
+            ]
+        ) == set(list(classifier.Fantasy.self_and_subgenres))
 
 
 class TestConsolidateWeights(object):

--- a/tests/core/models/test_identifier.py
+++ b/tests/core/models/test_identifier.py
@@ -278,19 +278,16 @@ class TestIdentifier(DatabaseTest):
         equivs = Identifier.recursively_equivalent_identifier_ids(
             self._db, [identifier.id], policy=high_levels_low_threshold
         )
-        assert (
-            set(
-                [
-                    identifier.id,
-                    strong_equivalent.id,
-                    weak_equivalent.id,
-                    level_2_equivalent.id,
-                    level_3_equivalent.id,
-                    level_4_equivalent.id,
-                ]
-            )
-            == set(equivs[identifier.id])
-        )
+        assert set(
+            [
+                identifier.id,
+                strong_equivalent.id,
+                weak_equivalent.id,
+                level_2_equivalent.id,
+                level_3_equivalent.id,
+                level_4_equivalent.id,
+            ]
+        ) == set(equivs[identifier.id])
 
         # If we only look at one level, we don't find the level 2, 3, or 4 identifiers.
         one_level = PresentationCalculationPolicy(
@@ -337,51 +334,42 @@ class TestIdentifier(DatabaseTest):
         equivs = Identifier.recursively_equivalent_identifier_ids(
             self._db, [identifier.id], policy=high_levels_lower_threshold
         )
-        assert (
-            set(
-                [
-                    identifier.id,
-                    strong_equivalent.id,
-                    level_2_equivalent.id,
-                    level_3_equivalent.id,
-                ]
-            )
-            == set(equivs[identifier.id])
-        )
+        assert set(
+            [
+                identifier.id,
+                strong_equivalent.id,
+                level_2_equivalent.id,
+                level_3_equivalent.id,
+            ]
+        ) == set(equivs[identifier.id])
 
         # It also works if we start from other identifiers.
         equivs = Identifier.recursively_equivalent_identifier_ids(
             self._db, [strong_equivalent.id], policy=high_levels_low_threshold
         )
-        assert (
-            set(
-                [
-                    identifier.id,
-                    strong_equivalent.id,
-                    weak_equivalent.id,
-                    level_2_equivalent.id,
-                    level_3_equivalent.id,
-                    level_4_equivalent.id,
-                ]
-            )
-            == set(equivs[strong_equivalent.id])
-        )
+        assert set(
+            [
+                identifier.id,
+                strong_equivalent.id,
+                weak_equivalent.id,
+                level_2_equivalent.id,
+                level_3_equivalent.id,
+                level_4_equivalent.id,
+            ]
+        ) == set(equivs[strong_equivalent.id])
 
         equivs = Identifier.recursively_equivalent_identifier_ids(
             self._db, [level_4_equivalent.id], policy=high_levels_low_threshold
         )
-        assert (
-            set(
-                [
-                    identifier.id,
-                    strong_equivalent.id,
-                    level_2_equivalent.id,
-                    level_3_equivalent.id,
-                    level_4_equivalent.id,
-                ]
-            )
-            == set(equivs[level_4_equivalent.id])
-        )
+        assert set(
+            [
+                identifier.id,
+                strong_equivalent.id,
+                level_2_equivalent.id,
+                level_3_equivalent.id,
+                level_4_equivalent.id,
+            ]
+        ) == set(equivs[level_4_equivalent.id])
 
         equivs = Identifier.recursively_equivalent_identifier_ids(
             self._db, [level_4_equivalent.id], policy=high_levels_high_threshold
@@ -457,19 +445,16 @@ class TestIdentifier(DatabaseTest):
         query = query.where(Identifier.id == identifier.id)
         results = self._db.execute(query)
         equivalent_ids = [r[0] for r in results]
-        assert (
-            set(
-                [
-                    identifier.id,
-                    strong_equivalent.id,
-                    weak_equivalent.id,
-                    level_2_equivalent.id,
-                    level_3_equivalent.id,
-                    level_4_equivalent.id,
-                ]
-            )
-            == set(equivalent_ids)
-        )
+        assert set(
+            [
+                identifier.id,
+                strong_equivalent.id,
+                weak_equivalent.id,
+                level_2_equivalent.id,
+                level_3_equivalent.id,
+                level_4_equivalent.id,
+            ]
+        ) == set(equivalent_ids)
 
         query = Identifier.recursively_equivalent_identifier_ids_query(
             Identifier.id, policy=two_levels_high_threshold
@@ -477,17 +462,14 @@ class TestIdentifier(DatabaseTest):
         query = query.where(Identifier.id.in_([identifier.id, level_3_equivalent.id]))
         results = self._db.execute(query)
         equivalent_ids = [r[0] for r in results]
-        assert (
-            set(
-                [
-                    identifier.id,
-                    strong_equivalent.id,
-                    level_2_equivalent.id,
-                    level_3_equivalent.id,
-                ]
-            )
-            == set(equivalent_ids)
-        )
+        assert set(
+            [
+                identifier.id,
+                strong_equivalent.id,
+                level_2_equivalent.id,
+                level_3_equivalent.id,
+            ]
+        ) == set(equivalent_ids)
 
     def test_licensed_through_collection(self):
         c1 = self._default_collection

--- a/tests/core/python_expression_dsl/test_evaluator.py
+++ b/tests/core/python_expression_dsl/test_evaluator.py
@@ -82,8 +82,8 @@ class TestDSLEvaluator(object):
             ("multiplication_with_two_operands", "9 * 3", 9 * 3),
             ("division_with_two_operands", "9 / 3", 9 / 3),
             ("division_with_two_operands_and_remainder", "9 / 4", 9.0 / 4.0),
-            ("exponentiation_with_two_operands", "9 ** 3", 9 ** 3),
-            ("exponentiation_with_three_operands", "2 ** 3 ** 3", 2 ** 3 ** 3),
+            ("exponentiation_with_two_operands", "9 ** 3", 9**3),
+            ("exponentiation_with_three_operands", "2 ** 3 ** 3", 2**3**3),
             (
                 "associative_law_for_addition",
                 "(a + b) + c == a + (b + c)",

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -1769,7 +1769,7 @@ class TestFeaturedFacets(EndToEndSearchTest):
         # It can be high-quality enough to be featured.
         assert isinstance(featurable, ScriptScore)
         source = filter.FEATURABLE_SCRIPT % dict(
-            cutoff=f.minimum_featured_quality ** 2, exponent=2
+            cutoff=f.minimum_featured_quality**2, exponent=2
         )
         assert source == featurable.script["source"]
 

--- a/tests/core/test_overdrive.py
+++ b/tests/core/test_overdrive.py
@@ -932,15 +932,12 @@ class TestOverdriveBibliographicCoverageProvider(OverdriveTest):
         assert 0 == pool.licenses_owned
         [lpdm1, lpdm2] = pool.delivery_mechanisms
         names = [x.delivery_mechanism.name for x in pool.delivery_mechanisms]
-        assert (
-            sorted(
-                [
-                    "application/pdf (application/vnd.adobe.adept+xml)",
-                    "Kindle via Amazon (Kindle DRM)",
-                ]
-            )
-            == sorted(names)
-        )
+        assert sorted(
+            [
+                "application/pdf (application/vnd.adobe.adept+xml)",
+                "Kindle via Amazon (Kindle DRM)",
+            ]
+        ) == sorted(names)
 
         # A Work was created and made presentation ready.
         assert "Agile Documentation" == pool.work.title

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -2436,7 +2436,7 @@ class TestWhereAreMyBooksScript(DatabaseTest):
         suppressed=0,
         not_owned=0,
         in_search_index=0,
-        **kwargs
+        **kwargs,
     ):
         """Runs explain_collection() and verifies expected output."""
         script = MockWhereAreMyBooks(self._db, **kwargs)

--- a/tests/core/util/test_opds_writer.py
+++ b/tests/core/util/test_opds_writer.py
@@ -47,15 +47,12 @@ class TestAtomFeed(object):
         link_child = AtomFeed.E.link_child()
         AtomFeed.add_link_to_entry(entry, [link_child], **kwargs)
 
-        assert (
-            etree.tostring(
-                etree.fromstring(
-                    '<link extra="extra info" href="url" title="1"><link_child/></link>'
-                ),
-                method="c14n2",
-            )
-            in etree.tostring(entry, method="c14n2")
-        )
+        assert etree.tostring(
+            etree.fromstring(
+                '<link extra="extra info" href="url" title="1"><link_child/></link>'
+            ),
+            method="c14n2",
+        ) in etree.tostring(entry, method="c14n2")
 
     def test_contributor(self):
         kwargs = {"{%s}role" % AtomFeed.OPF_NS: "ctb"}


### PR DESCRIPTION
## Description

Upgrade the version of `black` used by `pre-commit` and, by extension, the `git` pre-commit hook and the `Lint` GitHub workflow.

The first commit contains only the change to the version of `black`. The second commit contains changes to files that were reformatted by the new version of `black`.

## Motivation and Context

This prevents an exception caused by a breaking change to one of `blacks` underlying dependencies, `click`. 

See https://github.com/psf/black/issues/2964 for more details.

## How Has This Been Tested?

- Ran `pre-commit run --all-files` locally.
- CI workflows ran on `push`.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
