### PR TITLE
Fix: Only search for lanes within the current library

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1076,7 +1076,11 @@ class LanesController(AdminCirculationManagerController):
                             )
                         )
                 old_lane = get_one(
-                    self._db, Lane, display_name=display_name, parent=parent
+                    self._db,
+                    Lane,
+                    display_name=display_name,
+                    parent=parent,
+                    library=library,
                 )
                 if old_lane:
                     return LANE_WITH_PARENT_AND_DISPLAY_NAME_ALREADY_EXISTS


### PR DESCRIPTION
## Description

This change passes in the missing `library` parameter that appeared to
be the original intent of the check that determines if a lane already exists
with a given display name.

## Motivation and Context

Affects: https://www.notion.so/lyrasis/Inability-to-create-a-custom-lane-with-the-same-name-in-each-library-on-the-same-CM-f549719021a54fb1be0ec1882cc42cfd#d9f576304c5c478aa2bdf9b11cd3a028

The endpoint that creates/edits lanes was calling get_one() without
passing in the ID of the library being edited. This resulted
in get_one() possibly returning lanes that are defined for other
libraries, and this would cause the check that determines if a display
name is already used to fail. This would cause the admin UI to claim
that a lane already existed in the current library with the given name,
when in fact that lane was actually in another library entirely.

## How Has This Been Tested?

I tried duplicating the problem in the ticket on my local CM, and confirmed that the problem went away with this fix.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
