### PR TITLE
Adds option to the Enki collection library configuration to hide unavailable titles

### DIFF
--- a/api/enki.py
+++ b/api/enki.py
@@ -30,6 +30,7 @@ from core.model import (
     Session,
     Subject,
 )
+from core.model.configuration import ConfigurationAttributeValue
 from core.monitor import CollectionMonitor, IdentifierSweepMonitor, TimelineMonitor
 from core.testing import DatabaseTest
 from core.util.datetime_helpers import from_timestamp, strptime_utc, utc_now
@@ -56,8 +57,21 @@ class EnkiAPI(BaseCirculationAPI, HasSelfTests):
         },
     ] + BaseCirculationAPI.SETTINGS
 
-    LIBRARY_SETTINGS = [
+    LIBRARY_SETTINGS = BaseCirculationAPI.LIBRARY_SETTINGS + [
         {"key": ENKI_LIBRARY_ID_KEY, "label": _("Library ID"), "required": True},
+        {
+            "key": ExternalIntegration.DISPLAY_RESERVES,
+            "label": _("Show/Hide Titles with No Available Loans"),
+            "required": False,
+            "description": _(
+                "Titles with no available loans will not be displayed in the Catalog view."
+            ),
+            "type": "select",
+            "options": [
+                {"key": ConfigurationAttributeValue.YESVALUE.value, "label": "Show"},
+                {"key": ConfigurationAttributeValue.NOVALUE.value, "label": "Hide"},
+            ],
+        },
     ]
 
     list_endpoint = "ListAPI"


### PR DESCRIPTION

## Description

Adds option to the Enki collection library configuration to hide unavailable titles.
Since this feature was already implemented in the core (to support Biblioteca) the only necessary changes were in the config.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 https://www.notion.so/lyrasis/CALIFA-Enki-collection-reservations-are-failing-on-mobile-devices-66fd08c62271421095687dd0c51d2640

## How Has This Been Tested?
In order to test I did the following:
1. verified the configuration option was present and set to "show" in the libary configuration for my enki collection.
2. imported the Enki collection
3. refreshed the search index
4. searched for "Shortcake Murder" via the catalog interface and observed  the title was present.
5. updated the configuration to "hide" unavailable titles.
6. restarted the palace collection manager.
7. searched for "Shortcake Murder" via the catalog interface and observed  the title was _not_ present.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
