### PR TITLE
Push notifications API implementation

### DIFF
--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -356,3 +356,24 @@ SHARED_SECRET_DECRYPTION_ERROR = pd(
     title=_("Decryption error"),
     detail=_("Failed to decrypt a shared secret retrieved from another computer."),
 )
+
+DEVICE_TOKEN_NOT_FOUND = pd(
+    "http://librarysimplified.org/terms/problem/device-token-not-found",
+    status_code=404,
+    title=_("Device token not found"),
+    detail=_("Patron does not have a device registered with this token."),
+)
+
+DEVICE_TOKEN_ALREADY_EXISTS = pd(
+    "http://librarysimplified.org/terms/problem/device-token-already-exists",
+    status_code=409,
+    title=_("Device token already exists"),
+    detail=_("A device token with the same token already exists."),
+)
+
+DEVICE_TOKEN_TYPE_INVALID = pd(
+    "http://librarysimplified.org/terms/problem/device-token-type-invalid",
+    status_code=400,
+    title=_("Device token type invalid"),
+    detail=_("The token type provided is not valid."),
+)

--- a/api/routes.py
+++ b/api/routes.py
@@ -481,6 +481,24 @@ def patron_profile():
     return app.manager.profiles.protocol()
 
 
+@library_dir_route("/patrons/me/devices", methods=["GET"])
+@has_library
+@allows_patron_web
+@requires_auth
+@returns_problem_detail
+def patron_devices():
+    return app.manager.patron_devices.get_patron_device()
+
+
+@library_dir_route("/patrons/me/devices", methods=["PUT"])
+@has_library
+@allows_patron_web
+@requires_auth
+@returns_problem_detail
+def put_patron_devices():
+    return app.manager.patron_devices.create_patron_device()
+
+
 @library_dir_route("/loans", methods=["GET", "HEAD"])
 @has_library
 @allows_patron_web

--- a/core/model/devicetokens.py
+++ b/core/model/devicetokens.py
@@ -1,4 +1,4 @@
-from typing import TypeVar, Union
+from typing import Type, TypeVar, Union
 
 from sqlalchemy import Column, Enum, ForeignKey, Integer, Unicode
 from sqlalchemy.exc import IntegrityError
@@ -36,7 +36,7 @@ class DeviceToken(Base):
 
     @classmethod
     def create(
-        cls: type[T],
+        cls: Type[T],
         db,
         token_type: str,
         device_token: str,

--- a/core/model/devicetokens.py
+++ b/core/model/devicetokens.py
@@ -40,7 +40,7 @@ class DeviceToken(Base):
         db,
         token_type: str,
         device_token: str,
-        patron: "Union[Patron,int]",
+        patron: Union[Patron, int],
     ) -> T:
         """Create a DeviceToken while ensuring sql issues are managed.
         Raises InvalidTokenTypeError, DuplicateDeviceTokenError"""

--- a/core/model/devicetokens.py
+++ b/core/model/devicetokens.py
@@ -1,0 +1,72 @@
+from typing import TYPE_CHECKING, TypeVar
+
+from sqlalchemy import Column, Enum, ForeignKey, Integer, Unicode
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import relationship
+
+from . import Base
+
+if TYPE_CHECKING:
+    from core.model.patron import Patron
+
+
+class DeviceTokenTypes:
+    FCM_ANDROID = "FCMAndroid"
+    FCM_IOS = "FCMiOS"
+
+
+T = TypeVar("T")
+
+
+class DeviceToken(Base):
+    """Meant to store patron device tokens
+    Currently the only use case is mobile FCM tokens"""
+
+    __tablename__ = "devicetokens"
+
+    id = Column("id", Integer, primary_key=True)
+    patron_id = Column(Integer, ForeignKey("patrons.id"), index=True, nullable=False)
+    patron = relationship("Patron", backref="device_tokens", cascade="delete")
+
+    token_type_enum = Enum(
+        DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS, name="token_types"
+    )
+    token_type = Column(token_type_enum, nullable=False)
+
+    device_token = Column(Unicode, nullable=False, unique=True, index=True)
+
+    @classmethod
+    def create(
+        cls: type[T], db, token_type: str, device_token: str, patron: "Patron|int"
+    ) -> T:
+        """Create a DeviceToken while ensuring sql issues are managed.
+        Raises InvalidTokenTypeError, DuplicateDeviceTokenError"""
+
+        if token_type not in DeviceToken.token_type_enum.enums:
+            raise InvalidTokenTypeError(token_type)
+
+        kwargs = dict(device_token=device_token, token_type=token_type)
+        if type(patron) is int:
+            kwargs["patron_id"] = patron
+        else:
+            kwargs["patron_id"] = patron.id
+
+        device = DeviceToken(**kwargs)
+        try:
+            db.add(device)
+            db.commit()
+        except IntegrityError as e:
+            if "device_token" in e.args[0]:
+                raise DuplicateDeviceTokenError()
+            else:
+                raise
+
+        return device
+
+
+class InvalidTokenTypeError(Exception):
+    pass
+
+
+class DuplicateDeviceTokenError(Exception):
+    pass

--- a/core/model/devicetokens.py
+++ b/core/model/devicetokens.py
@@ -60,7 +60,7 @@ class DeviceToken(Base):
             db.commit()
         except IntegrityError as e:
             if "device_token" in e.args[0]:
-                raise DuplicateDeviceTokenError()
+                raise DuplicateDeviceTokenError() from e
             else:
                 raise
 

--- a/tests/api/test_device_tokens.py
+++ b/tests/api/test_device_tokens.py
@@ -1,6 +1,4 @@
-from unittest.mock import MagicMock
-
-import flask
+from unittest.mock import MagicMock, patch
 
 from api.problem_details import (
     DEVICE_TOKEN_ALREADY_EXISTS,
@@ -11,8 +9,9 @@ from core.model.devicetokens import DeviceToken, DeviceTokenTypes
 from tests.api.test_controller import ControllerTest
 
 
+@patch("api.controller.flask")
 class TestDeviceTokens(ControllerTest):
-    def test_create_invalid_type(self):
+    def test_create_invalid_type(self, flask):
         request = MagicMock()
         request.patron = self._patron()
         request.json = {"device_token": "xx", "token_type": "aninvalidtoken"}
@@ -22,7 +21,7 @@ class TestDeviceTokens(ControllerTest):
         assert detail is DEVICE_TOKEN_TYPE_INVALID
         assert detail.status_code == 400
 
-    def test_create_token(self):
+    def test_create_token(self, flask):
         request = MagicMock()
         request.patron = self._patron()
         request.json = {
@@ -45,7 +44,7 @@ class TestDeviceTokens(ControllerTest):
         assert device.device_token == "xxx"
         assert device.token_type == DeviceTokenTypes.FCM_ANDROID
 
-    def test_get_token(self):
+    def test_get_token(self, flask):
         patron = self._patron()
         device = DeviceToken.create(
             self._db, DeviceTokenTypes.FCM_ANDROID, "xx", patron
@@ -61,7 +60,7 @@ class TestDeviceTokens(ControllerTest):
         assert response[0]["token_type"] == DeviceTokenTypes.FCM_ANDROID
         assert response[0]["device_token"] == "xx"
 
-    def test_get_token_not_found(self):
+    def test_get_token_not_found(self, flask):
         patron = self._patron()
         device = DeviceToken.create(
             self._db, DeviceTokenTypes.FCM_ANDROID, "xx", patron
@@ -75,7 +74,7 @@ class TestDeviceTokens(ControllerTest):
 
         assert detail == DEVICE_TOKEN_NOT_FOUND
 
-    def test_get_token_different_patron(self):
+    def test_get_token_different_patron(self, flask):
         patron = self._patron()
         device = DeviceToken.create(
             self._db, DeviceTokenTypes.FCM_ANDROID, "xx", patron
@@ -89,7 +88,7 @@ class TestDeviceTokens(ControllerTest):
 
         assert detail == DEVICE_TOKEN_NOT_FOUND
 
-    def test_create_duplicate_token(self):
+    def test_create_duplicate_token(self, flask):
         patron = self._patron()
         device = DeviceToken.create(self._db, DeviceTokenTypes.FCM_IOS, "xxx", patron)
 

--- a/tests/api/test_device_tokens.py
+++ b/tests/api/test_device_tokens.py
@@ -1,0 +1,106 @@
+from unittest.mock import MagicMock
+
+import flask
+
+from api.problem_details import (
+    DEVICE_TOKEN_ALREADY_EXISTS,
+    DEVICE_TOKEN_NOT_FOUND,
+    DEVICE_TOKEN_TYPE_INVALID,
+)
+from core.model.devicetokens import DeviceToken, DeviceTokenTypes
+from tests.api.test_controller import ControllerTest
+
+
+class TestDeviceTokens(ControllerTest):
+    def test_create_invalid_type(self):
+        request = MagicMock()
+        request.patron = self._patron()
+        request.json = {"device_token": "xx", "token_type": "aninvalidtoken"}
+        flask.request = request
+        detail = self.app.manager.patron_devices.create_patron_device()
+
+        assert detail is DEVICE_TOKEN_TYPE_INVALID
+        assert detail.status_code == 400
+
+    def test_create_token(self):
+        request = MagicMock()
+        request.patron = self._patron()
+        request.json = {
+            "device_token": "xxx",
+            "token_type": DeviceTokenTypes.FCM_ANDROID,
+        }
+        flask.request = request
+        response = self.app.manager.patron_devices.create_patron_device()
+
+        assert response[1] == 201
+
+        devices = (
+            self._db.query(DeviceToken)
+            .filter(DeviceToken.patron_id == request.patron.id)
+            .all()
+        )
+
+        assert len(devices) == 1
+        device = devices[0]
+        assert device.device_token == "xxx"
+        assert device.token_type == DeviceTokenTypes.FCM_ANDROID
+
+    def test_get_token(self):
+        patron = self._patron()
+        device = DeviceToken.create(
+            self._db, DeviceTokenTypes.FCM_ANDROID, "xx", patron
+        )
+
+        request = MagicMock()
+        request.patron = patron
+        request.args = {"device_token": "xx"}
+        flask.request = request
+        response = self.app.manager.patron_devices.get_patron_device()
+
+        assert response[1] == 200
+        assert response[0]["token_type"] == DeviceTokenTypes.FCM_ANDROID
+        assert response[0]["device_token"] == "xx"
+
+    def test_get_token_not_found(self):
+        patron = self._patron()
+        device = DeviceToken.create(
+            self._db, DeviceTokenTypes.FCM_ANDROID, "xx", patron
+        )
+
+        request = MagicMock()
+        request.patron = patron
+        request.args = {"device_token": "xxs"}
+        flask.request = request
+        detail = self.app.manager.patron_devices.get_patron_device()
+
+        assert detail == DEVICE_TOKEN_NOT_FOUND
+
+    def test_get_token_different_patron(self):
+        patron = self._patron()
+        device = DeviceToken.create(
+            self._db, DeviceTokenTypes.FCM_ANDROID, "xx", patron
+        )
+
+        request = MagicMock()
+        request.patron = self._patron()
+        request.args = {"device_token": "xx"}
+        flask.request = request
+        detail = self.app.manager.patron_devices.get_patron_device()
+
+        assert detail == DEVICE_TOKEN_NOT_FOUND
+
+    def test_create_duplicate_token(self):
+        patron = self._patron()
+        device = DeviceToken.create(self._db, DeviceTokenTypes.FCM_IOS, "xxx", patron)
+
+        patron1 = self._patron()
+        request = MagicMock()
+        request.patron = patron1
+        request.json = {
+            "device_token": "xxx",
+            "token_type": DeviceTokenTypes.FCM_ANDROID,
+        }
+        flask.request = request
+        response = self.app.manager.patron_devices.create_patron_device()
+
+        assert response == DEVICE_TOKEN_ALREADY_EXISTS

--- a/tests/core/models/test_devicetoken.py
+++ b/tests/core/models/test_devicetoken.py
@@ -1,0 +1,39 @@
+import pytest
+
+from core.model.devicetokens import (
+    DeviceToken,
+    DeviceTokenTypes,
+    DuplicateDeviceTokenError,
+    InvalidTokenTypeError,
+)
+from core.testing import DatabaseTest
+
+
+class TestDeviceToken(DatabaseTest):
+    def test_create(self):
+        patron = self._patron()
+        device = DeviceToken.create(
+            self._db, DeviceTokenTypes.FCM_ANDROID, "xxxx", patron
+        )
+
+        new_device = self._db.query(DeviceToken).get(device.id)
+        assert new_device.device_token == "xxxx"
+        assert new_device.token_type == DeviceTokenTypes.FCM_ANDROID
+
+        # assert relationships
+        assert new_device.patron == patron
+        assert patron.device_tokens == [new_device]
+
+    def test_create_duplicate(self):
+        patron = self._patron()
+        device = DeviceToken.create(
+            self._db, DeviceTokenTypes.FCM_ANDROID, "xxxx", patron
+        )
+
+        with pytest.raises(DuplicateDeviceTokenError):
+            DeviceToken.create(self._db, DeviceTokenTypes.FCM_IOS, "xxxx", patron)
+
+    def test_invalid_type(self):
+        patron = self._patron()
+        with pytest.raises(InvalidTokenTypeError):
+            DeviceToken.create(self._db, "invalidtype", "xxxx", patron)


### PR DESCRIPTION


## Description
- model for DeviceTokens
  which stores the FCM token for patrons mobile devices
  It ensure uniqueness on the token string

- API to GET and PUT device tokens for patrons
- GET
  responds with 200 and token details
  404 if token is not found
- PUT
  responds with 201 if created
  400 if the token type is invalid
  409 if the token was not unique
- There is no DELETE method yet
  No use case is outlined for it

<!--- Describe your changes -->

## Motivation and Context
The Palace Manager needs to support the following push notifications in the iOS and Android apps
This is the first step, allowing the apps to store the FCM tokens for the mobile devices

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests were written and manual testing was done via Postman
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
