### PR TITLE
Removing the borrow button from the CM admin

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -2162,8 +2162,15 @@ class WorkController(CirculationManagerController):
         else:
             annotator = self.manager.annotator(lane=None)
 
+            # Hacks for admin UI hiding the borrow links
+            from_admin_web = "/admin/web/collection" in (flask.request.referrer or "")
+
             return AcquisitionFeed.single_entry(
-                self._db, work, annotator, max_age=OPDSFeed.DEFAULT_MAX_AGE
+                self._db,
+                work,
+                annotator,
+                max_age=OPDSFeed.DEFAULT_MAX_AGE,
+                from_admin_web=from_admin_web,
             )
 
     def related(

--- a/core/opds.py
+++ b/core/opds.py
@@ -1112,6 +1112,7 @@ class AcquisitionFeed(OPDSFeed):
         force_create=False,
         raw=False,
         use_cache=True,
+        from_admin_web=False,
         **response_kwargs
     ):
         """Create a single-entry OPDS document for one specific work.
@@ -1141,6 +1142,12 @@ class AcquisitionFeed(OPDSFeed):
             force_create=force_create,
             use_cache=use_cache,
         )
+
+        # Continuing our hack for removing borrows from the admin panel
+        if from_admin_web:
+            for e in entry:  # type: lxml.etree._Element
+                if e.get("rel") == OPDSFeed.BORROW_REL:
+                    e.set("href", "")
 
         # Since this <entry> tag is going to be the root of an XML
         # document it's essential that it include an up-to-date nsmap,


### PR DESCRIPTION
In case of the CM admin panel makes a request for a work
we should not respond with borrow links
This will cause the button to be hidden on the CM admin page

I would not mind having this PR rejected on the basis of the horrible hacks I've had to add
in order to hide the borrow links

## Description

<!--- Describe your changes -->

## Motivation and Context

On the admin panel there is a borrow button but no download button
This causes confusion for the admins using the system
Hence we remove the button altogether on the admin panel
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I have manually checked this feature on a few CM book detail pages
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
