### PR TITLE
Require library IDs in customlists import/export scripts

### DIFF
--- a/customlists/README.md
+++ b/customlists/README.md
@@ -37,9 +37,9 @@ optional arguments:
 
 ```bash
 $ ./bin/customlist_import --help
-usage: customlist_import [-h] --server SERVER --username USERNAME
---password PASSWORD [--schema-file SCHEMA_FILE] [--schema-report-file SCHEMA_REPORT_FILE]
---file FILE --output OUTPUT [--dry-run] [--verbose]
+usage: customlist_import [-h] --server SERVER --username USERNAME --password PASSWORD
+[--schema-file SCHEMA_FILE] [--schema-report-file SCHEMA_REPORT_FILE]
+--library-name LIBRARY_NAME --file FILE --output OUTPUT [--dry-run] [--verbose]
 
 Import custom lists.
 
@@ -52,10 +52,13 @@ optional arguments:
                         The schema file for custom lists
   --schema-report-file SCHEMA_REPORT_FILE
                         The schema file for custom list reports
+  --library-name LIBRARY_NAME
+                        The destination library short name
   --file FILE           The customlists file
   --output OUTPUT       The output report
   --dry-run             Show what would be done, but don't do it.
   --verbose, -v         Increase verbosity (can be specified multiple times)
+
 
 ```
 
@@ -81,8 +84,8 @@ optional arguments:
 ## Example
 
 The following copies all lists that belong to the library with the short name `HAZELNUT` from `source.example.com`
-to `target.example.com`, producing an `output.csv` file that  contains any manual steps that might need to be performed
-afterwards:
+to the library `WALNUT` on `target.example.com`, producing an `output.csv` file that  contains any manual steps that
+might need to be performed afterwards:
 
 ```bash
 $ ./bin/customlist_export \
@@ -96,6 +99,7 @@ $ ./bin/customlist_import \
   --server http://target.example.com \
   --username admin-example \
   --password 12345678 \
+  --library-name WALNUT \
   --file export.json \
   --output report.json
 

--- a/customlists/README.md
+++ b/customlists/README.md
@@ -13,9 +13,9 @@ In order to copy _customlists_ between CM instances, a suite of three command-li
 
 ```bash
 $ ./bin/customlist_export --help
-usage: customlist_export [-h] [--schema-file SCHEMA_FILE] --server SERVER
---username USERNAME --password PASSWORD --output OUTPUT [--list LIST [LIST ...]]
-[--verbose]
+usage: customlist_export [-h] [--schema-file SCHEMA_FILE]
+--server SERVER --username USERNAME --password PASSWORD --output OUTPUT
+ --library-name LIBRARY_NAME [--list LIST [LIST ...]] [--verbose]
 
 Fetch one or more custom lists.
 
@@ -27,6 +27,8 @@ optional arguments:
   --username USERNAME   The CM admin username
   --password PASSWORD   The CM admin password
   --output OUTPUT       The output file
+  --library-name LIBRARY_NAME
+                        The short name of the library that owns the lists.
   --list LIST [LIST ...]
                         Only export the named list (may be repeated)
   --verbose, -v         Increase verbosity (can be specified multiple times to export multiple lists)
@@ -78,14 +80,16 @@ optional arguments:
 
 ## Example
 
-The following copies all lists from `source.example.com` to `target.example.com`, producing an `output.csv` file that
-contains any manual steps that might need to be performed afterwards:
+The following copies all lists that belong to the library with the short name `HAZELNUT` from `source.example.com`
+to `target.example.com`, producing an `output.csv` file that  contains any manual steps that might need to be performed
+afterwards:
 
 ```bash
 $ ./bin/customlist_export \
   --server http://source.example.com \
   --username admin-example \
   --password 12345678 \
+  --library-name HAZELNUT \
   --output export.json
 
 $ ./bin/customlist_import \

--- a/customlists/customlist_import.py
+++ b/customlists/customlist_import.py
@@ -138,9 +138,7 @@ class CustomListImporter:
         )
 
         """Check that the book on the target CM has a matching ID and title."""
-        server_work_endpoint: str = (
-            f"{self._server_base}/admin/works/{book.id_type()}/{book.id()}"
-        )
+        server_work_endpoint: str = f"{self._server_base}/{self._library_name}/admin/works/{book.id_type()}/{book.id()}"
         response = self._session.get(server_work_endpoint)
         if response.status_code == 404:
             problem_missing = CustomListProblemBookMissing.create(

--- a/customlists/customlist_import.py
+++ b/customlists/customlist_import.py
@@ -41,6 +41,7 @@ class CustomListImporter:
     _output_file: str
     _schema_file: str
     _schema_report_file: str
+    _library_name: str
 
     @staticmethod
     def _fatal(message: str):
@@ -77,6 +78,9 @@ class CustomListImporter:
             help="The schema file for custom list reports",
             required=False,
             default="customlists/customlists-report.schema.json",
+        )
+        parser.add_argument(
+            "--library-name", help="The destination library short name", required=True
         )
         parser.add_argument("--file", help="The customlists file", required=True)
         parser.add_argument("--output", help="The output report", required=True)
@@ -256,7 +260,9 @@ class CustomListImporter:
             f"Checking that list '{customlist.name()}' ({customlist.id()}) does not exist on the target CM"
         )
 
-        server_list_endpoint: str = f"{self._server_base}/admin/custom_lists"
+        server_list_endpoint: str = (
+            f"{self._server_base}/{self._library_name}/admin/custom_lists"
+        )
         response = self._session.get(server_list_endpoint)
         if response.status_code >= 400:
             self._fatal_response("Failed to retrieve custom lists", response)
@@ -305,7 +311,7 @@ class CustomListImporter:
 
             # Send the new list to the server.
             server_list_endpoint: str = (
-                f"{self._server_base}/{customlist.library_id()}/admin/custom_lists"
+                f"{self._server_base}/{self._library_name}/admin/custom_lists"
             )
 
             response = self._session.post(
@@ -405,6 +411,7 @@ class CustomListImporter:
         self._dry_run = args.dry_run
         self._schema_file = args.schema_file
         self._schema_report_file = args.schema_report_file
+        self._library_name = args.library_name
         verbose: int = args.verbose or 0
         if verbose > 0:
             self._logger.setLevel(logging.INFO)

--- a/customlists/customlist_report.py
+++ b/customlists/customlist_report.py
@@ -137,7 +137,7 @@ class CustomListProblemBookMissing(CustomListBookProblem):
         cls, id: str, id_type: str, title: str, author: str
     ) -> "CustomListProblemBookMissing":
         return CustomListProblemBookMissing(
-            f"The book '{title}' (id {id}) appears to be missing on the importing CM",
+            f"The book '{title}' (id {id}) does not appear to be present in the target library on the importing CM",
             id=id,
             id_type=id_type,
             title=title,

--- a/tests/customlists/test_export.py
+++ b/tests/customlists/test_export.py
@@ -65,6 +65,8 @@ class TestExports:
                     "someone@example.com",
                     "--password",
                     "12345678",
+                    "--library-name",
+                    "ANYTHING",
                     "--output",
                     str(output_file),
                     "-v",
@@ -82,7 +84,9 @@ class TestExports:
         list_response = MockAPIServerResponse()
         list_response.status_code = 200
         list_response.set_content(b'{"custom_lists":[]}')
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", list_response)
+        mock_web_server.enqueue_response(
+            "GET", "/HAZELNUT/admin/custom_lists", list_response
+        )
 
         schema_path = TestExports._customlists_resource_path("customlists.schema.json")
         output_file = tmpdir.join("output.json")
@@ -94,6 +98,8 @@ class TestExports:
                 "someone@example.com",
                 "--password",
                 "12345678",
+                "--library-name",
+                "HAZELNUT",
                 "--output",
                 str(output_file),
                 "--schema-file",
@@ -109,6 +115,47 @@ class TestExports:
 
         assert 0 == exports.size()
 
+    def test_export_nonexistent_library(self, mock_web_server: MockAPIServer, tmpdir):
+        """If the library is nonexistent, the export fails."""
+        sign_response = MockAPIServerResponse()
+        sign_response.status_code = 200
+        mock_web_server.enqueue_response(
+            "POST", "/admin/sign_in_with_password", sign_response
+        )
+
+        list_response = MockAPIServerResponse()
+        list_response.status_code = 404
+        list_response.set_content(
+            b'{"type": "http://librarysimplified.org/terms/problem/library-not-found", "title": "Library not found.", "status": 404, "detail": "No library with the requested name on this server."}'
+        )
+        mock_web_server.enqueue_response(
+            "GET", "/NONEXISTENT/admin/custom_lists", list_response
+        )
+
+        schema_path = TestExports._customlists_resource_path("customlists.schema.json")
+        output_file = tmpdir.join("output.json")
+
+        with pytest.raises(CustomListExportFailed) as e:
+            CustomListExporter.create(
+                [
+                    "--server",
+                    mock_web_server.url("/"),
+                    "--username",
+                    "someone@example.com",
+                    "--password",
+                    "12345678",
+                    "--library-name",
+                    "NONEXISTENT",
+                    "--output",
+                    str(output_file),
+                    "--schema-file",
+                    schema_path,
+                    "-v",
+                ]
+            ).execute()
+
+        assert e.value.args[0] == "Failed to retrieve custom lists: 404 Not Found"
+
     def test_export_list_retrieval_fails(self, mock_web_server: MockAPIServer, tmpdir):
         """If fetching the OPDS feed for a list fails, the list is marked as broken."""
         sign_response = MockAPIServerResponse()
@@ -122,11 +169,15 @@ class TestExports:
         lists_response.content = TestExports._test_customlists_resource_bytes(
             "id90-customlists-response.json"
         )
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response)
+        mock_web_server.enqueue_response(
+            "GET", "/HAZELNUT/admin/custom_lists", lists_response
+        )
 
         list_response = MockAPIServerResponse()
         list_response.status_code = 404
-        mock_web_server.enqueue_response("GET", "/admin/custom_list/90", list_response)
+        mock_web_server.enqueue_response(
+            "GET", "/HAZELNUT/admin/custom_list/90", list_response
+        )
 
         schema_path = TestExports._customlists_resource_path("customlists.schema.json")
         output_file = tmpdir.join("output.json")
@@ -138,6 +189,8 @@ class TestExports:
                 "someone@example.com",
                 "--password",
                 "12345678",
+                "--library-name",
+                "HAZELNUT",
                 "--output",
                 str(output_file),
                 "--schema-file",
@@ -170,14 +223,16 @@ class TestExports:
         lists_response.content = TestExports._test_customlists_resource_bytes(
             "multiple-customlists-response.json"
         )
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response)
+        mock_web_server.enqueue_response(
+            "GET", "/HAZELNUT/admin/custom_lists", lists_response
+        )
 
         list_response_0 = MockAPIServerResponse()
         list_response_0.status_code = 200
         with open(TestExports._test_customlists_resource_path("feed90.xml")) as file:
             list_response_0.set_content(file.read().encode("utf-8"))
         mock_web_server.enqueue_response(
-            "GET", "/admin/custom_list/90", list_response_0
+            "GET", "/HAZELNUT/admin/custom_list/90", list_response_0
         )
 
         list_response_1 = MockAPIServerResponse()
@@ -185,7 +240,7 @@ class TestExports:
         with open(TestExports._test_customlists_resource_path("feed91.xml")) as file:
             list_response_1.set_content(file.read().encode("utf-8"))
         mock_web_server.enqueue_response(
-            "GET", "/admin/custom_list/91", list_response_1
+            "GET", "/HAZELNUT/admin/custom_list/91", list_response_1
         )
 
         schema_path = TestExports._customlists_resource_path("customlists.schema.json")
@@ -198,6 +253,8 @@ class TestExports:
                 "someone@example.com",
                 "--password",
                 "12345678",
+                "--library-name",
+                "HAZELNUT",
                 "--output",
                 str(output_file),
                 "--schema-file",
@@ -242,14 +299,16 @@ class TestExports:
         lists_response.content = TestExports._test_customlists_resource_bytes(
             "multiple-customlists-response.json"
         )
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response)
+        mock_web_server.enqueue_response(
+            "GET", "/HAZELNUT/admin/custom_lists", lists_response
+        )
 
         list_response_0 = MockAPIServerResponse()
         list_response_0.status_code = 200
         with open(TestExports._test_customlists_resource_path("feed90.xml")) as file:
             list_response_0.set_content(file.read().encode("utf-8"))
         mock_web_server.enqueue_response(
-            "GET", "/admin/custom_list/90", list_response_0
+            "GET", "/HAZELNUT/admin/custom_list/90", list_response_0
         )
 
         schema_path = TestExports._customlists_resource_path("customlists.schema.json")
@@ -262,6 +321,8 @@ class TestExports:
                 "someone@example.com",
                 "--password",
                 "12345678",
+                "--library-name",
+                "HAZELNUT",
                 "--output",
                 str(output_file),
                 "--schema-file",
@@ -302,7 +363,9 @@ class TestExports:
         lists_response.content = TestExports._test_customlists_resource_bytes(
             "multiple-customlists-response.json"
         )
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response)
+        mock_web_server.enqueue_response(
+            "GET", "/HAZELNUT/admin/custom_lists", lists_response
+        )
 
         list_response_0 = MockAPIServerResponse()
         list_response_0.status_code = 200
@@ -311,7 +374,7 @@ class TestExports:
         ) as file:
             list_response_0.set_content(file.read().encode("utf-8"))
         mock_web_server.enqueue_response(
-            "GET", "/admin/custom_list/90", list_response_0
+            "GET", "/HAZELNUT/admin/custom_list/90", list_response_0
         )
 
         schema_path = TestExports._customlists_resource_path("customlists.schema.json")
@@ -324,6 +387,8 @@ class TestExports:
                 "someone@example.com",
                 "--password",
                 "12345678",
+                "--library-name",
+                "HAZELNUT",
                 "--output",
                 str(output_file),
                 "--schema-file",

--- a/tests/customlists/test_import.py
+++ b/tests/customlists/test_import.py
@@ -74,6 +74,8 @@ class TestImports:
                     "someone@example.com",
                     "--password",
                     "12345678",
+                    "--library-name",
+                    "WALNUT",
                     "--schema-file",
                     str(schema_path),
                     "--schema-report-file",
@@ -87,6 +89,89 @@ class TestImports:
             ).execute()
 
         assert 1 == len(mock_web_server.requests())
+
+    def test_import_library_nonexistent(self, mock_web_server: MockAPIServer, tmpdir):
+        """If the target library does not exist, importing fails."""
+        sign_response = MockAPIServerResponse()
+        sign_response.status_code = 200
+        sign_response.headers[
+            "Set-Cookie"
+        ] = "csrf_token=DUZ8inJjpISkyCYjHx7PONZM8354pCu4; HttpOnly; Path=/"
+        mock_web_server.enqueue_response(
+            "POST", "/admin/sign_in_with_password", sign_response
+        )
+
+        collection_response_0 = MockAPIServerResponse()
+        collection_response_0.status_code = 200
+        collection_response_0.content = self.normalCollections()
+        mock_web_server.enqueue_response(
+            "GET",
+            "/admin/collections",
+            collection_response_0,
+        )
+
+        work_response_0 = MockAPIServerResponse()
+        work_response_0.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
+            work_response_0,
+        )
+
+        work_response_1 = MockAPIServerResponse()
+        work_response_1.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+            work_response_1,
+        )
+
+        lists_response_0 = MockAPIServerResponse()
+        lists_response_0.status_code = 404
+        lists_response_0.content = b"No!"
+        mock_web_server.enqueue_response(
+            "GET", "/WALNUT/admin/custom_lists", lists_response_0
+        )
+
+        update_response_0 = MockAPIServerResponse()
+        update_response_0.status_code = 200
+        mock_web_server.enqueue_response(
+            "POST", "/WALNUT/admin/custom_lists", update_response_0
+        )
+
+        schema_path = TestImports._customlists_resource_path("customlists.schema.json")
+        schema_report_path = TestImports._customlists_resource_path(
+            "customlists-report.schema.json"
+        )
+        input_file = TestImports._test_customlists_resource_path(
+            "example-customlists.json"
+        )
+        output_file = tmpdir.join("output.json")
+
+        with pytest.raises(CustomListImportFailed) as e:
+            CustomListImporter.create(
+                [
+                    "--server",
+                    mock_web_server.url("/"),
+                    "--username",
+                    "someone@example.com",
+                    "--password",
+                    "12345678",
+                    "--library-name",
+                    "WALNUT",
+                    "--schema-file",
+                    str(schema_path),
+                    "--schema-report-file",
+                    str(schema_report_path),
+                    "--file",
+                    str(input_file),
+                    "--output",
+                    str(output_file),
+                    "-v",
+                ]
+            ).execute()
+
+            assert e.value.args[0] == "Failed to retrieve custom lists: 404 Not Found"
 
     def test_import_cannot_retrieve_custom_lists(
         self, mock_web_server: MockAPIServer, tmpdir
@@ -125,7 +210,9 @@ class TestImports:
 
         lists_response_0 = MockAPIServerResponse()
         lists_response_0.status_code = 404
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response_0)
+        mock_web_server.enqueue_response(
+            "GET", "/WALNUT/admin/custom_lists", lists_response_0
+        )
 
         schema_path = TestImports._customlists_resource_path("customlists.schema.json")
         schema_report_path = TestImports._customlists_resource_path(
@@ -147,6 +234,8 @@ class TestImports:
                     "someone@example.com",
                     "--password",
                     "12345678",
+                    "--library-name",
+                    "WALNUT",
                     "--schema-file",
                     str(schema_path),
                     "--schema-report-file",
@@ -199,12 +288,14 @@ class TestImports:
         lists_response_0 = MockAPIServerResponse()
         lists_response_0.status_code = 200
         lists_response_0.content = self.emptyCustomlists()
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response_0)
+        mock_web_server.enqueue_response(
+            "GET", "/WALNUT/admin/custom_lists", lists_response_0
+        )
 
         update_response_0 = MockAPIServerResponse()
         update_response_0.status_code = 500
         mock_web_server.enqueue_response(
-            "POST", "/HAZELNUT/admin/custom_lists", update_response_0
+            "POST", "/WALNUT/admin/custom_lists", update_response_0
         )
 
         schema_path = TestImports._customlists_resource_path("customlists.schema.json")
@@ -223,6 +314,8 @@ class TestImports:
                 "someone@example.com",
                 "--password",
                 "12345678",
+                "--library-name",
+                "WALNUT",
                 "--schema-file",
                 str(schema_path),
                 "--schema-report-file",
@@ -305,12 +398,14 @@ class TestImports:
         lists_response_0.content = TestImports._test_customlists_resource_bytes(
             "id90-customlists-response.json"
         )
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response_0)
+        mock_web_server.enqueue_response(
+            "GET", "/WALNUT/admin/custom_lists", lists_response_0
+        )
 
         update_response_0 = MockAPIServerResponse()
         update_response_0.status_code = 500
         mock_web_server.enqueue_response(
-            "POST", "/HAZELNUT/admin/custom_lists", update_response_0
+            "POST", "/WALNUT/admin/custom_lists", update_response_0
         )
 
         schema_path = TestImports._customlists_resource_path("customlists.schema.json")
@@ -329,6 +424,8 @@ class TestImports:
                 "someone@example.com",
                 "--password",
                 "12345678",
+                "--library-name",
+                "WALNUT",
                 "--schema-file",
                 str(schema_path),
                 "--schema-report-file",
@@ -402,7 +499,9 @@ class TestImports:
         lists_response_0 = MockAPIServerResponse()
         lists_response_0.status_code = 200
         lists_response_0.content = self.emptyCustomlists()
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response_0)
+        mock_web_server.enqueue_response(
+            "GET", "/WALNUT/admin/custom_lists", lists_response_0
+        )
 
         schema_path = TestImports._customlists_resource_path("customlists.schema.json")
         schema_report_path = TestImports._customlists_resource_path(
@@ -420,6 +519,8 @@ class TestImports:
                 "someone@example.com",
                 "--password",
                 "12345678",
+                "--library-name",
+                "WALNUT",
                 "--schema-file",
                 str(schema_path),
                 "--schema-report-file",
@@ -497,7 +598,9 @@ class TestImports:
         lists_response_0 = MockAPIServerResponse()
         lists_response_0.status_code = 200
         lists_response_0.content = self.emptyCustomlists()
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response_0)
+        mock_web_server.enqueue_response(
+            "GET", "/WALNUT/admin/custom_lists", lists_response_0
+        )
 
         schema_path = TestImports._customlists_resource_path("customlists.schema.json")
         schema_report_path = TestImports._customlists_resource_path(
@@ -515,6 +618,8 @@ class TestImports:
                 "someone@example.com",
                 "--password",
                 "12345678",
+                "--library-name",
+                "WALNUT",
                 "--schema-file",
                 str(schema_path),
                 "--schema-report-file",
@@ -593,12 +698,14 @@ class TestImports:
         lists_response_0 = MockAPIServerResponse()
         lists_response_0.status_code = 200
         lists_response_0.content = self.emptyCustomlists()
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response_0)
+        mock_web_server.enqueue_response(
+            "GET", "/WALNUT/admin/custom_lists", lists_response_0
+        )
 
         update_response_0 = MockAPIServerResponse()
         update_response_0.status_code = 200
         mock_web_server.enqueue_response(
-            "POST", "/HAZELNUT/admin/custom_lists", update_response_0
+            "POST", "/WALNUT/admin/custom_lists", update_response_0
         )
 
         schema_path = TestImports._customlists_resource_path("customlists.schema.json")
@@ -617,6 +724,8 @@ class TestImports:
                 "someone@example.com",
                 "--password",
                 "12345678",
+                "--library-name",
+                "WALNUT",
                 "--schema-file",
                 str(schema_path),
                 "--schema-report-file",
@@ -650,7 +759,7 @@ class TestImports:
 
         assert 6 == len(mock_web_server.requests())
         req = mock_web_server.requests()[5]
-        assert "/HAZELNUT/admin/custom_lists" == req.path
+        assert "/WALNUT/admin/custom_lists" == req.path
         assert "POST" == req.method
         assert "DUZ8inJjpISkyCYjHx7PONZM8354pCu4" == req.headers["X-CSRF-Token"]
 
@@ -692,12 +801,14 @@ class TestImports:
         lists_response_0 = MockAPIServerResponse()
         lists_response_0.status_code = 200
         lists_response_0.content = self.emptyCustomlists()
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response_0)
+        mock_web_server.enqueue_response(
+            "GET", "/WALNUT/admin/custom_lists", lists_response_0
+        )
 
         update_response_0 = MockAPIServerResponse()
         update_response_0.status_code = 200
         mock_web_server.enqueue_response(
-            "POST", "/HAZELNUT/admin/custom_lists", update_response_0
+            "POST", "/WALNUT/admin/custom_lists", update_response_0
         )
 
         schema_path = TestImports._customlists_resource_path("customlists.schema.json")
@@ -716,6 +827,8 @@ class TestImports:
                 "someone@example.com",
                 "--password",
                 "12345678",
+                "--library-name",
+                "WALNUT",
                 "--schema-file",
                 str(schema_path),
                 "--schema-report-file",
@@ -753,7 +866,7 @@ class TestImports:
 
         assert 6 == len(mock_web_server.requests())
         req = mock_web_server.requests()[5]
-        assert "/HAZELNUT/admin/custom_lists" == req.path
+        assert "/WALNUT/admin/custom_lists" == req.path
 
     def emptyCollections(self):
         return TestImports._test_customlists_resource_bytes(
@@ -797,12 +910,14 @@ class TestImports:
         lists_response_0 = MockAPIServerResponse()
         lists_response_0.status_code = 200
         lists_response_0.content = self.emptyCustomlists()
-        mock_web_server.enqueue_response("GET", "/admin/custom_lists", lists_response_0)
+        mock_web_server.enqueue_response(
+            "GET", "/WALNUT/admin/custom_lists", lists_response_0
+        )
 
         update_response_0 = MockAPIServerResponse()
         update_response_0.status_code = 200
         mock_web_server.enqueue_response(
-            "POST", "/HAZELNUT/admin/custom_lists", update_response_0
+            "POST", "/WALNUT/admin/custom_lists", update_response_0
         )
 
         schema_path = TestImports._customlists_resource_path("customlists.schema.json")
@@ -826,6 +941,8 @@ class TestImports:
                     "someone@example.com",
                     "--password",
                     "12345678",
+                    "--library-name",
+                    "WALNUT",
                     "--schema-file",
                     str(schema_path),
                     "--schema-report-file",

--- a/tests/customlists/test_import.py
+++ b/tests/customlists/test_import.py
@@ -114,7 +114,7 @@ class TestImports:
         work_response_0.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
+            "/WALNUT/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
             work_response_0,
         )
 
@@ -122,7 +122,7 @@ class TestImports:
         work_response_1.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+            "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
         )
 
@@ -196,7 +196,7 @@ class TestImports:
         work_response_0.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
+            "/WALNUT/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
             work_response_0,
         )
 
@@ -204,7 +204,7 @@ class TestImports:
         work_response_1.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+            "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
         )
 
@@ -273,7 +273,7 @@ class TestImports:
         work_response_0.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
+            "/WALNUT/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
             work_response_0,
         )
 
@@ -281,7 +281,7 @@ class TestImports:
         work_response_1.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+            "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
         )
 
@@ -381,7 +381,7 @@ class TestImports:
         work_response_0.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
+            "/WALNUT/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
             work_response_0,
         )
 
@@ -389,7 +389,7 @@ class TestImports:
         work_response_1.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+            "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
         )
 
@@ -484,7 +484,7 @@ class TestImports:
         work_response_0.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
+            "/WALNUT/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
             work_response_0,
         )
 
@@ -492,7 +492,7 @@ class TestImports:
         work_response_1.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+            "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
         )
 
@@ -583,7 +583,7 @@ class TestImports:
         work_response_0.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
+            "/WALNUT/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
             work_response_0,
         )
 
@@ -591,7 +591,7 @@ class TestImports:
         work_response_1.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+            "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
         )
 
@@ -683,7 +683,7 @@ class TestImports:
         work_response_0.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
+            "/WALNUT/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
             work_response_0,
         )
 
@@ -691,7 +691,7 @@ class TestImports:
         work_response_1.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+            "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
         )
 
@@ -786,7 +786,7 @@ class TestImports:
         work_response_0.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
+            "/WALNUT/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
             work_response_0,
         )
 
@@ -794,7 +794,7 @@ class TestImports:
         work_response_1.status_code = 200
         mock_web_server.enqueue_response(
             "GET",
-            "/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+            "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
         )
 


### PR DESCRIPTION
## Description

This changes the customlist import and export scripts to explicitly take library short identifiers as parameters instead of extracting them from OPDS feeds. This allows for extracting only those lists that belong to a given library, and importing them into a specific library on a target CM.

## Motivation and Context

@tdilauro Noted that the existing scripts didn't quite fit the migration use case.

https://www.notion.so/lyrasis/Migrate-discrete-entries-in-client-library-lists-from-old-CM-to-new-CM-1b78b13b10234ee59830c343ef4862dc

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The existing test suite was updated to include the new endpoint calls, and I tested this on a local CM across a couple of libraries.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
