### PR TITLE
Script to automatically update customlists with search criteria

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -6,7 +6,6 @@ import os
 import sys
 import urllib.parse
 from datetime import date, datetime, timedelta
-from enum import auto
 from typing import Union
 
 import flask

--- a/bin/custom_list_update_new_entries
+++ b/bin/custom_list_update_new_entries
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+"""Updates CustomLists with newly added entries if they are configured for it
+"""
+
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import CustomListUpdateEntriesScript
+
+CustomListUpdateEntriesScript().run()

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -1928,6 +1928,7 @@ class JSONQuery(Query):
     class Conjunctives(Values):
         AND = "and"
         OR = "or"
+        NOT = "not"
 
     class QueryLeaf(Values):
         KEY = "key"
@@ -2037,7 +2038,7 @@ class JSONQuery(Query):
         if set(query.keys()).intersection(leaves) == leaves:
             es_query = self._parse_json_leaf(query)
         # Are we an {and, or} query
-        elif {self.Conjunctives.AND, self.Conjunctives.OR}.issuperset(query.keys()):
+        elif set(self.Conjunctives.values()).issuperset(query.keys()):
             es_query = self._parse_json_join(query)
         else:
             raise QueryParseException(
@@ -2112,6 +2113,8 @@ class JSONQuery(Query):
             joined_query = Bool(must=to_join)
         elif join == self.Conjunctives.OR:
             joined_query = Bool(should=to_join)
+        elif join == self.Conjunctives.NOT:
+            joined_query = Bool(must_not=to_join)
 
         return joined_query
 

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -1968,6 +1968,7 @@ class JSONQuery(Query):
         "imprint": _KEYWORD_ONLY,
         "language": _KEYWORD_ONLY,
         "licensepools.available": dict(path="licensepools"),
+        "licensepools.availability_time": dict(path="licensepools"),
         "licensepools.collection_id": dict(path="licensepools"),
         "licensepools.data_source_id": dict(path="licensepools"),
         "licensepools.licensed": dict(path="licensepools"),

--- a/core/model/customlist.py
+++ b/core/model/customlist.py
@@ -62,6 +62,10 @@ class CustomList(Base):
         uselist=True,
     )
 
+    auto_update_enabled = Column(Boolean, default=False, index=True)
+    auto_update_query = Column(Unicode, nullable=True)
+    auto_update_last_update = Column(DateTime, nullable=True)
+
     # Typing specific
     collections: List["Collection"]
 

--- a/core/model/customlist.py
+++ b/core/model/customlist.py
@@ -27,7 +27,7 @@ from .licensing import LicensePool
 from .work import Work
 
 if TYPE_CHECKING:
-    from . import Collection
+    from . import Collection, Library
 
 
 @total_ordering
@@ -62,12 +62,13 @@ class CustomList(Base):
         uselist=True,
     )
 
-    auto_update_enabled = Column(Boolean, default=False, index=True)
+    auto_update_enabled = Column(Boolean, default=False)
     auto_update_query = Column(Unicode, nullable=True)
     auto_update_last_update = Column(DateTime, nullable=True)
 
     # Typing specific
     collections: List["Collection"]
+    library: "Library"
 
     __table_args__ = (
         UniqueConstraint("data_source_id", "foreign_identifier"),

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -3512,7 +3512,10 @@ class CustomListUpdateEntriesScript(CustomListSweeperScript):
         """Run a search on a custom list, assuming we have auto_update_enabled with a valid query
         Only json type queries are supported right now, without any support for additional facets"""
         try:
-            json_query = json.loads(custom_list.auto_update_query)
+            if custom_list.auto_update_query:
+                json_query = json.loads(custom_list.auto_update_query)
+            else:
+                return
         except json.JSONDecodeError as e:
             self.log.error(
                 f"Could not decode custom list({custom_list.id}) saved query: {e}"

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -3557,7 +3557,7 @@ class CustomListUpdateEntriesScript(CustomListSweeperScript):
             ## No more works
             if not len(works):
                 self.log.info(
-                    f"Completed customlist auto update {custom_list.name} with {total_works_updated} works"
+                    f"{custom_list.name} customlist updated with {total_works_updated} works, moving on..."
                 )
                 break
 

--- a/migration/20220624-update-customlists-auto-update.sql
+++ b/migration/20220624-update-customlists-auto-update.sql
@@ -1,0 +1,7 @@
+DO $$
+ BEGIN
+  ALTER TABLE customlists ADD COLUMN IF NOT EXISTS auto_update_enabled BOOLEAN DEFAULT false;
+  ALTER TABLE customlists ADD COLUMN IF NOT EXISTS auto_update_query TEXT DEFAULT NULL;
+  ALTER TABLE customlists ADD COLUMN IF NOT EXISTS auto_update_last_update TIMESTAMP DEFAULT NULL;
+ END;
+$$;


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Script to automatically update customlists with search criteria
    
Currently it only supports JSON type saved searches
with no support for additional facets
    
Pending items:
- Actual crontab entry

## Motivation and Context
The need for library administrators to save specific searches into lists and have them automatically update.
[Notion](https://www.notion.so/lyrasis/CM-Automatically-add-new-titles-to-list-when-they-match-search-parameters-0191dee472764129a08ee8c2781236fd?d=a9c05e8141eb4aed8d77bb0f4989fd5f)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
