### PR TITLE
Proof of concept for exact terms json based search

### DIFF
--- a/core/external_search.py
+++ b/core/external_search.py
@@ -1935,7 +1935,7 @@ class JSONQuery(Query):
         GT = "gt"
 
     _KEYWORD_ONLY = {"keyword": True}
-    FIELD_MAPPING = {
+    FIELD_MAPPING: Dict[str, Dict] = {
         "audience": _KEYWORD_ONLY,
         "author": _KEYWORD_ONLY,
         "classifications.scheme": _KEYWORD_ONLY,
@@ -1988,7 +1988,7 @@ class JSONQuery(Query):
     def _is_keyword(self, name: str) -> bool:
         return self.FIELD_MAPPING[name].get("keyword") == True
 
-    def _nested_path(self, name: str) -> str:
+    def _nested_path(self, name: str) -> str | None:
         return self.FIELD_MAPPING[name].get("path")
 
     def _parse_json_query(self, query: Dict):

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -5,7 +5,7 @@ import logging
 import re
 import time
 from collections import defaultdict
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import ElasticsearchException, RequestError
@@ -1988,7 +1988,7 @@ class JSONQuery(Query):
     def _is_keyword(self, name: str) -> bool:
         return self.FIELD_MAPPING[name].get("keyword") == True
 
-    def _nested_path(self, name: str) -> str | None:
+    def _nested_path(self, name: str) -> Union[str, None]:
         return self.FIELD_MAPPING[name].get("path")
 
     def _parse_json_query(self, query: Dict):

--- a/core/lane.py
+++ b/core/lane.py
@@ -952,6 +952,10 @@ class SearchFacets(Facets):
             default_min_score = self.DEFAULT_MIN_SCORE
         self.min_score = kwargs.pop("min_score", default_min_score)
 
+        self.search_type = kwargs.pop("search_type", "default")
+        if self.search_type not in ["default", "json"]:
+            raise ValueError(f"Invalid search type: {self.search_type}")
+
         super().__init__(**kwargs)
         if media == Edition.ALL_MEDIUM:
             self.media = media
@@ -1040,6 +1044,10 @@ class SearchFacets(Facets):
         # in the search request.
         if languageQuery != "all":
             extra["languages"] = languages
+
+        search_type = get_argument("search_type")
+        if search_type:
+            extra["search_type"] = search_type
 
         return cls._from_request(
             config, get_argument, get_header, worklist, default_entrypoint, **extra

--- a/core/util/__init__.py
+++ b/core/util/__init__.py
@@ -570,3 +570,26 @@ def chunks(lst, chunk_size, start_index=0):
 
     for i in range(start_index, length, chunk_size):
         yield lst[i : i + chunk_size]
+
+
+class ValuesMeta(type):
+    """Metaclass to allow operators on simple constants defining classes"""
+
+    def __contains__(cls, value):
+        """Does the values exist in the constants of this class"""
+        return value in cls.values()
+
+    def values(cls):
+        """Fetch the values of constants defined in the class"""
+        values = set()
+        for key in dir(cls):
+            val = getattr(cls, key)
+            if not key.startswith("_") and not callable(val):
+                values.add(val)
+        return values
+
+
+class Values(metaclass=ValuesMeta):
+    """Like an enum class but a little more nuanced
+    Use this to define classes that define only constants
+    Operators can be defined in the metaclass"""

--- a/tests/api/test_controller.py
+++ b/tests/api/test_controller.py
@@ -4452,6 +4452,10 @@ class TestOPDSFeedController(CirculationControllerTest):
             response = self.manager.opds_feeds.search(None, feed_class=Mock)
             assert AudiobooksEntryPoint == self.called_with["facets"].entrypoint
 
+        with self.request_context_with_library("/?q=t&search_type=json"):
+            response = self.manager.opds_feeds.search(None, feed_class=Mock)
+            assert self.called_with["facets"].search_type == "json"
+
     def test_misconfigured_search(self):
         class BadSearch(CirculationManager):
             @property

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -4700,6 +4700,17 @@ class TestJSONQuery(ExternalSearchTest):
         with pytest.raises(QueryParseException, match=error_match):
             q.elasticsearch_query  # fetch the property
 
+    def test_regex_query(self):
+        q = self._jq(self._leaf("title", "book", op="regex"))
+        assert q.elasticsearch_query.to_dict() == {
+            "regexp": {
+                "title.keyword": {
+                    "flags": "ALL",
+                    "value": "book",
+                }
+            }
+        }
+
 
 class TestExternalSearchJSONQuery(EndToEndSearchTest):
     def _leaf(self, key, value, op="eq"):


### PR DESCRIPTION
## Description
The following have been proved through testing (unit and manual)
- Basic exact matches
- And'd queries
- Or'd queries
- Mixed And'd and Or'd queries
- <> type queries
- Nested And'd and Or'd queries
- "Nested Type" ES object queries with And/Or operators

To move from POC to Production ready code the following is required
- ~~Test/implement all supported keys~~
- ~~Test/implement exception cases~~
- ~~Test/implement API entrypoint for json based search~~
- ~~Inline documentation for all new/modified code~~

The above are completed.
This is no longer a Proof of concept. This should be production ready now.
Simply adding a `&search_type=json` as a query parameter to the search endpoint will utilise the json query workflow.


<!--- Describe your changes -->

## Motivation and Context
An advanced and exact terms based search was required to allow more control to the administrators
More details: https://www.notion.so/lyrasis/Proof-of-concept-Create-new-search-API-with-support-for-additional-metadata-elements-ef25fd3ec79241b9a003683403be752c

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
