### PR TITLE
Samples for any type of entry in an acquisition feed

### DIFF
--- a/core/model/resource.py
+++ b/core/model/resource.py
@@ -409,6 +409,7 @@ class Hyperlink(Base, LinkRelations):
     resource_id = Column(
         Integer, ForeignKey("resources.id"), index=True, nullable=False
     )
+    resource: Resource
 
     @classmethod
     def unmirrored(cls, collection):

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -41,6 +41,7 @@ from core.model import (
     create,
     get_one,
 )
+from core.model.resource import Hyperlink, Resource
 from core.opds import (
     AcquisitionFeed,
     Annotator,
@@ -57,6 +58,7 @@ from core.testing import DatabaseTest
 from core.util.datetime_helpers import datetime_utc, utc_now
 from core.util.flask_util import OPDSEntryResponse, OPDSFeedResponse, Response
 from core.util.opds_writer import AtomFeed, OPDSFeed, OPDSMessage
+from tests.core.utils import DBStatementCounter
 
 
 class TestBaseAnnotator(DatabaseTest):
@@ -397,6 +399,33 @@ class TestAnnotators(DatabaseTest):
         [entry] = feedparser.parse(str(raw_feed))["entries"]
         assert "schema_series" not in list(entry.items())
 
+    def test_samples(self):
+        work = self._work(with_license_pool=True)
+        edition = work.presentation_edition
+
+        resource = Resource(url="sampleurl")
+        self._db.add(resource)
+        self._db.commit()
+
+        sample_link = Hyperlink(
+            rel=Hyperlink.SAMPLE,
+            resource_id=resource.id,
+            identifier_id=edition.primary_identifier_id,
+            data_source_id=2,
+        )
+        self._db.add(sample_link)
+        self._db.commit()
+
+        with DBStatementCounter(self.connection) as counter:
+            links = Annotator.samples(edition)
+            count = counter.count
+
+            assert len(links) == 1
+            assert links[0].id == sample_link.id
+            assert links[0].resource.url == "sampleurl"
+            # accessing resource should not be another query
+            assert counter.count == count
+
 
 class TestOPDS(DatabaseTest):
     def links(self, entry, rel=None):
@@ -665,6 +694,60 @@ class TestOPDS(DatabaseTest):
 
         assert None == e4["issued"]
         assert None == e4["published"]
+
+    def test_acquisition_feed_includes_sample_links(self):
+        work = self._work(with_open_access_download=True)
+        edition = work.presentation_edition
+
+        resource = Resource(url="sampleurl")
+        link = Hyperlink(
+            rel=Hyperlink.SAMPLE,
+            identifier_id=edition.primary_identifier_id,
+            data_source_id=2,
+        )
+        link.resource = resource
+
+        work1 = self._work(with_open_access_download=True)
+        edition1 = work1.presentation_edition
+
+        link1 = Hyperlink(
+            rel=Hyperlink.SAMPLE,
+            identifier_id=edition1.primary_identifier_id,
+            data_source_id=2,
+        )
+        resource1 = Resource(url="sampleurl1")
+        link1.resource = resource1
+
+        # unrelated work/link should not show up
+        work2 = self._work(with_open_access_download=True)
+        edition2 = work2.presentation_edition
+
+        link2 = Hyperlink(
+            rel=Hyperlink.SAMPLE,
+            identifier_id=edition2.primary_identifier_id,
+            data_source_id=2,
+        )
+        link2.resource = Resource(url="notsampleurl")
+
+        self._db.add_all([resource, link, link1, link2])
+
+        # clear cache before links were added
+        work.simple_opds_entry = None
+        work1.simple_opds_entry = None
+        work2.simple_opds_entry = None
+
+        self._db.commit()
+
+        feed = AcquisitionFeed(self._db, "TestFeed", "http://some-url", [work, work1])
+
+        atom_links = OPDSXMLParser._xpath(
+            etree.parse(StringIO(str(feed))),
+            f"atom:entry/atom:link[@rel='{Hyperlink.SAMPLE}']",
+        )
+
+        assert len(atom_links) == 2
+        assert atom_links[0].attrib["href"] == resource.url
+        assert atom_links[1].attrib["href"] == resource1.url
 
     def test_acquisition_feed_includes_publisher_and_imprint_tag(self):
         work = self._work(with_open_access_download=True)


### PR DESCRIPTION
## Description
The links were already being processed from overdrive
The only thing done is they're being added to the feed

<!--- Describe your changes -->

## Motivation and Context
We needed samples to be added to the feeds being used by the Apps, so users may sample books/audio before a loan
The [ticket](https://www.notion.so/lyrasis/Add-support-for-OverDrive-book-previews-in-Palace-Manager-8651d52ffb0d4e48afca32a45f81e19a) is targeted at overdrive, but the solution is generic since the sample links are already being picked up from overdrive

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
