### PR TITLE
Assert preview link imported

### DIFF
--- a/tests/api/files/odl2/feed.json
+++ b/tests/api/files/odl2/feed.json
@@ -39,6 +39,11 @@
           "rel": "self",
           "href": "http://example.org/publication.json",
           "type": "application/opds-publication+json"
+        },
+        {
+          "rel": "http://opds-spec.org/acquisition/sample",
+          "href": "https://market.feedbooks.com/item/example/preview",
+          "type": "application/epub+zip"
         }
       ],
       "images": [

--- a/tests/api/test_odl2.py
+++ b/tests/api/test_odl2.py
@@ -24,6 +24,7 @@ from core.model import (
 )
 from core.model.configuration import ConfigurationFactory, ConfigurationStorage
 from core.model.constants import IdentifierConstants
+from core.model.resource import Hyperlink
 from tests.api.test_odl import LicenseHelper, LicenseInfoHelper, TestODLImporter
 
 
@@ -120,6 +121,9 @@ class TestODL2Importer(TestODLImporter):
         assert isinstance(moby_dick_edition, Edition)
         assert moby_dick_edition.primary_identifier.identifier == "978-3-16-148410-0"
         assert moby_dick_edition.primary_identifier.type == "ISBN"
+        assert Hyperlink.SAMPLE in {
+            l.rel for l in moby_dick_edition.primary_identifier.links
+        }
 
         assert "Moby-Dick" == moby_dick_edition.title
         assert "eng" == moby_dick_edition.language


### PR DESCRIPTION
## Description
Simple test addition to ensure SAMPLE links are tested for in ODL imports
The functionality always worked, this is to make sure it keeps working
<!--- Describe your changes -->

## Motivation and Context
The Palace Marketplace feed introduced sample links, we have added an `assert` to mark the addition of this feature
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
