### PR TITLE
Make audio/mpeg an "audiobook" format

### DIFF
--- a/core/model/constants.py
+++ b/core/model/constants.py
@@ -302,13 +302,13 @@ class MediaTypes(object):
         AUDIOBOOK_MANIFEST_MEDIA_TYPE,
         AUDIOBOOK_PACKAGE_MEDIA_TYPE,
         AUDIOBOOK_PACKAGE_LCP_MEDIA_TYPE,
+        MP3_MEDIA_TYPE,
     ]
 
     BOOK_MEDIA_TYPES = [
         EPUB_MEDIA_TYPE,
         PDF_MEDIA_TYPE,
         MOBI_MEDIA_TYPE,
-        MP3_MEDIA_TYPE,
         AMAZON_KF8_MEDIA_TYPE,
     ]
 

--- a/tests/core/models/test_edition.py
+++ b/tests/core/models/test_edition.py
@@ -14,6 +14,9 @@ from core.util.datetime_helpers import utc_now
 
 
 class TestEdition(DatabaseTest):
+    def test_audio_mpeg_is_audiobook(self):
+        assert Edition.AUDIO_MEDIUM == Edition.medium_from_media_type("audio/mpeg")
+
     def test_medium_from_media_type(self):
         # Verify that we can guess a value for Edition.medium from a
         # media type.


### PR DESCRIPTION
## Description

This makes an adjustment to the set of known content types so that
books using an audio/mpeg content type are classified as audio books
instead of eBooks.

## Motivation and Context

It seems that the audio/mpeg content type was introduced upstream one day without any explanation, and seems to have been (accidentally?) placed into the set of content types that denote eBooks instead of audio books. This means that OPDS feeds that are using the audio/mpeg content type have their books erroneously classified as eBooks.

Affects: https://www.notion.so/lyrasis/CM-considers-audio-mpeg-to-be-eBook-74b9dc74f8b74bb08007f1d2c18eb0fb

## How Has This Been Tested?

This has been tested against an old copy of the Biblioboard feeds (prior to the content type changes). I also wrote a one-line test that verifies that Editions are now assigned the expected type.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
