### PR TITLE
Fix the 'bytes' object has no attribute 'encode' and support str and bytes in SAML validator and parser

### DIFF
--- a/api/saml/metadata/federations/validator.py
+++ b/api/saml/metadata/federations/validator.py
@@ -108,7 +108,7 @@ class SAMLFederatedMetadataExpirationValidator(SAMLFederatedMetadataValidator):
         )
 
         try:
-            root = fromstring(metadata.encode("utf-8"))
+            root = fromstring(metadata)
         except Exception as exception:
             raise SAMLFederatedMetadataValidationError(
                 "Metadata's XML is not valid", str(exception)

--- a/api/saml/metadata/federations/validator.py
+++ b/api/saml/metadata/federations/validator.py
@@ -1,10 +1,12 @@
 import datetime
 import logging
 from abc import ABCMeta
+from typing import Union
 
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from onelogin.saml2.xmlparser import fromstring
 
+from api.saml.metadata.federations.model import SAMLFederation
 from core.exceptions import BaseError
 from core.util.datetime_helpers import from_timestamp, utc_now
 
@@ -90,14 +92,12 @@ class SAMLFederatedMetadataExpirationValidator(SAMLFederatedMetadataValidator):
 
         return parsed_date_time
 
-    def validate(self, federation, metadata):
+    def validate(self, federation: SAMLFederation, metadata: Union[str, bytes]) -> None:
         """Verify that federated SAML metadata has not expired.
 
         :param federation: SAML federation
-        :type federation: api.saml.metadata.federations.model.SAMLFederation
 
         :param metadata: SAML federation's aggregated metadata
-        :type metadata: Union[str, bytes]
 
         :raises SAMLFederatedMetadataValidationError: in the case of validation errors
         """

--- a/api/saml/metadata/federations/validator.py
+++ b/api/saml/metadata/federations/validator.py
@@ -97,7 +97,7 @@ class SAMLFederatedMetadataExpirationValidator(SAMLFederatedMetadataValidator):
         :type federation: api.saml.metadata.federations.model.SAMLFederation
 
         :param metadata: SAML federation's aggregated metadata
-        :type metadata: str
+        :type metadata: Union[str, bytes]
 
         :raises SAMLFederatedMetadataValidationError: in the case of validation errors
         """
@@ -106,6 +106,9 @@ class SAMLFederatedMetadataExpirationValidator(SAMLFederatedMetadataValidator):
                 federation
             )
         )
+
+        if isinstance(metadata, str):
+            metadata = metadata.encode()
 
         try:
             root = fromstring(metadata)

--- a/api/saml/metadata/parser.py
+++ b/api/saml/metadata/parser.py
@@ -1,11 +1,12 @@
 import logging
+from typing import Union
 
 from flask_babel import lazy_gettext as _
 from lxml.etree import XMLSyntaxError
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.constants import OneLogin_Saml2_Constants
 from onelogin.saml2.utils import OneLogin_Saml2_XML
-from onelogin.saml2.xmlparser import fromstring
+from onelogin.saml2.xmlparser import RestrictedElement, fromstring
 
 from api.saml.metadata.model import (
     SAMLAttribute,
@@ -88,14 +89,14 @@ class SAMLMetadataParser:
             OneLogin_Saml2_Constants.NS_PREFIX_ALG
         ] = OneLogin_Saml2_Constants.NS_ALG
 
-    def _convert_xml_string_to_dom(self, xml_metadata):
+    def _convert_xml_string_to_dom(
+        self, xml_metadata: Union[str, bytes]
+    ) -> RestrictedElement:
         """Converts an XML string containing SAML metadata into XML DOM
 
         :param xml_metadata: XML string containing SAML metadata
-        :type xml_metadata: Union[str, bytes]
 
         :return: XML DOM tree containing SAML metadata
-        :rtype: onelogin.saml2.xmlparser.RestrictedElement
 
         :raise: MetadataParsingError
         """

--- a/api/saml/metadata/parser.py
+++ b/api/saml/metadata/parser.py
@@ -104,7 +104,7 @@ class SAMLMetadataParser:
         )
 
         try:
-            metadata_dom = fromstring(xml_metadata.encode("utf-8"), forbid_dtd=True)
+            metadata_dom = fromstring(xml_metadata, forbid_dtd=True)
         except (
             ValueError,
             XMLSyntaxError,

--- a/api/saml/metadata/parser.py
+++ b/api/saml/metadata/parser.py
@@ -92,7 +92,7 @@ class SAMLMetadataParser:
         """Converts an XML string containing SAML metadata into XML DOM
 
         :param xml_metadata: XML string containing SAML metadata
-        :type xml_metadata: string
+        :type xml_metadata: Union[str, bytes]
 
         :return: XML DOM tree containing SAML metadata
         :rtype: onelogin.saml2.xmlparser.RestrictedElement
@@ -102,6 +102,9 @@ class SAMLMetadataParser:
         self._logger.debug(
             "Started converting XML string containing SAML metadata into XML DOM"
         )
+
+        if isinstance(xml_metadata, str):
+            xml_metadata = xml_metadata.encode()
 
         try:
             metadata_dom = fromstring(xml_metadata, forbid_dtd=True)

--- a/tests/api/saml/metadata/federations/test_validator.py
+++ b/tests/api/saml/metadata/federations/test_validator.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+from typing import Optional, Union
 
 import pytest
 from freezegun import freeze_time
@@ -20,19 +21,31 @@ class TestSAMLFederatedMetadataExpirationValidator:
     @parameterized.expand(
         [
             (
-                "incorrect_xml",
+                "incorrect_xml_str_type",
                 utc_now(),
                 fixtures.INCORRECT_XML,
                 SAMLFederatedMetadataValidationError,
             ),
             (
-                "without_valid_until_attribute",
+                "incorrect_xml_bytes_type",
+                utc_now(),
+                fixtures.INCORRECT_XML.encode(),
+                SAMLFederatedMetadataValidationError,
+            ),
+            (
+                "without_valid_until_attribute_metadata_str_type",
                 utc_now(),
                 fixtures.FEDERATED_METADATA_WITHOUT_VALID_UNTIL_ATTRIBUTE,
                 SAMLFederatedMetadataValidationError,
             ),
             (
-                "with_expired_valid_until_attribute",
+                "without_valid_until_attribute_metadata_bytes_type",
+                utc_now(),
+                fixtures.FEDERATED_METADATA_WITHOUT_VALID_UNTIL_ATTRIBUTE.encode(),
+                SAMLFederatedMetadataValidationError,
+            ),
+            (
+                "with_expired_valid_until_attribute_metadata_str_type",
                 fixtures.FEDERATED_METADATA_VALID_UNTIL
                 + SAMLFederatedMetadataExpirationValidator.MAX_CLOCK_SKEW
                 + datetime.timedelta(minutes=1),
@@ -40,7 +53,15 @@ class TestSAMLFederatedMetadataExpirationValidator:
                 SAMLFederatedMetadataValidationError,
             ),
             (
-                "with_valid_until_attribute_too_far_in_the_future",
+                "with_expired_valid_until_attribute_metadata_bytes_type",
+                fixtures.FEDERATED_METADATA_VALID_UNTIL
+                + SAMLFederatedMetadataExpirationValidator.MAX_CLOCK_SKEW
+                + datetime.timedelta(minutes=1),
+                fixtures.FEDERATED_METADATA_WITH_VALID_UNTIL_ATTRIBUTE.encode(),
+                SAMLFederatedMetadataValidationError,
+            ),
+            (
+                "with_valid_until_attribute_too_far_in_the_future_metadata_str_type",
                 fixtures.FEDERATED_METADATA_VALID_UNTIL
                 - SAMLFederatedMetadataExpirationValidator.MAX_VALID_TIME
                 - datetime.timedelta(minutes=1),
@@ -48,14 +69,29 @@ class TestSAMLFederatedMetadataExpirationValidator:
                 SAMLFederatedMetadataValidationError,
             ),
             (
-                "with_valid_until_attribute_less_than_current_time_and_less_than_max_clock_skew",
+                "with_valid_until_attribute_too_far_in_the_future_metadata_bytes_type",
+                fixtures.FEDERATED_METADATA_VALID_UNTIL
+                - SAMLFederatedMetadataExpirationValidator.MAX_VALID_TIME
+                - datetime.timedelta(minutes=1),
+                fixtures.FEDERATED_METADATA_WITH_VALID_UNTIL_ATTRIBUTE.encode(),
+                SAMLFederatedMetadataValidationError,
+            ),
+            (
+                "with_valid_until_attribute_less_than_current_time_and_less_than_max_clock_skew_metadata_str_type",
                 fixtures.FEDERATED_METADATA_VALID_UNTIL
                 + SAMLFederatedMetadataExpirationValidator.MAX_CLOCK_SKEW,
                 fixtures.FEDERATED_METADATA_WITH_VALID_UNTIL_ATTRIBUTE,
                 None,
             ),
             (
-                "with_valid_until_attribute_greater_than_current_time_and_less_than_max_valid_time",
+                "with_valid_until_attribute_less_than_current_time_and_less_than_max_clock_skew_metadata_bytes_type",
+                fixtures.FEDERATED_METADATA_VALID_UNTIL
+                + SAMLFederatedMetadataExpirationValidator.MAX_CLOCK_SKEW,
+                fixtures.FEDERATED_METADATA_WITH_VALID_UNTIL_ATTRIBUTE.encode(),
+                None,
+            ),
+            (
+                "with_valid_until_attribute_greater_than_current_time_and_less_than_max_valid_time_metadata_str_type",
                 fixtures.FEDERATED_METADATA_VALID_UNTIL
                 - SAMLFederatedMetadataExpirationValidator.MAX_VALID_TIME
                 + datetime.timedelta(minutes=1),
@@ -63,7 +99,15 @@ class TestSAMLFederatedMetadataExpirationValidator:
                 None,
             ),
             (
-                "with_real_incommon_metadata",
+                "with_valid_until_attribute_greater_than_current_time_and_less_than_max_valid_time_metadata_bytes_type",
+                fixtures.FEDERATED_METADATA_VALID_UNTIL
+                - SAMLFederatedMetadataExpirationValidator.MAX_VALID_TIME
+                + datetime.timedelta(minutes=1),
+                fixtures.FEDERATED_METADATA_WITH_VALID_UNTIL_ATTRIBUTE.encode(),
+                None,
+            ),
+            (
+                "with_real_incommon_metadata_str_type",
                 datetime_utc(2020, 11, 26, 14, 32, 42),
                 open(
                     os.path.join(
@@ -73,9 +117,28 @@ class TestSAMLFederatedMetadataExpirationValidator:
                 ).read(),
                 None,
             ),
+            (
+                "with_real_incommon_metadata_bytes_type",
+                datetime_utc(2020, 11, 26, 14, 32, 42),
+                open(
+                    os.path.join(
+                        os.path.dirname(os.path.abspath(__file__)),
+                        "../../../files/saml/incommon-metadata-idp-only.xml",
+                    )
+                )
+                .read()
+                .encode(),
+                None,
+            ),
         ]
     )
-    def test_validate(self, _, current_time, metadata, expected_exception):
+    def test_validate(
+        self,
+        _,
+        current_time: datetime.datetime,
+        metadata: Union[str, bytes],
+        expected_exception: Optional[Exception],
+    ):
         # Arrange
         validator = SAMLFederatedMetadataExpirationValidator()
         federation = SAMLFederation(

--- a/tests/api/saml/metadata/test_parser.py
+++ b/tests/api/saml/metadata/test_parser.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Union
 from unittest.mock import MagicMock, create_autospec
 
 import onelogin
@@ -31,16 +31,38 @@ from tests.api.saml import fixtures
 
 
 class TestSAMLMetadataParser:
-    def test_parse_raises_exception_when_xml_metadata_has_incorrect_format(self):
+    @parameterized.expand(
+        [
+            ("incorrect_xml_str_type", fixtures.INCORRECT_XML),
+            ("incorrect_xml_bytes_type", fixtures.INCORRECT_XML.encode()),
+        ]
+    )
+    def test_parse_raises_exception_when_xml_metadata_has_incorrect_format(
+        self, _, incorrect_xml: Union[str, bytes]
+    ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
 
         # Act
         with pytest.raises(SAMLMetadataParsingError):
-            metadata_parser.parse(fixtures.INCORRECT_XML)
+            metadata_parser.parse(incorrect_xml)
 
+    @parameterized.expand(
+        [
+            (
+                "incorrect_xml_with_one_idp_metadata_without_sso_service_str_type",
+                fixtures.INCORRECT_XML_WITH_ONE_IDP_METADATA_WITHOUT_SSO_SERVICE,
+            ),
+            (
+                "incorrect_xml_with_one_idp_metadata_without_sso_service_bytes_type",
+                fixtures.INCORRECT_XML_WITH_ONE_IDP_METADATA_WITHOUT_SSO_SERVICE.encode(),
+            ),
+        ]
+    )
     def test_parse_raises_exception_when_idp_metadata_does_not_contain_sso_service(
         self,
+        _,
+        incorrect_xml_with_one_idp_metadata_without_sso_service: Union[str, bytes],
     ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
@@ -48,11 +70,27 @@ class TestSAMLMetadataParser:
         # Act
         with pytest.raises(SAMLMetadataParsingError):
             metadata_parser.parse(
-                fixtures.INCORRECT_XML_WITH_ONE_IDP_METADATA_WITHOUT_SSO_SERVICE
+                incorrect_xml_with_one_idp_metadata_without_sso_service
             )
 
+    @parameterized.expand(
+        [
+            (
+                "incorrect_xml_with_one_idp_metadata_with_sso_service_with_wrong_binding_str_type",
+                fixtures.INCORRECT_XML_WITH_ONE_IDP_METADATA_WITH_SSO_SERVICE_WITH_WRONG_BINDING,
+            ),
+            (
+                "incorrect_xml_with_one_idp_metadata_with_sso_service_with_wrong_binding_bytes_type",
+                fixtures.INCORRECT_XML_WITH_ONE_IDP_METADATA_WITH_SSO_SERVICE_WITH_WRONG_BINDING.encode(),
+            ),
+        ]
+    )
     def test_parse_raises_exception_when_idp_metadata_contains_sso_service_with_wrong_binding(
         self,
+        _,
+        incorrect_xml_with_one_idp_metadata_with_sso_service_with_wrong_binding: Union[
+            str, bytes
+        ],
     ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
@@ -60,18 +98,32 @@ class TestSAMLMetadataParser:
         # Act
         with pytest.raises(SAMLMetadataParsingError):
             metadata_parser.parse(
-                fixtures.INCORRECT_XML_WITH_ONE_IDP_METADATA_WITH_SSO_SERVICE_WITH_WRONG_BINDING
+                incorrect_xml_with_one_idp_metadata_with_sso_service_with_wrong_binding
             )
 
+    @parameterized.expand(
+        [
+            (
+                "correct_xml_with_one_idp_metadata_without_display_names_str_type",
+                fixtures.CORRECT_XML_WITH_ONE_IDP_METADATA_WITHOUT_DISPLAY_NAMES,
+            ),
+            (
+                "correct_xml_with_one_idp_metadata_without_display_names_bytes_type",
+                fixtures.CORRECT_XML_WITH_ONE_IDP_METADATA_WITHOUT_DISPLAY_NAMES.encode(),
+            ),
+        ]
+    )
     def test_parse_does_not_raise_exception_when_xml_metadata_does_not_have_display_names(
         self,
+        _,
+        correct_xml_with_one_idp_metadata_without_display_names: Union[str, bytes],
     ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
 
         # Act
         parsing_results = metadata_parser.parse(
-            fixtures.CORRECT_XML_WITH_ONE_IDP_METADATA_WITHOUT_DISPLAY_NAMES
+            correct_xml_with_one_idp_metadata_without_display_names
         )
 
         # Assert
@@ -103,12 +155,23 @@ class TestSAMLMetadataParser:
             == parsing_result.provider
         )
 
-    def test_parse_correctly_parses_one_idp_metadata(self):
+    @parameterized.expand(
+        [
+            ("correct_xml_with_idp_1_str_type", fixtures.CORRECT_XML_WITH_IDP_1),
+            (
+                "correct_xml_with_idp_1_bytes_type",
+                fixtures.CORRECT_XML_WITH_IDP_1.encode(),
+            ),
+        ]
+    )
+    def test_parse_correctly_parses_one_idp_metadata(
+        self, _, correct_xml_with_idp_1: Union[str, bytes]
+    ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
 
         # Act
-        parsing_results = metadata_parser.parse(fixtures.CORRECT_XML_WITH_IDP_1)
+        parsing_results = metadata_parser.parse(correct_xml_with_idp_1)
 
         # Assert
         assert 1 == len(parsing_results)
@@ -191,12 +254,23 @@ class TestSAMLMetadataParser:
             == parsing_result.provider
         )
 
-    def test_parse_correctly_parses_idp_metadata_without_name_id_format(self):
+    @parameterized.expand(
+        [
+            ("correct_xml_with_idp_1_str_type", fixtures.CORRECT_XML_WITH_IDP_1),
+            (
+                "correct_xml_with_idp_1_bytes_type",
+                fixtures.CORRECT_XML_WITH_IDP_1.encode(),
+            ),
+        ]
+    )
+    def test_parse_correctly_parses_idp_metadata_without_name_id_format(
+        self, _, correct_xml_with_idp_1: Union[str, bytes]
+    ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
 
         # Act
-        parsing_results = metadata_parser.parse(fixtures.CORRECT_XML_WITH_IDP_1)
+        parsing_results = metadata_parser.parse(correct_xml_with_idp_1)
 
         # Assert
         assert 1 == len(parsing_results)
@@ -279,13 +353,29 @@ class TestSAMLMetadataParser:
             == parsing_result.provider
         )
 
-    def test_parse_correctly_parses_idp_metadata_with_one_certificate(self):
+    @parameterized.expand(
+        [
+            (
+                "correct_xml_with_one_idp_metadata_with_one_certificate_str_type",
+                fixtures.CORRECT_XML_WITH_ONE_IDP_METADATA_WITH_ONE_CERTIFICATE,
+            ),
+            (
+                "correct_xml_with_one_idp_metadata_with_one_certificate_bytes_type",
+                fixtures.CORRECT_XML_WITH_ONE_IDP_METADATA_WITH_ONE_CERTIFICATE.encode(),
+            ),
+        ]
+    )
+    def test_parse_correctly_parses_idp_metadata_with_one_certificate(
+        self,
+        _,
+        correct_xml_with_one_idp_metadata_with_one_certificate: Union[str, bytes],
+    ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
 
         # Act
         parsing_results = metadata_parser.parse(
-            fixtures.CORRECT_XML_WITH_ONE_IDP_METADATA_WITH_ONE_CERTIFICATE
+            correct_xml_with_one_idp_metadata_with_one_certificate
         )
 
         # Assert
@@ -369,12 +459,26 @@ class TestSAMLMetadataParser:
             == parsing_result.provider
         )
 
-    def test_parse_correctly_parses_metadata_with_multiple_descriptors(self):
+    @parameterized.expand(
+        [
+            (
+                "correct_xml_with_multiple_idps_str_type",
+                fixtures.CORRECT_XML_WITH_MULTIPLE_IDPS,
+            ),
+            (
+                "correct_xml_with_multiple_idps_bytes_type",
+                fixtures.CORRECT_XML_WITH_MULTIPLE_IDPS.encode(),
+            ),
+        ]
+    )
+    def test_parse_correctly_parses_metadata_with_multiple_descriptors(
+        self, _, correct_xml_with_multiple_idps: Union[str, bytes]
+    ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
 
         # Act
-        parsing_results = metadata_parser.parse(fixtures.CORRECT_XML_WITH_MULTIPLE_IDPS)
+        parsing_results = metadata_parser.parse(correct_xml_with_multiple_idps)
 
         # Assert
         assert 2 == len(parsing_results)
@@ -504,22 +608,49 @@ class TestSAMLMetadataParser:
             == parsing_results[1].provider
         )
 
-    def test_parse_raises_exception_when_sp_metadata_does_not_contain_acs_service(self):
+    @parameterized.expand(
+        [
+            (
+                "incorrect_xml_with_one_sp_metadata_without_acs_service_str_type",
+                fixtures.INCORRECT_XML_WITH_ONE_SP_METADATA_WITHOUT_ACS_SERVICE,
+            ),
+            (
+                "incorrect_xml_with_one_sp_metadata_without_acs_service_bytes_type",
+                fixtures.INCORRECT_XML_WITH_ONE_SP_METADATA_WITHOUT_ACS_SERVICE.encode(),
+            ),
+        ]
+    )
+    def test_parse_raises_exception_when_sp_metadata_does_not_contain_acs_service(
+        self,
+        _,
+        incorrect_xml_with_one_sp_metadata_without_acs_service: Union[str, bytes],
+    ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
 
         # Act
         with pytest.raises(SAMLMetadataParsingError):
             metadata_parser.parse(
-                fixtures.INCORRECT_XML_WITH_ONE_SP_METADATA_WITHOUT_ACS_SERVICE
+                incorrect_xml_with_one_sp_metadata_without_acs_service
             )
 
-    def test_parse_correctly_parses_one_sp_metadata(self):
+    @parameterized.expand(
+        [
+            ("correct_xml_with_one_sp_str_type", fixtures.CORRECT_XML_WITH_ONE_SP),
+            (
+                "correct_xml_with_one_sp_bytes_type",
+                fixtures.CORRECT_XML_WITH_ONE_SP.encode(),
+            ),
+        ]
+    )
+    def test_parse_correctly_parses_one_sp_metadata(
+        self, _, correct_xml_with_one_sp: Union[str, bytes]
+    ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
 
         # Act
-        parsing_results = metadata_parser.parse(fixtures.CORRECT_XML_WITH_ONE_SP)
+        parsing_results = metadata_parser.parse(correct_xml_with_one_sp)
 
         # Assert
         assert 1 == len(parsing_results)


### PR DESCRIPTION
## Description

Fixed the `AttributeError:'bytes' object has no attribute 'encode'` error in SAML validator/parser when running `saml_monitor` script. 
Added support for both `str` and `bytes` types in SAML metadata validator/parser.

## Motivation and Context

This is a result of this [ticket](https://www.notion.so/lyrasis/SAML-Investigate-the-saml_monitor_script-to-see-how-it-is-pulling-InCommon-federation-metadata-and--745955a430344b5aae3133f49b4f8ad4). 

Upon investigating the `saml_monitor` script I found out it doesn't work. Error was in metadata validator and parser due to the fact that `onelogin`'s function `fromstring` accepts `bytes` type. In the previous version of the code the `xml_metadata` and `metadata` vars were first encoded to bytes and then passed to `fromstring`. However, when `saml_monitor` script passes that `{xml_}metadata` to validator/parser it is already a `bytes` type and encoding of `bytes` to `bytes` fails. 

Not to break other parts of the system and other tests I added a check to see if the validator/parser gets `str` and encodes the variable to `bytes` if it does. 
 
## How Has This Been Tested?

Manually ran the `saml_monitor` script. 
Added tests with `bytes` metadata. All new and existing tests passed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly - [Docs](https://www.notion.so/lyrasis/saml_monitor-script-for-pulling-SAML-federation-metadata-921725d4deaa4e2098c02c939d5832f8)
- [X] All new and existing tests passed.
