### PR TITLE
Feature/fix to search doc

### DIFF
--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1556,10 +1556,9 @@ class Work(Base):
 
             try:
                 search_doc = cls.search_doc_as_dict(cast(WorkTypevar, item))
+                results.append(search_doc)
             except:
                 logging.exception(f"Could not create search document for {item}")
-
-            results.append(search_doc)
 
         return results
 

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1553,7 +1553,12 @@ class Work(Base):
             item.classifications = list(  # type: ignore
                 filter(lambda idx: idx[0] == item.id, all_subjects)
             )
-            search_doc = cls.search_doc_as_dict(cast(WorkTypevar, item))
+
+            try:
+                search_doc = cls.search_doc_as_dict(cast(WorkTypevar, item))
+            except:
+                logging.exception(f"Could not create search document for {item}")
+
             results.append(search_doc)
 
         return results

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1667,7 +1667,8 @@ class Work(Base):
                 lc["licensed"] = (
                     item.unlimited_access or item.self_hosted or item.licenses_owned > 0
                 )
-                lc["medium"] = doc.presentation_edition.medium
+                if doc.presentation_edition:
+                    lc["medium"] = doc.presentation_edition.medium
                 lc["licensepool_id"] = item.id
                 lc["quality"] = doc.quality
                 result["licensepools"].append(lc)

--- a/tests/core/models/test_work.py
+++ b/tests/core/models/test_work.py
@@ -1306,6 +1306,19 @@ class TestWork(DatabaseTest):
             x["collection_id"] for x in search_doc["licensepools"]
         }
 
+    def test_to_search_doc_no_edition(self):
+        """There was a bug where to_search_documents would crash if
+        a presentation_edition was missing"""
+        work = self._work(with_license_pool=True)
+        work.presentation_edition = None
+        search_doc = work.to_search_document()
+
+        assert "edition" not in search_doc
+        assert len(search_doc["licensepools"]) == 1
+        assert (
+            "medium" not in search_doc["licensepools"][0]
+        )  # No presentation edition means no medium
+
     def test_age_appropriate_for_patron(self):
         work = self._work()
         work.audience = Classifier.AUDIENCE_YOUNG_ADULT


### PR DESCRIPTION
## Description
Fixed a bug wherein if a presentation edition did not exist for a work
the to_search_document would fail, which in turn would cause
the search indexing job to fail as well
<!--- Describe your changes -->

## Motivation and Context
A side effect of this was that custom lanes and search queries would not return these titles
[Notion](https://www.notion.so/lyrasis/Investigate-custom-lanes-populating-with-only-1-title-c9ac0704bc7a4ee88458449f3eac6982)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
