### PR TITLE
Made the admin email case insensitive migration file executable

### DIFF
--- a/migration/20220509-admin-email-unique-constraint.py
+++ b/migration/20220509-admin-email-unique-constraint.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import logging
 import os
 import sys


### PR DESCRIPTION
## Description
Matched the permissions to other files in the `migrations` folder
<!--- Describe your changes -->

## Motivation and Context
Automated migrations were failing due to the lack of permissions

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

This has not been tested locally as I do not have the automation script locally.
However, the permissions have been matched to the other files of the same folder.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
