### PR TITLE
Always use fulfillment context when fetching OverDrive loans

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import re
 import urllib.parse
-from typing import Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import dateutil
 import flask
@@ -515,24 +515,24 @@ class OverdriveAPI(
             if error in d:
                 raise d[error](message)
 
-    def get_loan(self, patron, pin, overdrive_id, is_fulfillment=False):
-        url = self.CHECKOUTS_ENDPOINT + "/" + overdrive_id.upper()
-        data = self.patron_request(
-            patron, pin, url, is_fulfillment=is_fulfillment
-        ).json()
+    def get_loan(
+        self, patron: Patron, pin: Optional[str], overdrive_id: str
+    ) -> Dict[str, Any]:
+        """Get patron's loan information for the identified item.
+
+        :param patron: A patron.
+        :param pin: An optional PIN/password for the patron.
+        :param overdrive_id: The OverDrive identifier for an item.
+        :return: Information about the loan.
+        """
+        url = f"{self.CHECKOUTS_ENDPOINT}/{overdrive_id.upper()}"
+        data = self.patron_request(patron, pin, url, is_fulfillment=True).json()
         self.raise_exception_on_error(data)
         return data
 
     def get_hold(self, patron, pin, overdrive_id):
         url = self.endpoint(self.HOLD_ENDPOINT, product_id=overdrive_id.upper())
         data = self.patron_request(patron, pin, url).json()
-        self.raise_exception_on_error(data)
-        return data
-
-    def get_loans(self, patron, pin):
-        """Get a JSON structure describing all of a patron's outstanding
-        loans."""
-        data = self.patron_request(patron, pin, self.CHECKOUTS_ENDPOINT).json()
         self.raise_exception_on_error(data)
         return data
 
@@ -591,7 +591,7 @@ class OverdriveAPI(
         self, patron, pin, overdrive_id, format_type
     ) -> Union["OverdriveManifestFulfillmentInfo", Tuple[str, str]]:
         """Get the link to the ACSM or manifest for an existing loan."""
-        loan = self.get_loan(patron, pin, overdrive_id, is_fulfillment=True)
+        loan = self.get_loan(patron, pin, overdrive_id)
         if not loan:
             raise NoActiveLoan("Could not find active loan for %s" % overdrive_id)
         download_link = None
@@ -726,8 +726,18 @@ class OverdriveAPI(
         self.raise_exception_on_error(data)
         return data
 
-    def get_patron_checkouts(self, patron, pin):
-        data = self.patron_request(patron, pin, self.CHECKOUTS_ENDPOINT).json()
+    def get_patron_checkouts(
+        self, patron: Patron, pin: Optional[str]
+    ) -> Dict[str, Any]:
+        """Get information for the given patron's loans.
+
+        :param patron: A patron.
+        :param pin: An optional PIN/password for the patron.
+        :return: Information about the patron's loans.
+        """
+        data = self.patron_request(
+            patron, pin, self.CHECKOUTS_ENDPOINT, is_fulfillment=True
+        ).json()
         self.raise_exception_on_error(data)
         return data
 
@@ -793,7 +803,7 @@ class OverdriveAPI(
             )
 
     @classmethod
-    def process_checkout_data(cls, checkout, collection):
+    def process_checkout_data(cls, checkout: Dict[str, Any], collection: Collection):
         """Convert one checkout from Overdrive's list of checkouts
         into a LoanInfo object.
 

--- a/core/config.py
+++ b/core/config.py
@@ -513,6 +513,8 @@ class Configuration(ConfigurationConstants):
         key = os.environ.get(f"{prefix}_{cls.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}")
         secret = os.environ.get(f"{prefix}_{cls.OD_FULFILLMENT_CLIENT_SECRET_SUFFIX}")
         if key is None or secret is None:
+            raise CannotLoadConfiguration("Missing fulfillment credentials.")
+        if not key:
             raise CannotLoadConfiguration("Invalid fulfillment credentials.")
         return {"key": key, "secret": secret}
 

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1051,7 +1051,7 @@ class TestOverdriveAPI(OverdriveAPITest):
 
         class MockAPI(MockOverdriveAPI):
             def get_loan(self, patron, pin, overdrive_id):
-                self.get_loan_called_with = (patron, pin, overdrive_id, is_fulfillment)
+                self.get_loan_called_with = (patron, pin, overdrive_id)
                 return loan_info
 
             def get_download_link(self, loan, format_type, error_url):
@@ -1087,7 +1087,6 @@ class TestOverdriveAPI(OverdriveAPITest):
             patron,
             "1234",
             "http://download-link",
-            True,
         ) == api.get_loan_called_with
 
         # It returned a dictionary that contained no information

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1050,7 +1050,7 @@ class TestOverdriveAPI(OverdriveAPITest):
         loan_info = {"isFormatLockedIn": False}
 
         class MockAPI(MockOverdriveAPI):
-            def get_loan(self, patron, pin, overdrive_id, is_fulfillment=False):
+            def get_loan(self, patron, pin, overdrive_id):
                 self.get_loan_called_with = (patron, pin, overdrive_id, is_fulfillment)
                 return loan_info
 


### PR DESCRIPTION
## Description

This branch changes the way we fetch OverDrive loans to always authorize the request with a patron bearer token that was obtained in the context of the fulfillment (rather than collection) client credentials. The method signature for `OverdriveAPI.get_loan` is changed because we no longer need to specify the context.

It also removes the unused `OverdriveAPI.get_loans` method, which exactly duplicated `OverdriveAPI.get_patron_checkouts`.

## Motivation and Context

Until now, when not actively fulfilling a loan, we would fetch loans using a patron bearer token that was obtained in the context of the collection (rather than fulfillment) client credentials. At least some of the time, the information returned did not contain the information we needed to adequately understand the formats available or the already selected.

## How Has This Been Tested?

Adjusted a test for method signature change. All tests pass locally.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
