### PR TITLE
Modifies the local analytics export to optionally keep track of last export

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -2007,7 +2007,7 @@ class LocalAnalyticsExportScript(Script):
                     if end >= current_time:
                         end = current_time
 
-        if output_dir:
+        if output_dir != None:
             if not os.path.exists(output_dir):
                 os.makedirs(output_dir)
 
@@ -2023,7 +2023,9 @@ class LocalAnalyticsExportScript(Script):
             exporter = exporter or LocalAnalyticsExporter()
             output.write(exporter.export(self._db, start, end))
         finally:
-            output.close()
+            # only close output if it was created within this method
+            if output_dir != None:
+                output.close()
 
         if keep_track_of_last:
             state = dict(last_completed_date=end)


### PR DESCRIPTION

## Description
This PR allows the local-analytics-export to optionally remember its last export and output csv files to a specified location.
It preserves the older behavior, but adds new parameters for csv file out put and specifying that you want to keep track of the last export's date and time.
## Motivation and Context
https://www.notion.so/lyrasis/Sync-circulation-data-to-Redshift-5d28927cce67451caadc9eb7c8eb0936

## How Has This Been Tested?
Manually using the following combinations of parameters:

```
poetry run ./bin/local_analytics_export
poetry run ./bin/local_analytics_export --start <date> --end <date>
poetry run ./bin/local_analytics_export  --output-dir output
poetry run ./bin/local_analytics_export --keep-track-of-last --output-dir output --start <date>
poetry run ./bin/local_analytics_export --keep-track-of-last --output-dir output --end <date>
poetry run ./bin/local_analytics_export --keep-track-of-last --output-dir output --start <date> --end <date>
```


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
