### PR TITLE
Attempt to work around a failure to update coverage records

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -1351,7 +1351,9 @@ class OverdriveCirculationMonitor(CollectionMonitor, TimelineMonitor):
                         progress.exception = e
                     else:
                         time.sleep(1)
-                        self.log.warning(f"retrying book {book}")
+                        self.log.warning(
+                            f"retrying book {book} (attempt {attempt} of {OverdriveCirculationMonitor.MAXIMUM_BOOK_RETRIES})"
+                        )
 
             if self.should_stop(start, book, book_changed):
                 break

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -1298,7 +1298,7 @@ class OverdriveCirculationMonitor(CollectionMonitor, TimelineMonitor):
     basic Editions for any new LicensePools that show up.
     """
 
-    MAXIMUM_BOOK_RETRIES = 10
+    MAXIMUM_BOOK_RETRIES = 3
     SERVICE_NAME = "Overdrive Circulation Monitor"
     PROTOCOL = ExternalIntegration.OVERDRIVE
     OVERLAP = datetime.timedelta(minutes=1)

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -3,9 +3,11 @@ import json
 import os
 import random
 from datetime import timedelta
+from typing import Dict
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy.orm.exc import StaleDataError
 
 from api.authenticator import BasicAuthenticationProvider
 from api.circulation import CirculationAPI, FulfillmentInfo, HoldInfo, LoanInfo
@@ -2268,6 +2270,122 @@ class TestOverdriveCirculationMonitor(OverdriveAPITest):
         # We processed four books: 1, 2, None (which was ignored)
         # and 3.
         assert "Books processed: 4." == progress.achievements
+
+    def test_catch_up_from_with_failures_retried(self):
+        """Check that book failures are retried."""
+
+        class MockAPI:
+            tries: Dict[str, int] = {}
+
+            def __init__(self, *ignore, **kwignore):
+                self.licensepools = []
+                self.update_licensepool_calls = []
+
+            def recently_changed_ids(self, start, cutoff):
+                return [1, 2, 3]
+
+            def update_licensepool(self, book_id):
+                current_count = self.tries.get(str(book_id)) or 0
+                current_count = current_count + 1
+                self.tries[str(book_id)] = current_count
+
+                if current_count < 9:
+                    raise StaleDataError("Ouch!")
+
+                pool, is_new, is_changed = self.licensepools.pop(0)
+                self.update_licensepool_calls.append((book_id, pool))
+                return pool, is_new, is_changed
+
+        class MockAnalytics:
+            def __init__(self, _db):
+                self._db = _db
+                self.events = []
+
+            def collect_event(self, *args):
+                self.events.append(args)
+
+        monitor = OverdriveCirculationMonitor(
+            self._db, self.collection, api_class=MockAPI, analytics_class=MockAnalytics
+        )
+        api = monitor.api
+
+        # A MockAnalytics object was created and is ready to receive analytics
+        # events.
+        assert isinstance(monitor.analytics, MockAnalytics)
+        assert self._db == monitor.analytics._db
+
+        lp1 = self._licensepool(None)
+        lp1.last_checked = utc_now()
+        lp2 = self._licensepool(None)
+        lp3 = self._licensepool(None)
+        api.licensepools.append((lp1, True, True))
+        api.licensepools.append((lp2, False, False))
+        api.licensepools.append((lp3, False, True))
+
+        progress = TimestampData()
+        start = object()
+        cutoff = object()
+        monitor.catch_up_from(start, cutoff, progress)
+
+        assert api.tries["1"] == 9
+        assert api.tries["2"] == 9
+        assert api.tries["3"] == 9
+        assert not progress.is_failure
+
+    def test_catch_up_from_with_failures_all(self):
+        """If an individual book fails, the import continues, but ends in failure after handling all the books."""
+
+        class MockAPI:
+            tries: Dict[str, int] = {}
+
+            def __init__(self, *ignore, **kwignore):
+                self.licensepools = []
+                self.update_licensepool_calls = []
+
+            def recently_changed_ids(self, start, cutoff):
+                return [1, 2, 3]
+
+            def update_licensepool(self, book_id):
+                current_count = self.tries.get(str(book_id)) or 0
+                current_count = current_count + 1
+                self.tries[str(book_id)] = current_count
+                raise StaleDataError("Ouch!")
+
+        class MockAnalytics:
+            def __init__(self, _db):
+                self._db = _db
+                self.events = []
+
+            def collect_event(self, *args):
+                self.events.append(args)
+
+        monitor = OverdriveCirculationMonitor(
+            self._db, self.collection, api_class=MockAPI, analytics_class=MockAnalytics
+        )
+        api = monitor.api
+
+        # A MockAnalytics object was created and is ready to receive analytics
+        # events.
+        assert isinstance(monitor.analytics, MockAnalytics)
+        assert self._db == monitor.analytics._db
+
+        lp1 = self._licensepool(None)
+        lp1.last_checked = utc_now()
+        lp2 = self._licensepool(None)
+        lp3 = self._licensepool(None)
+        api.licensepools.append((lp1, True, True))
+        api.licensepools.append((lp2, False, False))
+        api.licensepools.append((lp3, False, True))
+
+        progress = TimestampData()
+        start = object()
+        cutoff = object()
+        monitor.catch_up_from(start, cutoff, progress)
+
+        assert api.tries["1"] == 10
+        assert api.tries["2"] == 10
+        assert api.tries["3"] == 10
+        assert progress.is_failure
 
 
 class TestNewTitlesOverdriveCollectionMonitor(OverdriveAPITest):

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -2289,7 +2289,7 @@ class TestOverdriveCirculationMonitor(OverdriveAPITest):
                 current_count = current_count + 1
                 self.tries[str(book_id)] = current_count
 
-                if current_count < 9:
+                if current_count < 2:
                     raise StaleDataError("Ouch!")
 
                 pool, is_new, is_changed = self.licensepools.pop(0)
@@ -2327,9 +2327,9 @@ class TestOverdriveCirculationMonitor(OverdriveAPITest):
         cutoff = object()
         monitor.catch_up_from(start, cutoff, progress)
 
-        assert api.tries["1"] == 9
-        assert api.tries["2"] == 9
-        assert api.tries["3"] == 9
+        assert api.tries["1"] == 2
+        assert api.tries["2"] == 2
+        assert api.tries["3"] == 2
         assert not progress.is_failure
 
     def test_catch_up_from_with_failures_all(self):
@@ -2382,9 +2382,9 @@ class TestOverdriveCirculationMonitor(OverdriveAPITest):
         cutoff = object()
         monitor.catch_up_from(start, cutoff, progress)
 
-        assert api.tries["1"] == 10
-        assert api.tries["2"] == 10
-        assert api.tries["3"] == 10
+        assert api.tries["1"] == 3
+        assert api.tries["2"] == 3
+        assert api.tries["3"] == 3
         assert progress.is_failure
 
 


### PR DESCRIPTION
## Description

This catches the StaleDataError exception that might be raised
by a long-running Overdrive import when something else happens to
modify overlapping work coverage records at the same time the import
runs. This is, at best, a workaround, and may not actually fix the
problem.

This change essentially catches the exception, rolls back the transaction (which should only affect a single book), and then continues the import.

The real fix is to get rid of the work coverage records table.

## Motivation and Context

Long-running Overdrive imports fail due to this exception, and the exception _might_ indicate a problem that's actually harmless.

Affects: https://www.notion.so/lyrasis/Brooklyn-PL-overdrive_new_title-fails-updating-work-coverage-records-7c42a0c4278d4c5c8ad91c986a4a90b2

## How Has This Been Tested?

Unfortunately, I tried several imports locally and couldn't reproduce the issue. After a rather painful session of inspecting the code, and working from the stack traces given in the original ticket, I think this change might be the best I can do right now.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
