### PR TITLE
Feature/opds2 schema

### DIFF
--- a/bin/odl2_schema_validate
+++ b/bin/odl2_schema_validate
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""Update the circulation manager server with new books from
+OPDS import collections."""
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from webpub_manifest_parser.odl import ODLFeedParserFactory
+
+from api.odl2 import ODL2Importer
+
+# NOTE: We need to import it explicitly to initialize MirrorUploader.IMPLEMENTATION_REGISTRY
+from core import s3  # noqa: autoflake
+from core.opds2_import import RWPMManifestParser
+from core.opds_schema import ODL2SchemaValidation
+from core.scripts import RunCollectionMonitorScript
+
+import_script = RunCollectionMonitorScript(
+    ODL2SchemaValidation,
+    import_class=ODL2Importer,
+    parser=RWPMManifestParser(ODLFeedParserFactory()),
+)
+
+import_script.run()

--- a/bin/opds2_schema_validate
+++ b/bin/opds2_schema_validate
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""Update the circulation manager server with new books from
+OPDS import collections."""
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from webpub_manifest_parser.opds2 import OPDS2FeedParserFactory
+
+# NOTE: We need to import it explicitly to initialize MirrorUploader.IMPLEMENTATION_REGISTRY
+from core import s3  # noqa: autoflake
+from core.model.configuration import ExternalIntegration
+from core.opds2_import import OPDS2Importer, RWPMManifestParser
+from core.opds_schema import OPDS2SchemaValidation
+from core.scripts import OPDSImportScript
+
+import_script = OPDSImportScript(
+    importer_class=OPDS2Importer,
+    monitor_class=OPDS2SchemaValidation,
+    protocol=ExternalIntegration.OPDS2_IMPORT,
+    parser=RWPMManifestParser(OPDS2FeedParserFactory()),
+)
+
+import_script.run()

--- a/core/opds_schema.py
+++ b/core/opds_schema.py
@@ -1,0 +1,47 @@
+import json
+import os
+
+import requests
+from jsonschema import Draft7Validator, RefResolver
+
+from core.opds2_import import OPDS2ImportMonitor
+
+
+class OPDS2SchemaValidation(OPDS2ImportMonitor):
+    def import_one_feed(self, feed):
+        opds2_schema = None
+        with open("core/resources/opds2_schema/feed.schema.json") as fp:
+            opds2_schema = json.load(fp)
+
+        dir = os.path.dirname(os.path.realpath(__file__))
+
+        handlers = {
+            "https": OPDS2RefHandler.fetch_file,
+        }
+
+        resolver = RefResolver("file://" + dir + "/", opds2_schema, handlers=handlers)
+        schema_validator = Draft7Validator(opds2_schema, resolver=resolver)
+        schema_validator.validate(feed, opds2_schema)
+
+    def follow_one_link(self, url, do_get=None):
+        """We don't need all pages, the first page should be fine for validation"""
+        next_links, feed = super().follow_one_link(url, do_get)
+        return [], feed
+
+    def feed_contains_new_data(self, feed):
+        return True
+
+
+class OPDS2RefHandler:
+    @classmethod
+    def fetch_file(cls, name: str):
+        """Fetch file from local filesystem if present, else fetch remotely"""
+        dir = os.path.dirname(os.path.realpath(__file__))
+        filename = name.split("/")[-1]
+        localpath = f"{dir}/resources/opds2_schema"
+
+        if os.path.exists(f"{localpath}/{filename}"):
+            with open(f"{localpath}/{filename}") as fp:
+                return json.load(fp)
+        else:
+            return requests.get(name).json()

--- a/core/resources/opds2_schema/feed.schema.json
+++ b/core/resources/opds2_schema/feed.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://drafts.opds.io/schema/feed.schema.json",
+  "title": "OPDS Feed",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "description": "Contains feed-level metadata such as title or number of items",
+      "$ref": "feed-metadata.schema.json"
+    },
+    "links": {
+      "description": "Feed-level links such as search or pagination",
+      "type": "array",
+      "items": {
+        "$ref": "readium-link.schema.json"
+      },
+      "uniqueItems": true,
+      "contains": {
+        "properties": {
+          "rel": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "self"
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "const": "self"
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "rel"
+        ]
+      }
+    },
+    "publications": {
+      "description": "A list of publications that can be acquired",
+      "type": "array",
+      "items": {
+        "$ref": "publication.schema.json"
+      },
+      "uniqueItems": true
+    },
+    "navigation": {
+      "description": "Navigation for the catalog using links",
+      "type": "array",
+      "items": {
+        "$ref": "readium-link.schema.json"
+      },
+      "uniqueItems": true,
+      "allOf": [
+        {
+          "description": "Each Link Object in a navigation collection must contain a title",
+          "items": {
+            "required": [
+              "title"
+            ]
+          }
+        }
+      ]
+    },
+    "facets": {
+      "description": "Facets are meant to re-order or obtain a subset for the current list of publications",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "metadata": {
+            "$ref": "feed-metadata.schema.json"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "readium-link.schema.json"
+            },
+            "uniqueItems": true
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "groups": {
+      "description": "Groups provide a curated experience, grouping publications or navigation links together",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "metadata": {
+            "$ref": "feed-metadata.schema.json"
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "readium-link.schema.json"
+            },
+            "uniqueItems": true
+          },
+          "publications": {
+            "type": "array",
+            "items": {
+              "$ref": "publication.schema.json"
+            },
+            "uniqueItems": true
+          },
+          "navigation": {
+            "type": "array",
+            "items": {
+              "$ref": "readium-link.schema.json"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "metadata"
+        ]
+      }
+    }
+  },
+  "required": [
+    "metadata",
+    "links"
+  ],
+  "additionalProperties": {
+    "$ref": "https://readium.org/webpub-manifest/schema/subcollection.schema.json"
+  },
+  "anyOf": [
+    {
+      "required": [
+        "publications"
+      ]
+    },
+    {
+      "required": [
+        "navigation"
+      ]
+    },
+    {
+      "required": [
+        "groups"
+      ]
+    }
+  ]
+}

--- a/core/resources/opds2_schema/odl-feed.schema.json
+++ b/core/resources/opds2_schema/odl-feed.schema.json
@@ -1,0 +1,147 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://drafts.opds.io/schema/feed.schema.json",
+    "title": "OPDS Feed",
+    "type": "object",
+    "properties": {
+      "metadata": {
+        "description": "Contains feed-level metadata such as title or number of items",
+        "$ref": "feed-metadata.schema.json"
+      },
+      "links": {
+        "description": "Feed-level links such as search or pagination",
+        "type": "array",
+        "items": {
+          "$ref": "readium-link.schema.json"
+        },
+        "uniqueItems": true,
+        "contains": {
+          "properties": {
+            "rel": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "const": "self"
+                },
+                {
+                  "type": "array",
+                  "contains": {
+                    "const": "self"
+                  }
+                }
+              ]
+            }
+          },
+          "required": [
+            "rel"
+          ]
+        }
+      },
+      "publications": {
+        "description": "A list of publications that can be acquired",
+        "type": "array",
+        "items": {
+          "$ref": "publication.schema.json"
+        },
+        "uniqueItems": true
+      },
+      "navigation": {
+        "description": "Navigation for the catalog using links",
+        "type": "array",
+        "items": {
+          "$ref": "readium-link.schema.json"
+        },
+        "uniqueItems": true,
+        "allOf": [
+          {
+            "description": "Each Link Object in a navigation collection must contain a title",
+            "items": {
+              "required": [
+                "title"
+              ]
+            }
+          }
+        ]
+      },
+      "facets": {
+        "description": "Facets are meant to re-order or obtain a subset for the current list of publications",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "metadata": {
+              "$ref": "feed-metadata.schema.json"
+            },
+            "links": {
+              "type": "array",
+              "items": {
+                "$ref": "readium-link.schema.json"
+              },
+              "uniqueItems": true
+            }
+          }
+        },
+        "uniqueItems": true
+      },
+      "groups": {
+        "description": "Groups provide a curated experience, grouping publications or navigation links together",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "metadata": {
+              "$ref": "feed-metadata.schema.json"
+            },
+            "links": {
+              "type": "array",
+              "items": {
+                "$ref": "readium-link.schema.json"
+              },
+              "uniqueItems": true
+            },
+            "publications": {
+              "type": "array",
+              "items": {
+                "$ref": "odl-publication.schema.json"
+              },
+              "uniqueItems": true
+            },
+            "navigation": {
+              "type": "array",
+              "items": {
+                "$ref": "readium-link.schema.json"
+              },
+              "uniqueItems": true
+            }
+          },
+          "required": [
+            "metadata"
+          ]
+        }
+      }
+    },
+    "required": [
+      "metadata",
+      "links"
+    ],
+    "additionalProperties": {
+      "$ref": "https://readium.org/webpub-manifest/schema/subcollection.schema.json"
+    },
+    "anyOf": [
+      {
+        "required": [
+          "publications"
+        ]
+      },
+      {
+        "required": [
+          "navigation"
+        ]
+      },
+      {
+        "required": [
+          "groups"
+        ]
+      }
+    ]
+  }

--- a/core/resources/opds2_schema/odl-feed.schema.json
+++ b/core/resources/opds2_schema/odl-feed.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://drafts.opds.io/schema/feed.schema.json",
+    "$id": "https://drafts.opds.io/schema/odl-feed.schema.json",
     "title": "OPDS Feed",
     "type": "object",
     "properties": {
@@ -41,7 +41,7 @@
         "description": "A list of publications that can be acquired",
         "type": "array",
         "items": {
-          "$ref": "publication.schema.json"
+          "$ref": "odl-publication.schema.json"
         },
         "uniqueItems": true
       },
@@ -121,8 +121,7 @@
       }
     },
     "required": [
-      "metadata",
-      "links"
+      "metadata"
     ],
     "additionalProperties": {
       "$ref": "https://readium.org/webpub-manifest/schema/subcollection.schema.json"

--- a/core/resources/opds2_schema/odl-licenses.schema.json
+++ b/core/resources/opds2_schema/odl-licenses.schema.json
@@ -1,0 +1,71 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "odl-licenses.schema.json",
+    "title": "OPDS Publication",
+    "type": "object",
+    "properties": {
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "identifier": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "object",
+                    "properties": {
+                        "currency": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "number"
+                        }
+                    }
+                },
+                "created": {
+                    "type": "string"
+                },
+                "terms": {
+                    "type": "object",
+                    "properties": {
+                        "checkouts": {
+                            "type": "integer"
+                        },
+                        "expires": {
+                            "type": "string"
+                        },
+                        "concurrency": {
+                            "type": "integer"
+                        },
+                        "length": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "protection": {
+                    "type": "object",
+                    "properties": {
+                        "format": {
+                            "type": "array"
+                        },
+                        "devices": {
+                            "type": "integer"
+                        },
+                        "copy": {
+                            "type": "boolean"
+                        },
+                        "print": {
+                            "type": "boolean"
+                        },
+                        "tts": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "links": {}
+    }
+}

--- a/core/resources/opds2_schema/odl-licenses.schema.json
+++ b/core/resources/opds2_schema/odl-licenses.schema.json
@@ -11,7 +11,19 @@
                     "type": "string"
                 },
                 "format": {
-                    "type": "string"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": [
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "price": {
                     "type": "object",
@@ -65,7 +77,6 @@
                     }
                 }
             }
-        },
-        "links": {}
+        }
     }
 }

--- a/core/resources/opds2_schema/odl-publication.schema.json
+++ b/core/resources/opds2_schema/odl-publication.schema.json
@@ -18,6 +18,7 @@
           "rel": {
             "type": "string",
             "enum": [
+              "self",
               "http://opds-spec.org/acquisition/open-access"
             ]
           }

--- a/core/resources/opds2_schema/odl-publication.schema.json
+++ b/core/resources/opds2_schema/odl-publication.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://drafts.opds.io/schema/odl-publication.schema.json",
+  "title": "OPDS Publication",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "$ref": "readium-metadata.schema.json"
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "$ref": "readium-link.schema.json"
+      },
+      "contains": {
+        "description": "An ODL publication MAY contain acquisition links.",
+        "properties": {
+          "rel": {
+            "type": "string",
+            "enum": [
+              "http://opds-spec.org/acquisition/open-access"
+            ]
+          }
+        }
+      }
+    },
+    "licenses": {
+      "type": "array",
+      "items": {
+        "$ref": "odl-licenses.schema.json"
+      }
+    },
+    "images": {
+      "description": "Images are meant to be displayed to the user when browsing publications",
+      "type": "array",
+      "items": {
+        "$ref": "readium-link.schema.json"
+      },
+      "minItems": 1,
+      "allOf": [
+        {
+          "description": "At least one image resource must use one of the following formats: image/jpeg, image/png or image/gif.",
+          "contains": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "image/jpeg",
+                  "image/png",
+                  "image/gif"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "required": [
+    "metadata",
+    "images"
+  ]
+}

--- a/core/resources/opds2_schema/publication.schema.json
+++ b/core/resources/opds2_schema/publication.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://drafts.opds.io/schema/publication.schema.json",
+  "title": "OPDS Publication",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "$ref": "readium-metadata.schema.json"
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "$ref": "readium-link.schema.json"
+      },
+      "contains": {
+        "description": "A publication must contain at least one acquisition link.",
+        "properties": {
+          "rel": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "preview",
+                  "http://opds-spec.org/acquisition",
+                  "http://opds-spec.org/acquisition/buy",
+                  "http://opds-spec.org/acquisition/open-access",
+                  "http://opds-spec.org/acquisition/borrow",
+                  "http://opds-spec.org/acquisition/sample",
+                  "http://opds-spec.org/acquisition/subscribe"
+                ]
+              },
+              {
+                "type": "array",
+                "contains": {
+                  "type": "string",
+                  "enum": [
+                    "preview",
+                    "http://opds-spec.org/acquisition",
+                    "http://opds-spec.org/acquisition/buy",
+                    "http://opds-spec.org/acquisition/open-access",
+                    "http://opds-spec.org/acquisition/borrow",
+                    "http://opds-spec.org/acquisition/sample",
+                    "http://opds-spec.org/acquisition/subscribe"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "images": {
+      "description": "Images are meant to be displayed to the user when browsing publications",
+      "type": "array",
+      "items": {
+        "$ref": "readium-link.schema.json"
+      },
+      "minItems": 1,
+      "allOf": [
+        {
+          "description": "At least one image resource must use one of the following formats: image/jpeg, image/png or image/gif.",
+          "contains": {
+            "properties": {
+              "type": {
+                "enum": [
+                  "image/jpeg",
+                  "image/png",
+                  "image/gif"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "required": [
+    "metadata",
+    "links",
+    "images"
+  ]
+}

--- a/core/resources/opds2_schema/readium-link.schema.json
+++ b/core/resources/opds2_schema/readium-link.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://readium.org/webpub-manifest/schema/link.schema.json",
+  "title": "Link Object for the Readium Web Publication Manifest",
+  "type": "object",
+  "properties": {
+    "href": {
+      "description": "URI or URI template of the linked resource",
+      "type": "string"
+    },
+    "type": {
+      "description": "MIME type of the linked resource",
+      "type": "string"
+    },
+    "templated": {
+      "description": "Indicates that a URI template is used in href",
+      "type": "boolean"
+    },
+    "title": {
+      "description": "Title of the linked resource",
+      "type": "string"
+    },
+    "rel": {
+      "description": "Relation between the linked resource and its containing collection",
+      "type": [
+        "string",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "properties": {
+      "description": "Properties associated to the linked resource",
+      "allOf": [
+        { "$ref": "https://drafts.opds.io/schema/properties.schema.json" },
+        { "$ref": "extensions/epub/properties.schema.json" },
+        { "$ref": "extensions/presentation/properties.schema.json" }
+      ]
+    },
+    "height": {
+      "description": "Height of the linked resource in pixels",
+      "type": "integer",
+      "exclusiveMinimum": 0
+    },
+    "width": {
+      "description": "Width of the linked resource in pixels",
+      "type": "integer",
+      "exclusiveMinimum": 0
+    },
+    "bitrate": {
+      "description": "Bitrate of the linked resource in kbps",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "duration": {
+      "description": "Length of the linked resource in seconds",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "language": {
+      "description": "Expected language of the linked resource",
+      "type": [
+        "string",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "alternate": {
+      "description": "Alternate resources for the linked resource",
+      "type": "array",
+      "items": {
+        "$ref": "link.schema.json"
+      }
+    },
+    "children": {
+      "description": "Resources that are children of the linked resource, in the context of a given collection role",
+      "type": "array",
+      "items": {
+        "$ref": "link.schema.json"
+      }
+    }
+  },
+  "required": [
+    "href"
+  ],
+  "if": {
+    "properties": {
+      "templated": {
+        "enum": [
+          false, null
+        ]
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "href": {
+        "type": "string",
+        "format": "uri-reference"
+      }
+    }
+  },
+  "else": {
+    "properties": {
+      "href": {
+        "type": "string",
+        "format": "uri-template"
+      }
+    }
+  }
+}

--- a/core/resources/opds2_schema/readium-metadata.schema.json
+++ b/core/resources/opds2_schema/readium-metadata.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://readium.org/webpub-manifest/schema/metadata.schema.json",
+  "title": "Metadata",
+  "type": "object",
+  "properties": {
+    "identifier": {
+      "type": "string",
+      "format": "uri"
+    },
+    "@type": {
+      "type": "string",
+      "format": "uri"
+    },
+    "conformsTo": {
+      "type": [
+        "string",
+        "array"
+      ],
+      "format": "uri",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "title": {
+      "$ref": "https://readium.org/webpub-manifest/schema/language-map.schema.json"
+    },
+    "subtitle": {
+      "$ref": "https://readium.org/webpub-manifest/schema/language-map.schema.json"
+    },
+    "modified": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "published": {
+      "type": "string",
+      "anyOf": [
+        {
+          "format": "date"
+        },
+        {
+          "format": "date-time"
+        }
+      ]
+    },
+    "language": {
+      "description": "The language must be a valid BCP 47 tag.",
+      "type": [
+        "string",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "sortAs": {
+      "$ref": "https://readium.org/webpub-manifest/schema/language-map.schema.json"
+    },
+    "author": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "translator": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "editor": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "artist": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "illustrator": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "letterer": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "penciler": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "colorist": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "inker": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "narrator": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "contributor": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "publisher": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "imprint": {
+      "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+    },
+    "subject": {
+      "$ref": "https://readium.org/webpub-manifest/schema/subject.schema.json"
+    },
+    "readingProgression": {
+      "type": "string",
+      "enum": [
+        "rtl",
+        "ltr",
+        "ttb",
+        "btt",
+        "auto"
+      ],
+      "default": "auto"
+    },
+    "description": {
+      "type": "string"
+    },
+    "duration": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "numberOfPages": {
+      "type": "integer",
+      "exclusiveMinimum": 0
+    },
+    "belongsTo": {
+      "type": "object",
+      "properties": {
+        "collection": {
+          "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+        },
+        "series": {
+          "$ref": "https://readium.org/webpub-manifest/schema/contributor.schema.json"
+        }
+      }
+    }
+  },
+  "required": [
+    "title"
+  ],
+  "allOf": [
+    {
+      "$ref": "https://readium.org/webpub-manifest/schema/extensions/epub/metadata.schema.json"
+    },
+    {
+      "$ref": "https://readium.org/webpub-manifest/schema/extensions/presentation/metadata.schema.json"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ exclude = [
     'core/classifier',
     'core/configuration/ignored_identifier.py',
     'core/opds2_import.py',
+    'core/opds_schema.py',
     'tests/core/test_opds2_import.py',
+    'tests/core/test_opds_validate.py'
 ]
 files = [
     "core",

--- a/tests/core/files/opds/odl2_feed.json
+++ b/tests/core/files/opds/odl2_feed.json
@@ -1,0 +1,1041 @@
+{
+    "metadata": {
+        "title": "Feedbooks",
+        "itemsPerPage": 100,
+        "currentPage": 1,
+        "numberOfItems": 787
+    },
+    "links": [
+        {
+            "type": "application/opds+json",
+            "rel": "self",
+            "href": "https://market.feedbooks.com/api/libraries/harvest.json"
+        },
+        {
+            "type": "application/opds+json",
+            "rel": "next",
+            "href": "https://market.feedbooks.com/api/libraries/harvest.json?page=2&token=sfv12i2uzvmoulkq9bvu"
+        },
+        {
+            "type": "application/opds+json",
+            "rel": "last",
+            "href": "https://market.feedbooks.com/api/libraries/harvest.json?page=8&token=sfv12i2uzvmoulkq9bvu"
+        }
+    ],
+    "publications": [
+        {
+            "metadata": {
+                "@type": "http://schema.org/Book",
+                "title": "Secret Language of Sisters, The",
+                "language": "en",
+                "modified": "2021-04-17T10:24:22Z",
+                "published": "2019-08-01T00:00:00Z",
+                "identifier": "urn:ISBN:9781338252989",
+                "author": [
+                    {
+                        "name": "Luanne Rice",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/store/browse/recent.json?author_id=3633&lang=en"
+                            }
+                        ]
+                    }
+                ],
+                "narrator": [
+                    {
+                        "name": "Kate Rudd",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/store/browse/recent.json?contributor_id=1234140&lang=en"
+                            }
+                        ]
+                    }
+                ],
+                "publisher": {
+                    "name": "Scholastic Inc. Audio",
+                    "links": [
+                        {
+                            "type": "application/opds+json",
+                            "href": "https://market.feedbooks.com/store/browse/recent.json?lang=en&publisher=Scholastic+Inc.+Audio"
+                        }
+                    ]
+                },
+                "description": "New York Times bestselling adult author Luanne Rice makes her dazzling YA debut with this gorgeous, unputdownable story of love, hope, and redemption. \n\nWhen Ruth Ann (Roo) McCabe responds to a text message while she's driving, her life as she knows it ends. The car flips, and Roo winds up in a hospital bed, paralyzed. Silent. Everyone thinks she's in a coma, but Roo has locked-in syndrome--she can see and hear and understand everything around her, but no one knows it. She's trapped inside her own body, screaming to be heard.\n\nMathilda (Tilly) is Roo's sister and best friend. She was the one who texted Roo and inadvertently caused the accident. Now, Tilly must grapple with her overwhelming guilt and her growing feelings for Roo's boyfriend, Newton--the only other person who seems to get what Tilly is going through.\n\nBut Tilly might be the only person who can solve the mystery of her sister's condition--who can see through Roo's silence to the truth underneath.\n\nSomehow, through medicine or miracles, will both sisters find a way to heal?",
+                "subject": [
+                    {
+                        "code": "FBFIC000000",
+                        "name": "Fiction",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC000000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBJUV000000",
+                        "name": "Juvenile & young adult",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBJUV000000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBJUV000000N",
+                        "name": "Themes",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBJUV000000N.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBJUV009001N",
+                        "name": "Family",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBJUV009001N.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBJUV013070",
+                        "name": "Siblings",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBJUV013070.json?lang=en"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "images": [
+                {
+                    "href": "https://covers.feedbooks.net/item/3264313.jpg?size=large&t=1602926692",
+                    "type": "image/jpeg",
+                    "width": 260,
+                    "height": 420
+                },
+                {
+                    "href": "https://covers.feedbooks.net/item/3264313.jpg?t=1602926692",
+                    "type": "image/jpeg",
+                    "width": 100,
+                    "height": 180
+                }
+            ],
+            "licenses": [
+                {
+                    "metadata": {
+                        "identifier": "urn:uuid:8b58d9e4-6fb0-4d22-bb1a-3a9a51eb5087",
+                        "format": [
+                            "application/audiobook+lcp",
+                            "text/html"
+                        ],
+                        "created": "2021-09-29T19:22:29+02:00",
+                        "source": "http://www.cantook.net/",
+                        "price": {
+                            "currency": "USD",
+                            "value": 79.99
+                        },
+                        "terms": {
+                            "checkouts": 15,
+                            "concurrency": 5,
+                            "length": 5097600
+                        },
+                        "protection": {
+                            "format": [
+                                "application/vnd.readium.lcp.license.v1.0+json"
+                            ],
+                            "devices": 6
+                        },
+                        "order": {
+                            "name": "Tester Books",
+                            "identifier": "202109-262-013664",
+                            "href": "https://market.feedbooks.com/carts/13664"
+                        }
+                    },
+                    "links": [
+                        {
+                            "rel": "http://opds-spec.org/acquisition/borrow",
+                            "href": "https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}",
+                            "type": "application/vnd.readium.license.status.v1.0+json",
+                            "templated": true
+                        },
+                        {
+                            "rel": "self",
+                            "href": "https://license.feedbooks.net/copy/status/?uuid=8b58d9e4-6fb0-4d22-bb1a-3a9a51eb5087",
+                            "type": "application/vnd.odl.info+json"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "@type": "http://schema.org/Book",
+                "title": "Heartbreaker",
+                "language": "en",
+                "modified": "2021-07-06T20:43:41Z",
+                "published": "2021-05-25T00:00:00Z",
+                "identifier": "urn:ISBN:9781665103107",
+                "author": [
+                    {
+                        "name": "Karen Robards",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/store/browse/recent.json?author_id=6648&lang=en"
+                            }
+                        ]
+                    }
+                ],
+                "narrator": [
+                    {
+                        "name": "Lisa Jandovitz",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/store/browse/recent.json?contributor_id=1441778&lang=en"
+                            }
+                        ]
+                    }
+                ],
+                "publisher": {
+                    "name": "Blackstone Publishing",
+                    "links": [
+                        {
+                            "type": "application/opds+json",
+                            "href": "https://market.feedbooks.com/store/browse/recent.json?lang=en&publisher=Blackstone+Publishing"
+                        }
+                    ]
+                },
+                "description": "<p>While vacationing in Utah’s mountain wilderness, Lynn Nelson suddenly finds herself having to deal with her teenage daughter Rory’s raging hormones. The object of Rory’s passion is their guide, drop-dead gorgeous Jess Feldman, a man the divorced Lynn instinctively distrusts, even as she shields herself from his blazing baby blues. But after Lynn and Rory fall off a cliff of sheared rock, Jess becomes their only hope. Risking his life, he navigates them through the impenetrable forest thousands of feet below, unwittingly plunging them into a danger more menacing than they could have imagined. Exhausted and injured, all they have is one another—a terrified child, and a man and a woman who rediscover passion in each other’s arms—as they race against time for their lives.</p>",
+                "subject": [
+                    {
+                        "code": "FBFIC000000",
+                        "name": "Fiction",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC000000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBFIC019000",
+                        "name": "Literary",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC019000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBFIC027000",
+                        "name": "Romance",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC027000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBFIC027020",
+                        "name": "Contemporary",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC027020.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBFIC022000",
+                        "name": "Mystery & detective",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC022000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBFIC030000",
+                        "name": "Suspense",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC030000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBFIC027110",
+                        "name": "Suspense",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC027110.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "READ0000",
+                        "scheme": "http://schema.org/Audience",
+                        "name": "Adult",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/top.json?age=READ0000&lang=en"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "images": [
+                {
+                    "href": "https://covers.feedbooks.net/item/4141052.jpg?size=large&t=1625604221",
+                    "type": "image/jpeg",
+                    "width": 260,
+                    "height": 420
+                },
+                {
+                    "href": "https://covers.feedbooks.net/item/4141052.jpg?t=1625604221",
+                    "type": "image/jpeg",
+                    "width": 100,
+                    "height": 180
+                }
+            ],
+            "licenses": [
+                {
+                    "metadata": {
+                        "identifier": "urn:uuid:874a5001-de62-40c1-ae95-29ca0c0a19d3",
+                        "format": [
+                            "application/audiobook+lcp",
+                            "text/html"
+                        ],
+                        "created": "2021-10-04T16:21:20+02:00",
+                        "source": "http://www.cantook.net/",
+                        "price": {
+                            "currency": "USD",
+                            "value": 59.95
+                        },
+                        "terms": {
+                            "concurrency": 1,
+                            "length": 5097600
+                        },
+                        "protection": {
+                            "format": [
+                                "application/vnd.readium.lcp.license.v1.0+json"
+                            ],
+                            "devices": 6
+                        },
+                        "order": {
+                            "name": "Tester Requests 3",
+                            "identifier": "202110-262-013793",
+                            "href": "https://market.feedbooks.com/carts/13793"
+                        }
+                    },
+                    "links": [
+                        {
+                            "rel": "http://opds-spec.org/acquisition/borrow",
+                            "href": "https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}",
+                            "type": "application/vnd.readium.license.status.v1.0+json",
+                            "templated": true
+                        },
+                        {
+                            "rel": "self",
+                            "href": "https://license.feedbooks.net/copy/status/?uuid=874a5001-de62-40c1-ae95-29ca0c0a19d3",
+                            "type": "application/vnd.odl.info+json"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "@type": "http://schema.org/Book",
+                "title": "Past Prologue",
+                "language": "en",
+                "modified": "2021-08-21T04:37:21Z",
+                "published": "2019-07-23T00:00:00Z",
+                "numberOfPages": 34,
+                "identifier": "urn:ISBN:9781982139582",
+                "author": [
+                    {
+                        "name": "Diana Gabaldon",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/store/browse/recent.json?author_id=4830&lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Steve Berry",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/store/browse/recent.json?author_id=16652&lang=en"
+                            }
+                        ]
+                    }
+                ],
+                "publisher": {
+                    "name": "Simon & Schuster",
+                    "links": [
+                        {
+                            "type": "application/opds+json",
+                            "href": "https://market.feedbooks.com/store/browse/recent.json?lang=en&publisher=Simon+%26+Schuster"
+                        }
+                    ]
+                },
+                "description": "<i>Where should we go? All that we knew is gone, and all that we have is each other&hellip;</i><BR> <BR>In this short story from the thrilling anthology <i>MatchUp</i>, bestselling authors Diana Gabaldon and Steve Berry—along with their popular series characters Jamie Fraser and Cotton Malone—team up for the first time ever.",
+                "belongsTo": {
+                    "collection": "The MatchUp Collection"
+                },
+                "subject": [
+                    {
+                        "code": "FBFIC000000",
+                        "name": "Fiction",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC000000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBFIC003000",
+                        "name": "Anthologies (multiple authors)",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC003000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "READ0000",
+                        "scheme": "http://schema.org/Audience",
+                        "name": "Adult",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/top.json?age=READ0000&lang=en"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "images": [
+                {
+                    "href": "https://covers.feedbooks.net/item/3126702.jpg?size=large&t=1590787701",
+                    "type": "image/jpeg",
+                    "width": 260,
+                    "height": 420
+                },
+                {
+                    "href": "https://covers.feedbooks.net/item/3126702.jpg?t=1590787701",
+                    "type": "image/jpeg",
+                    "width": 100,
+                    "height": 180
+                }
+            ],
+            "licenses": [
+                {
+                    "metadata": {
+                        "identifier": "urn:uuid:a89913d2-0511-4b12-89d5-57ba64870be5",
+                        "format": [
+                            "application/epub+zip",
+                            "text/html"
+                        ],
+                        "created": "2021-09-29T19:22:21+02:00",
+                        "source": "http://www.cantook.net/",
+                        "price": {
+                            "currency": "USD",
+                            "value": 9.99
+                        },
+                        "terms": {
+                            "expires": "2023-09-29",
+                            "concurrency": 1,
+                            "length": 5097600
+                        },
+                        "protection": {
+                            "format": [
+                                "application/vnd.adobe.adept+xml",
+                                "application/vnd.readium.lcp.license.v1.0+json"
+                            ],
+                            "devices": 6,
+                            "copy": false,
+                            "print": false,
+                            "tts": false
+                        },
+                        "order": {
+                            "name": "Tester Books",
+                            "identifier": "202109-262-013664",
+                            "href": "https://market.feedbooks.com/carts/13664"
+                        }
+                    },
+                    "links": [
+                        {
+                            "rel": "http://opds-spec.org/acquisition/borrow",
+                            "href": "https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}",
+                            "type": "application/vnd.readium.license.status.v1.0+json",
+                            "templated": true
+                        },
+                        {
+                            "rel": "self",
+                            "href": "https://license.feedbooks.net/copy/status/?uuid=a89913d2-0511-4b12-89d5-57ba64870be5",
+                            "type": "application/vnd.odl.info+json"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "@type": "http://schema.org/Book",
+                "title": "The Eighth Sister: A Thriller",
+                "language": "en",
+                "modified": "2021-09-24T09:03:04Z",
+                "published": "2019-04-09T00:00:00Z",
+                "numberOfPages": 478,
+                "identifier": "urn:ISBN:9781503958302",
+                "author": [
+                    {
+                        "name": "Robert Dugoni",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/store/browse/recent.json?author_id=35158&lang=en"
+                            }
+                        ]
+                    }
+                ],
+                "publisher": {
+                    "name": "Thomas & Mercer",
+                    "links": [
+                        {
+                            "type": "application/opds+json",
+                            "href": "https://market.feedbooks.com/store/browse/recent.json?lang=en&publisher=Thomas+%26+Mercer"
+                        }
+                    ]
+                },
+                "description": "<p>\n                        <b>An Amazon Charts, <i>Washington Post</i>, and <i>Wall Street Journal</i> bestseller. </b>\n                    </p>\n                    <p>\n                        <b>A pulse-pounding thriller of espionage, spy games, and treachery by the <i>New York Times</i> bestselling author of the Tracy Crosswhite Series.</b>\n                    </p>\n                    <p>Former CIA case officer Charles Jenkins is a man at a crossroads: in his early sixties, he has a family, a new baby on the way, and a security consulting business on the brink of bankruptcy. Then his former bureau chief shows up at his house with a risky new assignment: travel undercover to Moscow and locate a Russian agent believed to be killing members of a clandestine US spy cell known as the seven sisters.</p>\n                    <p>Desperate for money, Jenkins agrees to the mission and heads to the Russian capital. But when he finds the mastermind agent behind the assassinations&#x2014;the so-called eighth sister&#x2014;she is not who or what he was led to believe. Then again, neither is anyone else in this deadly game of cat and mouse.</p>\n                    <p>Pursued by a dogged Russian intelligence officer, Jenkins executes a daring escape across the Black Sea, only to find himself abandoned by the agency he serves. With his family and freedom at risk, Jenkins is in the fight of his life&#x2014;against his own country.</p>",
+                "belongsTo": {
+                    "collection": "Charles Jenkins",
+                    "series": [
+                        {
+                            "name": "Charles Jenkins",
+                            "position": 1,
+                            "links": [
+                                {
+                                    "type": "application/opds+json",
+                                    "href": "https://market.feedbooks.com/series/42251.json?lang=en"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "subject": [
+                    {
+                        "code": "FBFIC000000",
+                        "name": "Fiction",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC000000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBFIC031000",
+                        "name": "Thrillers",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC031000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "INFEN000",
+                        "name": "English literature",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/top.json?influence=INFEN000&lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "INFENUSA",
+                        "name": "American and Canadian literature",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/top.json?influence=INFENUSA&lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "READ0000",
+                        "scheme": "http://schema.org/Audience",
+                        "name": "Adult",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/top.json?age=READ0000&lang=en"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "images": [
+                {
+                    "href": "https://covers.feedbooks.net/item/4239559.jpg?size=large&t=1632474184",
+                    "type": "image/jpeg",
+                    "width": 260,
+                    "height": 420
+                },
+                {
+                    "href": "https://covers.feedbooks.net/item/4239559.jpg?t=1632474184",
+                    "type": "image/jpeg",
+                    "width": 100,
+                    "height": 180
+                }
+            ],
+            "licenses": [
+                {
+                    "metadata": {
+                        "identifier": "urn:uuid:3cd67474-2958-45c7-92b0-3d5d6e798474",
+                        "format": [
+                            "application/epub+zip",
+                            "text/html"
+                        ],
+                        "created": "2021-09-29T18:21:15+02:00",
+                        "source": "http://www.cantook.net/",
+                        "price": {
+                            "currency": "USD",
+                            "value": 65.89
+                        },
+                        "terms": {
+                            "checkouts": 40,
+                            "concurrency": 10,
+                            "length": 5097600
+                        },
+                        "protection": {
+                            "format": [
+                                "application/vnd.adobe.adept+xml",
+                                "application/vnd.readium.lcp.license.v1.0+json"
+                            ],
+                            "devices": 6,
+                            "copy": false,
+                            "print": false,
+                            "tts": false
+                        },
+                        "order": {
+                            "name": "Amazon cart",
+                            "po_number": "Amazon test +",
+                            "identifier": "202109-262-013540",
+                            "href": "https://market.feedbooks.com/carts/13540"
+                        }
+                    },
+                    "links": [
+                        {
+                            "rel": "http://opds-spec.org/acquisition/borrow",
+                            "href": "https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}",
+                            "type": "application/vnd.readium.license.status.v1.0+json",
+                            "templated": true
+                        },
+                        {
+                            "rel": "self",
+                            "href": "https://license.feedbooks.net/copy/status/?uuid=3cd67474-2958-45c7-92b0-3d5d6e798474",
+                            "type": "application/vnd.odl.info+json"
+                        }
+                    ]
+                },
+                {
+                    "metadata": {
+                        "identifier": "urn:uuid:4d1b9fd3-b943-434a-919a-dceca8044552",
+                        "format": [
+                            "application/epub+zip",
+                            "text/html"
+                        ],
+                        "created": "2021-09-29T19:22:18+02:00",
+                        "source": "http://www.cantook.net/",
+                        "price": {
+                            "currency": "USD",
+                            "value": 16.48
+                        },
+                        "terms": {
+                            "checkouts": 5,
+                            "concurrency": 5,
+                            "length": 5097600
+                        },
+                        "protection": {
+                            "format": [
+                                "application/vnd.adobe.adept+xml",
+                                "application/vnd.readium.lcp.license.v1.0+json"
+                            ],
+                            "devices": 6,
+                            "copy": false,
+                            "print": false,
+                            "tts": false
+                        },
+                        "order": {
+                            "name": "Tester Books",
+                            "identifier": "202109-262-013664",
+                            "href": "https://market.feedbooks.com/carts/13664"
+                        }
+                    },
+                    "links": [
+                        {
+                            "rel": "http://opds-spec.org/acquisition/borrow",
+                            "href": "https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}",
+                            "type": "application/vnd.readium.license.status.v1.0+json",
+                            "templated": true
+                        },
+                        {
+                            "rel": "self",
+                            "href": "https://license.feedbooks.net/copy/status/?uuid=4d1b9fd3-b943-434a-919a-dceca8044552",
+                            "type": "application/vnd.odl.info+json"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "metadata": {
+                "@type": "http://schema.org/Book",
+                "title": "Your Story, My Story",
+                "language": "en",
+                "modified": "2021-10-04T16:30:46Z",
+                "published": "2021-01-01T00:00:00Z",
+                "identifier": "urn:ISBN:9781713651147",
+                "author": [
+                    {
+                        "name": "Connie Palmen",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/store/browse/recent.json?author_id=170563&lang=en"
+                            }
+                        ]
+                    }
+                ],
+                "translator": [
+                    {
+                        "name": "Eileen J. Stevens",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/store/browse/recent.json?contributor_id=1447608&lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "Anna Asbury",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/store/browse/recent.json?contributor_id=790096&lang=en"
+                            }
+                        ]
+                    }
+                ],
+                "narrator": [
+                    {
+                        "name": "Guy Mott",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/store/browse/recent.json?contributor_id=1468854&lang=en"
+                            }
+                        ]
+                    }
+                ],
+                "publisher": {
+                    "name": "Brilliance Audio",
+                    "links": [
+                        {
+                            "type": "application/opds+json",
+                            "href": "https://market.feedbooks.com/store/browse/recent.json?lang=en&publisher=Brilliance+Audio"
+                        }
+                    ]
+                },
+                "description": "<p><b>From the award-winning author of <i>The Friendship</i> comes a shattering, brilliantly inventive novel based on the volatile true love story of literary icons Sylvia Plath and Ted Hughes.</b></p><p>In 1963 Sylvia Plath took her own life in her London flat. Her death was the culmination of a brief, brilliant life lived in the shadow of clinical depression—a condition exacerbated by her tempestuous relationship with mercurial poet Ted Hughes. The ensuing years saw Plath rise to martyr status while Hughes was cast as the cause of her suicide, his infidelity at the heart of her demise.</p><p>For decades, Hughes never bore witness to the truth of their marriage—one buried beneath a mudslide of apocryphal stories, gossip, sensationalism, and myth. Until now.</p><p>In this mesmerizing fictional work, Connie Palmen tells his side of the story, previously untold, delivered in Ted Hughes’s own uncompromising voice. A brutal and lyrical confessional, <i>Your Story, My Story</i> paints an indelible picture of their seven-year relationship—the soaring highs and profound lows of star-crossed soul mates bedeviled by their personal demons. It will forever change the way we think about these two literary icons.</p>",
+                "subject": [
+                    {
+                        "code": "FBFIC000000",
+                        "name": "Fiction",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC000000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBFIC019000",
+                        "name": "Literary",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC019000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "FBFIC041000",
+                        "name": "Biographical",
+                        "scheme": "http://www.feedbooks.com/categories",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/category/FBFIC041000.json?lang=en"
+                            }
+                        ]
+                    },
+                    {
+                        "code": "READ0000",
+                        "scheme": "http://schema.org/Audience",
+                        "name": "Adult",
+                        "links": [
+                            {
+                                "type": "application/opds+json",
+                                "href": "https://market.feedbooks.com/top.json?age=READ0000&lang=en"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "images": [
+                {
+                    "href": "https://covers.feedbooks.net/item/4319263.jpg?size=large&t=1633365046",
+                    "type": "image/jpeg",
+                    "width": 260,
+                    "height": 420
+                },
+                {
+                    "href": "https://covers.feedbooks.net/item/4319263.jpg?t=1633365046",
+                    "type": "image/jpeg",
+                    "width": 100,
+                    "height": 180
+                }
+            ],
+            "licenses": [
+                {
+                    "metadata": {
+                        "identifier": "urn:uuid:9759cd84-2619-4a02-8b03-6ccd1ba5ec72",
+                        "format": [
+                            "application/audiobook+lcp",
+                            "text/html"
+                        ],
+                        "created": "2021-10-01T18:24:19+02:00",
+                        "source": "http://www.cantook.net/",
+                        "price": {
+                            "currency": "USD",
+                            "value": 69.99
+                        },
+                        "terms": {
+                            "checkouts": 40,
+                            "concurrency": 10,
+                            "length": 5097600
+                        },
+                        "protection": {
+                            "format": [
+                                "application/vnd.readium.lcp.license.v1.0+json"
+                            ],
+                            "devices": 6
+                        },
+                        "order": {
+                            "name": "Amazon Audio",
+                            "po_number": "Amazon Audio test ",
+                            "identifier": "202110-262-013768",
+                            "href": "https://market.feedbooks.com/carts/13768"
+                        }
+                    },
+                    "links": [
+                        {
+                            "rel": "http://opds-spec.org/acquisition/borrow",
+                            "href": "https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}",
+                            "type": "application/vnd.readium.license.status.v1.0+json",
+                            "templated": true
+                        },
+                        {
+                            "rel": "self",
+                            "href": "https://license.feedbooks.net/copy/status/?uuid=9759cd84-2619-4a02-8b03-6ccd1ba5ec72",
+                            "type": "application/vnd.odl.info+json"
+                        }
+                    ]
+                },
+                {
+                    "metadata": {
+                        "identifier": "urn:uuid:71374d6c-5eaa-4297-b536-fe9d4f02289c",
+                        "format": [
+                            "application/audiobook+lcp",
+                            "text/html"
+                        ],
+                        "created": "2021-10-01T18:24:20+02:00",
+                        "source": "http://www.cantook.net/",
+                        "price": {
+                            "currency": "USD",
+                            "value": 17.5
+                        },
+                        "terms": {
+                            "checkouts": 5,
+                            "concurrency": 5,
+                            "length": 5097600
+                        },
+                        "protection": {
+                            "format": [
+                                "application/vnd.readium.lcp.license.v1.0+json"
+                            ],
+                            "devices": 6
+                        },
+                        "order": {
+                            "name": "Amazon Audio",
+                            "po_number": "Amazon Audio test ",
+                            "identifier": "202110-262-013768",
+                            "href": "https://market.feedbooks.com/carts/13768"
+                        }
+                    },
+                    "links": [
+                        {
+                            "rel": "http://opds-spec.org/acquisition/borrow",
+                            "href": "https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}",
+                            "type": "application/vnd.readium.license.status.v1.0+json",
+                            "templated": true
+                        },
+                        {
+                            "rel": "self",
+                            "href": "https://license.feedbooks.net/copy/status/?uuid=71374d6c-5eaa-4297-b536-fe9d4f02289c",
+                            "type": "application/vnd.odl.info+json"
+                        }
+                    ]
+                },
+                {
+                    "metadata": {
+                        "identifier": "urn:uuid:5e21b578-9db4-46c6-802d-8f59c923c270",
+                        "format": [
+                            "application/audiobook+lcp",
+                            "text/html"
+                        ],
+                        "created": "2021-10-01T18:24:21+02:00",
+                        "source": "http://www.cantook.net/",
+                        "price": {
+                            "currency": "USD",
+                            "value": 63
+                        },
+                        "terms": {
+                            "expires": "2023-10-01",
+                            "concurrency": 1,
+                            "length": 5097600
+                        },
+                        "protection": {
+                            "format": [
+                                "application/vnd.readium.lcp.license.v1.0+json"
+                            ],
+                            "devices": 6
+                        },
+                        "order": {
+                            "name": "Amazon Audio",
+                            "po_number": "Amazon Audio test ",
+                            "identifier": "202110-262-013768",
+                            "href": "https://market.feedbooks.com/carts/13768"
+                        }
+                    },
+                    "links": [
+                        {
+                            "rel": "http://opds-spec.org/acquisition/borrow",
+                            "href": "https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}",
+                            "type": "application/vnd.readium.license.status.v1.0+json",
+                            "templated": true
+                        },
+                        {
+                            "rel": "self",
+                            "href": "https://license.feedbooks.net/copy/status/?uuid=5e21b578-9db4-46c6-802d-8f59c923c270",
+                            "type": "application/vnd.odl.info+json"
+                        }
+                    ]
+                },
+                {
+                    "metadata": {
+                        "identifier": "urn:uuid:f782a41f-f4d9-4917-8276-edfe1dac35de",
+                        "format": [
+                            "application/audiobook+lcp",
+                            "text/html"
+                        ],
+                        "created": "2021-10-01T18:24:21+02:00",
+                        "source": "http://www.cantook.net/",
+                        "price": {
+                            "currency": "USD",
+                            "value": 29.75
+                        },
+                        "terms": {
+                            "checkouts": 26,
+                            "concurrency": 1,
+                            "length": 5097600
+                        },
+                        "protection": {
+                            "format": [
+                                "application/vnd.readium.lcp.license.v1.0+json"
+                            ],
+                            "devices": 6
+                        },
+                        "order": {
+                            "name": "Amazon Audio",
+                            "po_number": "Amazon Audio test ",
+                            "identifier": "202110-262-013768",
+                            "href": "https://market.feedbooks.com/carts/13768"
+                        }
+                    },
+                    "links": [
+                        {
+                            "rel": "http://opds-spec.org/acquisition/borrow",
+                            "href": "https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}",
+                            "type": "application/vnd.readium.license.status.v1.0+json",
+                            "templated": true
+                        },
+                        {
+                            "rel": "self",
+                            "href": "https://license.feedbooks.net/copy/status/?uuid=f782a41f-f4d9-4917-8276-edfe1dac35de",
+                            "type": "application/vnd.odl.info+json"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/tests/core/files/opds/opds2_feed.json
+++ b/tests/core/files/opds/opds2_feed.json
@@ -1,0 +1,130 @@
+{
+    "links": [
+        {
+            "href": "http://bookshelf-feed-demo.us-east-1.elasticbeanstalk.com/v1/publications?page=1&limit=100",
+            "rel": "self",
+            "type": "application/opds+json"
+        },
+        {
+            "href": "http://bookshelf-feed-demo.us-east-1.elasticbeanstalk.com/v1/publications?page=1&limit=100",
+            "rel": "first",
+            "type": "application/opds+json"
+        },
+        {
+            "href": "http://bookshelf-feed-demo.us-east-1.elasticbeanstalk.com/v1/publications?page=130&limit=100",
+            "rel": "last",
+            "type": "application/opds+json"
+        },
+        {
+            "href": "http://bookshelf-feed-demo.us-east-1.elasticbeanstalk.com/v1/publications?page=2&limit=100",
+            "rel": "next",
+            "type": "application/opds+json"
+        }
+    ],
+    "metadata": {
+        "currentPage": 1,
+        "itemsPerPage": 100,
+        "numberOfItems": 12957,
+        "title": "CLOSED BETA BOOKSHELF"
+    },
+    "publications": [
+        {
+            "images": [
+                {
+                    "href": "https://palace-bookshelf-downloads.dp.la/d85dc431-a0d3-45cf-a62f-29cd949a32be.png",
+                    "type": "image/png"
+                }
+            ],
+            "links": [
+                {
+                    "href": "https://palace-bookshelf-downloads.dp.la/03999f44-6750-4a8c-ab51-9da076d1ef75.epub",
+                    "rel": "http://opds-spec.org/acquisition/open-access",
+                    "type": "application/epub+zip"
+                },
+                {
+                    "href": "http://bookshelf-feed-demo.us-east-1.elasticbeanstalk.com/v1/publications/5d7d7820-1a47-49d2-b9fc-dcd09935c0ea",
+                    "rel": "self",
+                    "type": "application/opds+json"
+                }
+            ],
+            "metadata": {
+                "@type": "https://schema.org/EBook",
+                "description": "Iyi ni inkuru y'umwana muto w'umuhungu wishoraga ahantu hose,  kandi akagira umuryango udasanzwe.",
+                "identifier": "urn:uuid:5d7d7820-1a47-49d2-b9fc-dcd09935c0ea",
+                "language": "rw",
+                "modified": "2021-09-10T20:55:45Z",
+                "published": "2017-12-07",
+                "publisher": "African Storybook Initiative",
+                "title": "Ngewe n'umuryango wange",
+                "author": [
+                    "Cornelius Wambi Gulere, Waako Joshua"
+                ]
+            }
+        },
+        {
+            "images": [
+                {
+                    "href": "https://palace-bookshelf-downloads.dp.la/f67bf5b3-f17b-4b8d-bfc0-1f7053adbba4.png",
+                    "type": "image/png"
+                }
+            ],
+            "links": [
+                {
+                    "href": "https://palace-bookshelf-downloads.dp.la/f3cfde8c-bb7e-4360-8efc-80f2f5e6140c.epub",
+                    "rel": "http://opds-spec.org/acquisition/open-access",
+                    "type": "application/epub+zip"
+                },
+                {
+                    "href": "http://bookshelf-feed-demo.us-east-1.elasticbeanstalk.com/v1/publications/1efd6eb1-4f0b-47d1-922c-7d68c9960596",
+                    "rel": "self",
+                    "type": "application/opds+json"
+                }
+            ],
+            "metadata": {
+                "@type": "https://schema.org/EBook",
+                "description": "Plantez une graine de haricot et voyez ce qui se passe quand vous l'arrosez et en prenez soin.",
+                "identifier": "urn:uuid:1efd6eb1-4f0b-47d1-922c-7d68c9960596",
+                "language": "fr",
+                "modified": "2021-09-10T20:55:43Z",
+                "published": "2015-08-14",
+                "publisher": "African Storybook Initiative",
+                "title": "Le Haricot Qui Germe",
+                "author": [
+                    "Clare Verbeek, Thembani Dladla, Zanele Buthelezi"
+                ]
+            }
+        },
+        {
+            "images": [
+                {
+                    "href": "https://palace-bookshelf-downloads.dp.la/98de999b-154c-4b84-af34-f2e98ed7a42c.jpeg",
+                    "type": "image/jpeg"
+                }
+            ],
+            "links": [
+                {
+                    "href": "https://palace-bookshelf-downloads.dp.la/5f419309-e2fe-4461-b064-907aad064dc3.epub",
+                    "rel": "http://opds-spec.org/acquisition/open-access",
+                    "type": "application/epub+zip"
+                },
+                {
+                    "href": "http://bookshelf-feed-demo.us-east-1.elasticbeanstalk.com/v1/publications/c66bd95a-18cd-49be-8e0f-1f2a85a0a94b",
+                    "rel": "self",
+                    "type": "application/opds+json"
+                }
+            ],
+            "metadata": {
+                "@type": "https://schema.org/EBook",
+                "description": "<p>Recopilación de cuentos infantiles en verso y prosa:</p>  <p>Mi hogar</p>  <p>La mariposa</p>  <p>Don Narices</p>  <p>El zapatero remendón</p>  <p>El gorrión</p>  <p>La vuelta al mundo</p>  <p>Un día de libertad</p>  <p>La muñeca</p>  <p>El mosquito</p>  <p>La perla</p>  <p>Las cerezas</p>  <p>Las castañas</p>  <p>Las golondrinas</p>  <p>Antonieta</p>  <p>La hiedra</p>  <p>Los rosales</p>  <p>La conciencia</p>  <p>El viento</p>",
+                "identifier": "urn:uuid:c66bd95a-18cd-49be-8e0f-1f2a85a0a94b",
+                "language": "es",
+                "modified": "2021-09-10T20:55:49Z",
+                "published": "1912-01-01",
+                "title": "Cuentos del Hogar",
+                "author": [
+                    "Teodoro Baró"
+                ]
+            }
+        }
+    ]
+}

--- a/tests/core/files/opds/palace_feed.opds
+++ b/tests/core/files/opds/palace_feed.opds
@@ -1,0 +1,3383 @@
+<feed xmlns:app="http://www.w3.org/2007/app" xmlns:bib="http://bib.schema.org/" xmlns:bibframe="http://bibframe.org/vocab/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:drm="http://librarysimplified.org/terms/drm" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" xmlns:schema="http://schema.org/" xmlns:simplified="http://librarysimplified.org/terms/" xmlns="http://www.w3.org/2005/Atom">
+  <id>/OB/lists/Open%20Bookshelf/crawlable</id>
+  <title>Open Bookshelf</title>
+  <updated>2022-04-04T19:41:49Z</updated>
+  <link href="/OB/lists/Open%20Bookshelf/crawlable" rel="self" />
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Star</title>
+    <author>
+      <name>H. G. Wells</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/H.%20G.%20Wells/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="H. G. Wells" />
+    </author>
+    <summary type="html">&lt;p&gt;In January 1900, the people of Earth awaken to the news that a strange luminous object has erupted, into the Solar System, after disturbing the normal orbit of the planet Neptune. Although initially it is only of interest to astronomers, eventually the world media announces that it is a whole star, heading in a collision course toward the center of our star system. From Wikipedia.&lt;/p&gt;</summary>
+    <simplified:pwid>48c20dff-6798-2326-0dd8-cfb873a70e2c</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/FeedBooks/URI/http%3A//www.feedbooks.com/book/607/607.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/FeedBooks/URI/http%3A//www.feedbooks.com/book/607/607.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1926-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/607/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/607</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/607" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2022-01-10T23:25:28Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/8076/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/607/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/607/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Anthem</title>
+    <author>
+      <name>Ayn Rand</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Ayn%20Rand/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Ayn Rand" />
+    </author>
+    <summary type="html">&lt;p&gt;Anthem is a dystopian fiction novella by Ayn Rand, first published in 1938. It takes place at some unspecified future date when mankind has entered another dark age as a result of the evils of irrationality and collectivism and the weaknesses of socialistic thinking and economics. Technological advancement is now carefully planned (when it is allowed to occur at all) and the concept of individuality has been eliminated (for example, the word "I" has disappeared from the language). As is common in her work, Rand draws a clear distinction between the "socialist/communal" values of equality and brotherhood and the "productive/capitalist" values of achievement and individuality.&#13;
+&lt;br /&gt;Many of the novella's core themes, such as the struggle between individualism and collectivism, are echoed in Rand's later books, such as The Fountainhead and Atlas Shrugged. However, the style of "Anthem" is unique among Rand's work, more narrative-centered and economical, lacking the intense didactic expressions of philosophical abstraction that occur in later works. It is probably her most accessible work.&lt;/p&gt;</summary>
+    <simplified:pwid>1bdc8999-d1c2-138f-fd54-b1544ab1e5c8</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/FeedBooks/URI/http%3A//www.feedbooks.com/book/2837/2837.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/FeedBooks/URI/http%3A//www.feedbooks.com/book/2837/2837.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1938-05-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2837/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/2837</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2837" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-11-18T20:10:58Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/9760/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2837/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/2837/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Christmas</title>
+    <author>
+      <name>Zona Gale</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Zona%20Gale/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Zona Gale" />
+    </author>
+    <summary type="html">&lt;p&gt;This story has its scene laid in Old Trail Town, a town which is undergoing a temporary period of financial depression, because the Ebenezer Rule Factory Company has been obliged to shut clown for the time being, and Abel Ames&amp;#x27;s Granger Company Merchandise Emporium is in straitened circumstances, owing to the failure of about half the towns-folk to settle their bills for last year&amp;#x27;s Christmas presents. So the church committees and the town meeting and other official bodies get together and vote that this year, for the good of the community at large, no one shall give presents, -and despite a few feeble protests from mothers who foresee heart-aches and tears for the little ones, the measure is carried with general approval. But it happens that a certain maiden lady, Mary Chavah, receives word that her sister has died, leaving a little orphaned boy, who is to be sent on to her, and will arrive just before Christmas. And it is the Christmas spirit brought by the advent of this little child into the house of Mary Chavah that sets at nought all the wise economical forethought of the worldly minded Abels and Simeons and Ebenezers. There is a good deal of symbolism lurking behind the simple surface narrative, making an effective little parable, embodying much indulgent criticism of human frailty and shortsightedness.&lt;/p&gt;</summary>
+    <simplified:pwid>37c1fc07-d4ee-7249-6ec7-2cfc745cb757</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/3522/image%3A1d80e575ac2c93913930e7eaecfe67a4.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/3522/image%3A1d80e575ac2c93913930e7eaecfe67a4.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1912-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3522/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/3522</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3522" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-11-18T16:50:44Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10087/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3522/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/3522/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Sign of Silence</title>
+    <author>
+      <name>William Le Queux</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/William%20Le%20Queux/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="William Le Queux" />
+    </author>
+    <summary type="html">&lt;p&gt;&amp;quot;Really, it&amp;#x27;s the most extraordinary story of London life that I&amp;#x27;ve ever heard,&amp;quot; Phrida Shand declared, leaning forward in her chair, clasping her small white hands as, with her elbows upon the table-Ã -deux, she looked at me with her wondrous dark eyes across the bowl of red tulips between us.&lt;/p&gt;</summary>
+    <simplified:pwid>e3c929ab-4399-68cd-e4f6-72d945d524fd</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4400/image%3A7ea404185e7492d565cce28220d101ea.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4400/image%3A7ea404185e7492d565cce28220d101ea.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Mystery" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Mystery" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1915-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4400/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4400</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4400" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:41Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10599/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4400/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4400/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>For Solo Cello, op. 12</title>
+    <author>
+      <name>Mary Robinette Kowal</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Mary%20Robinette%20Kowal/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Mary Robinette Kowal" />
+    </author>
+    <summary type="html">&lt;p&gt;Excerpt:&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;His keys dropped, rattling on the parquet floor. Julius stared at them, unwilling to look at the bandaged stump where his left hand had been two weeks ago. He should be used to it by now. He should not still be trying to pass things from his right hand to his left.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;But it still felt like his hand was there.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;The shaking began again, a tremelo building in his hand and knees. Julius pressed his right handâ€“his only handâ€“against his mouth so he did not vomit on the floor. Reaching for calm, he imagined playing through Belpardaâ€™s Ã‰tude No. 1. It focused on bowing, on the right hand. Forget the left. When he was eight, Julius had learned it on a cello as big as he had been. The remembered bounce of the bow against the strings pulsed in his right hand.&lt;/p&gt;</summary>
+    <simplified:pwid>07f543ac-24c1-0629-df42-c18625eb13c2</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/2900/image%3A6c62d592adef9fd93eec39ceca32758d.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/2900/image%3A6c62d592adef9fd93eec39ceca32758d.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>2007-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2900/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/2900</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2900" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:40Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/9827/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc-nd/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2900/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/2900/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Pony Rider Boys in Alaska</title>
+    <author>
+      <name>Frank Gee Patchin</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Frank%20Gee%20Patchin/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Frank Gee Patchin" />
+    </author>
+    <summary type="html">&lt;p&gt;It is a safe guess that the Doctor never had worked more heroically over a patient. Well, he saved the chief--had him on his feet and hopping around as lively as a jack-rabbit in less than twenty-four hours. There was great rejoicing among Anna&amp;#x27;s people, and Darwood was feasted and made much of. He was almost as big a man as Old Hoots himself. Nothing was too good for him in that camp.&lt;/p&gt;</summary>
+    <simplified:pwid>0f21d995-5538-9f02-c28d-9257e5883b4e</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4464/image%3Ac217b6a9c0b6b6f96b7139237fd1064e.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4464/image%3Ac217b6a9c0b6b6f96b7139237fd1064e.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Adventure" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Adventure" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1924-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4464/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4464</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4464" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:40Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10602/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4464/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4464/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Alone Again Or</title>
+    <author>
+      <name>Michael  Bassette</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Michael%20%20Bassette/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Michael  Bassette" />
+    </author>
+    <summary type="html">&lt;p&gt;A psychedelic cyberpunk novel.  &lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Excerpt:&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Syd looked up at the man who was still nameless to him. The man was playing with one of his canine teeth. When he realized Syd was done, he extended the same hand.  With hesitation Syd shook the man&amp;#x27;s hand.  &amp;quot;Now, down at the end of the hall there is a bathroom with a full shower if you&amp;#x27;d like to clean yourself up,&amp;quot; he said, indicating a doorway other than the one Syd had entered through. &amp;quot;We recommend it. She&amp;#x27;s in room 501C. Just tell the man at the elevator. He&amp;#x27;ll take you right to her. Good day.&amp;quot;  Syd left and made his way down the institutional halls until he found the bathroom with the picture of the faceless figure wearing pants.&lt;/p&gt;</summary>
+    <simplified:pwid>9605d5c9-20f6-1de2-dc0d-a5b774f2b653</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/FeedBooks/URI/http%3A//www.feedbooks.com/book/1994/1994.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/FeedBooks/URI/http%3A//www.feedbooks.com/book/1994/1994.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>2006-01-02</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/1994/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/1994</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/1994" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-09-29T00:00:00Z</published>
+    <updated>2021-10-04T21:00:34Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/13911/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/1994/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/1994/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>An Incident on Route 12</title>
+    <author>
+      <name>James Henry Schmitz</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/James%20Henry%20Schmitz/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="James Henry Schmitz" />
+    </author>
+    <summary type="html">&lt;p&gt;He was already a thief, prepared to steal again. He didn&amp;#x27;t know that he himself was only booty! Phil Garfield was thirty miles south of the little town of Redmon on Route Twelve when he was startled by a series of sharp, clanking noises. They came from under the Packard&amp;#x27;s hood. The car immediately began to lose speed. Garfield jammed down the accelerator, had a sense of sick helplessness at the complete lack of response from the motor. The Packard rolled on, getting rid of its momentum, and came to a stop. (Source: GoodReads)&lt;/p&gt;</summary>
+    <simplified:pwid>50b69ec5-b499-b639-e67d-80cd038bd4a8</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/FeedBooks/URI/http%3A//www.feedbooks.com/book/2009/2009.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/FeedBooks/URI/http%3A//www.feedbooks.com/book/2009/2009.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1962-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2009/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/2009</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2009" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-09-29T00:00:00Z</published>
+    <updated>2021-10-04T21:00:33Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/13910/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2009/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/2009/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Two Christmas Celebrations, A.D. I. and MDCCCLV.</title>
+    <author>
+      <name>Theodore Parker</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Theodore%20Parker/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Theodore Parker" />
+    </author>
+    <summary type="html">&lt;p&gt;Christmas classics short stories are a collection of renowned Christmas tales which are admired throughout the world. Start reading to unlock the Christmas magic.&lt;/p&gt;</summary>
+    <simplified:pwid>152170f7-a160-456f-ab3a-865025c5a14c</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/3518/image%3Aeaec4b300d043a9b7fd243401b042861.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/3518/image%3Aeaec4b300d043a9b7fd243401b042861.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1856-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3518/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/3518</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3518" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:31Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10099/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3518/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/3518/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Compatible</title>
+    <author>
+      <name>Richard R. Smith</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Richard%20R.%20Smith/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Richard R. Smith" />
+    </author>
+    <summary type="html">&lt;p&gt;There are many waysâ€”murder includedâ€”in which husbands can settle certain problems. This was even more drastic!&lt;/p&gt;</summary>
+    <simplified:pwid>646c9625-76a8-1855-bfc9-8cb79b91d28d</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/3935/image%3A1aacfed214ae3cec19d6c514382dcfb4.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/3935/image%3A1aacfed214ae3cec19d6c514382dcfb4.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1958-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3935/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/3935</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3935" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:31Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10332/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3935/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/3935/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Weapons of Mystery</title>
+    <author>
+      <name>Joseph Hocking</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Joseph%20Hocking/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Joseph Hocking" />
+    </author>
+    <summary type="html">My story begins on the morning of December 18, 18--, while sitting at breakfast. Let it be understood before we go further that I was a bachelor living in lodgings. I had been left an orphan just before I came of age, and was thus cast upon the world at a time when it is extremely dangerous for young men to be alone...</summary>
+    <simplified:pwid>17a8d2db-9517-2581-dc4d-185eebd5f85b</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/3527/image%3A432daec2f336a9af7a9fc9b4d4974322.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/3527/image%3A432daec2f336a9af7a9fc9b4d4974322.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Mystery" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Mystery" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1890-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3527/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/3527</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3527" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:30Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10095/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3527/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/3527/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Pantheism Its Story and Significance</title>
+    <author>
+      <name>J. Allanson Picton</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/J.%20Allanson%20Picton/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="J. Allanson Picton" />
+    </author>
+    <summary type="html">&lt;p&gt;Religions Ancient and Modern Pantheism is a philosophical and/or religious world view that sees the entire universe as a single, eternal, divine unity. It usually goes hand in hand with monism-the idea that the universe is made up of a single substance (matter) in a multitude of changing forms. Since nothing exists outside of this all-encompassing whole, the universe itself must be God. The Pantheistic God is not an anthropomorphic god, and individual believers differ on the level of divinity to ascribe to the deity. This ambiguity allows Pantheism to be compatible with the beliefs of various religions or even with the personal philosophies of secular freethinkers.&lt;/p&gt;</summary>
+    <simplified:pwid>ba339cc5-2b28-2a24-fa5a-afc87e052e45</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/3497/image%3A3a27271233d05973c60e12525e267795.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/3497/image%3A3a27271233d05973c60e12525e267795.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Nonfiction" scheme="http://librarysimplified.org/terms/fiction/" label="Nonfiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Social%20Sciences" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Social Sciences" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/History" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="History" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Religion%20%26%20Spirituality" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Religion &amp; Spirituality" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Philosophy" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Philosophy" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1905-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3497/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/3497</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3497" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:30Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10079/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3497/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/3497/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Ultima Thule</title>
+    <author>
+      <name>Mack Reynolds</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Mack%20Reynolds/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Mack Reynolds" />
+    </author>
+    <summary type="html">&lt;p&gt;Ronny Bronston has dreamed all his life of getting a United Planets job that would take him off-world. He finally gets the opportunity when he is given a provisional assignment with Bureau of Investigation, Section G. But will he be able to complete his assignment and find the elusive Tommy Paine?&lt;/p&gt;</summary>
+    <simplified:pwid>362244a7-97c9-3061-a8e7-1f320a468bac</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4350/image%3Ad7c3b21eba4599badda9fd03c5f37880.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4350/image%3Ad7c3b21eba4599badda9fd03c5f37880.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1961-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4350/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4350</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4350" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:29Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10540/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4350/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4350/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Adventure League</title>
+    <author>
+      <name>Hilda T. Skae</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Hilda%20T.%20Skae/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Hilda T. Skae" />
+    </author>
+    <summary type="html">&lt;p&gt;Of interest for its portrayal of class relations is Hilda T. Skae&amp;#x27;s children&amp;#x27;s mystery, The Adventure League, which is described as the tale of upper-class Scottish kids trying to prove that their working class friend didn&amp;#x27;t commit the crime. From GoogleBooks.&lt;/p&gt;</summary>
+    <simplified:pwid>5193a86c-dcfe-53d2-bc27-ccf254b6ef8c</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4452/image%3A7e4ff9b4376ebfda112ead86fefa8e58.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4452/image%3A7e4ff9b4376ebfda112ead86fefa8e58.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1907-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4452/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4452</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4452" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:25Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10583/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4452/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4452/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Ivory Snuff Box</title>
+    <author>
+      <name>Frederic Arnold Kummer</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Frederic%20Arnold%20Kummer/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Frederic Arnold Kummer" />
+    </author>
+    <summary type="html">&lt;p&gt;A small box of ivory for holding snuff, with no real value, has been stolen from the French ambassador. Detective Duvall is ordered to travel back to London emergently, and recover the snuff box at all costs.&lt;/p&gt;</summary>
+    <simplified:pwid>b2358c35-bab4-2010-4e36-f3a5b6b0086b</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4257/image%3A273048464a4fe4889f20f3066dbeed87.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4257/image%3A273048464a4fe4889f20f3066dbeed87.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Mystery" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Mystery" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1912-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4257/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4257</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4257" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:24Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10498/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4257/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4257/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Paliser Case</title>
+    <author>
+      <name>Edgar Saltus</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Edgar%20Saltus/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Edgar Saltus" />
+    </author>
+    <summary type="html">&lt;p&gt;A drama of gold, of pain, of curious crime and the heart of a girl, by one of America&amp;#x27;s most brilliant writers.&lt;/p&gt;&lt;p&gt;Mystery, tragedy, comedy, glimpses of a Harlem Bohemia, and the blasÃ© social atmosphere of multi-millionaires are overlaid with the freshness and vitality of the Spanish singer Cassy Cara, a wholly delightful girl. The development of the plot is piquant and most engaging.&lt;/p&gt;</summary>
+    <simplified:pwid>8476dc9f-7b3a-744a-c883-bf3d1960432f</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4137/image%3A2b775d869fffc2476ab809d916480297.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4137/image%3A2b775d869fffc2476ab809d916480297.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Mystery" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Mystery" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1919-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4137/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4137</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4137" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:22Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10417/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4137/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4137/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The People of the Ruins</title>
+    <author>
+      <name>Edward Shanks</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Edward%20Shanks/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Edward Shanks" />
+    </author>
+    <summary type="html">&lt;p&gt;General strike in 1924 marks the beginning of the collapse of civilization. 150 years later England is reduced to neolithical barbarism. (From GoogleBooks)&lt;/p&gt;</summary>
+    <simplified:pwid>1f0a8fea-34dd-2eaa-eec8-0d046533f688</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/3087/image%3Aaf28d856f5a3a9aed991a3ea1e818a36.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/3087/image%3Aaf28d856f5a3a9aed991a3ea1e818a36.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1920-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3087/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/3087</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3087" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:20Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/9889/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3087/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/3087/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Cavern of the Shining Ones</title>
+    <author>
+      <name>Hal K. Wells</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Hal%20K.%20Wells/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Hal K. Wells" />
+    </author>
+    <summary type="html">&lt;p&gt;Layroh&amp;#x27;s hiring of husky down-and-outers for his expedition is part of a plan made ages past. From GoogleBooks.&lt;/p&gt;</summary>
+    <simplified:pwid>623cce30-51a4-8b5c-7c67-eed0d2f1b40e</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/3312/image%3Af00eee17340dcb477916e66cce91d73b.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/3312/image%3Af00eee17340dcb477916e66cce91d73b.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1932-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3312/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/3312</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3312" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:20Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/9953/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3312/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/3312/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Cerbo en Vitra ujo</title>
+    <author>
+      <name>Mary Robinette Kowal</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Mary%20Robinette%20Kowal/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Mary Robinette Kowal" />
+    </author>
+    <summary type="html">&lt;p&gt;Excerpt:&lt;/p&gt;&lt;p&gt;Behind the steady drone of gardenâ€™s humidifiers, Grete caught the woosh-snick of the airlock door opening. She kept her attention on her Sunset-Glory rose to give Kaj a chance to sneak up on her. His footsteps pounded between the raised beds, without a hint of stealth. Grete put her pruning shears down as he barreled around the Milhollenâ€™s prize Emperor artichoke.&lt;/p&gt;</summary>
+    <simplified:pwid>052d41cc-2a5e-d6b4-448a-7cae37a6cb62</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/2898/image%3Ad09ef2ba335ea44467818caef54af883.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/2898/image%3Ad09ef2ba335ea44467818caef54af883.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Horror" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Horror" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>2006-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2898/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/2898</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2898" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:18Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/9808/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc-nd/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2898/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/2898/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>This Little Pig</title>
+    <author>
+      <name>Mary Robinette Kowal</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Mary%20Robinette%20Kowal/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Mary Robinette Kowal" />
+    </author>
+    <summary type="html">&lt;p&gt;Excerpt:&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Hey, Aage,&amp;quot; Lasse held a towel and a coverall. &amp;quot;Let&amp;#x27;s hose you off again.&amp;quot;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Aage frowned. &amp;quot;Where&amp;#x27;s Concetta?&amp;quot;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;She&amp;#x27;s round the other side of the van.&amp;quot; He smirked. &amp;quot;Want me to call her?&amp;quot;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Aage&amp;#x27;s eyes widened and he waved his hands. &amp;quot;No! No, no, no. I just didn&amp;#x27;t see her.&amp;quot; He looked at the towels and coveralls again. &amp;quot;Where&amp;#x27;d you get those?&amp;quot;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Concetta brought them.&amp;quot;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Every time Aage stepped, his wet underwear shifted and clung to his body. The briefs slowly tried to climb up the crack between his buttocks, aiming to be the world&amp;#x27;s worst wedgie. With the van behind them, there was no way Aage was going to reach back to free his briefs.&lt;/p&gt;</summary>
+    <simplified:pwid>8299ead7-a06b-9d93-ab13-65685c263168</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/2897/image%3A0aafb993252768a7804bc9593c0fd277.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/2897/image%3A0aafb993252768a7804bc9593c0fd277.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>2007-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2897/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/2897</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2897" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-10-04T21:00:18Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/9805/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc-nd/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2897/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/2897/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Sons and Lovers</title>
+    <author>
+      <name>D. H. Lawrence</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/D.%20H.%20Lawrence/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="D. H. Lawrence" />
+    </author>
+    <summary type="html">&lt;p&gt;The third published novel of D. H. Lawrence, taken by many to be his earliest masterpiece, tells the story of Paul Morel, a young man and budding artist. Richard Aldington explains the semi-autobiographical nature of his masterpiece: &lt;br/&gt;When you have experienced Sons and Lovers you have lived through the agonies of the young Lawrence striving to win free from his old life&amp;#x27;. Generally, it is not only considered as an evocative portrayal of working-class life in a mining community, but also an intense study of family, class and early sexual relationships.&lt;/p&gt;</summary>
+    <simplified:pwid>8ffb6c8a-2ed1-aaa2-66c6-39d38d53ec0b</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/d-h-lawrence/sons-and-lovers/cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/d-h-lawrence/sons-and-lovers/cover.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Standard Ebooks</dcterms:publisher>
+    <dcterms:issued>1913-01-02</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/d-h-lawrence/sons-and-lovers/report" rel="issues" />
+    <id>https://standardebooks.org/ebooks/d-h-lawrence/sons-and-lovers</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/d-h-lawrence/sons-and-lovers" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="Standard Ebooks" />
+    <published>2018-02-16T00:00:00Z</published>
+    <updated>2021-09-30T00:41:13Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/7419/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7419/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7419/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7419/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7419/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="application/kepub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7419/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7419/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="application/x-mobipocket-ebook" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7419/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/d-h-lawrence/sons-and-lovers/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://standardebooks.org/ebooks/d-h-lawrence/sons-and-lovers/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Call of the Wild</title>
+    <author>
+      <name>Jack London</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Jack%20London/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Jack London" />
+    </author>
+    <summary type="html">&lt;p&gt;Jack London spent nearly a year in Alaska and the Klondike, mining for gold and braving the Alaskan winter. There he was inspired to write what would become &lt;em&gt;The Call of the Wild&lt;/em&gt;, one of his most famous novels. &lt;em&gt;The Call of the Wild&lt;/em&gt; tells the tale of a domesticated dog stolen from his California family and sold to sledders in Alaska. As he adapts to the harsh and wild environment, he slowly sheds domestication and returns to his primal roots.&lt;/p&gt;&lt;p&gt;&lt;em&gt;The Call of the Wild&lt;/em&gt; was Londonâ€™s first major success, ensuring heâ€™d have a readership for his future writing and paving the way for him to become one of the first writers to amass a fortune from just his fiction.&lt;/p&gt;</summary>
+    <simplified:pwid>74adaca0-dc8b-b19d-a608-ac2559185a92</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/jack-london/the-call-of-the-wild/cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/jack-london/the-call-of-the-wild/cover.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Adventure" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Adventure" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Standard Ebooks</dcterms:publisher>
+    <dcterms:issued>1903-01-02</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/jack-london/the-call-of-the-wild/report" rel="issues" />
+    <id>https://standardebooks.org/ebooks/jack-london/the-call-of-the-wild</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/jack-london/the-call-of-the-wild" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="Standard Ebooks" />
+    <published>2018-02-16T00:00:00Z</published>
+    <updated>2021-09-30T00:35:18Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/7346/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7346/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7346/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7346/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7346/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="application/kepub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7346/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7346/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="application/x-mobipocket-ebook" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7346/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/jack-london/the-call-of-the-wild/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://standardebooks.org/ebooks/jack-london/the-call-of-the-wild/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Invisible Man</title>
+    <author>
+      <name>H. G. Wells</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/H.%20G.%20Wells/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="H. G. Wells" />
+    </author>
+    <summary type="html">&lt;p&gt;Griffin, a scientist, has devoted his life to the study of optics. As his work progresses, he invents a method of making a person invisible. After testing the experiment on himself, he comes to realize that while the experiment was a complete success, he has no way of reversing his invisibility.&lt;/p&gt;&lt;p&gt;Written in a time of rapid scientific progress and industrial development, Wells uses Griffinâ€™s struggle with his condition and descent into obsession and madness to reflect on the dangers of unbridled scientific progress untempered by compassion or humanity.&lt;/p&gt;&lt;p&gt;&lt;em&gt;The Invisible Man&lt;/em&gt; was initially serialized in &lt;em&gt;Pearsonâ€™s Weekly&lt;/em&gt; in 1897, after which it was published as a whole novel that same year.&lt;/p&gt;</summary>
+    <simplified:pwid>e7ee8061-7993-047a-29f7-a58f5afd0d23</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/h-g-wells/the-invisible-man/cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/h-g-wells/the-invisible-man/cover.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Standard Ebooks</dcterms:publisher>
+    <dcterms:issued>1897-01-02</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/h-g-wells/the-invisible-man/report" rel="issues" />
+    <id>https://standardebooks.org/ebooks/h-g-wells/the-invisible-man</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/h-g-wells/the-invisible-man" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="Standard Ebooks" />
+    <published>2018-02-16T00:00:00Z</published>
+    <updated>2021-09-30T00:32:48Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/7466/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7466/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7466/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7466/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7466/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="application/kepub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7466/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7466/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="application/x-mobipocket-ebook" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7466/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/h-g-wells/the-invisible-man/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://standardebooks.org/ebooks/h-g-wells/the-invisible-man/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Canterville Ghost</title>
+    <author>
+      <name>Oscar Wilde</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Oscar%20Wilde/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Oscar Wilde" />
+    </author>
+    <summary type="html">There has been a ghost in the house for three hundred years, and LordCanterville's family have had enough of it. So Lord Canterville sells his grandold house to an American family. Mr Hiram B. Otis is happy to buy the house andthe ghost - because of course Americans don't believe in ghosts.The Canterville ghost has great plans to frighten the life out of the Otisfamily. But Americans don't frighten easily - especially not two noisy littleboys - and the poor ghost has a few surprises waiting for him.</summary>
+    <simplified:pwid>b69e3b48-f374-f41a-7824-a2eb9596a1ce</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/FeedBooks/URI/http%3A//www.feedbooks.com/book/7/7.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/FeedBooks/URI/http%3A//www.feedbooks.com/book/7/7.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Occult%20Horror" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Occult Horror" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Humorous%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Humorous Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Ghost%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Ghost Stories" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1887-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/7/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/7</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/7" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-09-29T00:00:00Z</published>
+    <updated>2021-09-28T00:58:23Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/13853/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/7/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/7/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Under My Shade</title>
+    <author>
+      <name>Lulu Ebenis</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Lulu%20Ebenis/eng/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Lulu Ebenis" />
+    </author>
+    <summary type="html">&lt;p&gt;A tree tells the story of the many things it sees, day after day, taking place in the shade.    	&lt;/p&gt;&lt;p&gt;Reading Level 2 	 	&lt;/p&gt;&lt;p&gt;Keywords: nature; tree; children; school&lt;/p&gt;</summary>
+    <simplified:pwid>fd0cd82c-495e-046a-2818-8af5fd5bc0b0</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+for+All+Australia/URI/http%3A//lfa.cantookstation.com/resource_entries/5bc9fc522357941c6ed2b177.atom/ab2ff568-a7c8-424a-81e6-bcd08b803dc6.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+for+All+Australia/URI/http%3A//lfa.cantookstation.com/resource_entries/5bc9fc522357941c6ed2b177.atom/ab2ff568-a7c8-424a-81e6-bcd08b803dc6.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="4-8" scheme="http://schema.org/typicalAgeRange" label="4-8" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Library For All</dcterms:publisher>
+    <bib:publisherImprint>Papua New Guinea Collection</bib:publisherImprint>
+    <dcterms:issued>2018-10-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://lfa.cantookstation.com/resource_entries/5bc9fc522357941c6ed2b177.atom/report" rel="issues" />
+    <id>http://lfa.cantookstation.com/resource_entries/5bc9fc522357941c6ed2b177.atom</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://lfa.cantookstation.com/resource_entries/5bc9fc522357941c6ed2b177.atom" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="Library for All Australia" />
+    <published>2018-10-20T00:00:00Z</published>
+    <updated>2021-09-21T21:10:25Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/20854/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://lfa.cantookstation.com/resource_entries/5bc9fc522357941c6ed2b177.atom/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://lfa.cantookstation.com/resource_entries/5bc9fc522357941c6ed2b177.atom/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Nightmare Abbey</title>
+    <author>
+      <name>Thomas Love Peacock</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Thomas%20Love%20Peacock/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Thomas Love Peacock" />
+    </author>
+    <summary type="html">&lt;p&gt;Published in 1818, Peacockâ€™s novella &lt;em&gt;Nightmare Abbey&lt;/em&gt; is a gentle satire of the then-popular gothic movement in literature. He pokes fun at the genreâ€™s obsessions and most of the bookâ€™s characters are caricatures of well-known personages of the time.&lt;/p&gt;&lt;p&gt;Young Scythrop is the only son of Mr. Glowry, living in the semi-ruined Nightmare Abbey on his estate in Lincolnshire. Mr. Glowry, the survivor of a miserable marriage, is addicted to the depressing and the morbid, surrounding himself with servants whose names, such as Raven, Graves and Skellet, reflect his obsessions. His friends, also, are chosen from those who best reflect his misanthropic views.&lt;/p&gt;&lt;p&gt;Scythrop himself imagines himself a philosopher with a unique view of the world, and to this end has written a treatise titled â€œPhilosophical Gas; or, a Project for a General Illumination of the Human Mind.â€ Only seven copies of this treatise have ever been sold, and Scythrop dreams of being united with one of the buyers. His passions, though, become more earthy when he falls in love both with his cousin Marionetta and then also with a mysterious woman who appears in his apartment and begs him for asylum, thus creating a situation of romantic farce as he tries to decide between the two.&lt;/p&gt;&lt;p&gt;These events are interleaved between entertaining discussions among the varied guests at Nightmare Abbey, richly filled with humor, allusions and quotation.&lt;/p&gt;&lt;p&gt;&lt;em&gt;Nightmare Abbey&lt;/em&gt; is probably Peacockâ€™s most successful work of fiction, and helped establish his position as an important satirist of his times. His satire, though, is light-hearted rather than savage and is directed more at foolish opinions than attacking particular persons.&lt;/p&gt;</summary>
+    <simplified:pwid>f88d026b-5cfd-862f-33d7-6c1e675928c4</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/thomas-love-peacock/nightmare-abbey/cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/thomas-love-peacock/nightmare-abbey/cover.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Humorous%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Humorous Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Gothic%20Horror" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Gothic Horror" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Suspense/Thriller" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Suspense/Thriller" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Standard Ebooks</dcterms:publisher>
+    <dcterms:issued>1818-11-02</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/thomas-love-peacock/nightmare-abbey/report" rel="issues" />
+    <id>https://standardebooks.org/ebooks/thomas-love-peacock/nightmare-abbey</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/thomas-love-peacock/nightmare-abbey" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="Standard Ebooks" />
+    <published>2018-02-16T00:00:00Z</published>
+    <updated>2021-09-15T20:46:19Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/7374/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7374/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7374/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7374/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7374/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="application/kepub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7374/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7374/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="application/x-mobipocket-ebook" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7374/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/thomas-love-peacock/nightmare-abbey/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://standardebooks.org/ebooks/thomas-love-peacock/nightmare-abbey/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Island of Doctor Moreau</title>
+    <author>
+      <name>H. G. Wells</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/H.%20G.%20Wells/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="H. G. Wells" />
+    </author>
+    <summary type="html">&lt;p&gt;&lt;em&gt;The Island of Doctor Moreau&lt;/em&gt; is the narration of Edward Prendick, a shipwrecked man who finds himself on a mysterious island full of humanoid animal creatures. He comes to find that these creatures are the work of Dr. Moreau, a man who experiments in vivisection, and his assistant Montgomery.&lt;/p&gt;&lt;p&gt;The story of Dr. Moreauâ€™s island began as an article in the January, 1895 issue of &lt;em&gt;Saturday Review&lt;/em&gt;. It was later adapted into a novel. Its themes reflect concerns growing in the society of the day, like the cruelty of vivisection, degenerationism, and the theory of evolution.&lt;/p&gt;</summary>
+    <simplified:pwid>a16629e5-dd41-40ad-a0f6-ea980a79d0f9</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/h-g-wells/the-island-of-doctor-moreau/cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/h-g-wells/the-island-of-doctor-moreau/cover.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Standard Ebooks</dcterms:publisher>
+    <dcterms:issued>1895-01-02</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/h-g-wells/the-island-of-doctor-moreau/report" rel="issues" />
+    <id>https://standardebooks.org/ebooks/h-g-wells/the-island-of-doctor-moreau</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/h-g-wells/the-island-of-doctor-moreau" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="Standard Ebooks" />
+    <published>2018-02-16T00:00:00Z</published>
+    <updated>2021-09-14T21:27:10Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/7431/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7431/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7431/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7431/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7431/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="application/kepub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7431/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7431/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="application/x-mobipocket-ebook" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7431/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/h-g-wells/the-island-of-doctor-moreau/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://standardebooks.org/ebooks/h-g-wells/the-island-of-doctor-moreau/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Haunted Bookshop</title>
+    <author>
+      <name>Christopher Morley</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Christopher%20Morley/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Christopher Morley" />
+    </author>
+    <summary type="html">&lt;p&gt;â€œThis shop is hauntedâ€ reads the sign on the front of the bookshop; not by the ghost of a person from the past, but by the ghosts of all great literature which haunt all libraries and bookstores.&lt;/p&gt;&lt;p&gt;The owner of the bookshop is so focused on his books that he cannot see the unusual things that are going on in his shop. It takes a young advertising salesman who is seeking new business and the daughter of a rich client who has been sent to earn a living for herself in the bookshop to discover the plot thatâ€™s brewing amongst the bookshelves.&lt;/p&gt;&lt;p&gt;&lt;em&gt;The Haunted Bookshop&lt;/em&gt; is a gentle mystery story which is full of wonderful literary references. It is set in the aftermath of the First World War before the Paris Peace Conference took place in an age where the â€œLost and Foundâ€ columns are &lt;em&gt;the&lt;/em&gt; place to look for significant information.&lt;/p&gt;</summary>
+    <simplified:pwid>c88dca16-2dbd-dcfb-51eb-11a53f8a53bb</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/christopher-morley/the-haunted-bookshop/cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/christopher-morley/the-haunted-bookshop/cover.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Mystery" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Mystery" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Standard Ebooks</dcterms:publisher>
+    <dcterms:issued>1919-01-02</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/christopher-morley/the-haunted-bookshop/report" rel="issues" />
+    <id>https://standardebooks.org/ebooks/christopher-morley/the-haunted-bookshop</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/christopher-morley/the-haunted-bookshop" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="Standard Ebooks" />
+    <published>2018-04-27T00:00:00Z</published>
+    <updated>2021-09-14T21:25:39Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/13501/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/13501/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/13501/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/13501/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/13501/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="application/kepub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/13501/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/13501/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="application/x-mobipocket-ebook" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/13501/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/christopher-morley/the-haunted-bookshop/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://standardebooks.org/ebooks/christopher-morley/the-haunted-bookshop/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Ghost Pirates</title>
+    <author>
+      <name>William Hope Hodgson</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/William%20Hope%20Hodgson/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="William Hope Hodgson" />
+    </author>
+    <summary type="html">"The Ghost Pirates . . . is a powerful account of a doomed and haunted ship on its last voyage, and of the terrible sea-devils (of quasi-human aspect, and perhaps the spirits of bygone buccaneers) that besiege it and finally drag it down to an unknown fate. With its command of maritime knowledge, and its clever selection of hints and incidents suggestive of latent horrors in nature, this book at times reaches enviable peaks of power." -- H.P. Lovecraft &#13;
+&#13;
+William Hope Hodgson (1877-1918) was an English author. He produced a large body of work, consisting of essays, short fiction, and novels, spanning several overlapping genres including horror, fantastic fiction and science fiction. Early in his writing career he dedicated effort to poetry, although few of his poems were published during his lifetime. He also attracted some notice as a photographer and achieved some renown as a bodybuilder. He began a four-year apprenticeship as a cabin boy in 1891. In 1899, he opened W. H. Hodgson's School of Physical Culture offering tailored exercise regimes for personal training. He wrote articles such as Physical Culture Versus Recreative Exercises (1903). Hodgson turned his attention to fiction, publishing his first short story, The Goddess of Death (1904). In 1906 the American magazine The Monthly Story Magazine published From the Tideless Sea, the first of Hodgson's Sargasso Sea stories. His first published novel, The Boats of the "Glen Carrig," appeared in 1907. Amongst his other works are The House on the Borderland (1908), The Ghost Pirates (1909), Carnacki: The Ghost Finder (1910) and The Night Land (1912).</summary>
+    <simplified:pwid>c41e3821-09df-f0e5-c169-88eda654896f</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/FeedBooks/URI/http%3A//www.feedbooks.com/book/2427/2427.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/FeedBooks/URI/http%3A//www.feedbooks.com/book/2427/2427.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Ghost%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Ghost Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Occult%20Horror" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Occult Horror" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1909-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2427/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/2427</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2427" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-09-14T21:21:08Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/9513/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/2427/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/2427/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Legend of Sleepy Hollow</title>
+    <author>
+      <name>Washington Irving</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Washington%20Irving/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Washington Irving" />
+    </author>
+    <summary type="html">"The Legend of Sleepy Hollow" is a horror story by American author Washington Irving, contained in his collection of 34 essays and short stories entitled The Sketch Book of Geoffrey Crayon, Gent.. Written while Irving was living abroad in Birmingham, England, "The Legend of Sleepy Hollow" was first published in 1820.</summary>
+    <simplified:pwid>0695a9eb-9261-517e-65d6-81dcb25f8b99</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/FeedBooks/URI/http%3A//www.feedbooks.com/book/196/196.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/FeedBooks/URI/http%3A//www.feedbooks.com/book/196/196.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Occult%20Horror" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Occult Horror" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Ghost%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Ghost Stories" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1820-05-15</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/196/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/196</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/196" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-09-14T21:09:36Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/7805/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/196/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/196/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Turn of the Screw</title>
+    <author>
+      <name>Henry James</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Henry%20James/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Henry James" />
+    </author>
+    <summary type="html">&lt;p&gt;One of the most famous ghost stories in literature, &lt;i&gt;The Turn of the Screw&lt;/i&gt; earned its place in the annals of influential English novellas not for its qualities as a gothic ghost story, but rather for the many complex and subtle ways the reader can come to opposing conclusions as to taleâ€™s very nature. Are the ghosts the governess sees real, or are they figments of her quiet insanity?&lt;/p&gt;
+			&lt;p&gt;&lt;i&gt;The Turn of the Screw&lt;/i&gt; was originally published as a serial, and later went through many revisions by &lt;a href="https://standardebooks.org/ebooks/henry-james"&gt;James&lt;/a&gt; himself. Though there arenâ€™t any overt suggestion that James intended his novella to be anything but a simple ghost story, the ambiguity in the narrative has captured the imagination of generations of readers and critics.&lt;/p&gt;</summary>
+    <simplified:pwid>81cd6791-9aba-b5f0-55fa-98e3ace6eaf8</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/FeedBooks/URI/http%3A//www.feedbooks.com/book/300/300.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/FeedBooks/URI/http%3A//www.feedbooks.com/book/300/300.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Occult%20Horror" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Occult Horror" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Ghost%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Ghost Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1898-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/300/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/300</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/300" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-09-14T20:35:40Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/7903/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/300/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/300/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Picture of Dorian Gray</title>
+    <author>
+      <name>Oscar Wilde</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Oscar%20Wilde/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Oscar Wilde" />
+    </author>
+    <summary type="html">&lt;p&gt;&lt;i&gt;The Picture of Dorian Gray&lt;/i&gt; was first published as a serial in &lt;i&gt;Lippencottâ€™s Monthly Magazine&lt;/i&gt;, and the publishers thought it would so offend readers that they removed nearly 500 words without &lt;a href="https://standardebooks.org/ebooks/oscar-wilde"&gt;Wildeâ€™s&lt;/a&gt; approval. Wilde soon expanded it and republished it as a novel, including a short preface justifying his art. Even though his contemporaries considered it so offensive that some argued for his prosecution, &lt;i&gt;Dorian Gray&lt;/i&gt; today survives as a classic philosophical novel that explores themes of aestheticism and double lives. Couched in Wildeâ€™s trademark cutting wit, &lt;i&gt;Dorian Gray&lt;/i&gt; is still being adapted today, with Dorian and his moldering portrait remaining cultural touchstones.&lt;/p&gt;</summary>
+    <simplified:pwid>57f04d99-9e40-2219-22e1-8ccb4cfc33c0</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/oscar-wilde/the-picture-of-dorian-gray/cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/oscar-wilde/the-picture-of-dorian-gray/cover.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Standard Ebooks</dcterms:publisher>
+    <dcterms:issued>1890-06-20</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/oscar-wilde/the-picture-of-dorian-gray/report" rel="issues" />
+    <id>https://standardebooks.org/ebooks/oscar-wilde/the-picture-of-dorian-gray</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/oscar-wilde/the-picture-of-dorian-gray" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="Standard Ebooks" />
+    <published>2018-02-16T00:00:00Z</published>
+    <updated>2021-09-14T20:22:39Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/7364/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7364/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7364/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7364/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7364/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="application/kepub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7364/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7364/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="application/x-mobipocket-ebook" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7364/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/oscar-wilde/the-picture-of-dorian-gray/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://standardebooks.org/ebooks/oscar-wilde/the-picture-of-dorian-gray/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Strange Case of Dr. Jekyll and Mr. Hyde</title>
+    <author>
+      <name>Robert Louis Stevenson</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Robert%20Louis%20Stevenson/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Robert Louis Stevenson" />
+    </author>
+    <summary type="html">&lt;p&gt;&lt;i&gt;The Strange Case of Dr. Jekyll and Mr. Hyde&lt;/i&gt; is the classic novella of split personality. Stevenson wrote it in just a few days while sick and bedridden, and famously burned the first draft after his wife suggested it should be written as an allegory and not as a story. He re-wrote it in three to six days, and after a few weeks of editing and revision he published what would become one of his most famous and best-selling works.&lt;/p&gt;&#13;
+			&lt;p&gt;The story follows a London lawyer as he investigates the relationship between a brilliant scientist and a misshappen misanthrope. As the link between the two becomes clearer, &lt;i&gt;Jekyll and Hyde&lt;/i&gt; develops into an allegory on the nature of good and evil.&lt;/p&gt;</summary>
+    <simplified:pwid>c1c219c2-dc8d-389d-16c5-3c4bb644be45</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/robert-louis-stevenson/the-strange-case-of-dr-jekyll-and-mr-hyde/cover.jpg" type="image/jpeg" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Standard+Ebooks/URI/https%3A//standardebooks.org/ebooks/robert-louis-stevenson/the-strange-case-of-dr-jekyll-and-mr-hyde/cover.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Horror" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Horror" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Standard Ebooks</dcterms:publisher>
+    <dcterms:issued>1886-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/robert-louis-stevenson/the-strange-case-of-dr-jekyll-and-mr-hyde/report" rel="issues" />
+    <id>https://standardebooks.org/ebooks/robert-louis-stevenson/the-strange-case-of-dr-jekyll-and-mr-hyde</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/robert-louis-stevenson/the-strange-case-of-dr-jekyll-and-mr-hyde" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="Standard Ebooks" />
+    <published>2018-02-16T00:00:00Z</published>
+    <updated>2021-09-14T20:21:08Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/7377/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7377/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7377/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7377/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7377/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="application/kepub+zip" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7377/fulfill/4" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7377/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="application/x-mobipocket-ebook" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/7377/fulfill/5" rel="http://opds-spec.org/acquisition/open-access" type="text/html; charset=utf-8" dcterms:rights="http://librarysimplified.org/terms/rights-status/generic-open-access">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://standardebooks.org/ebooks/robert-louis-stevenson/the-strange-case-of-dr-jekyll-and-mr-hyde/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://standardebooks.org/ebooks/robert-louis-stevenson/the-strange-case-of-dr-jekyll-and-mr-hyde/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Cow-Country</title>
+    <author>
+      <name>B.M. Bower</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/B.M.%20Bower/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="B.M. Bower" />
+    </author>
+    <summary type="html">&lt;p&gt;Through hazards, difficulties and dangers, Bob sets out to discover life for himself. With awfully wild terrain and Indians around him, he has to find his way. More than the threats posed by nature are those that are created by other humans. A tale of swashbuckling adventures!&lt;/p&gt;</summary>
+    <simplified:pwid>aa52f341-384f-73f1-8e00-7fcba6930637</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/921/image%3Aa9774dbcece599e4fe12e22feab90655.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/921/image%3Aa9774dbcece599e4fe12e22feab90655.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Westerns" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Westerns" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1921-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/921/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/921</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/921" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-06-05T18:52:07Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/8359/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/921/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/921/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Isidudu</title>
+    <contributor opf:role="trl">
+      <name>Nokuthula Bernelee Dyonase</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Catherine Groenewald</name>
+    </contributor>
+    <author>
+      <name>Zimbili Dlamini, Hlengiwe Zondi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Zimbili%20Dlamini%2C%20Hlengiwe%20Zondi/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Zimbili Dlamini, Hlengiwe Zondi" />
+    </author>
+    <summary type="html">Umama akekho,  ngoku utata upheka isidudu sesidlo sakusasa.</summary>
+    <simplified:pwid>932001f9-d331-440d-f119-e5f82ed7387c</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14947/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D14947.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14947/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D14947.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-01-27</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14947/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=14947</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14947" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:52:20Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14108/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14947/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14947/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>UMgcini nekhaya leenkedama</title>
+    <contributor opf:role="trl">
+      <name>Kholeka Mabeta</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Magriet Brink</name>
+    </contributor>
+    <author>
+      <name>Ursula Nafula, Nina Orange</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Ursula%20Nafula%2C%20Nina%20Orange/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Ursula Nafula, Nina Orange" />
+    </author>
+    <summary type="html">Ibali ngezilwanyane ezisindisiweyo zaze zagcinwa kwikhaya leenkedama. Ezi zilwanyana zigcinwa ngumntu okhethekileyo neqela lakhe.</summary>
+    <simplified:pwid>d84237a6-1fa8-78e0-5b7c-21d228608e49</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14123/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D14123.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14123/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D14123.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2015-11-17</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14123/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=14123</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14123" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:51:21Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14089/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14123/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14123/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Ibhayisekile kaNamukuru</title>
+    <contributor opf:role="trl">
+      <name>Kholeka Mabeta</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Wiehan de Jager</name>
+    </contributor>
+    <author>
+      <name>Munanga ASb teachers</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Munanga%20ASb%20teachers/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Munanga ASb teachers" />
+    </author>
+    <summary type="html">Inkawu imka nebhayisekile kaNamukuru!</summary>
+    <simplified:pwid>cd80e03e-d9f5-c743-8860-8056245b8639</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14120/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D14120.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14120/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D14120.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2015-11-17</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14120/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=14120</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14120" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:49:47Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14086/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14120/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D14120/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>UJaaka umlobi</title>
+    <contributor opf:role="trl">
+      <name>Nokuthula Bernelee Dyonase</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Zablon Alex Nguku</name>
+    </contributor>
+    <author>
+      <name>Tom Sabwa, Childrenâ€™s Development Center at Masese</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Tom%20Sabwa%2C%20Children%E2%80%99s%20Development%20Center%20at%20Masese/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Tom Sabwa, Childrenâ€™s Development Center at Masese" />
+    </author>
+    <summary type="html">Omusaadha omuvubi ku Mwiga Kiyira.</summary>
+    <simplified:pwid>9a6f1245-5e34-2763-6aa5-f11bb6b91d90</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13206/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D13206.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13206/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D13206.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2015-09-23</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13206/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=13206</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13206" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:48:41Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14070/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13206/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13206/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Ingozi embi</title>
+    <contributor opf:role="trl">
+      <name>Anezwa Madondile</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Rob Owen</name>
+    </contributor>
+    <author>
+      <name>Zanele Buthelezi, Thembani Dladla, Clare Verbeek</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Zanele%20Buthelezi%2C%20Thembani%20Dladla%2C%20Clare%20Verbeek/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Zanele Buthelezi, Thembani Dladla, Clare Verbeek" />
+    </author>
+    <summary type="html">Two children see a terrible accident between a truck and a car.</summary>
+    <simplified:pwid>a0951041-ddb4-1c46-d18f-e6a16e6daf21</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13203/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D13203.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13203/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D13203.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2015-09-22</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13203/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=13203</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13203" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:32:32Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14069/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13203/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13203/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>UTingi kunye neenkomo</title>
+    <contributor opf:role="trl">
+      <name>Lunathi Ntunzi</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Ingrid Schechter</name>
+    </contributor>
+    <author>
+      <name>Ingrid Schechter</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Ingrid%20Schechter/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Ingrid Schechter" />
+    </author>
+    <summary type="html">Umakhulu usindisa ubomi bukaTingi.</summary>
+    <simplified:pwid>488a9bc9-8e96-fb52-57a0-305759357bfd</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13200/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D13200.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13200/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D13200.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2015-09-21</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13200/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=13200</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13200" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:31:42Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14068/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13200/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D13200/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Ukhozo lwembewu oluncinane</title>
+    <contributor opf:role="trl">
+      <name>Nal'ibali</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Maya Marshak</name>
+    </contributor>
+    <author>
+      <name>Nicola Rijsdijk</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Nicola%20Rijsdijk/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Nicola Rijsdijk" />
+    </author>
+    <summary type="html">Kweli bali sifunda banzi ngokubaluleka kwezityalo kunye nemfundo.</summary>
+    <simplified:pwid>3a072ee3-e15c-c717-adfb-50c36b643c8a</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11582/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D11582.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11582/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D11582.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2015-06-18</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11582/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=11582</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11582" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:30:55Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14063/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11582/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11582/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Abahlobo</title>
+    <contributor opf:role="trl">
+      <name>Nolitha Bikitsha</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Catherine Groenewald</name>
+    </contributor>
+    <author>
+      <name>Zimbili Dlamini, Hlengiwe Zondi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Zimbili%20Dlamini%2C%20Hlengiwe%20Zondi/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Zimbili Dlamini, Hlengiwe Zondi" />
+    </author>
+    <summary type="html">Ibali ngekwenkwe nabahlobo bayo,  kanye nezinto abathanda ukuzenza.</summary>
+    <simplified:pwid>dd61ce85-c1e2-1acb-cefb-a7e5cf2680e0</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9880/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D9880.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9880/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D9880.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2015-03-18</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9880/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=9880</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9880" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:29:54Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14058/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9880/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9880/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Ilizwe lethu elimangalisayo</title>
+    <contributor opf:role="trl">
+      <name>Ntombizodwa Gxowa-Dlayedwa</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Herminder Ohri</name>
+    </contributor>
+    <author>
+      <name>Herminder Ohri</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Herminder%20Ohri/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Herminder Ohri" />
+    </author>
+    <summary type="html">Ibali ngendlela ilizwe elenziwe ngayo kwa noluntu.</summary>
+    <simplified:pwid>4baf8705-ba59-2185-ec0e-b315287dcc29</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7456/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D7456.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7456/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D7456.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2014-08-26</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7456/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=7456</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7456" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:28:53Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14053/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7456/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7456/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Isikolo sasehlathini</title>
+    <contributor opf:role="trl">
+      <name>Ntombizodwa Gxowa-Dlayedwa</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Ketan Raut</name>
+    </contributor>
+    <author>
+      <name>Madhav Chavan, Meera Tendolkar</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Madhav%20Chavan%2C%20Meera%20Tendolkar/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Madhav Chavan, Meera Tendolkar" />
+    </author>
+    <summary type="html">Izilwanyana zasehlathini ziya esikolweni esitsha ngomdla omkhulu. Kodwa ziphelelwa ngumdla zakubona ukuthi utitshala wabo omtsha ngubani.</summary>
+    <simplified:pwid>8da1aa0d-7a97-9f83-a5f6-4ff38287e9b4</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7279/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D7279.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7279/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D7279.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2014-08-13</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7279/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=7279</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7279" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:27:56Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14050/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7279/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7279/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Umbala omdaka</title>
+    <contributor opf:role="trl">
+      <name>Xolisa Guzula</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Sue Kramer</name>
+    </contributor>
+    <author>
+      <name>Reviva Schermbrucker</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Reviva%20Schermbrucker/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Reviva Schermbrucker" />
+    </author>
+    <summary type="html">Lencwadi iphethe izivakalisi kunye nemifanekiso yezinto ziqhelekileyo ezimbala omdaka.</summary>
+    <simplified:pwid>c7de6652-ce08-6c58-75c3-7ce8536cc50c</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7255/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D7255.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7255/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D7255.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2014-08-08</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7255/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=7255</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7255" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:27:06Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14049/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7255/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7255/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>UNozibele namanwele amathathu</title>
+    <contributor opf:role="trl">
+      <name>Ntombizodwa Gxowa-Dlayedwa</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Wiehan de Jager</name>
+    </contributor>
+    <author>
+      <name>Tessa Welch</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Tessa%20Welch/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Tessa Welch" />
+    </author>
+    <summary type="html">Ngobunye ubusuku elahlekile,  uNozibele uzifumana efika endlini angayaziyo. Ingaba ngekabani le ndlu? Kuqhubeka ntoni emva kokuba uNozibele enkqonkqoze wavulelwa?</summary>
+    <simplified:pwid>02c4762f-94cf-a4e5-1ff4-7fe2ab51de93</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D6711/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D6711.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D6711/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D6711.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2014-07-15</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D6711/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=6711</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D6711" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:26:08Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14047/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D6711/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D6711/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>UKato ohlakaniphileyo nengxaki enkulu</title>
+    <contributor opf:role="trl">
+      <name>Kholeka Mabeta</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Herminder Ohri</name>
+    </contributor>
+    <author>
+      <name>Herminder Ohri</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Herminder%20Ohri/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Herminder Ohri" />
+    </author>
+    <summary type="html">UKato nosapho lwakhe lwamagala wayehlala kumyezo thile. Ngenye imini,  kwafika bantu bathile bephethe oomatshini bezokugawula imithi. Wazisindisa kanjani uKato nabahlobo bakhe kuloongxaki enkulu?</summary>
+    <simplified:pwid>43ba6097-6277-8b80-ebae-db8d8ed5c14d</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3126/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D3126.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3126/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D3126.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-05-03</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3126/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=3126</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3126" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:22:58Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14043/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3126/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3126/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>NguMvundla noFudo (Kwakhona!)</title>
+    <contributor opf:role="trl">
+      <name>African Storybook</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Padmanabha</name>
+    </contributor>
+    <author>
+      <name>Venkatramana Gowda, Divaspathy Hegde</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Venkatramana%20Gowda%2C%20Divaspathy%20Hegde/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Venkatramana Gowda, Divaspathy Hegde" />
+    </author>
+    <summary type="html">Usakhumbula ukuthi ufudo olucothayo noluzimiseleyo lwamoyisa kanjani umvundla kugqatso lwabo lwakudala-dala? Ngoku esi sibini sidibene kwakhona,  kwaye sinomsebenzi okumele siwugqibile. Ingaba ezi ntshaba zizophumelela ukusebenzisana?</summary>
+    <simplified:pwid>9233ca43-79ff-0f2c-f5e1-31f56ed8c7fd</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3084/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D3084.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3084/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D3084.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-05-03</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3084/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=3084</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3084" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:22:03Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14042/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3084/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3084/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>UJoja ingwenya noNogolide ibhabhathane</title>
+    <contributor opf:role="trl">
+      <name>Kholeka Mabeta</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Herminder Ohri</name>
+    </contributor>
+    <author>
+      <name>Herminder Ohri</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Herminder%20Ohri/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Herminder Ohri" />
+    </author>
+    <summary type="html">Ingaba yintoni injongo yobuhlobo ukuba ayikokuncedana? Eli libali labahlobo ababini abahlakaniphileyo ngokungaqhelekanga.</summary>
+    <simplified:pwid>c79920ca-cb8b-0206-f6c1-4f1019cd571f</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2944/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D2944.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2944/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D2944.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-05-03</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2944/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=2944</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2944" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:20:36Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14040/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2944/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2944/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Umbala obomvu</title>
+    <contributor opf:role="ill">
+      <name>Sue Kramer</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Thandabantu Magengelele</name>
+    </contributor>
+    <author>
+      <name>Reviva Schermbrucker</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Reviva%20Schermbrucker/xho/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Reviva Schermbrucker" />
+    </author>
+    <summary type="html">&lt;p&gt;Izivakalisi kunye nemifanekiso yezinto ziqhelekileyo ezimbala ubomvu.&lt;/p&gt;</summary>
+    <simplified:pwid>b211b81f-8fdf-7013-c580-d7e81093c5e2</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2750/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D2750.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2750/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D2750.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>xh</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2014-04-20</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2750/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=2750</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2750" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-05-02T21:19:37Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14037/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2750/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D2750/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Ashton-Kirk, Investigator</title>
+    <author>
+      <name>John T. McIntyre</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/John%20T.%20McIntyre/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="John T. McIntyre" />
+    </author>
+    <summary type="html">&lt;p&gt;Those who have found their way to Ashton-Kirk's door have been of many races and interests. Men of science have often been surprised to find him in touch with the latest discoveries, scholars searching among strange tongues and dialects, and others deep in tattered scrolls, ancient tablets and forgotten books have been his frequent visitors. But among them come many who seek his help in solving problems in crime.&lt;/p&gt;</summary>
+    <simplified:pwid>51898ebf-9410-79b7-4a13-fddde1a0008b</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4579/image%3A8009d17d1fd55d7fb45379e7de75f765.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4579/image%3A8009d17d1fd55d7fb45379e7de75f765.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Mystery" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Mystery" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1910-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4579/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4579</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4579" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-04-30T21:37:17Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10668/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4579/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4579/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>The Hate Disease</title>
+    <author>
+      <name>Murray Leinster</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Murray%20Leinster/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Murray Leinster" />
+    </author>
+    <summary type="html">&lt;p&gt;The Med Service people hit strange problems as routine: if they weren't weirdos, they weren't tough enough to merit Med Service attention. Now the essence of a weird problem is that it involves a factor nobody ever thought of before ... or the absence of one nobody ever missed ...&lt;/p&gt;</summary>
+    <simplified:pwid>d5ad9be4-8bf4-a720-55bf-18a8f41e56cf</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4539/image%3A9d2a6f35a379632cbe86c7c4a3714395.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4539/image%3A9d2a6f35a379632cbe86c7c4a3714395.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1963-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4539/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4539</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4539" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-04-30T21:31:02Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10665/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4539/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4539/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Am I Still There?</title>
+    <author>
+      <name>James R. Hall</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/James%20R.%20Hall/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="James R. Hall" />
+    </author>
+    <summary type="html">&lt;p&gt;Which must in essence, of course, simply be the question "What do I mean by 'I'?"&lt;/p&gt;</summary>
+    <simplified:pwid>7b59b25e-2de7-efe0-669b-31f7fcdd7fb6</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4523/image%3A6316adb550374a9bd2161c9beb7e6671.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4523/image%3A6316adb550374a9bd2161c9beb7e6671.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1963-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4523/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4523</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4523" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-04-30T14:31:11Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10648/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4523/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4523/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Kimbia Sungura, Kimbia!</title>
+    <contributor opf:role="ill">
+      <name>Wiehan de Jager</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Brigid Simiyu</name>
+    </contributor>
+    <author>
+      <name>Phumy Zikode</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Phumy%20Zikode/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Phumy Zikode" />
+    </author>
+    <summary type="html">&lt;p&gt;Tofaa linaanguka kutoka mti aliokuwa amelala Sungura. Sungura anasikia sauti ikisema, &amp;quot;Kimbia Sungura, kimbia!&amp;quot;&lt;/p&gt;</summary>
+    <simplified:pwid>134d12f3-147f-44cd-7eff-df18c374262a</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21140/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21140.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21140/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21140.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-07-09</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21140/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=21140</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21140" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T22:14:37Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15774/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21140/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21140/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Ngurumo na mwanawe Radi</title>
+    <contributor opf:role="ill">
+      <name>Jesse Breytenbach</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Brigid Simiyu</name>
+    </contributor>
+    <author>
+      <name>Ogot Owino</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Ogot%20Owino/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Ogot Owino" />
+    </author>
+    <summary type="html">&lt;p&gt;Ngurumo na mwanawe waliishi duniani. Kwa ajili ya uharibifu wa mwanawe, mfalme aliwatuma kuishi angani mbali na watu.&lt;/p&gt;</summary>
+    <simplified:pwid>0170c773-83c9-c136-fef0-baaeebe67e8f</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21141/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21141.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21141/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21141.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-07-09</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21141/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=21141</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21141" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T22:13:35Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15775/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21141/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21141/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Mamba na Mbwa</title>
+    <contributor opf:role="ill">
+      <name>Rob Owen</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Brigid Simiyu</name>
+    </contributor>
+    <author>
+      <name>Candiru Enzikuru Mary</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Candiru%20Enzikuru%20Mary/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Candiru Enzikuru Mary" />
+    </author>
+    <summary type="html">&lt;p&gt;Mbwa anakuta mayai kando ya mto na kuyapeleka nyumbani. Je, mama mamba atasemaje atakapogundua?&lt;/p&gt;</summary>
+    <simplified:pwid>bf8f4420-3149-14d9-4aa9-4c0ae38bbf11</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21151/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21151.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21151/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21151.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-07-10</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21151/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=21151</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21151" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T22:12:40Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15780/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21151/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21151/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Nilivyopotea sokoni</title>
+    <contributor opf:role="trl">
+      <name>Dorcas Wepukhulu</name>
+    </contributor>
+    <author>
+      <name>Ursula Nafula</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Ursula%20Nafula/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Ursula Nafula" />
+    </author>
+    <contributor opf:role="ill">
+      <name>Catherine Groenewald</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>African Storybook</name>
+    </contributor>
+    <author>
+      <name>Timothy Kabare</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Timothy%20Kabare/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Timothy Kabare" />
+    </author>
+    <summary type="html">&lt;p&gt;Mvulana ameahidiwa zawadi nzuri akihitimu umri wa miaka sita. Soma uone kinachotokea.&lt;/p&gt;</summary>
+    <simplified:pwid>d492ed95-d3e7-5542-ff1d-5d590905ad4e</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21814/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21814.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21814/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21814.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-10-03</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21814/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=21814</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21814" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T22:11:29Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15791/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21814/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21814/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Kuhesabu Kabichi</title>
+    <contributor opf:role="ill">
+      <name>Magriet Brink</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Ursula Nafula</name>
+    </contributor>
+    <author>
+      <name>Penelope Smith</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Penelope%20Smith/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Penelope Smith" />
+    </author>
+    <summary type="html">&lt;p&gt;Hadithi ya hisabati kuhusu kuhesabu na kugawanya. (Hadithi hii iliwezeshwa na ufadhili wa Oppenheimer Memorial Trust).&lt;/p&gt;</summary>
+    <simplified:pwid>2246b6ca-1fdd-194c-57e4-17da9e87bb0f</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21863/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21863.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21863/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21863.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-10-07</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21863/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=21863</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21863" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T22:09:25Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15800/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21863/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21863/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Dunia yetu</title>
+    <contributor opf:role="trl">
+      <name>Ursula Nafula</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Herminder Ohri</name>
+    </contributor>
+    <author>
+      <name>Herminder Ohri</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Herminder%20Ohri/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Herminder Ohri" />
+    </author>
+    <summary type="html">Hadithi kuhusu kuumbwa kwa dunia na watu.</summary>
+    <simplified:pwid>cb678b9b-096d-e628-6d44-ff01a487a5b3</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22001/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22001.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22001/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22001.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-11-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22001/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=22001</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22001" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T22:07:26Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15808/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22001/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22001/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Mbuzi, mfalme bandia</title>
+    <contributor opf:role="trl">
+      <name>Brigid Simiyu</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Marleen Visser</name>
+    </contributor>
+    <author>
+      <name>Alice Nakasango</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Alice%20Nakasango/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Alice Nakasango" />
+    </author>
+    <summary type="html">Sasa unajua kwa nini mbuzi wana kiburi! Soma hadithi hii upate kujua yaliyotokea.</summary>
+    <simplified:pwid>46e04f98-27fe-ecdd-aae2-8347a317cd92</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22059/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22059.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22059/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22059.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-11-15</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22059/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=22059</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22059" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T22:06:15Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15814/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22059/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22059/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Gawanya sawa!</title>
+    <author>
+      <name>Hamsa Venkatakrishnan</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Hamsa%20Venkatakrishnan/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Hamsa Venkatakrishnan" />
+    </author>
+    <contributor opf:role="ill">
+      <name>Magriet Brink</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Brigid Simiyu</name>
+    </contributor>
+    <author>
+      <name>Penelope Smith</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Penelope%20Smith/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Penelope Smith" />
+    </author>
+    <summary type="html">&lt;p&gt;Hadithi ya hisabati kuhusu umuhimu wa kugawana hata kama ni vigumu kufanya hivyo kamili!&lt;/p&gt;</summary>
+    <simplified:pwid>61d06d24-47d4-7d57-b314-f6cca6699ed8</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22064/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22064.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22064/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22064.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-11-15</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22064/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=22064</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22064" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T22:04:37Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15817/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22064/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22064/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Aku, Rafikiye Jua</title>
+    <contributor opf:role="ill">
+      <name>Idowu Abayomi Oluwasegun</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Ursula Nafula</name>
+    </contributor>
+    <author>
+      <name>Aisha Nelson</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Aisha%20Nelson/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Aisha Nelson" />
+    </author>
+    <summary type="html">&lt;p&gt;Msichana mmoja mpweke anapata rafiki wa ajabu,  na pamoja,  wanaleta furaha na maisha katika kijiji kimoja. (Hadithi hii iliandikwa katika Waksha iliyoandaliwa Abuja,  Nigeria, 2018 kwa ushirikiano kati ya African Storybook na British Council).&lt;/p&gt;</summary>
+    <simplified:pwid>08d829dc-d2bd-54cd-b9f9-b80648050c34</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22560/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22560.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22560/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22560.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2018-04-03</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22560/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=22560</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22560" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T22:02:35Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15844/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22560/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22560/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Mto wa Upinde wenye miujiza</title>
+    <contributor opf:role="ill">
+      <name>Edwin Irabor</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Ursula Nafula</name>
+    </contributor>
+    <author>
+      <name>Mimi Werna</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Mimi%20Werna/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Mimi Werna" />
+    </author>
+    <summary type="html">&lt;p&gt;Mama anawaelezea wanawe hadithi kuhusu jinsi mto wa upinde ulivyokuja kuwa angani. (Hadithi hii iliandikwa wakati wa Waksha huko Abuja, 2018 iliyoandaliwa kwa ushirikiano kati ya African Storybook na British Council Nigeria).&lt;/p&gt;</summary>
+    <simplified:pwid>647148d1-1ee3-d156-1a02-6b3c6e25bc68</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22572/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22572.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22572/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22572.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2018-04-06</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22572/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=22572</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22572" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T22:00:01Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15846/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22572/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22572/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Robo za Bwana Hadaa</title>
+    <contributor opf:role="trl">
+      <name>Ursula Nafula</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Marleen Visser</name>
+    </contributor>
+    <author>
+      <name>Lorato Trok</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Lorato%20Trok/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Lorato Trok" />
+    </author>
+    <summary type="html">Hadithi inahusu robo za mkate na chakula cha mchana. (Kitabu hiki kiliwezeshwa na ufadhili kutoka kwa Openheimer Memorial Trust).</summary>
+    <simplified:pwid>052e3f28-56a6-23d4-6540-e10d69d334ea</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22747/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22747.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22747/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22747.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2018-05-18</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22747/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=22747</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22747" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:58:34Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15849/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22747/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22747/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Ndalo na Pendo â€“ Marafiki wakubwa</title>
+    <contributor opf:role="trl">
+      <name>Ursula Nafula</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Rob Owen</name>
+    </contributor>
+    <author>
+      <name>Ruth Odondi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Ruth%20Odondi/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Ruth Odondi" />
+    </author>
+    <summary type="html">Ndalo anamsaidia babake kumchunga Pendo,  ng'ombe wa family yake ambaye kupitia kwake,  yeye anapata pesa za matumizi anazotumia kununua vitabu.</summary>
+    <simplified:pwid>c2163d19-3c9b-cd3e-3f34-e864a64db132</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22750/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22750.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22750/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22750.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2018-05-18</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22750/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=22750</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22750" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:57:04Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15850/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22750/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22750/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Tembo Mdogo</title>
+    <contributor opf:role="ill">
+      <name>Ben Terarc</name>
+    </contributor>
+    <author>
+      <name>Ben Terarc</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Ben%20Terarc/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Ben Terarc" />
+    </author>
+    <summary type="html">Tembo Mdogo aachwa porini nakupotea njia. Anapata msaada kupitia rafiki mpya.</summary>
+    <simplified:pwid>d9657ddf-8a7f-acdc-5170-0eecc9f2c657</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23110/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D23110.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23110/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D23110.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2018-06-13</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23110/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=23110</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23110" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:56:09Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15857/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23110/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23110/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Ninafurahi kufanya hivi</title>
+    <contributor opf:role="trl">
+      <name>African Storybook</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Wiehan de Jager</name>
+    </contributor>
+    <author>
+      <name>Ursula Nafula</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Ursula%20Nafula/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Ursula Nafula" />
+    </author>
+    <summary type="html">Sentensi fupi kuhusu vitendo ambavyo mtoto anafurahi kufanya.</summary>
+    <simplified:pwid>7d9c0459-941b-4026-6fa2-7369d1d36826</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31301/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D31301.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31301/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D31301.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2018-09-19</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31301/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=31301</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31301" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:55:22Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15872/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31301/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31301/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Petro na mbwa wake</title>
+    <contributor opf:role="trl">
+      <name>Ursula Nafula</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Brian Wambi</name>
+    </contributor>
+    <author>
+      <name>Bethelihem Waltenegus</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Bethelihem%20Waltenegus/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Bethelihem Waltenegus" />
+    </author>
+    <summary type="html">Hadithi inayonyesha urafiki wa dhati kati ya mvulana mdogo na mbwa wake.</summary>
+    <simplified:pwid>afadb729-4d57-86c8-f8f0-655fd7aaba57</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31418/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D31418.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31418/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D31418.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2018-09-25</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31418/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=31418</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31418" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:54:21Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15874/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31418/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D31418/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Zama omwa nawa</title>
+    <contributor opf:role="ill">
+      <name> Vusi Malindi</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Hamukoto Efraim</name>
+    </contributor>
+    <author>
+      <name>Michael Oguttu</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Michael%20Oguttu/ndo/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Michael Oguttu" />
+    </author>
+    <summary type="html">&lt;p&gt;Okahokolo hano otaka tengeneke nkene tuna okulonga uunona omikalo,  otwa pumbwa ihe okusimaneka omasinda gayo.&lt;/p&gt;</summary>
+    <simplified:pwid>465523ec-a597-9149-b5dc-fce7b91cc6a4</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23885/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D23885.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23885/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D23885.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>ng</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2018-07-12</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23885/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=23885</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23885" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:52:49Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16054/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23885/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23885/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Omutonateli nokapangelo ke</title>
+    <contributor opf:role="ill">
+      <name>Magriet Brink</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Hamukoto Efraim</name>
+    </contributor>
+    <author>
+      <name>Nina Orange</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Nina%20Orange/ndo/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Nina Orange" />
+    </author>
+    <summary type="html">&lt;p&gt;Okahokolo kombinga yokuhupitha uunamenyo sho tau thiki pokapangelo koothigwa. Uunamwenyo mbuka ohaupangwa wotautonatelwa komuntu ngoka apyokoka nawa,  opamwe naayakuli ooyakwawo.&lt;/p&gt;</summary>
+    <simplified:pwid>ffe7e7bb-64a6-10a7-722b-a6a7528eae5b</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23893/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D23893.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23893/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D23893.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>ng</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2018-07-12</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23893/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=23893</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23893" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:51:45Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16056/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23893/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D23893/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Jaaka O Pescador</title>
+    <contributor opf:role="trl">
+      <name>Marcella Lang</name>
+    </contributor>
+    <author>
+      <name>Childrenâ€™s Development Center at Masese</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Children%E2%80%99s%20Development%20Center%20at%20Masese/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Childrenâ€™s Development Center at Masese" />
+    </author>
+    <contributor opf:role="ill">
+      <name>Zablon Alex Nguku</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Translators without Borders</name>
+    </contributor>
+    <author>
+      <name>Tom Sabwa</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Tom%20Sabwa/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Tom Sabwa" />
+    </author>
+    <summary type="html">&lt;p&gt;Uma descriÃ§Ã£o da vida de um dedicado pescador do Nilo.&lt;/p&gt;</summary>
+    <simplified:pwid>c40f3abf-3df5-d59e-11f3-48141e56643f</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16569/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16569.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16569/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16569.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>pt</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-07-07</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16569/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=16569</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16569" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:41:03Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16122/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16569/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16569/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Contando Os Animais</title>
+    <contributor opf:role="trl">
+      <name>Debora Santos</name>
+    </contributor>
+    <author>
+      <name>Thembani Dladla</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Thembani%20Dladla/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Thembani Dladla" />
+    </author>
+    <author>
+      <name>Clare Verbeek</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Clare%20Verbeek/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Clare Verbeek" />
+    </author>
+    <contributor opf:role="ill">
+      <name>Rob Owen</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Translators without Borders</name>
+    </contributor>
+    <author>
+      <name>Zanele Buthelezi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Zanele%20Buthelezi/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Zanele Buthelezi" />
+    </author>
+    <summary type="html">&lt;p&gt;Todos os animais estÃ£o com sede. Conte os animais conforme estÃ£o indo beber Ã¡gua.&lt;/p&gt;</summary>
+    <simplified:pwid>73c0d787-0cac-08cb-523d-c19e3fafacb1</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16562/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16562.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16562/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16562.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>pt</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-07-07</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16562/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=16562</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16562" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:39:40Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16115/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16562/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16562/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>A Cabra, O Cachorro E a Vaca</title>
+    <contributor opf:role="trl">
+      <name>Debora Santos</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Marleen Visser</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Translators without Borders</name>
+    </contributor>
+    <author>
+      <name>Fabian Wakholi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Fabian%20Wakholi/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Fabian Wakholi" />
+    </author>
+    <summary type="html">&lt;p&gt;A Cabra, o Cachorro e a Vaca sÃ£o bons amigos. Eles estÃ£o viajando juntos em um tÃ¡xi, mas quando chega a hora de pagar o motorista, um dos amigos faz algo inesperado.&lt;/p&gt;</summary>
+    <simplified:pwid>8356afa2-4fc7-d1da-a29b-9fdb20ca694f</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16419/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16419.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16419/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16419.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>pt</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-05-31</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16419/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=16419</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16419" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:38:04Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16111/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16419/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16419/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Amigos</title>
+    <contributor opf:role="trl">
+      <name>Debora Santos</name>
+    </contributor>
+    <author>
+      <name>Hlengiwe Zondi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Hlengiwe%20Zondi/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Hlengiwe Zondi" />
+    </author>
+    <contributor opf:role="ill">
+      <name>Catherine Groenewald</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Translators without Borders</name>
+    </contributor>
+    <author>
+      <name>Zimbili Dlamini</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Zimbili%20Dlamini/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Zimbili Dlamini" />
+    </author>
+    <summary type="html">&lt;p&gt;Vem, amigo, o que vocÃª gosta de fazer?&lt;/p&gt;</summary>
+    <simplified:pwid>9a359b8f-f8ca-7194-4e13-fccb32c05c7d</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16417/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16417.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16417/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16417.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>pt</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-05-31</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16417/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=16417</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16417" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:36:42Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16109/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16417/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16417/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Vaca Com Um SÃ³ Chifre</title>
+    <contributor opf:role="trl">
+      <name>NÃ¡dia Morais</name>
+    </contributor>
+    <author>
+      <name>Khothatso Ranoosi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Khothatso%20Ranoosi/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Khothatso Ranoosi" />
+    </author>
+    <author>
+      <name>Mpho Ntlhanngoe</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Mpho%20Ntlhanngoe/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Mpho Ntlhanngoe" />
+    </author>
+    <contributor opf:role="ill">
+      <name>Marion Drew</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Translators without Borders</name>
+    </contributor>
+    <author>
+      <name>Sebongile Daniel</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Sebongile%20Daniel/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Sebongile Daniel" />
+    </author>
+    <summary type="html">&lt;p&gt;Alguma vez viram uma vaca com um sÃ³ chifre e sem cauda?&lt;/p&gt;</summary>
+    <simplified:pwid>8d9cf78f-9624-d073-923e-716b2042bb31</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16408/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16408.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16408/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16408.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>pt</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-05-31</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16408/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=16408</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16408" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:35:13Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16100/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16408/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16408/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Contar Gatos</title>
+    <contributor opf:role="trl">
+      <name>NÃ¡dia Morais</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Jesse Breytenbach</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Translators without Borders</name>
+    </contributor>
+    <author>
+      <name>Nina Orange</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Nina%20Orange/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Nina Orange" />
+    </author>
+    <summary type="html">&lt;p&gt;Livro de contar, de zero a nove.&lt;/p&gt;</summary>
+    <simplified:pwid>5bf73a8d-9645-6056-6495-8bccd53f7e3b</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16196/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16196.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16196/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D16196.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>pt</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-05-11</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16196/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=16196</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16196" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:33:52Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16099/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16196/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D16196/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>O Menino De Que NinguÃ©m Gostava</title>
+    <contributor opf:role="trl">
+      <name>Translators without Borders, NÃ¡dia Morais</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Wiehan de Jager</name>
+    </contributor>
+    <author>
+      <name>Phumy Zikode</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Phumy%20Zikode/por/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Phumy Zikode" />
+    </author>
+    <summary type="html">Um menino feio entra numa floresta para encontrar uma raiz especial para se tornar bonito, a pedido de uma mulher misteriosa.</summary>
+    <simplified:pwid>f9d6b2b8-065c-1407-f7c4-9e60267f5e94</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D15806/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D15806.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D15806/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D15806.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>pt</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-04-13</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D15806/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=15806</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D15806" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T21:32:29Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16094/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D15806/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D15806/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Siku tuliyouona upinde</title>
+    <contributor opf:role="ill">
+      <name>Wiehan de Jager</name>
+    </contributor>
+    <author>
+      <name>Ursula Nafula</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Ursula%20Nafula/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Ursula Nafula" />
+    </author>
+    <summary type="html">Mvulana anauona upinde kwa mara ya kwanza. Bila kujua ni nini,  anatamani ikiwa wangeuweka kijijini mwao.</summary>
+    <simplified:pwid>27167a26-c42d-63ba-b443-7cf4628a4910</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11139/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D11139.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11139/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D11139.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2015-06-11</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11139/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=11139</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11139" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-04-29T21:27:19Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15638/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11139/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D11139/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Ajali mbaya</title>
+    <author>
+      <name>Clare Verbeek</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Clare%20Verbeek/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Clare Verbeek" />
+    </author>
+    <author>
+      <name>Thembani Dladla</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Thembani%20Dladla/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Thembani Dladla" />
+    </author>
+    <contributor opf:role="ill">
+      <name>Rob Owen</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Ursula Nafula</name>
+    </contributor>
+    <author>
+      <name>Zanele Buthelezi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Zanele%20Buthelezi/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Zanele Buthelezi" />
+    </author>
+    <summary type="html">&lt;p&gt;Watoto wawili wanashuhudia ajali mbaya inayowashtuwa sana.&lt;/p&gt;</summary>
+    <simplified:pwid>64f2080b-5bf5-c4e0-1342-fb17e376f286</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10555/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D10555.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10555/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D10555.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2015-05-20</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10555/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=10555</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10555" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-04-29T21:25:44Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15635/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10555/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10555/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Mwana wa Tumbili (Colour-in)</title>
+    <contributor opf:role="trl">
+      <name>Baraka Fatma</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Jesse Breytenbach</name>
+    </contributor>
+    <author>
+      <name>Wesley Kipkorir Rop</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Wesley%20Kipkorir%20Rop/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Wesley Kipkorir Rop" />
+    </author>
+    <summary type="html">Tumbili anaamua kumweka mwanawe njiani ili abarikiwe na wapita njia akitumaini kuwa hatampoteza tena kama alivyokuwa akiwapoteza wengine.</summary>
+    <simplified:pwid>92b804ea-cac2-c2f1-263f-3359e28324c3</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10166/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D10166.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10166/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D10166.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2015-04-23</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10166/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=10166</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10166" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-04-29T21:24:15Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15629/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10166/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D10166/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Mwalimu wangu (Colour-in)</title>
+    <author>
+      <name>Hlengiwe Zondi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Hlengiwe%20Zondi/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Hlengiwe Zondi" />
+    </author>
+    <contributor opf:role="ill">
+      <name>Jesse Pietersen</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Pete Mhunzi</name>
+    </contributor>
+    <author>
+      <name>Zimbili Dlamini</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Zimbili%20Dlamini/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Zimbili Dlamini" />
+    </author>
+    <summary type="html">&lt;p&gt;Msichana huyu mdogo anampenda mwalimu wake sana,  anataka awe kama yeye kwa hali na mali.&lt;/p&gt;</summary>
+    <simplified:pwid>1c81ad63-79f8-9176-f4fc-f959f301041e</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8477/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D8477.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8477/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D8477.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2014-11-04</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8477/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=8477</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8477" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-04-29T21:23:24Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15608/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8477/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8477/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Fisi na Kunguru</title>
+    <contributor opf:role="trl">
+      <name>Pete Mhunzi</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Wiehan de Jager</name>
+    </contributor>
+    <author>
+      <name>Ann Nduku</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Ann%20Nduku/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Ann Nduku" />
+    </author>
+    <summary type="html">Urafiki baina ya fisi na kunguru unakatika baada ya kunguru kumdanganya fisi. Soma uone vipi hili lilitokea.</summary>
+    <simplified:pwid>cd71371b-3bed-772f-c7d3-dd80c1c98013</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8698/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D8698.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8698/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D8698.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2014-11-14</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8698/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=8698</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8698" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-04-29T21:21:57Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15611/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8698/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D8698/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Hadithi kumhusu Wangari Maathai</title>
+    <contributor opf:role="trl">
+      <name>Ursula Nafula</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Maya Marshak</name>
+    </contributor>
+    <author>
+      <name>Nicola Rijsdijk</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Nicola%20Rijsdijk/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Nicola Rijsdijk" />
+    </author>
+    <summary type="html">Hi ni hadithi ya kuvutia kumhusu Wangari Maathai. Inaeleza jinsi maisha ya Wangari yalikuwa utotoni na jinis alivyovutiwa na umuhimu wa kuhifadhi mazingira na kuwashawishi wengine kufanya hivyo.</summary>
+    <simplified:pwid>dfc129eb-ba04-cc5f-9c6e-2c3fdce0641d</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9911/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D9911.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9911/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D9911.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2015-03-25</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9911/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=9911</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9911" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-04-29T21:20:45Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15626/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9911/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D9911/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>My grandma</title>
+    <contributor opf:role="ill">
+      <name>Ingrid Schechter</name>
+    </contributor>
+    <author>
+      <name>Augustine Napagi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Augustine%20Napagi/eng/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Augustine Napagi" />
+    </author>
+    <summary type="html">A boy visits her grandma and get some fun.</summary>
+    <simplified:pwid>76b85730-ea32-b3b4-6098-b6cecc97b500</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7652/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D7652.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7652/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D7652.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-04-25</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7652/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=7652</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7652" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-09-30T00:00:00Z</published>
+    <updated>2021-04-29T16:15:39Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/14537/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7652/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D7652/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Paka mwerevu na Mbwa mjinga</title>
+    <author>
+      <name>Teki'a Gebrehiwot</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Teki%27a%20Gebrehiwot/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Teki'a Gebrehiwot" />
+    </author>
+    <contributor opf:role="ill">
+      <name>Salim Kasamba</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Brigid Simiyu</name>
+    </contributor>
+    <author>
+      <name>Solomon Abreha</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Solomon%20Abreha/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Solomon Abreha" />
+    </author>
+    <summary type="html">&lt;p&gt;Je, paka ni mwerevu kuliko mbwa? (Hadithi hii iliandikwa wakati wa waksha ya walimu huko Adwa, Ethiopia, 2017, kwa ushirikiano na shirika la Imagine1Day).&lt;/p&gt;</summary>
+    <simplified:pwid>326d73f4-ce10-c5a2-04cf-e62706215421</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22065/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22065.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22065/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22065.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-11-16</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22065/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=22065</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22065" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T00:52:35Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15818/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22065/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22065/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Leah, Roba na Ng'ombe</title>
+    <contributor opf:role="trl">
+      <name>Brigid Simiyu</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Marion Drew</name>
+    </contributor>
+    <author>
+      <name>Matlotlisang Tenane</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Matlotlisang%20Tenane/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Matlotlisang Tenane" />
+    </author>
+    <summary type="html">Roba na Leah wana shida na ng'ombe mmoja. Ng'ombe ameketi karibu na kisima cha kijiji.</summary>
+    <simplified:pwid>e4d96370-9657-87e7-b9e8-b83c6fd3bc73</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22080/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22080.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22080/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22080.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-11-16</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22080/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=22080</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22080" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T00:50:57Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15823/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22080/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22080/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Jua, Mwezi, na Maji</title>
+    <contributor opf:role="trl">
+      <name>Brigid Simiyu</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Salim Kasamba</name>
+    </contributor>
+    <author>
+      <name>Owino Ogot</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Owino%20Ogot/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Owino Ogot" />
+    </author>
+    <summary type="html">Hadithi inayoeleza kwa nini jua na mwezi vinaishi angani.</summary>
+    <simplified:pwid>6c081289-ae0c-e233-1f1c-591be8901deb</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22081/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22081.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22081/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22081.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-11-16</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22081/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=22081</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22081" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T00:49:45Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15824/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22081/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22081/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Mimi ni mashuhuri!</title>
+    <contributor opf:role="ill">
+      <name>Vusi Malindi</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Brigid Simiyu</name>
+    </contributor>
+    <author>
+      <name>Michael Oguttu</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Michael%20Oguttu/swa/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Michael Oguttu" />
+    </author>
+    <summary type="html">&lt;p&gt;Ni vizuri tutambue uzuri wetu sisi wenyewe.&lt;/p&gt;</summary>
+    <simplified:pwid>0d40127b-284d-b357-a8b7-be5a0bcf6295</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22086/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22086.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22086/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D22086.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>sw</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-11-16</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22086/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=22086</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22086" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T00:48:31Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/15829/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22086/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D22086/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Vurhena Bya Nangila</title>
+    <contributor opf:role="trl">
+      <name>Mkomati John Mongwe</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name> Vusi Malindi</name>
+    </contributor>
+    <author>
+      <name>Violet Otieno</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Violet%20Otieno/tso/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Violet Otieno" />
+    </author>
+    <summary type="html">Xana Nangila u ta swi kota ku humelela laha ku nga tsandzeka swihontlovila swa vavanuna?</summary>
+    <simplified:pwid>aab7e63d-45ba-5092-5f01-245058c79d8d</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18992/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D18992.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18992/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D18992.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>ts</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-11-30</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18992/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=18992</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18992" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T00:47:10Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16350/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18992/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18992/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Mukapu</title>
+    <contributor opf:role="trl">
+      <name>Vonani Bila</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Catherine Groenewald</name>
+    </contributor>
+    <author>
+      <name>Zimbili Dlamini, Hlengiwe Zondi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Zimbili%20Dlamini%2C%20Hlengiwe%20Zondi/tso/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Zimbili Dlamini, Hlengiwe Zondi" />
+    </author>
+    <summary type="html">Mhani a nga kona kutani Tanana u le ku swekeni ka mukapu wa nimixo.</summary>
+    <simplified:pwid>f2bd8219-e86d-90ae-a54f-888ac09d063b</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18997/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D18997.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18997/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D18997.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>ts</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-11-30</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18997/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=18997</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18997" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T00:46:04Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16351/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18997/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18997/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Mudyondzisi Wa Mina</title>
+    <contributor opf:role="trl">
+      <name>Vonani Bila</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Jesse Pietersen</name>
+    </contributor>
+    <author>
+      <name>Zimbili Dlamini, Hlengiwe Zondi</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Zimbili%20Dlamini%2C%20Hlengiwe%20Zondi/tso/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Zimbili Dlamini, Hlengiwe Zondi" />
+    </author>
+    <summary type="html">Xinhwanyetana xi tsakela ku fana na mudyondzisi wa xona.</summary>
+    <simplified:pwid>634b0188-4720-d882-6630-4254df8f5501</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18998/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D18998.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18998/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D18998.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>ts</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-11-30</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18998/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=18998</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18998" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T00:45:05Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16352/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18998/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D18998/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Ku Endzela Kokwana Wa Xisati Hi Tiholideyi</title>
+    <contributor opf:role="trl">
+      <name>Mkomati John Mongwe</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Catherine Groenewald</name>
+    </contributor>
+    <author>
+      <name>Violet Otieno</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Violet%20Otieno/tso/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Violet Otieno" />
+    </author>
+    <summary type="html">Vana vambirhi va tsaka loko va lulamisela ku endzela kokwana wa vona wa xisati ekaya ka yena hi nkarhi wa tiholideyi.</summary>
+    <simplified:pwid>362f1777-c52d-efe0-1dc1-4dd5a891e19c</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19018/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D19018.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19018/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D19018.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>ts</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-11-30</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19018/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=19018</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19018" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T00:43:52Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16353/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19018/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19018/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Kondlo Ehansi Ka Murhi</title>
+    <author>
+      <name>Pumla Mdontswa</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Pumla%20Mdontswa/tso/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Pumla Mdontswa" />
+    </author>
+    <author>
+      <name>Zanele Zuma</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Zanele%20Zuma/tso/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Zanele Zuma" />
+    </author>
+    <contributor opf:role="ill">
+      <name>Wiehan de Jager</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Mkomati John Mongwe</name>
+    </contributor>
+    <author>
+      <name>Phumy Zikode</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Phumy%20Zikode/tso/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Phumy Zikode" />
+    </author>
+    <summary type="html">&lt;p&gt;Loko kondlo ri etlele ehansi ka murhi wa apula,  apula ri wele ehansi. Hi nkarhi wun&amp;#x27;we,  Kondlo ri twa rito ri huwelela hi matimba swinene ri ku,  &amp;quot;Nyamalala Kondlo nyamalala!&amp;quot;&lt;/p&gt;</summary>
+    <simplified:pwid>73529350-40cc-560c-92e2-bde3374aa24f</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19020/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D19020.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19020/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D19020.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>ts</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2016-11-30</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19020/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=19020</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19020" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T00:41:48Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16355/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19020/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D19020/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Xana Ku Na Un'wana Wo Fana Na Mina?</title>
+    <contributor opf:role="trl">
+      <name>Tinyiko Hlangwani</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Jess Jardim-Wedepohl</name>
+    </contributor>
+    <author>
+      <name>Fred Strydom</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Fred%20Strydom/tso/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Fred Strydom" />
+    </author>
+    <summary type="html">A ndzi tivi loko ku ri na mina un'wana kun'wana emisaveni.</summary>
+    <simplified:pwid>02bdf612-912a-9881-95c0-5bd5c9609381</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21531/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21531.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21531/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D21531.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>ts</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2017-08-23</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21531/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=21531</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21531" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T00:39:47Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16358/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21531/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D21531/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>UNozibele nezinwele ezintathu</title>
+    <author>
+      <name>Tessa Welch</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Tessa%20Welch/zul/Children" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Tessa Welch" />
+    </author>
+    <contributor opf:role="trl">
+      <name>Zimbili Dlamini</name>
+    </contributor>
+    <contributor opf:role="ill">
+      <name>Wiehan de Jager</name>
+    </contributor>
+    <contributor opf:role="trl">
+      <name>Phumy Zikode</name>
+    </contributor>
+    <summary type="html">&lt;p&gt;UNozibele uyaduka ebumnyameni. Ngabe uzoyithola indlela eya ekhaya?&lt;/p&gt;</summary>
+    <simplified:pwid>ead6eda5-a600-f621-dc0d-55018272fc0a</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3896/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D3896.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/African+Storybook/URI/https%3A//www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3896/https%253A%252F%252Fwww.africanstorybook.org%252Fthumbnails%252Fepub.php%253Fid%253D3896.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Children" scheme="http://schema.org/audience" label="Children" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <dcterms:language>zu</dcterms:language>
+    <dcterms:publisher>African Storybook Initiative</dcterms:publisher>
+    <dcterms:issued>2014-05-26</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3896/report" rel="issues" />
+    <id>https://www.africanstorybook.org/thumbnails/epub.php?id=3896</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3896" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="African Storybook" />
+    <published>2018-10-01T00:00:00Z</published>
+    <updated>2021-04-29T00:37:39Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/16454/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="http://creativecommons.org/licenses/by/4.0/">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3896/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/https://www.africanstorybook.org/thumbnails/epub.php%3Fid%3D3896/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Feet Of Clay</title>
+    <author>
+      <name>Phillip Hoskins</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Phillip%20Hoskins/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Phillip Hoskins" />
+    </author>
+    <summary type="html">Life is pretty strange when a god who is good and benevolent must prove that he has FEET OF CLAY.</summary>
+    <simplified:pwid>c5193969-4695-920b-34de-d03703035337</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4846/image%3A6f1292f9140cd5961e7223faa8076002.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4846/image%3A6f1292f9140cd5961e7223faa8076002.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Feedbooks</dcterms:publisher>
+    <dcterms:issued>1958-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4846/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4846</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4846" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-04-29T00:02:13Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10926/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4846/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4846/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Conquest Over Time</title>
+    <author>
+      <name>Michael Shaara</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Michael%20Shaara/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Michael Shaara" />
+    </author>
+    <summary type="html">&lt;p&gt;"Now this here planet," he said cautiously, "is whacky in a lot of ways. First of all they call it Mert. Just plain Mert. And they live in houses strictly from Dickens, all carriages, no sewers, narrow streets, stuff like that." But that wasn't all.... Travis, in reaching Diomed III before any others, found himself waging a one-man fight against more than this; he was bucking the strangest way of life you have ever heard of!&lt;/p&gt;</summary>
+    <simplified:pwid>ac5675d1-32f8-b610-2194-a00e8778e020</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4765/image%3A6fc18922548a7dcf85e65361f8358885.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4765/image%3A6fc18922548a7dcf85e65361f8358885.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:publisher>Feedbooks</dcterms:publisher>
+    <dcterms:issued>1956-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4765/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4765</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4765" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-04-29T00:00:10Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10809/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4765/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4765/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Pipe of Peace</title>
+    <author>
+      <name>James McKimmey</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/James%20McKimmey/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="James McKimmey" />
+    </author>
+    <summary type="html">&lt;p&gt;There's a song that says "it's later than you think" and it is perhaps lamentable that someone didn't sing it for Henry that beautiful morning....&lt;/p&gt;</summary>
+    <simplified:pwid>31aede53-386a-ceb4-a95e-c61f46946337</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/4358/image%3Afa51087641c7bd579ca846ed1015b44e.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/4358/image%3Afa51087641c7bd579ca846ed1015b44e.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1953-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4358/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/4358</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4358" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-04-28T23:58:19Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10538/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/4358/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/4358/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Benefactor</title>
+    <author>
+      <name>George H. Smith</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/George%20H.%20Smith/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="George H. Smith" />
+    </author>
+    <summary type="html">&lt;p&gt;We can anticipate that robots will be fiercely resented, at first, in a society that will see them as the latestâ€”and an indestructibleâ€”widespread threat to the workers whom they will replace. The men who will seek to alter the status quo will be called "robot lovers" and stoned. But what happens next?&lt;/p&gt;</summary>
+    <simplified:pwid>e5810a3d-c79c-7c31-4aaa-6e1c51bf0e38</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/3932/image%3A1743bd5d1d94f1eb4cd8540124b6d22d.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/3932/image%3A1743bd5d1d94f1eb4cd8540124b6d22d.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1958-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3932/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/3932</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3932" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-04-28T23:53:16Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10329/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3932/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/3932/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <entry schema:additionalType="http://schema.org/EBook">
+    <title>Solar Stiff</title>
+    <author>
+      <name>Chas. A. Stopher</name>
+      <link href="https://openbookshelf.dp.la/OB/works/contributor/Chas.%20A.%20Stopher/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="contributor" title="Chas. A. Stopher" />
+    </author>
+    <summary type="html">&lt;p&gt;Totem poles are a dime a dozen north of 63Â° ... but only Ketch, the lying Eskimo, vowed they dropped out of frigid northern skies.&lt;/p&gt;</summary>
+    <simplified:pwid>472d3108-d65e-f201-5074-d96eed828cdb</simplified:pwid>
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/Library+staff/URI/http%3A//www.feedbooks.com/book/3867/image%3Ad40597050c3a35623547cf69e8dfef9e.png" type="image/png" rel="http://opds-spec.org/image" />
+    <link href="https://s3.amazonaws.com/open-bookshelf-covers/scaled/300/Library+staff/URI/http%3A//www.feedbooks.com/book/3867/image%3Ad40597050c3a35623547cf69e8dfef9e.png" type="image/png" rel="http://opds-spec.org/image/thumbnail" />
+    <category term="Adult" scheme="http://schema.org/audience" label="Adult" />
+    <category term="http://librarysimplified.org/terms/fiction/Fiction" scheme="http://librarysimplified.org/terms/fiction/" label="Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Science%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Science Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Literary%20Fiction" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Literary Fiction" />
+    <category term="http://librarysimplified.org/terms/genres/Simplified/Short%20Stories" scheme="http://librarysimplified.org/terms/genres/Simplified/" label="Short Stories" />
+    <dcterms:language>en</dcterms:language>
+    <dcterms:issued>1954-01-01</dcterms:issued>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3867/report" rel="issues" />
+    <id>http://www.feedbooks.com/book/3867</id>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3867" type="application/atom+xml;type=entry;profile=opds-catalog" rel="alternate" />
+    <bibframe:distribution bibframe:ProviderName="FeedBooks" />
+    <published>2018-03-25T00:00:00Z</published>
+    <updated>2021-04-28T23:51:32Z</updated>
+    <link href="https://openbookshelf.dp.la/OB/works/10294/fulfill/1" rel="http://opds-spec.org/acquisition/open-access" type="application/epub+zip" dcterms:rights="https://creativecommons.org/licenses/by-nc/4.0">
+      <opds:availability status="available" />
+    </link>
+    <link href="https://openbookshelf.dp.la/OB/works/URI/http://www.feedbooks.com/book/3867/related_books" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="related" title="Recommended Works" />
+    <link href="https://openbookshelf.dp.la/OB/analytics/URI/http://www.feedbooks.com/book/3867/open_book" rel="http://librarysimplified.org/terms/rel/analytics/open-book" />
+  </entry>
+  <link href="https://openbookshelf.dp.la/OB/lists/Open%20Bookshelf/crawlable?available=all&amp;size=100&amp;key=%5B1619653892.21483%2C+%22%5Cu2728%5Cu1192%5Cu0706%5Cu24c0%5Cu3021%5Cu38e0%5Cu549c%5Cu042a%5Cu0089%5Cu4077%5Cu17db%5Cu4c2d%5Cu6000%5Cu0001%22%2C+%22%5Cu2723%5Cu100a%5Cu4980%5Cu44e5%5Cu01d1%5Cu50d0%5Cu021e%5Cu01dc%5Cu60ee%5Cu0200%5Cu0000%5Cu0000%22%2C+9571%5D&amp;collection=full&amp;order=last_update" rel="next" />
+  <link href="https://openbookshelf.dp.la/OB/groups/" rel="start" title="All Books" />
+  <simplified:breadcrumbs>
+    <link href="https://openbookshelf.dp.la/OB/groups/" title="All Books" />
+  </simplified:breadcrumbs>
+  <link href="https://openbookshelf.dp.la/OB/authentication_document" rel="http://opds-spec.org/auth/document" />
+  <link href="https://openbookshelf.dp.la/OB/search/" type="application/opensearchdescription+xml" rel="search" />
+  <link href="https://openbookshelf.dp.la/OB/lists/Open%20Bookshelf/crawlable" type="application/atom+xml;profile=opds-catalog;kind=acquisition" rel="http://opds-spec.org/crawlable" />
+  <link role="navigation" href="https://thepalaceproject.org/" type="text/html" rel="related" title="Palace Project" />
+  <link href="mailto:ebooks@dp.la" rel="help" />
+</feed>

--- a/tests/core/test_opds_validate.py
+++ b/tests/core/test_opds_validate.py
@@ -1,0 +1,25 @@
+import json
+
+from webpub_manifest_parser.opds2 import OPDS2FeedParserFactory
+
+from core.model.configuration import ExternalIntegration
+from core.model.datasource import DataSource
+from core.opds2_import import OPDS2Importer, RWPMManifestParser
+from core.opds_schema import OPDS2SchemaValidation
+from tests.core.test_opds2_import import OPDS2Test
+
+
+class TestOPDS2Validation(OPDS2Test):
+    def test_opds2_schema(self):
+        self._default_collection.protocol = ExternalIntegration.OPDS2_IMPORT
+        self._default_collection.data_source = DataSource.FEEDBOOKS
+        validator = OPDS2SchemaValidation(
+            self._db,
+            collection=self._default_collection,
+            import_class=OPDS2Importer,
+            parser=RWPMManifestParser(OPDS2FeedParserFactory()),
+        )
+        with open("tests/core/files/opds/opds2_feed.json") as fp:
+            bookshelf_opds2 = json.load(fp)
+
+        validator.import_one_feed(bookshelf_opds2)

--- a/tests/core/test_opds_validate.py
+++ b/tests/core/test_opds_validate.py
@@ -1,11 +1,13 @@
 import json
 
+from webpub_manifest_parser.odl import ODLFeedParserFactory
 from webpub_manifest_parser.opds2 import OPDS2FeedParserFactory
 
+from api.odl2 import ODL2Importer
 from core.model.configuration import ExternalIntegration
 from core.model.datasource import DataSource
 from core.opds2_import import OPDS2Importer, RWPMManifestParser
-from core.opds_schema import OPDS2SchemaValidation
+from core.opds_schema import ODL2SchemaValidation, OPDS2SchemaValidation
 from tests.core.test_opds2_import import OPDS2Test
 
 
@@ -23,3 +25,21 @@ class TestOPDS2Validation(OPDS2Test):
             bookshelf_opds2 = json.load(fp)
 
         validator.import_one_feed(bookshelf_opds2)
+
+
+class TestODL2Validation(OPDS2Test):
+    def test_odl2_schema(self):
+        self._default_collection.protocol = ExternalIntegration.ODL2
+        self._default_collection.data_source = DataSource.FEEDBOOKS
+        validator = ODL2SchemaValidation(
+            self._db,
+            collection=self._default_collection,
+            import_class=ODL2Importer,
+            parser=RWPMManifestParser(ODLFeedParserFactory()),
+        )
+        with open("tests/core/files/opds/odl2_feed.json") as fp:
+            bookshelf_odl2 = fp.read()
+
+        imported, failures = validator.import_one_feed(bookshelf_odl2)
+
+        assert (len(imported), len(failures)) == (0, 0)


### PR DESCRIPTION
## Description

In an ideal world we would simply reference "https://raw.githubusercontent.com/opds-community/drafts/master/schema/feed.schema.json"
and be done with it, no changes required
However, the above in turn refers to "https://readium.org/webpub-manifest/schema/link.schema.json"
and "https://readium.org/webpub-manifest/schema/metadata.schema.json", both of which have
regexs that are not recognized under python regex library
They are valid regexs under PCRE and similar libraries but the jsonschema libraries
will be using the standard library

These regexs have been removed in the local version of the schema (only 3 places existed)
and a custom refresolver has been used to either pick up local or remote references

<!--- Describe your changes -->

## Motivation and Context

An OPDS 2 schema validation tool is required to check new and existing OPDS 2 feeds for validity.
An executable tool has been added for this purpose `bin/opds2_schema_validate`

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested manually against http://bookshelf-feed-demo.us-east-1.elasticbeanstalk.com/v1/publications

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
