### PR TITLE
Fix for empty string defaults for Configuration Settings

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1713,7 +1713,7 @@ class SettingsController(AdminCirculationManagerController):
                         )
                     )
 
-        value_missing = not value
+        value_missing = value is None
         value_required = setting.get("required")
 
         if value_missing and value_required:

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1864,7 +1864,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
                 {
                     "key": BARCODE_FORMAT_CODABAR,
                     "label": _(
-                        "Patron identifiers are are rendered as barcodes in Codabar format"
+                        "Patron identifiers are rendered as barcodes in Codabar format"
                     ),
                 },
                 {

--- a/tests/api/admin/controller/test_patron_auth.py
+++ b/tests/api/admin/controller/test_patron_auth.py
@@ -588,7 +588,20 @@ class TestPatronAuth(SettingsControllerTest):
                 auth_service,
             ).value
         )
-        common_args = self._common_basic_auth_arguments()
+        common_args: list = self._common_basic_auth_arguments()
+
+        # test empty (BARCODE_FORMAT_NONE) values
+        for c in common_args:
+            if c[0] == BasicAuthenticationProvider.IDENTIFIER_BARCODE_FORMAT:
+                common_args.remove(c)
+                break
+
+        common_args.append(
+            (
+                BasicAuthenticationProvider.IDENTIFIER_BARCODE_FORMAT,
+                BasicAuthenticationProvider.BARCODE_FORMAT_NONE,
+            )
+        )
         with self.request_context_with_admin("/", method="POST"):
             flask.request.form = MultiDict(
                 [
@@ -622,6 +635,12 @@ class TestPatronAuth(SettingsControllerTest):
         assert (
             "pass"
             == auth_service2.setting(BasicAuthenticationProvider.TEST_PASSWORD).value
+        )
+        assert (
+            ""
+            == auth_service2.setting(
+                BasicAuthenticationProvider.IDENTIFIER_BARCODE_FORMAT
+            ).value
         )
         assert (
             "true" == auth_service2.setting(MilleniumPatronAPI.VERIFY_CERTIFICATE).value


### PR DESCRIPTION
These were considered as missing values and treated the same as a None type

## Description
Rather than using a `not` check, simply use an `is None` check
Its explicit and doesn't cause this confusion

<!--- Describe your changes -->

## Motivation and Context
Saving a "Patron Authentication" with "Patron identifiers are not rendered as barcodes" was throwing an Error (400) 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
