### PR TITLE
Fixed issue in SAMLWayfless postprocessing with nonetype patron

### DIFF
--- a/api/saml/wayfless.py
+++ b/api/saml/wayfless.py
@@ -80,13 +80,13 @@ class SAMLWAYFlessAcquisitionLinkProcessor(
     def fulfill(
         self, patron, pin, licensepool, delivery_mechanism, fulfillment: FulfillmentInfo
     ) -> FulfillmentInfo:
-        db = Session.object_session(patron)
 
         self._logger.debug(
             f"WAYFless acquisition link template: {self._wayfless_url_template}"
         )
 
         if self._wayfless_url_template:
+            db = Session.object_session(patron)
             saml_credential = self._saml_credential_manager.lookup_saml_token_by_patron(
                 db, patron
             )

--- a/tests/api/saml/test_controller.py
+++ b/tests/api/saml/test_controller.py
@@ -21,7 +21,9 @@ from api.saml.metadata.model import (
     SAMLUIInfo,
 )
 from api.saml.provider import SAML_INVALID_SUBJECT, SAMLWebSSOAuthenticationProvider
+from api.saml.wayfless import SAMLWAYFlessAcquisitionLinkProcessor
 from core.model import Credential, Library
+from core.testing import DatabaseTest
 from core.util.problem_detail import ProblemDetail
 from tests.api.saml import fixtures
 from tests.api.saml.controller_test import ControllerTest
@@ -438,3 +440,14 @@ class TestSAMLController(ControllerTest):
                 provider.saml_callback.assert_called_once_with(
                     self._db, finish_authentication_result
                 )
+
+
+class TestSAMLWAYFlessAcquisitionLinkProcessor(DatabaseTest):
+    def test_fulfill_no_wayless_template_url(self):
+        processor = SAMLWAYFlessAcquisitionLinkProcessor(self._default_collection)
+        assert processor._wayfless_url_template == None
+
+        mocked_fulfillment = MagicMock()
+        # As long as there is no template url, no actions should take place
+        response = processor.fulfill(None, None, None, None, mocked_fulfillment)
+        assert response == mocked_fulfillment


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Ensured none type patrons are not accessed while trying to post process a fulfilment
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to fulfil a license without a patron (for open access licenses) would throw an error. 
No open access works were fulfil-able due to this
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new test case has been written targeting fulfilment post processing without any valid data
for collections not having an wayfless template url
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
