### PR TITLE
Fix broken LCP prioritization

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -32,7 +32,7 @@ from core.model import (
     Patron,
     Session,
 )
-from core.model.formats import DePrioritizeLCPNonEPUBs, FormatPriorities
+from core.model.formats import FormatPriorities
 from core.opds import AcquisitionFeed, Annotator, UnfulfillableWork
 from core.util.datetime_helpers import from_timestamp
 from core.util.opds_writer import OPDSFeed
@@ -229,11 +229,8 @@ class CirculationManagerAnnotator(Annotator):
                 FormatPriorities.DEPRIORITIZE_LCP_NON_EPUBS_KEY, external
             )
         )
-        _prioritize = (
-            drm_setting.json_value
-            or DePrioritizeLCPNonEPUBs.DO_NOT_DEPRIORITIZE_LCP_NON_EPUBS
-        )
-        return _prioritize == DePrioritizeLCPNonEPUBs.DEPRIORITIZE_LCP_NON_EPUBS
+        _prioritize: bool = drm_setting.bool_value or False
+        return _prioritize
 
     def visible_delivery_mechanisms(
         self, licensepool: Optional[LicensePool]

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -192,10 +192,9 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
             _block = True
 
         if _block:
+            _deny_fields = SIPClient.PATRON_STATUS_FIELDS_THAT_DENY_BORROWING_PRIVILEGES
             self.patron_status_should_block = True
-            self.fields_that_deny_borrowing = (
-                SIPClient.PATRON_STATUS_FIELDS_THAT_DENY_BORROWING_PRIVILEGES
-            )
+            self.fields_that_deny_borrowing = _deny_fields
         else:
             self.patron_status_should_block = False
             self.fields_that_deny_borrowing = []
@@ -353,7 +352,13 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
                     patrondata.authorization_expires = value
                     break
 
-        patrondata.block_reason = self.info_to_patrondata_block_reason(info, patrondata)
+        if self.patron_status_should_block:
+            patrondata.block_reason = self.info_to_patrondata_block_reason(
+                info, patrondata
+            )
+        else:
+            patrondata.block_reason = PatronData.NO_VALUE
+
         return patrondata
 
     def info_to_patrondata_block_reason(

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -184,12 +184,20 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         self.ssl_key = integration.setting(self.SSL_KEY).value
         self.dialect = Sip2Dialect.load_dialect(integration.setting(self.ILS).value)
         self.client = client
-        patron_status_block = integration.setting(self.PATRON_STATUS_BLOCK).json_value
-        if patron_status_block is None or patron_status_block:
+
+        # Check if patrons should be blocked based on SIP status
+        # If nothing is specified, the default is True (block patrons!)
+        _block = integration.setting(self.PATRON_STATUS_BLOCK).json_value
+        if _block is None:
+            _block = True
+
+        if _block:
+            self.patron_status_should_block = True
             self.fields_that_deny_borrowing = (
                 SIPClient.PATRON_STATUS_FIELDS_THAT_DENY_BORROWING_PRIVILEGES
             )
         else:
+            self.patron_status_should_block = False
             self.fields_that_deny_borrowing = []
 
     @property

--- a/api/util/patron.py
+++ b/api/util/patron.py
@@ -73,13 +73,19 @@ class PatronUtility:
 
         from api.authenticator import PatronData
 
-        if patron.block_reason is not None:
-            if patron.block_reason is PatronData.EXCESSIVE_FINES:
-                # The authentication mechanism itself may know that
-                # the patron has outstanding fines, even if the circulation
-                # manager is not configured to make that deduction.
-                raise OutstandingFines()
-            raise AuthorizationBlocked()
+        if patron.block_reason is None:
+            return
+
+        if patron.block_reason == PatronData.NO_VALUE:
+            return
+
+        if patron.block_reason is PatronData.EXCESSIVE_FINES:
+            # The authentication mechanism itself may know that
+            # the patron has outstanding fines, even if the circulation
+            # manager is not configured to make that deduction.
+            raise OutstandingFines()
+
+        raise AuthorizationBlocked()
 
     @classmethod
     def has_excess_fines(cls, patron):

--- a/core/model/formats.py
+++ b/core/model/formats.py
@@ -1,5 +1,4 @@
 import sys
-from enum import Enum
 from typing import List, Mapping, Optional
 
 from flask_babel import lazy_gettext as _
@@ -143,11 +142,6 @@ class FormatPriorities:
         return self._prioritized_content_types.get(content_type, 0)
 
 
-class DePrioritizeLCPNonEPUBs(Enum):
-    DEPRIORITIZE_LCP_NON_EPUBS = "De-prioritize"
-    DO_NOT_DEPRIORITIZE_LCP_NON_EPUBS = "Do not de-prioritize"
-
-
 class FormatPrioritiesConfigurationTrait(ConfigurationTrait):
     """A configuration trait that can be used to enable format/DRM prioritization."""
 
@@ -198,7 +192,7 @@ class FormatPrioritiesConfigurationTrait(ConfigurationTrait):
         label=_("De-prioritize LCP non-EPUBs"),
         description=_(
             "De-prioritize all LCP content except for EPUBs. Setting this configuration option to "
-            "<tt>DEPRIORITIZE_LCP_NON_EPUBS</tt> will preserve any priorities specified above, but will artificially "
+            "<i>De-prioritize</i> will preserve any priorities specified above, but will artificially "
             "push (for example) LCP audiobooks and PDFs to the lowest priority."
             "<br/>"
             "<br/>"
@@ -206,6 +200,9 @@ class FormatPrioritiesConfigurationTrait(ConfigurationTrait):
         ),
         type=ConfigurationAttributeType.SELECT,
         required=False,
-        default=DePrioritizeLCPNonEPUBs.DO_NOT_DEPRIORITIZE_LCP_NON_EPUBS.value,
-        options=ConfigurationOption.from_enum(DePrioritizeLCPNonEPUBs),
+        default="false",
+        options=[
+            ConfigurationOption(label=_("De-prioritize"), key="true"),
+            ConfigurationOption(label=_("Do not de-prioritize"), key="false"),
+        ],
     )

--- a/migration/20220608-fix-broken-deprioritize-lcp-config.py
+++ b/migration/20220608-fix-broken-deprioritize-lcp-config.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+import logging
+import os
+import sys
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.model import production_session
+
+logging.basicConfig()
+logger = logging.getLogger()
+logger.setLevel("INFO")
+
+
+def execute_migration(db: Session) -> None:
+    db.execute(
+        text(
+            """
+UPDATE configurationsettings
+  SET value = 'false'
+  WHERE value = 'Do not de-prioritize'
+    """
+        )
+    )
+    db.execute(
+        text(
+            """
+UPDATE configurationsettings
+  SET value = 'true'
+  WHERE value = 'De-prioritize'
+    """
+        )
+    )
+    db.commit()
+
+
+#
+# The purpose of this migration is to fix any weird values that were inserted
+# into the configurationsettings table by the Admin API. Previous versions of
+# the code represented the LCP priority setting as an enum, and the Admin API
+# inserted the configuration labels rather than the enum values into the database.
+#
+
+
+def main() -> None:
+    session = production_session()
+    try:
+        execute_migration(session)
+    finally:
+        session.close()
+
+
+main()


### PR DESCRIPTION
## Description

This adjusts the way the LCP prioritization configuration settings are exposed in order to prevent the admin UI from placing string labels into the database.

## Motivation and Context

The previous "de-prioritize LCP content" feature was broken because the
configuration settings were exposed in a manner that allowed the Admin
UI to place string labels into the database instead of the enumeration
values that were intended to go in instead. This switches to a model
where we store boolean values, and includes a database migration to
fix up any databases that were affected.

Affects: https://www.notion.so/lyrasis/De-prioritize-LCP-switch-is-broken-c9b295a78c1142a1922ed2d7e3143836

## How Has This Been Tested?

I examined my local database, and also ran the migration to check that it works.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
