### PR TITLE
Feature/local list sharing

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -6,6 +6,7 @@ import os
 import sys
 import urllib.parse
 from datetime import date, datetime, timedelta
+from typing import Union
 
 import flask
 import jwt
@@ -74,6 +75,7 @@ from core.model.configuration import ExternalIntegrationLink
 from core.opds import AcquisitionFeed
 from core.opds2_import import OPDS2Importer
 from core.opds_import import OPDSImporter, OPDSImportMonitor
+from core.query.customlist import CustomListQueries
 from core.s3 import S3UploaderConfiguration
 from core.selftest import HasSelfTests
 from core.util.datetime_helpers import utc_now
@@ -794,6 +796,26 @@ class CustomListsController(AdminCirculationManagerController):
                         entry_count=list.size,
                     )
                 )
+
+            for list in library.shared_custom_lists:
+                collections = []
+                for collection in list.collections:
+                    collections.append(
+                        dict(
+                            id=collection.id,
+                            name=collection.name,
+                            protocol=collection.protocol,
+                        )
+                    )
+                custom_lists.append(
+                    dict(
+                        id=list.id,
+                        name=list.name,
+                        collections=collections,
+                        entry_count=list.size,
+                    )
+                )
+
             return dict(custom_lists=custom_lists)
 
         if flask.request.method == "POST":
@@ -997,6 +1019,26 @@ class CustomListsController(AdminCirculationManagerController):
             for lane in surviving_lanes:
                 lane.update_size(self._db, self.search_engine)
             return Response(str(_("Deleted")), 200)
+
+    def share_locally(self) -> Union[ProblemDetail, Response]:
+        """Share this customlist with a library on this local CM"""
+        library_id = flask.request.form.get("library")
+        customlist_id = flask.request.form.get("customlist")
+        if not library_id or not customlist_id:
+            return INVALID_INPUT
+
+        library: Library = get_one(self._db, Library, id=library_id)
+        customlist: CustomList = get_one(self._db, CustomList, id=customlist_id)
+        response = CustomListQueries.share_locally_with_library(
+            self._db, customlist, library
+        )
+
+        if response is True:
+            self._db.commit()
+            return Response(200)
+        else:
+            self._db.rollback()
+            return response
 
 
 class LanesController(AdminCirculationManagerController):

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -503,3 +503,19 @@ MISSING_IDENTIFIER = pd(
     title=_("Missing identifier"),
     detail=_("No identifier was used."),
 )
+
+CUSTOMLIST_SOURCE_COLLECTION_MISSING = pd(
+    "http://librarysimplified.org/terms/problem/customlist-source-collection-missing",
+    status_code=400,
+    title=_("Source collection missing"),
+    detail=_("A source collection is not present in the library."),
+)
+
+CUSTOMLIST_ENTRY_NOT_VALID_FOR_LIBRARY = pd(
+    "http://librarysimplified.org/terms/problem/customlist-entry-not-valid-for-library",
+    status_code=400,
+    title=_("Entry not valid for library"),
+    detail=_(
+        "An entry in the customlist was not valid for the library being shared with."
+    ),
+)

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -667,6 +667,15 @@ def custom_list(list_id):
     return app.manager.admin_custom_lists_controller.custom_list(list_id)
 
 
+@library_route("/admin/custom_list/share", methods=["POST"])
+@has_library
+@returns_json_or_response_or_problem_detail
+@requires_admin
+@requires_csrf_token
+def custom_list_share():
+    return app.manager.admin_custom_lists_controller.share_locally()
+
+
 @library_route("/admin/lanes", methods=["GET", "POST"])
 @has_library
 @returns_json_or_response_or_problem_detail

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -667,13 +667,26 @@ def custom_list(list_id):
     return app.manager.admin_custom_lists_controller.custom_list(list_id)
 
 
-@library_route("/admin/custom_list/share", methods=["POST"])
+@library_route("/admin/custom_list/<list_id>/share", methods=["POST"])
 @has_library
 @returns_json_or_response_or_problem_detail
 @requires_admin
 @requires_csrf_token
-def custom_list_share():
-    return app.manager.admin_custom_lists_controller.share_locally()
+def custom_list_share(list_id):
+    return app.manager.admin_custom_lists_controller.share_locally(list_id)
+
+
+@library_route("/admin/custom_list/<list_id>/collection/share", methods=["POST"])
+@has_library
+@returns_json_or_response_or_problem_detail
+@requires_admin
+@requires_csrf_token
+def custom_list_share_library_collection(list_id):
+    return (
+        app.manager.admin_custom_lists_controller.share_locally_with_library_collection(
+            list_id
+        )
+    )
 
 
 @library_route("/admin/lanes", methods=["GET", "POST"])

--- a/core/model/customlist.py
+++ b/core/model/customlist.py
@@ -314,12 +314,16 @@ customlist_sharedlibrary = Table(
     Column(
         "customlist_id",
         Integer,
-        ForeignKey("customlists.id"),
+        ForeignKey("customlists.id", ondelete="CASCADE"),
         index=True,
         nullable=False,
     ),
     Column(
-        "library_id", Integer, ForeignKey("libraries.id"), index=True, nullable=False
+        "library_id",
+        Integer,
+        ForeignKey("libraries.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
     ),
     UniqueConstraint("customlist_id", "library_id"),
 )

--- a/core/model/customlist.py
+++ b/core/model/customlist.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    Table,
     Unicode,
     UniqueConstraint,
 )
@@ -48,6 +49,13 @@ class CustomList(Base):
     size = Column(Integer, nullable=False, default=0)
 
     entries = relationship("CustomListEntry", backref="customlist")
+
+    # List sharing mechanisms
+    shared_locally_with_libraries = relationship(
+        "Library",
+        secondary=lambda: customlist_sharedlibrary,
+        backref="shared_custom_lists",
+    )
 
     __table_args__ = (
         UniqueConstraint("data_source_id", "foreign_identifier"),
@@ -290,6 +298,23 @@ class CustomList(Base):
 
     def update_size(self):
         self.size = len(self.entries)
+
+
+customlist_sharedlibrary = Table(
+    "customlist_sharedlibraries",
+    Base.metadata,
+    Column(
+        "customlist_id",
+        Integer,
+        ForeignKey("customlists.id"),
+        index=True,
+        nullable=False,
+    ),
+    Column(
+        "library_id", Integer, ForeignKey("libraries.id"), index=True, nullable=False
+    ),
+    UniqueConstraint("customlist_id", "library_id"),
+)
 
 
 class CustomListEntry(Base):

--- a/core/model/customlist.py
+++ b/core/model/customlist.py
@@ -2,6 +2,7 @@
 
 import logging
 from functools import total_ordering
+from typing import TYPE_CHECKING, List
 
 from sqlalchemy import (
     Boolean,
@@ -24,6 +25,9 @@ from .datasource import DataSource
 from .identifier import Identifier
 from .licensing import LicensePool
 from .work import Work
+
+if TYPE_CHECKING:
+    from . import Collection
 
 
 @total_ordering
@@ -48,14 +52,18 @@ class CustomList(Base):
     # cached when the list contents change.
     size = Column(Integer, nullable=False, default=0)
 
-    entries = relationship("CustomListEntry", backref="customlist")
+    entries = relationship("CustomListEntry", backref="customlist", uselist=True)
 
     # List sharing mechanisms
     shared_locally_with_libraries = relationship(
         "Library",
-        secondary=lambda: customlist_sharedlibrary,
+        secondary=lambda: customlist_sharedlibrary,  # type: ignore
         backref="shared_custom_lists",
+        uselist=True,
     )
+
+    # Typing specific
+    collections: List["Collection"]
 
     __table_args__ = (
         UniqueConstraint("data_source_id", "foreign_identifier"),

--- a/core/model/library.py
+++ b/core/model/library.py
@@ -1,7 +1,7 @@
 # Library
 import logging
 from collections import Counter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from expiringdict import ExpiringDict
 from sqlalchemy import (
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
         CachedFeed,
         CachedMARCFile,
         CirculationEvent,
+        Collection,
         ConfigurationSetting,
         CustomList,
         ExternalIntegration,
@@ -136,6 +137,9 @@ class Library(Base, HasSessionCache):
     # used for Library.has_root_lane.  This is invalidated whenever
     # Lane configuration changes, and it will also expire on its own.
     _has_root_lane_cache = ExpiringDict(max_len=1000, max_age_seconds=3600)
+
+    # Typing specific
+    collections: List["Collection"]
 
     def __repr__(self):
         return (

--- a/core/model/library.py
+++ b/core/model/library.py
@@ -108,6 +108,8 @@ class Library(Base, HasSessionCache):
         backref="library",
         lazy="joined",
     )
+    # Lists shared with this library
+    shared_custom_lists: "CustomList"
 
     # A Library may have many ExternalIntegrations.
     integrations = relationship(

--- a/core/query/customlist.py
+++ b/core/query/customlist.py
@@ -1,0 +1,39 @@
+from typing import Union
+
+from api.admin.problem_details import (
+    CUSTOMLIST_ENTRY_NOT_VALID_FOR_LIBRARY,
+    CUSTOMLIST_SOURCE_COLLECTION_MISSING,
+)
+from core.model.customlist import CustomList, CustomListEntry
+from core.model.library import Library
+from core.model.licensing import LicensePool
+from core.util.problem_detail import ProblemDetail
+
+
+class CustomListQueries:
+    @classmethod
+    def share_locally_with_library(
+        cls, _db, customlist: CustomList, library: Library
+    ) -> Union[ProblemDetail, bool]:
+        # All customlist collections must be present in the library
+        for collection in customlist.collections:
+            if collection not in library.collections:
+                return CUSTOMLIST_SOURCE_COLLECTION_MISSING
+
+        # All entries must be valid for the library
+        library_collection_ids = [c.id for c in library.collections]
+        entry: CustomListEntry
+        for entry in customlist.entries:
+            valid_license = (
+                _db.query(LicensePool)
+                .filter(
+                    LicensePool.work_id == entry.work_id,
+                    LicensePool.collection_id.in_(library_collection_ids),
+                )
+                .first()
+            )
+            if valid_license is None:
+                return CUSTOMLIST_ENTRY_NOT_VALID_FOR_LIBRARY
+
+        customlist.shared_locally_with_libraries.append(library)
+        return True


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Local sharing of customlists between libraries
    
- New endpoint to share a list to a library
- New endpoint to share a list to any list associated with a specific collection
- On share we check that the collections and entries are in fact accessible to the library
- Beyond this, on list update we do not check for accessibility

Caveats
- Customlists already have odd behaviour on collection dissociation, this is retained, we do not delete list items if a collection is dissociated with a library that is sharing the collection
- Only the primary library can make changes to the shared lists
- In case a list is shared via a collection share, only the current list of libraries with that collection get access to the list. Any new library which gets associated with the collection will need to be reshared.
- We have no delete endpoint at the moment
- After sharing a list, an admin can add collections and works that are not accessible to a shared library into a list. This needs to be manually managed

## Motivation and Context
In case of collections shared across multiple libraries, it becomes a problem an operational problem to manage identical lists across the set of libraries.
For this we have introduced list sharing between libraries on the same CM.
[Notion ticket](https://www.notion.so/lyrasis/List-Sharing-between-Libraries-on-the-same-Palace-Manager-ebe85785816944069919f2005fec6e4e)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
