### PR TITLE
Changed security on the individual_admins endpoint

### DIFF
--- a/api/admin/controller/individual_admin_settings.py
+++ b/api/admin/controller/individual_admin_settings.py
@@ -20,6 +20,13 @@ class IndividualAdminSettingsController(SettingsController):
             return self.process_post()
 
     def process_get(self):
+        logged_in_admin = flask.request.admin
+        for role in logged_in_admin.roles:
+            if role.role in (AdminRole.SYSTEM_ADMIN, AdminRole.LIBRARY_MANAGER):
+                break
+        else:
+            return FORBIDDEN_BY_POLICY
+
         admins = []
         for admin in self._db.query(Admin).order_by(Admin.email):
             roles = []

--- a/api/admin/controller/individual_admin_settings.py
+++ b/api/admin/controller/individual_admin_settings.py
@@ -27,7 +27,7 @@ class IndividualAdminSettingsController(SettingsController):
         admin = getattr(flask.request, "admin", None)
 
         if not admin:
-            return False
+            return None
 
         for role in admin.roles:
             if role.role in (

--- a/core/model/admin.py
+++ b/core/model/admin.py
@@ -247,6 +247,9 @@ class AdminRole(Base, HasSessionCache):
         SITEWIDE_LIBRARIAN,
         LIBRARIAN,
     ]
+    LESS_THAN = -1
+    EQUAL = 0
+    GREATER_THAN = 1
 
     def cache_key(self):
         return (self.admin_id, self.library_id, self.role)
@@ -262,6 +265,17 @@ class AdminRole(Base, HasSessionCache):
             (self.library and self.library.short_name),
             self.admin.email,
         )
+
+    def compare_role(self, other: AdminRole) -> int:
+        """Compare one role to the other for heirarchy"""
+        self_ix = self.ROLES.index(self.role)
+        other_ix = self.ROLES.index(other.role)
+        if self_ix == other_ix:
+            return self.EQUAL
+        elif self_ix > other_ix:  # Lower priority role is later in the array
+            return self.LESS_THAN
+        else:
+            return self.GREATER_THAN
 
 
 Index(

--- a/tests/api/admin/controller/test_individual_admins.py
+++ b/tests/api/admin/controller/test_individual_admins.py
@@ -34,6 +34,9 @@ class TestIndividualAdmins(SettingsControllerTest):
         admin5, ignore = create(self._db, Admin, email="admin5@l2.org")
         admin5.add_role(AdminRole.LIBRARIAN, library2)
 
+        admin6, ignore = create(self._db, Admin, email="admin6@l2.org")
+        admin6.add_role(AdminRole.SITEWIDE_LIBRARY_MANAGER)
+
         with self.request_context_with_admin("/", admin=admin1):
             # A system admin can see all other admins' roles.
             response = (
@@ -83,6 +86,14 @@ class TestIndividualAdmins(SettingsControllerTest):
                             }
                         ],
                     },
+                    {
+                        "email": "admin6@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.SITEWIDE_LIBRARY_MANAGER,
+                            }
+                        ],
+                    },
                 ],
                 key=lambda x: x["email"],
             ) == sorted(admins, key=lambda x: x["email"])
@@ -95,10 +106,6 @@ class TestIndividualAdmins(SettingsControllerTest):
             admins = response.get("individualAdmins")
             assert sorted(
                 [
-                    {
-                        "email": "admin1@nypl.org",
-                        "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
-                    },
                     {
                         "email": "admin2@nypl.org",
                         "roles": [
@@ -119,20 +126,10 @@ class TestIndividualAdmins(SettingsControllerTest):
                         ],
                     },
                     {
-                        "email": "admin4@l2.org",
+                        "email": "admin6@l2.org",
                         "roles": [
                             {
-                                "role": AdminRole.LIBRARY_MANAGER,
-                                "library": library2.short_name,
-                            }
-                        ],
-                    },
-                    {
-                        "email": "admin5@l2.org",
-                        "roles": [
-                            {
-                                "role": AdminRole.LIBRARIAN,
-                                "library": library2.short_name,
+                                "role": AdminRole.SITEWIDE_LIBRARY_MANAGER,
                             }
                         ],
                     },
@@ -156,14 +153,9 @@ class TestIndividualAdmins(SettingsControllerTest):
             assert sorted(
                 [
                     {
-                        "email": "admin1@nypl.org",
-                        "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
-                    },
-                    {
                         "email": "admin2@nypl.org",
                         "roles": [{"role": AdminRole.SITEWIDE_LIBRARIAN}],
                     },
-                    {"email": "admin3@nypl.org", "roles": []},
                     {
                         "email": "admin4@l2.org",
                         "roles": [
@@ -179,6 +171,14 @@ class TestIndividualAdmins(SettingsControllerTest):
                             {
                                 "role": AdminRole.LIBRARIAN,
                                 "library": library2.short_name,
+                            }
+                        ],
+                    },
+                    {
+                        "email": "admin6@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.SITEWIDE_LIBRARY_MANAGER,
                             }
                         ],
                     },

--- a/tests/api/admin/controller/test_individual_admins.py
+++ b/tests/api/admin/controller/test_individual_admins.py
@@ -146,37 +146,7 @@ class TestIndividualAdmins(SettingsControllerTest):
             response = (
                 self.manager.admin_individual_admin_settings_controller.process_get()
             )
-            admins = response.get("individualAdmins")
-            assert sorted(
-                [
-                    {
-                        "email": "admin1@nypl.org",
-                        "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
-                    },
-                    {
-                        "email": "admin2@nypl.org",
-                        "roles": [
-                            {
-                                "role": AdminRole.LIBRARY_MANAGER,
-                                "library": self._default_library.short_name,
-                            },
-                            {"role": AdminRole.SITEWIDE_LIBRARIAN},
-                        ],
-                    },
-                    {
-                        "email": "admin3@nypl.org",
-                        "roles": [
-                            {
-                                "role": AdminRole.LIBRARIAN,
-                                "library": self._default_library.short_name,
-                            }
-                        ],
-                    },
-                    {"email": "admin4@l2.org", "roles": []},
-                    {"email": "admin5@l2.org", "roles": []},
-                ],
-                key=lambda x: x["email"],
-            ) == sorted(admins, key=lambda x: x["email"])
+            assert response is FORBIDDEN_BY_POLICY
 
         with self.request_context_with_admin("/", admin=admin4):
             response = (
@@ -220,39 +190,7 @@ class TestIndividualAdmins(SettingsControllerTest):
             response = (
                 self.manager.admin_individual_admin_settings_controller.process_get()
             )
-            admins = response.get("individualAdmins")
-            assert sorted(
-                [
-                    {
-                        "email": "admin1@nypl.org",
-                        "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
-                    },
-                    {
-                        "email": "admin2@nypl.org",
-                        "roles": [{"role": AdminRole.SITEWIDE_LIBRARIAN}],
-                    },
-                    {"email": "admin3@nypl.org", "roles": []},
-                    {
-                        "email": "admin4@l2.org",
-                        "roles": [
-                            {
-                                "role": AdminRole.LIBRARY_MANAGER,
-                                "library": library2.short_name,
-                            }
-                        ],
-                    },
-                    {
-                        "email": "admin5@l2.org",
-                        "roles": [
-                            {
-                                "role": AdminRole.LIBRARIAN,
-                                "library": library2.short_name,
-                            }
-                        ],
-                    },
-                ],
-                key=lambda x: x["email"],
-            ) == sorted(admins, key=lambda x: x["email"])
+            assert response is FORBIDDEN_BY_POLICY
 
     def test_individual_admins_post_errors(self):
         with self.request_context_with_admin("/", method="POST"):

--- a/tests/api/admin/controller/test_individual_admins.py
+++ b/tests/api/admin/controller/test_individual_admins.py
@@ -192,6 +192,62 @@ class TestIndividualAdmins(SettingsControllerTest):
             )
             assert response is FORBIDDEN_BY_POLICY
 
+        with self.request_context_with_admin("/", admin=admin6):
+            response = (
+                self.manager.admin_individual_admin_settings_controller.process_get()
+            )
+            admins = response.get("individualAdmins")
+            assert sorted(
+                [
+                    {
+                        "email": "admin2@nypl.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARY_MANAGER,
+                                "library": self._default_library.short_name,
+                            },
+                            {"role": AdminRole.SITEWIDE_LIBRARIAN},
+                        ],
+                    },
+                    {
+                        "email": "admin3@nypl.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARIAN,
+                                "library": self._default_library.short_name,
+                            }
+                        ],
+                    },
+                    {
+                        "email": "admin4@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARY_MANAGER,
+                                "library": library2.short_name,
+                            }
+                        ],
+                    },
+                    {
+                        "email": "admin5@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.LIBRARIAN,
+                                "library": library2.short_name,
+                            }
+                        ],
+                    },
+                    {
+                        "email": "admin6@l2.org",
+                        "roles": [
+                            {
+                                "role": AdminRole.SITEWIDE_LIBRARY_MANAGER,
+                            }
+                        ],
+                    },
+                ],
+                key=lambda x: x["email"],
+            ) == sorted(admins, key=lambda x: x["email"])
+
     def test_individual_admins_post_errors(self):
         with self.request_context_with_admin("/", method="POST"):
             flask.request.form = MultiDict([])

--- a/tests/api/admin/controller/test_individual_admins.py
+++ b/tests/api/admin/controller/test_individual_admins.py
@@ -138,12 +138,11 @@ class TestIndividualAdmins(SettingsControllerTest):
             ) == sorted(admins, key=lambda x: x["email"])
 
         with self.request_context_with_admin("/", admin=admin3):
-            # A librarian or library manager of a specific library can see all admins, but only
-            # roles that affect their libraries.
-            response = (
-                self.manager.admin_individual_admin_settings_controller.process_get()
+            # A librarian cannot view this API anymore
+            pytest.raises(
+                AdminNotAuthorized,
+                self.manager.admin_individual_admin_settings_controller.process_get,
             )
-            assert response is FORBIDDEN_BY_POLICY
 
         with self.request_context_with_admin("/", admin=admin4):
             response = (
@@ -187,10 +186,10 @@ class TestIndividualAdmins(SettingsControllerTest):
             ) == sorted(admins, key=lambda x: x["email"])
 
         with self.request_context_with_admin("/", admin=admin5):
-            response = (
-                self.manager.admin_individual_admin_settings_controller.process_get()
+            pytest.raises(
+                AdminNotAuthorized,
+                self.manager.admin_individual_admin_settings_controller.process_get,
             )
-            assert response is FORBIDDEN_BY_POLICY
 
         with self.request_context_with_admin("/", admin=admin6):
             response = (


### PR DESCRIPTION
## Description
Only Library Managers and System Admins may access this endpoint
Library Users will receive a 403

This PR relates to 2 tickets
- [View restrictions](https://www.notion.so/lyrasis/CM-Remove-ability-for-library-Users-to-view-all-admins-in-a-Collection-Manager-ea01a9e96bd94fe08ca0d081e062aee6)
- [Edit restrictions](https://www.notion.so/lyrasis/Remove-ability-for-library-staff-administrator-role-to-see-and-edit-other-library-s-login-informatio-dd416398e16443e3aa675f563d7955b2)

The [view ticket](https://www.notion.so/lyrasis/CM-Remove-ability-for-library-Users-to-view-all-admins-in-a-Collection-Manager-ea01a9e96bd94fe08ca0d081e062aee6) has been implemented as such
System admins - Can view everything
Sitewide Managers - Can view Sitewide managers and Library managers
Library Managers - Can view Sitewide managers (as they are also managing their library) and managers of the same libraries


The [edit ticket](https://www.notion.so/lyrasis/Remove-ability-for-library-staff-administrator-role-to-see-and-edit-other-library-s-login-informatio-dd416398e16443e3aa675f563d7955b2) mentions the need to stop managers from being able to edit the details of other users, however while testing it seems this is already in place.
Editing a profile is limited to either System Admins, Sitewide Managers, or Managers of the same library.


<!--- Describe your changes -->

## Motivation and Context
Only administrators should not be able to view Administrators of any library
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

The previous tests were changed to cover this scenario
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
