### PR TITLE
Add an option to de-prioritize LCP non-EPUBs

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -212,7 +212,7 @@ class CirculationManagerAnnotator(Annotator):
         return prioritized_drm_schemes, prioritized_content_types
 
     @staticmethod
-    def _deprioritized_lcp_audiobooks(
+    def _deprioritized_lcp_content(
         licensepool: LicensePool,
     ) -> bool:
         collection: Collection = licensepool.collection
@@ -221,7 +221,7 @@ class CirculationManagerAnnotator(Annotator):
         # Consult the configuration information for the external integration
         # that underlies the license pool's collection. The configuration
         # information _might_ contain a flag that indicates whether to deprioritize
-        # LCP audiobooks.
+        # LCP content.
 
         drm_setting: ConfigurationSetting = (
             ConfigurationSetting.for_externalintegration(
@@ -249,7 +249,7 @@ class CirculationManagerAnnotator(Annotator):
             prioritized_drm_schemes=prioritized_drm_schemes,
             prioritized_content_types=prioritized_content_types,
             hidden_content_types=self.hidden_content_types,
-            deprioritize_lcp_non_epubs=CirculationManagerAnnotator._deprioritized_lcp_audiobooks(
+            deprioritize_lcp_non_epubs=CirculationManagerAnnotator._deprioritized_lcp_content(
                 licensepool
             ),
         ).prioritize_for_pool(licensepool)

--- a/api/opds.py
+++ b/api/opds.py
@@ -221,7 +221,8 @@ class CirculationManagerAnnotator(Annotator):
         # Consult the configuration information for the external integration
         # that underlies the license pool's collection. The configuration
         # information _might_ contain a flag that indicates whether to deprioritize
-        # LCP content.
+        # LCP content. By default, if no configuration value is specified, then
+        # the priority of LCP content will be left completely unchanged.
 
         drm_setting: ConfigurationSetting = (
             ConfigurationSetting.for_externalintegration(

--- a/api/opds.py
+++ b/api/opds.py
@@ -32,7 +32,7 @@ from core.model import (
     Patron,
     Session,
 )
-from core.model.formats import FormatPriorities
+from core.model.formats import DePrioritizeLCPNonEPUBs, FormatPriorities
 from core.opds import AcquisitionFeed, Annotator, UnfulfillableWork
 from core.util.datetime_helpers import from_timestamp
 from core.util.opds_writer import OPDSFeed
@@ -211,6 +211,29 @@ class CirculationManagerAnnotator(Annotator):
 
         return prioritized_drm_schemes, prioritized_content_types
 
+    @staticmethod
+    def _deprioritized_lcp_audiobooks(
+        licensepool: LicensePool,
+    ) -> bool:
+        collection: Collection = licensepool.collection
+        external: ExternalIntegration = collection.external_integration
+
+        # Consult the configuration information for the external integration
+        # that underlies the license pool's collection. The configuration
+        # information _might_ contain a flag that indicates whether to deprioritize
+        # LCP audiobooks.
+
+        drm_setting: ConfigurationSetting = (
+            ConfigurationSetting.for_externalintegration(
+                FormatPriorities.DEPRIORITIZE_LCP_NON_EPUBS_KEY, external
+            )
+        )
+        _prioritize = (
+            drm_setting.json_value
+            or DePrioritizeLCPNonEPUBs.DO_NOT_DEPRIORITIZE_LCP_NON_EPUBS
+        )
+        return _prioritize == DePrioritizeLCPNonEPUBs.DEPRIORITIZE_LCP_NON_EPUBS
+
     def visible_delivery_mechanisms(
         self, licensepool: Optional[LicensePool]
     ) -> List[LicensePoolDeliveryMechanism]:
@@ -226,6 +249,9 @@ class CirculationManagerAnnotator(Annotator):
             prioritized_drm_schemes=prioritized_drm_schemes,
             prioritized_content_types=prioritized_content_types,
             hidden_content_types=self.hidden_content_types,
+            deprioritize_lcp_non_epubs=CirculationManagerAnnotator._deprioritized_lcp_audiobooks(
+                licensepool
+            ),
         ).prioritize_for_pool(licensepool)
 
     def annotate_work_entry(

--- a/core/model/formats.py
+++ b/core/model/formats.py
@@ -122,7 +122,7 @@ class FormatPriorities:
         treats all other DRM mechanisms and content types as equal."""
         if (
             drm_scheme == DeliveryMechanism.LCP_DRM
-            and content_type == MediaTypes.AUDIOBOOK_PACKAGE_LCP_MEDIA_TYPE
+            and content_type != MediaTypes.EPUB_MEDIA_TYPE
         ):
             return -1
         else:

--- a/core/model/formats.py
+++ b/core/model/formats.py
@@ -105,7 +105,7 @@ class FormatPriorities:
 
         if self._deprioritize_lcp_non_epubs:
             mechanisms_filtered.sort(
-                key=lambda mechanism: FormatPriorities._artificial_lcp_audiobook_priority(
+                key=lambda mechanism: FormatPriorities._artificial_lcp_content_priority(
                     drm_scheme=mechanism.delivery_mechanism.drm_scheme,
                     content_type=mechanism.delivery_mechanism.content_type,
                 ),
@@ -115,10 +115,10 @@ class FormatPriorities:
         return mechanisms_filtered
 
     @staticmethod
-    def _artificial_lcp_audiobook_priority(
+    def _artificial_lcp_content_priority(
         drm_scheme: Optional[str], content_type: Optional[str]
     ) -> int:
-        """A comparison function that arbitrarily deflates the priority of LCP audiobooks. The comparison function
+        """A comparison function that arbitrarily deflates the priority of LCP content. The comparison function
         treats all other DRM mechanisms and content types as equal."""
         if (
             drm_scheme == DeliveryMechanism.LCP_DRM

--- a/tests/core/models/test_licensing.py
+++ b/tests/core/models/test_licensing.py
@@ -1751,9 +1751,6 @@ class TestFormatPriorities:
                 "application/vnd.readium.lcp.license.v1.0+json", "application/epub+zip"
             ),
             mock_mechanism(
-                "application/vnd.readium.lcp.license.v1.0+json", "application/pdf"
-            ),
-            mock_mechanism(
                 "application/vnd.librarysimplified.bearer-token+json",
                 "application/epub+zip",
             ),
@@ -1776,6 +1773,9 @@ class TestFormatPriorities:
             ),
             mock_mechanism(
                 "application/vnd.librarysimplified.findaway.license+json", None
+            ),
+            mock_mechanism(
+                "application/vnd.readium.lcp.license.v1.0+json", "application/pdf"
             ),
             mock_mechanism(
                 "application/vnd.readium.lcp.license.v1.0+json",


### PR DESCRIPTION
## Description

This adds a simple configuration flag that allows for artificially
reducing the priority of any LCP content that isn't an EPUB. This is a
bit of an ad-hoc solution because we don't have a good way to express
something as complex as format prioritization rules in the admin UI.

## Motivation and Context

We want to use LCP content as much as possible to reduce the monetary costs incurred by _other unnamed DRM systems_, but LCP audiobooks and PDFs aren't quite ready for consumption yet due to client issues. This allows us to prioritize LCP EPUBs but leave everything else as low priority.

Affects: https://www.notion.so/lyrasis/Deprioritize-LCP-for-Audiobooks-and-PDFs-75aab340be9a4fcdb647169ea8afacd0

## How Has This Been Tested?

The existing format-related tests run as before (with the addition of an extra format to ensure that PDFs work properly too). New tests were written that demonstrate how formats are prioritized with this flag enabled.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
