### PR TITLE
Make the “do not block” SIP setting actually avoid blocking

### DIFF
--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -192,10 +192,9 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             _block = True
 
         if _block:
+            _deny_fields = SIPClient.PATRON_STATUS_FIELDS_THAT_DENY_BORROWING_PRIVILEGES
             self.patron_status_should_block = True
-            self.fields_that_deny_borrowing = (
-                SIPClient.PATRON_STATUS_FIELDS_THAT_DENY_BORROWING_PRIVILEGES
-            )
+            self.fields_that_deny_borrowing = _deny_fields
         else:
             self.patron_status_should_block = False
             self.fields_that_deny_borrowing = []
@@ -353,7 +352,13 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
                     patrondata.authorization_expires = value
                     break
 
-        patrondata.block_reason = self.info_to_patrondata_block_reason(info, patrondata)
+        if self.patron_status_should_block:
+            patrondata.block_reason = self.info_to_patrondata_block_reason(
+                info, patrondata
+            )
+        else:
+            patrondata.block_reason = PatronData.NO_VALUE
+
         return patrondata
 
     def info_to_patrondata_block_reason(

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -184,12 +184,20 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         self.ssl_key = integration.setting(self.SSL_KEY).value
         self.dialect = Sip2Dialect.load_dialect(integration.setting(self.ILS).value)
         self.client = client
-        patron_status_block = integration.setting(self.PATRON_STATUS_BLOCK).json_value
-        if patron_status_block is None or patron_status_block:
+
+        # Check if patrons should be blocked based on SIP status
+        # If nothing is specified, the default is True (block patrons!)
+        _block = integration.setting(self.PATRON_STATUS_BLOCK).json_value
+        if _block is None:
+            _block = True
+
+        if _block:
+            self.patron_status_should_block = True
             self.fields_that_deny_borrowing = (
                 SIPClient.PATRON_STATUS_FIELDS_THAT_DENY_BORROWING_PRIVILEGES
             )
         else:
+            self.patron_status_should_block = False
             self.fields_that_deny_borrowing = []
 
     @property

--- a/api/util/patron.py
+++ b/api/util/patron.py
@@ -73,13 +73,19 @@ class PatronUtility:
 
         from api.authenticator import PatronData
 
-        if patron.block_reason is not None:
-            if patron.block_reason is PatronData.EXCESSIVE_FINES:
-                # The authentication mechanism itself may know that
-                # the patron has outstanding fines, even if the circulation
-                # manager is not configured to make that deduction.
-                raise OutstandingFines()
-            raise AuthorizationBlocked()
+        if patron.block_reason is None:
+            return
+
+        if patron.block_reason == PatronData.NO_VALUE:
+            return
+
+        if patron.block_reason is PatronData.EXCESSIVE_FINES:
+            # The authentication mechanism itself may know that
+            # the patron has outstanding fines, even if the circulation
+            # manager is not configured to make that deduction.
+            raise OutstandingFines()
+
+        raise AuthorizationBlocked()
 
     @classmethod
     def has_excess_fines(cls, patron):


### PR DESCRIPTION
## Description

This adjusts the SIP code so that the checks that would cause a patron to be blocked from borrowing further books are fully disabled if the "do not block" setting is enabled. Previously, the "do not block" setting mistakenly only applied to flag-based blocks instead of fine-based blocks.

## Motivation and Context

The San Jose Public Library does not block users with fines from borrowing digital materials. The issue is that Palace is blocking users with more than $20 in fines from checking out in the app.

https://www.notion.so/lyrasis/Investigate-how-to-not-block-checkout-access-for-barcode-with-fines-f512ca133fae4a1796931f4a14331fe5

## How Has This Been Tested?

The test suite already included some SIP status samples that included excessive fines. I added a new test case to ensure that the user _would_ be blocked for excessive fines if the configuration setting is unset, and that the user _would not_ be blocked if the configuration setting _is_ set. :dizzy_face: 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
