### PR TITLE
Make Overdrive migration explicit

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -273,7 +273,7 @@ class OverdriveAPI(
         its own Patron Authentication.
         """
         return "websiteid:%s authorizationname:%s" % (
-            self._configuration.website_id,
+            self._configuration.overdrive_website_id,
             self.ils_name(library),
         )
 

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -11,7 +11,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError, SAWarning
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.sql import compiler, select
 from sqlalchemy.sql.expression import literal_column, table
@@ -456,7 +456,7 @@ class SessionManager(object):
         return session
 
 
-def production_session(initialize_data=True):
+def production_session(initialize_data=True) -> Session:
     url = Configuration.database_url()
     if url.startswith('"'):
         url = url[1:]

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -231,17 +231,6 @@ class OverdriveCoreAPI(HasExternalIntegration):
         self._external_integration = collection.external_integration
         self._collection_id = collection.id
 
-        if collection.parent:
-            # This is an Overdrive Advantage account.
-            self.parent_library_id = collection.parent.external_account_id
-
-            # We're going to inherit all of the Overdrive credentials
-            # from the parent (the main Overdrive account), except for the
-            # library ID, which we already set.
-            collection = collection.parent
-        else:
-            self.parent_library_id = None
-
         # Initialize configuration information.
         self._configuration_storage = ConfigurationStorage(self)
         self._configuration_factory = ConfigurationFactory()
@@ -249,13 +238,34 @@ class OverdriveCoreAPI(HasExternalIntegration):
             configuration_storage=self._configuration_storage, db=_db
         )
 
-        self._migrate_configuration(
-            collection=collection, configuration=self._configuration
-        )
-        self._server_nickname = (
-            self._configuration.server_nickname
-            or OverdriveConfiguration.PRODUCTION_SERVERS
-        )
+        if collection.parent:
+            # This is an Overdrive Advantage account.
+            self.parent_library_id = collection.parent.external_account_id
+
+            # We're going to inherit all of the Overdrive credentials
+            # from the parent (the main Overdrive account), except for the
+            # library ID, which we already set.
+            parent_integration = collection.parent.external_integration
+
+            self._configuration.client_key = parent_integration.setting(
+                "overdrive_client_key"
+            )
+            self._configuration.client_password = parent_integration.setting(
+                "overdrive_client_secret"
+            )
+            self._configuration.website_id = parent_integration.setting(
+                "overdrive_website_id"
+            )
+        else:
+            self.parent_library_id = None
+
+        if not self._configuration.client_key:
+            raise ValueError("Overdrive client key is not configured")
+        if not self._configuration.client_password:
+            raise ValueError("Overdrive client password/secret is not configured")
+        if not self._configuration.website_id:
+            raise ValueError("Overdrive website ID is not configured")
+
         self._hosts = self._determine_hosts(configuration=self._configuration)
 
         # This is set by an access to .token, or by a call to
@@ -275,39 +285,6 @@ class OverdriveCoreAPI(HasExternalIntegration):
             server_nickname = OverdriveConfiguration.PRODUCTION_SERVERS
 
         return dict(self.HOSTS[server_nickname])
-
-    def _migrate_configuration(
-        self, collection: Collection, configuration: OverdriveConfiguration
-    ) -> None:
-        """Attempt to load configuration data that was saved using the old
-        external integration methods. Delete the old data when we're done."""
-        integration: ExternalIntegration = collection.external_integration
-        old_client_key: Optional[str] = integration.setting(
-            ExternalIntegration.USERNAME
-        ).value
-        if old_client_key:
-            configuration.client_key = old_client_key
-
-        old_client_secret: Optional[str] = integration.setting(
-            ExternalIntegration.PASSWORD
-        ).value
-        if old_client_secret:
-            configuration.client_password = old_client_secret
-
-        old_website_id: Optional[str] = integration.setting(self.WEBSITE_ID).value
-        if old_website_id:
-            configuration.website_id = old_website_id
-
-        old_server_nickname: Optional[str] = integration.setting(
-            self.SERVER_NICKNAME
-        ).value
-        if old_server_nickname:
-            configuration.server_nickname = old_server_nickname
-
-        integration.set_setting(ExternalIntegration.USERNAME, None)
-        integration.set_setting(ExternalIntegration.PASSWORD, None)
-        integration.set_setting(self.WEBSITE_ID, None)
-        integration.set_setting(self.SERVER_NICKNAME, None)
 
     def external_integration(self, db: Session) -> ExternalIntegration:
         return self._external_integration
@@ -739,9 +716,9 @@ class MockOverdriveCoreAPI(OverdriveCoreAPI):
         integration = collection.create_external_integration(
             protocol=ExternalIntegration.OVERDRIVE
         )
-        integration.username = client_key
-        integration.password = client_secret
-        integration.set_setting("website_id", website_id)
+        integration.set_setting("overdrive_client_key", client_key)
+        integration.set_setting("overdrive_client_secret", client_secret)
+        integration.set_setting("overdrive_website_id", website_id)
         library.collections.append(collection)
         OverdriveCoreAPI.ils_name_setting(_db, collection, library).value = ils_name
         return collection

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -99,7 +99,7 @@ class OverdriveConfiguration(ConfigurationGrouping, BaseImporterConfiguration):
     PRODUCTION_SERVERS = "production"
     TESTING_SERVERS = "testing"
 
-    server_nickname = ConfigurationMetadata(
+    overdrive_server_nickname = ConfigurationMetadata(
         key=OVERDRIVE_SERVER_NICKNAME,
         label=_("Server family"),
         type=ConfigurationAttributeType.SELECT,
@@ -270,7 +270,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
             raise CannotLoadConfiguration("Overdrive website ID is not configured")
 
         self._server_nickname = (
-            self._configuration.server_nickname
+            self._configuration.overdrive_server_nickname
             or OverdriveConfiguration.PRODUCTION_SERVERS
         )
 
@@ -287,7 +287,8 @@ class OverdriveCoreAPI(HasExternalIntegration):
         # Figure out which hostnames we'll be using when constructing
         # endpoint URLs.
         server_nickname = (
-            configuration.server_nickname or OverdriveConfiguration.PRODUCTION_SERVERS
+            configuration.overdrive_server_nickname
+            or OverdriveConfiguration.PRODUCTION_SERVERS
         )
         if server_nickname not in self.HOSTS:
             server_nickname = OverdriveConfiguration.PRODUCTION_SERVERS

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -81,14 +81,14 @@ class OverdriveConfiguration(ConfigurationGrouping, BaseImporterConfiguration):
         description="The web site identifier.",
         required=True,
     )
-    client_key = ConfigurationMetadata(
+    overdrive_client_key = ConfigurationMetadata(
         key=OVERDRIVE_CLIENT_KEY,
         label=_("Client Key"),
         type=ConfigurationAttributeType.TEXT,
         description="The Overdrive client key.",
         required=True,
     )
-    client_password = ConfigurationMetadata(
+    overdrive_client_secret = ConfigurationMetadata(
         key=OVERDRIVE_CLIENT_SECRET,
         label=_("Client Secret"),
         type=ConfigurationAttributeType.TEXT,
@@ -248,10 +248,10 @@ class OverdriveCoreAPI(HasExternalIntegration):
             # library ID, which we already set.
             parent_integration = collection.parent.external_integration
 
-            self._configuration.client_key = parent_integration.setting(
+            self._configuration.overdrive_client_key = parent_integration.setting(
                 OverdriveConfiguration.OVERDRIVE_CLIENT_KEY
             )
-            self._configuration.client_password = parent_integration.setting(
+            self._configuration.overdrive_client_secret = parent_integration.setting(
                 OverdriveConfiguration.OVERDRIVE_CLIENT_SECRET
             )
             self._configuration.website_id = parent_integration.setting(
@@ -260,9 +260,9 @@ class OverdriveCoreAPI(HasExternalIntegration):
         else:
             self.parent_library_id = None
 
-        if not self._configuration.client_key:
+        if not self._configuration.overdrive_client_key:
             raise CannotLoadConfiguration("Overdrive client key is not configured")
-        if not self._configuration.client_password:
+        if not self._configuration.overdrive_client_secret:
             raise CannotLoadConfiguration(
                 "Overdrive client password/secret is not configured"
             )
@@ -687,10 +687,10 @@ class OverdriveCoreAPI(HasExternalIntegration):
         return self._configuration.website_id.encode("utf-8")
 
     def client_key(self) -> bytes:
-        return self._configuration.client_key.encode("utf-8")
+        return self._configuration.overdrive_client_key.encode("utf-8")
 
     def client_secret(self) -> bytes:
-        return self._configuration.client_password.encode("utf-8")
+        return self._configuration.overdrive_client_secret.encode("utf-8")
 
     def library_id(self) -> str:
         return self._library_id

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -276,7 +276,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
             or OverdriveConfiguration.PRODUCTION_SERVERS
         )
 
-        self._hosts = self._determine_hosts(configuration=self._configuration)
+        self._hosts = self._determine_hosts(server_nickname=self._server_nickname)
 
         # This is set by an access to .token, or by a call to
         # check_creds() or refresh_creds().
@@ -285,13 +285,9 @@ class OverdriveCoreAPI(HasExternalIntegration):
         # This is set by an access to .collection_token
         self._collection_token = None
 
-    def _determine_hosts(self, configuration: OverdriveConfiguration) -> Dict[str, str]:
+    def _determine_hosts(self, *, server_nickname: str) -> Dict[str, str]:
         # Figure out which hostnames we'll be using when constructing
         # endpoint URLs.
-        server_nickname = (
-            configuration.overdrive_server_nickname
-            or OverdriveConfiguration.PRODUCTION_SERVERS
-        )
         if server_nickname not in self.HOSTS:
             server_nickname = OverdriveConfiguration.PRODUCTION_SERVERS
 

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -67,6 +67,14 @@ class OverdriveConfiguration(ConfigurationGrouping, BaseImporterConfiguration):
     OVERDRIVE_SERVER_NICKNAME = "overdrive_server_nickname"
     OVERDRIVE_WEBSITE_ID = "overdrive_website_id"
 
+    # Note that the library ID is not included here because it is not Overdrive-specific
+    OVERDRIVE_CONFIGURATION_KEYS = {
+        OVERDRIVE_CLIENT_KEY,
+        OVERDRIVE_CLIENT_SECRET,
+        OVERDRIVE_SERVER_NICKNAME,
+        OVERDRIVE_WEBSITE_ID,
+    }
+
     library_id = ConfigurationMetadata(
         key=Collection.EXTERNAL_ACCOUNT_ID_KEY,
         label=_("Library ID"),
@@ -248,15 +256,9 @@ class OverdriveCoreAPI(HasExternalIntegration):
             # library ID, which we already set.
             parent_integration = collection.parent.external_integration
 
-            self._configuration.overdrive_client_key = parent_integration.setting(
-                OverdriveConfiguration.OVERDRIVE_CLIENT_KEY
-            )
-            self._configuration.overdrive_client_secret = parent_integration.setting(
-                OverdriveConfiguration.OVERDRIVE_CLIENT_SECRET
-            )
-            self._configuration.overdrive_website_id = parent_integration.setting(
-                OverdriveConfiguration.OVERDRIVE_WEBSITE_ID
-            )
+            for key in OverdriveConfiguration.OVERDRIVE_CONFIGURATION_KEYS:
+                parent_value = parent_integration.setting(key)
+                self._configuration.set_setting_value(key, parent_value.value)
         else:
             self.parent_library_id = None
 

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -62,6 +62,11 @@ from .util.string_helpers import base64
 class OverdriveConfiguration(ConfigurationGrouping, BaseImporterConfiguration):
     """The basic Overdrive configuration"""
 
+    OVERDRIVE_CLIENT_KEY = "overdrive_client_key"
+    OVERDRIVE_CLIENT_SECRET = "overdrive_client_secret"
+    OVERDRIVE_SERVER_NICKNAME = "overdrive_server_nickname"
+    OVERDRIVE_WEBSITE_ID = "overdrive_website_id"
+
     library_id = ConfigurationMetadata(
         key=Collection.EXTERNAL_ACCOUNT_ID_KEY,
         label=_("Library ID"),
@@ -70,21 +75,21 @@ class OverdriveConfiguration(ConfigurationGrouping, BaseImporterConfiguration):
         required=True,
     )
     website_id = ConfigurationMetadata(
-        key="overdrive_website_id",
+        key=OVERDRIVE_WEBSITE_ID,
         label=_("Website ID"),
         type=ConfigurationAttributeType.TEXT,
         description="The web site identifier.",
         required=True,
     )
     client_key = ConfigurationMetadata(
-        key="overdrive_client_key",
+        key=OVERDRIVE_CLIENT_KEY,
         label=_("Client Key"),
         type=ConfigurationAttributeType.TEXT,
         description="The Overdrive client key.",
         required=True,
     )
     client_password = ConfigurationMetadata(
-        key="overdrive_client_secret",
+        key=OVERDRIVE_CLIENT_SECRET,
         label=_("Client Secret"),
         type=ConfigurationAttributeType.TEXT,
         description="The Overdrive client secret.",
@@ -95,7 +100,7 @@ class OverdriveConfiguration(ConfigurationGrouping, BaseImporterConfiguration):
     TESTING_SERVERS = "testing"
 
     server_nickname = ConfigurationMetadata(
-        key="overdrive_server_nickname",
+        key=OVERDRIVE_SERVER_NICKNAME,
         label=_("Server family"),
         type=ConfigurationAttributeType.SELECT,
         required=False,
@@ -116,8 +121,6 @@ class OverdriveCoreAPI(HasExternalIntegration):
 
     # Production and testing have different host names for some of the
     # API endpoints. This is configurable on the collection level.
-    SERVER_NICKNAME = "server_nickname"
-
     HOSTS = {
         OverdriveConfiguration.PRODUCTION_SERVERS: dict(
             host="https://api.overdrive.com",
@@ -194,8 +197,6 @@ class OverdriveCoreAPI(HasExternalIntegration):
 
     TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
-    WEBSITE_ID = "website_id"
-
     # When associating an Overdrive account with a library, it's
     # necessary to also specify an "ILS name" obtained from
     # Overdrive. Components that don't authenticate patrons (such as
@@ -248,13 +249,13 @@ class OverdriveCoreAPI(HasExternalIntegration):
             parent_integration = collection.parent.external_integration
 
             self._configuration.client_key = parent_integration.setting(
-                "overdrive_client_key"
+                OverdriveConfiguration.OVERDRIVE_CLIENT_KEY
             )
             self._configuration.client_password = parent_integration.setting(
-                "overdrive_client_secret"
+                OverdriveConfiguration.OVERDRIVE_CLIENT_SECRET
             )
             self._configuration.website_id = parent_integration.setting(
-                "overdrive_website_id"
+                OverdriveConfiguration.OVERDRIVE_WEBSITE_ID
             )
         else:
             self.parent_library_id = None
@@ -723,9 +724,11 @@ class MockOverdriveCoreAPI(OverdriveCoreAPI):
         integration = collection.create_external_integration(
             protocol=ExternalIntegration.OVERDRIVE
         )
-        integration.set_setting("overdrive_client_key", client_key)
-        integration.set_setting("overdrive_client_secret", client_secret)
-        integration.set_setting("overdrive_website_id", website_id)
+        integration.set_setting(OverdriveConfiguration.OVERDRIVE_CLIENT_KEY, client_key)
+        integration.set_setting(
+            OverdriveConfiguration.OVERDRIVE_CLIENT_SECRET, client_secret
+        )
+        integration.set_setting(OverdriveConfiguration.OVERDRIVE_WEBSITE_ID, website_id)
         library.collections.append(collection)
         OverdriveCoreAPI.ils_name_setting(_db, collection, library).value = ils_name
         return collection

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -74,7 +74,7 @@ class OverdriveConfiguration(ConfigurationGrouping, BaseImporterConfiguration):
         description="The library identifier.",
         required=True,
     )
-    website_id = ConfigurationMetadata(
+    overdrive_website_id = ConfigurationMetadata(
         key=OVERDRIVE_WEBSITE_ID,
         label=_("Website ID"),
         type=ConfigurationAttributeType.TEXT,
@@ -254,7 +254,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
             self._configuration.overdrive_client_secret = parent_integration.setting(
                 OverdriveConfiguration.OVERDRIVE_CLIENT_SECRET
             )
-            self._configuration.website_id = parent_integration.setting(
+            self._configuration.overdrive_website_id = parent_integration.setting(
                 OverdriveConfiguration.OVERDRIVE_WEBSITE_ID
             )
         else:
@@ -266,7 +266,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
             raise CannotLoadConfiguration(
                 "Overdrive client password/secret is not configured"
             )
-        if not self._configuration.website_id:
+        if not self._configuration.overdrive_website_id:
             raise CannotLoadConfiguration("Overdrive website ID is not configured")
 
         self._server_nickname = (
@@ -684,7 +684,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
         return HTTP.post_with_timeout(url, payload, headers=headers, **kwargs)
 
     def website_id(self) -> bytes:
-        return self._configuration.website_id.encode("utf-8")
+        return self._configuration.overdrive_website_id.encode("utf-8")
 
     def client_key(self) -> bytes:
         return self._configuration.overdrive_client_key.encode("utf-8")

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -268,6 +268,11 @@ class OverdriveCoreAPI(HasExternalIntegration):
         if not self._configuration.website_id:
             raise CannotLoadConfiguration("Overdrive website ID is not configured")
 
+        self._server_nickname = (
+            self._configuration.server_nickname
+            or OverdriveConfiguration.PRODUCTION_SERVERS
+        )
+
         self._hosts = self._determine_hosts(configuration=self._configuration)
 
         # This is set by an access to .token, or by a call to
@@ -447,8 +452,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
     def fulfillment_authorization_header(self) -> str:
         is_test_mode = (
             True
-            if self._configuration.server_nickname
-            == OverdriveConfiguration.TESTING_SERVERS
+            if self._server_nickname == OverdriveConfiguration.TESTING_SERVERS
             else False
         )
         try:

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -260,11 +260,13 @@ class OverdriveCoreAPI(HasExternalIntegration):
             self.parent_library_id = None
 
         if not self._configuration.client_key:
-            raise ValueError("Overdrive client key is not configured")
+            raise CannotLoadConfiguration("Overdrive client key is not configured")
         if not self._configuration.client_password:
-            raise ValueError("Overdrive client password/secret is not configured")
+            raise CannotLoadConfiguration(
+                "Overdrive client password/secret is not configured"
+            )
         if not self._configuration.website_id:
-            raise ValueError("Overdrive website ID is not configured")
+            raise CannotLoadConfiguration("Overdrive website ID is not configured")
 
         self._hosts = self._determine_hosts(configuration=self._configuration)
 

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -447,7 +447,8 @@ class OverdriveCoreAPI(HasExternalIntegration):
     def fulfillment_authorization_header(self) -> str:
         is_test_mode = (
             True
-            if self._server_nickname == OverdriveConfiguration.TESTING_SERVERS
+            if self._configuration.server_nickname
+            == OverdriveConfiguration.TESTING_SERVERS
             else False
         )
         try:

--- a/migration/20220428-namespace-overdrive-configuration.py
+++ b/migration/20220428-namespace-overdrive-configuration.py
@@ -153,7 +153,7 @@ def update_configuration(db: Session, integration: int) -> None:
 
 def execute_migration(db: Session) -> None:
     select = text(
-    """
+        """
     SELECT e.id
         FROM collections c
         JOIN externalintegrations e on c.external_integration_id = e.id

--- a/migration/20220428-namespace-overdrive-configuration.py
+++ b/migration/20220428-namespace-overdrive-configuration.py
@@ -22,8 +22,9 @@ def delete_key(db: Session, integration: int, key: str) -> None:
     delete_key = text(
         """
 DELETE FROM configurationsettings
-WHERE key = :key
-AND external_integration_id = :id
+    WHERE key = :key
+        AND external_integration_id = :id
+        AND library_id is NULL
 """
     )
     db.execute(delete_key, {"id": f"{integration}", "key": key})
@@ -33,9 +34,10 @@ def rename_key(db: Session, integration: int, old_key: str, new_key: str) -> Non
     rename_key = text(
         """
 UPDATE configurationsettings
-SET key = :new_key
-WHERE key = :old_key
-AND external_integration_id = :id
+    SET key = :new_key
+        WHERE key = :old_key
+        AND external_integration_id = :id
+        AND library_id is NULL
     """
     )
     db.execute(
@@ -52,6 +54,7 @@ def update_key_value(db: Session, integration: int, old_key: str, new_key: str) 
 SELECT c.value FROM configurationsettings AS c
   WHERE c.key = :key
     AND c.external_integration_id = :id
+    AND c.library_id is NULL
     """
     )
     result_old_key = db.execute(select_key, {"id": f"{integration}", "key": old_key})

--- a/migration/20220428-namespace-overdrive-configuration.py
+++ b/migration/20220428-namespace-overdrive-configuration.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+import logging
+import os
+import sys
+from typing import Optional
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.model import production_session
+
+logging.basicConfig()
+logger = logging.getLogger()
+logger.setLevel("INFO")
+
+
+def delete_key(db: Session, integration: int, key: str) -> None:
+    delete_key = text(
+        """
+DELETE FROM configurationsettings
+WHERE key = :key
+AND external_integration_id = :id
+"""
+    )
+    db.execute(delete_key, {"id": f"{integration}", "key": key})
+
+
+def rename_key(db: Session, integration: int, old_key: str, new_key: str) -> None:
+    rename_key = text(
+        """
+UPDATE configurationsettings
+SET key = :new_key
+WHERE key = :old_key
+AND external_integration_id = :id
+    """
+    )
+    db.execute(
+        rename_key, {"id": f"{integration}", "old_key": old_key, "new_key": new_key}
+    )
+
+
+def update_key_value(db: Session, integration: int, old_key: str, new_key: str) -> int:
+    # Try to retrieve the values of any old or new keys.
+    # Note that the CM's configuration complicates things by
+    # having keys that may be present but with null values.
+    select_old_key = text(
+        """
+SELECT c.value FROM configurationsettings AS c
+  WHERE c.key = :key
+    AND c.external_integration_id = :id
+    """
+    )
+    result_old_key = db.execute(
+        select_old_key, {"id": f"{integration}", "key": old_key}
+    )
+
+    existing_old_key_present: bool = False
+    existing_old_key: Optional[str] = None
+    if result_old_key.rowcount > 0:
+        existing_old_key_present = True
+        existing_old_key = result_old_key.fetchone()[0]
+
+    select_new_key = text(
+        """
+SELECT c.value FROM configurationsettings AS c
+  WHERE c.key = :key
+    AND c.external_integration_id = :id
+    """
+    )
+    result_new_key = db.execute(
+        select_new_key, {"id": f"{integration}", "key": new_key}
+    )
+
+    existing_new_key_present: bool = False
+    existing_new_key: Optional[str] = None
+    if result_new_key.rowcount > 0:
+        existing_new_key_present = True
+        existing_new_key = result_new_key.fetchone()[0]
+
+    if existing_old_key_present:
+        logger.info(f"Discovered old key '{old_key}' -> '{existing_old_key}'")
+    if existing_new_key_present:
+        logger.info(f"Discovered new key '{new_key}' -> '{existing_new_key}'")
+
+    # If keys have a non-null value, something is seriously wrong!
+    if not existing_old_key and not existing_new_key:
+        raise RuntimeError(
+            f"External integration {integration} has neither a '{old_key}' or a '{new_key}'"
+        )
+
+    # If both the old key and the new key exist, then keep whichever one is non-null,
+    # preferring the new key to the old key.
+    if existing_old_key_present and existing_new_key_present:
+        if existing_new_key:
+            logger.info(f"Deleting old key '{old_key}'")
+            delete_key(db=db, integration=integration, key=old_key)
+        else:
+            assert existing_old_key
+            rename_key(db=db, integration=integration, old_key=old_key, new_key=new_key)
+        return 1
+
+    # Otherwise, if only the old key exists, rename it to the new key.
+    if existing_old_key_present:
+        assert not existing_new_key
+        assert not existing_new_key_present
+        assert existing_old_key
+
+        logger.info(f"Renaming old key '{old_key}' -> new key '{new_key}'")
+        rename_key(db=db, integration=integration, old_key=old_key, new_key=new_key)
+        return 1
+
+    # The old key didn't exist, the new key exists, so there's nothing to do.
+    assert existing_new_key
+    assert existing_new_key_present
+    assert not existing_old_key
+    assert not existing_old_key_present
+
+    logger.info(
+        f"New key '{new_key}' already exists, and old key '{old_key}' does not; nothing to do!"
+    )
+    return 0
+
+
+def update_configuration(db: Session, integration: int) -> None:
+    updated = 0
+    updated += update_key_value(
+        db=db,
+        integration=integration,
+        old_key="username",
+        new_key="overdrive_client_key",
+    )
+    updated += update_key_value(
+        db=db,
+        integration=integration,
+        old_key="password",
+        new_key="overdrive_client_secret",
+    )
+    updated += update_key_value(
+        db=db,
+        integration=integration,
+        old_key="website_id",
+        new_key="overdrive_website_id",
+    )
+    updated += update_key_value(
+        db=db,
+        integration=integration,
+        old_key="server_nickname",
+        new_key="overdrive_server_nickname",
+    )
+
+    if updated > 0:
+        logger.info("Updates were made, committing...")
+        db.commit()
+    else:
+        logger.info("No updates were necessary")
+
+
+def execute_migration(db: Session) -> None:
+    select = text(
+        """
+SELECT e.id FROM externalintegrations AS e
+  WHERE e.protocol = 'Overdrive'
+    """
+    )
+    integrations = db.execute(select).fetchall()
+    for integration_row in integrations:
+        update_configuration(db, integration_row[0])
+
+
+def main() -> None:
+    session = production_session()
+    try:
+        execute_migration(session)
+    finally:
+        session.close()
+
+
+main()

--- a/migration/20220428-namespace-overdrive-configuration.py
+++ b/migration/20220428-namespace-overdrive-configuration.py
@@ -47,16 +47,14 @@ def update_key_value(db: Session, integration: int, old_key: str, new_key: str) 
     # Try to retrieve the values of any old or new keys.
     # Note that the CM's configuration complicates things by
     # having keys that may be present but with null values.
-    select_old_key = text(
+    select_key = text(
         """
 SELECT c.value FROM configurationsettings AS c
   WHERE c.key = :key
     AND c.external_integration_id = :id
     """
     )
-    result_old_key = db.execute(
-        select_old_key, {"id": f"{integration}", "key": old_key}
-    )
+    result_old_key = db.execute(select_key, {"id": f"{integration}", "key": old_key})
 
     existing_old_key_present: bool = False
     existing_old_key: Optional[str] = None
@@ -64,16 +62,7 @@ SELECT c.value FROM configurationsettings AS c
         existing_old_key_present = True
         existing_old_key = result_old_key.fetchone()[0]
 
-    select_new_key = text(
-        """
-SELECT c.value FROM configurationsettings AS c
-  WHERE c.key = :key
-    AND c.external_integration_id = :id
-    """
-    )
-    result_new_key = db.execute(
-        select_new_key, {"id": f"{integration}", "key": new_key}
-    )
+    result_new_key = db.execute(select_key, {"id": f"{integration}", "key": new_key})
 
     existing_new_key_present: bool = False
     existing_new_key: Optional[str] = None

--- a/migration/20220428-namespace-overdrive-configuration.py
+++ b/migration/20220428-namespace-overdrive-configuration.py
@@ -153,9 +153,11 @@ def update_configuration(db: Session, integration: int) -> None:
 
 def execute_migration(db: Session) -> None:
     select = text(
-        """
-SELECT e.id FROM externalintegrations AS e
-  WHERE e.protocol = 'Overdrive'
+    """
+    SELECT e.id
+        FROM collections c
+        JOIN externalintegrations e on c.external_integration_id = e.id
+            WHERE e.protocol = 'Overdrive' AND c.parent_id IS NULL
     """
     )
     integrations = db.execute(select).fetchall()

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1521,9 +1521,6 @@ class TestOverdriveAPI(OverdriveAPITest):
         self._default_collection.external_integration.setting(
             "overdrive_website_id"
         ).value = "100"
-        self._default_collection.external_integration.setting(
-            "overdrive_server_nickname"
-        ).value = "testing"
 
         # Mocked testing credentials
         encoded_auth = base64.b64encode("TestingKey:TestingSecret".encode())

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1513,13 +1513,13 @@ class TestOverdriveAPI(OverdriveAPITest):
         self._default_collection.external_integration.protocol = "Overdrive"
         self._default_collection.external_account_id = 1
         self._default_collection.external_integration.setting(
-            "overdrive_client_key"
+            OverdriveConfiguration.OVERDRIVE_CLIENT_KEY
         ).value = "user"
         self._default_collection.external_integration.setting(
-            "overdrive_client_secret"
+            OverdriveConfiguration.OVERDRIVE_CLIENT_SECRET
         ).value = "password"
         self._default_collection.external_integration.setting(
-            "overdrive_website_id"
+            OverdriveConfiguration.OVERDRIVE_WEBSITE_ID
         ).value = "100"
 
         # Mocked testing credentials
@@ -1553,13 +1553,13 @@ class TestOverdriveAPI(OverdriveAPITest):
         self._default_collection.external_integration.protocol = "Overdrive"
         self._default_collection.external_account_id = 1
         self._default_collection.external_integration.setting(
-            "overdrive_client_key"
+            OverdriveConfiguration.OVERDRIVE_CLIENT_KEY
         ).value = "user"
         self._default_collection.external_integration.setting(
-            "overdrive_client_secret"
+            OverdriveConfiguration.OVERDRIVE_CLIENT_SECRET
         ).value = "password"
         self._default_collection.external_integration.setting(
-            "overdrive_website_id"
+            OverdriveConfiguration.OVERDRIVE_WEBSITE_ID
         ).value = "100"
 
         # use a real Overdrive API

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1512,9 +1512,15 @@ class TestOverdriveAPI(OverdriveAPITest):
         credential = self._credential(patron=patron)
         self._default_collection.external_integration.protocol = "Overdrive"
         self._default_collection.external_account_id = 1
-        self._default_collection.external_integration.setting("overdrive_client_key").value = "user"
-        self._default_collection.external_integration.setting("overdrive_client_secret").value = "password"
-        self._default_collection.external_integration.setting("overdrive_website_id").value = "100"
+        self._default_collection.external_integration.setting(
+            "overdrive_client_key"
+        ).value = "user"
+        self._default_collection.external_integration.setting(
+            "overdrive_client_secret"
+        ).value = "password"
+        self._default_collection.external_integration.setting(
+            "overdrive_website_id"
+        ).value = "100"
 
         # Mocked testing credentials
         encoded_auth = base64.b64encode("TestingKey:TestingSecret".encode())
@@ -1546,9 +1552,15 @@ class TestOverdriveAPI(OverdriveAPITest):
         patron.authorization_identifier = "barcode"
         self._default_collection.external_integration.protocol = "Overdrive"
         self._default_collection.external_account_id = 1
-        self._default_collection.external_integration.setting("overdrive_client_key").value = "user"
-        self._default_collection.external_integration.setting("overdrive_client_secret").value = "password"
-        self._default_collection.external_integration.setting("overdrive_website_id").value = "100"
+        self._default_collection.external_integration.setting(
+            "overdrive_client_key"
+        ).value = "user"
+        self._default_collection.external_integration.setting(
+            "overdrive_client_secret"
+        ).value = "password"
+        self._default_collection.external_integration.setting(
+            "overdrive_website_id"
+        ).value = "100"
 
         # use a real Overdrive API
         od_api = OverdriveAPI(self._db, self._default_collection)

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1521,6 +1521,9 @@ class TestOverdriveAPI(OverdriveAPITest):
         self._default_collection.external_integration.setting(
             "overdrive_website_id"
         ).value = "100"
+        self._default_collection.external_integration.setting(
+            "overdrive_server_nickname"
+        ).value = "testing"
 
         # Mocked testing credentials
         encoded_auth = base64.b64encode("TestingKey:TestingSecret".encode())

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1512,6 +1512,9 @@ class TestOverdriveAPI(OverdriveAPITest):
         credential = self._credential(patron=patron)
         self._default_collection.external_integration.protocol = "Overdrive"
         self._default_collection.external_account_id = 1
+        self._default_collection.external_integration.setting("overdrive_client_key").value = "user"
+        self._default_collection.external_integration.setting("overdrive_client_secret").value = "password"
+        self._default_collection.external_integration.setting("overdrive_website_id").value = "100"
 
         # Mocked testing credentials
         encoded_auth = base64.b64encode("TestingKey:TestingSecret".encode())
@@ -1543,6 +1546,9 @@ class TestOverdriveAPI(OverdriveAPITest):
         patron.authorization_identifier = "barcode"
         self._default_collection.external_integration.protocol = "Overdrive"
         self._default_collection.external_account_id = 1
+        self._default_collection.external_integration.setting("overdrive_client_key").value = "user"
+        self._default_collection.external_integration.setting("overdrive_client_secret").value = "password"
+        self._default_collection.external_integration.setting("overdrive_website_id").value = "100"
 
         # use a real Overdrive API
         od_api = OverdriveAPI(self._db, self._default_collection)

--- a/tests/core/test_overdrive.py
+++ b/tests/core/test_overdrive.py
@@ -186,7 +186,7 @@ class TestOverdriveCoreAPI(OverdriveTestWithAPI):
         # hostnames.
         def api_with_setting(x):
             integration = self.collection.external_integration
-            integration.setting(c.SERVER_NICKNAME).value = x
+            integration.setting("overdrive_server_nickname").value = x
             return c(self._db, self.collection)
 
         testing = api_with_setting(OverdriveConfiguration.TESTING_SERVERS)
@@ -365,9 +365,9 @@ class TestOverdriveCoreAPI(OverdriveTestWithAPI):
             protocol=ExternalIntegration.OVERDRIVE,
             external_account_id="1",
         )
-        main.external_integration.username = "user"
-        main.external_integration.password = "password"
-        main.external_integration.setting("website_id").value = "100"
+        main.external_integration.setting("overdrive_client_key").value = "user"
+        main.external_integration.setting("overdrive_client_secret").value = "password"
+        main.external_integration.setting("overdrive_website_id").value = "100"
         main.external_integration.setting("ils_name").value = "default"
 
         # Here's an Overdrive API client for that collection.


### PR DESCRIPTION
## Description

The previous Overdrive PR added some code to rename old configuration
settings to their new names for the current code. This had a bad
interaction with the nullable value column in the configuration
settings table. This change adds an explicit migration script, and
updates all of the unit tests that were now failing due to the old
configuration keys no longer being present.

## Motivation and Context

Affects: https://www.notion.so/lyrasis/Move-OverDrive-configuration-migration-code-into-the-current-standard-migration-mechanism-af3adcc60ba54958ad1c050279e34594

## How Has This Been Tested?

The existing test suite was updated to ensure the small configuration changes needed in the CM were tested.
I tested against my own local CM in various ways by manually inserting values into the configuration settings table in order to force the migration script to do work.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
