### PR TITLE
Fix logging for named SIP properties.

### DIFF
--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -86,13 +86,20 @@ class named:
     """A variable-length field in a SIP2 response."""
 
     def __init__(
-        self, internal_name, sip_code, required=False, length=None, allow_multiple=False
+        self,
+        internal_name,
+        sip_code,
+        required=False,
+        length=None,
+        allow_multiple=False,
+        log=None,
     ):
         self.sip_code = sip_code
         self.internal_name = internal_name
         self.req = required
         self.length = length
         self.allow_multiple = allow_multiple
+        self.log = log or logging.getLogger("SIPClient")
 
     @property
     def required(self):
@@ -106,7 +113,12 @@ class named:
         `field.req`.
         """
         return named(
-            self.internal_name, self.sip_code, True, self.length, self.allow_multiple
+            self.internal_name,
+            self.sip_code,
+            True,
+            self.length,
+            self.allow_multiple,
+            log=self.log,
         )
 
     def consume(self, value, in_progress):
@@ -121,7 +133,7 @@ class named:
             dictionary.
         """
         if self.length and len(value) != self.length:
-            self.log.warn(
+            self.log.warning(
                 "Expected string of length %d for field %s, but got %r",
                 self.length,
                 self.sip_code,
@@ -744,7 +756,7 @@ class SIPClient(Constants):
                     # This is an extension field. Do the best we can.
                     # This basically means storing it in the dictionary
                     # under its SIP code.
-                    field = named(sip_code, sip_code, allow_multiple=True)
+                    field = named(sip_code, sip_code, allow_multiple=True, log=self.log)
 
                 if field:
                     field.consume(value, parsed)

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -40,6 +40,9 @@ from core.util.datetime_helpers import utc_now
 # fields in a way that makes it easy to reliably parse response
 # documents.
 
+# Client-level logger.
+client_logger = logging.getLogger("SIPClient")
+
 
 class fixed:
     """A fixed-width field in a SIP2 response."""
@@ -87,19 +90,19 @@ class named:
 
     def __init__(
         self,
-        internal_name,
-        sip_code,
+        internal_name: str,
+        sip_code: str,
         required=False,
-        length=None,
+        length: int = None,
         allow_multiple=False,
-        log=None,
+        log: logging.Logger = None,
     ):
         self.sip_code = sip_code
         self.internal_name = internal_name
         self.req = required
         self.length = length
         self.allow_multiple = allow_multiple
-        self.log = log or logging.getLogger("SIPClient")
+        self.log = log or client_logger
 
     @property
     def required(self):
@@ -212,7 +215,7 @@ class Constants:
 
 class SIPClient(Constants):
 
-    log = logging.getLogger("SIPClient")
+    log = client_logger
 
     # Maximum retries of a SIP message before failing.
     MAXIMUM_RETRIES = 5


### PR DESCRIPTION
## Description

This branch fixes a programming error by allowing `SIPClient`’s `named` objects to either have a `Logger` object injected or to create a default one, so that one is always available when the object attempts to generate a log message.

## Motivation and Context

When a `named` (non-fixed) SIP message field was not the correct length, the associated `named` object would attempt to log a warning, but the `Logger` object it attempted to use was undefined.

## How Has This Been Tested?

- Manually tested in local development environment.
- All tests passed.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
