### PR TITLE
Patron support email address is no longer mandatory

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -266,16 +266,19 @@ class Configuration(CoreConfiguration):
             "description": _(
                 "An email address a patron can use if they need help, e.g. 'simplyehelp@yourlibrary.org'."
             ),
-            "required": True,
+            # "required": True,
+            "category": "Basic Information",
             "format": "email",
             "level": CoreConfiguration.SYS_ADMIN_ONLY,
         },
         {
             "key": HELP_WEB,
             "label": _("Patron support web site"),
-            "description": _("A URL for patrons to get help."),
+            "description": _(
+                "A URL for patrons to get help. Either this field or patron support email address must be provided."
+            ),
             "format": "url",
-            "category": "Patron Support",
+            "category": "Basic Information",
             "level": CoreConfiguration.ALL_ACCESS,
         },
         {

--- a/tests/api/admin/controller/test_library.py
+++ b/tests/api/admin/controller/test_library.py
@@ -239,6 +239,23 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
             response = self.manager.admin_library_settings_controller.process_post()
             assert response.uri == INCOMPLETE_CONFIGURATION.uri
 
+        # Either patron support email or website MUST be present
+        with self.request_context_with_admin("/", method="POST"):
+            flask.request.form = MultiDict(
+                [
+                    ("name", "Email or Website Library"),
+                    ("short_name", "Email or Website"),
+                    ("website", "http://example.org"),
+                    ("default_notification_email_address", "email@example.org"),
+                ]
+            )
+            response = self.manager.admin_library_settings_controller.process_post()
+            assert response.uri == INCOMPLETE_CONFIGURATION.uri
+            assert (
+                "Patron support email address or Patron support web site"
+                in response.detail
+            )
+
         # Test a web primary and secondary color that doesn't contrast
         # well on white. Here primary will, secondary should not.
         with self.request_context_with_admin("/", method="POST"):


### PR DESCRIPTION
## Description
Either support email address or support website MUST be configured
<!--- Describe your changes -->

## Motivation and Context
Some libraries do not have email addresses for support, they have websites.
The CM must allow either one to be configured per library.
[Notion](https://www.notion.so/lyrasis/Add-ability-to-add-a-help-URL-or-a-patron-support-email-address-in-the-CM-0aa0da7870fe44d9aa4c5937f2cd0d19)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
New and existing tests are passing
Authentication document and opds feed were checked the website link and/or email
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
