### PR TITLE
Attempt to use ID values from URIs instead of id elements

### DIFF
--- a/customlists/customlist_export.py
+++ b/customlists/customlist_export.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 from typing import IO, Iterable, List, Union
+from urllib.parse import unquote
 
 import feedparser
 import jsonschema
@@ -391,10 +392,15 @@ class CustomListExporter:
                 if link.rel == "alternate":
                     match = re.search("^(.*)/works/([^/]+)/(.*)$", link.href)
                     if match is not None:
+                        id_quoted: str = match.group(3)
+                        id_type_quoted: str = match.group(2)
+                        id: str = unquote(id_quoted)
+                        id_type: str = unquote(id_type_quoted)
+
                         custom_list.add_book(
                             Book(
-                                id=entry.id,
-                                id_type=match.group(2),
+                                id=id,
+                                id_type=id_type,
                                 title=entry.title,
                                 author=entry.author,
                             )
@@ -406,7 +412,7 @@ class CustomListExporter:
                     ProblematicBook(
                         id=entry.id,
                         title=entry.title,
-                        message=f"Could not determine the identifier type for book {entry.id}, {entry.title}",
+                        message=f"Could not determine the identifier type for book {entry.title} (OPDS entry ID: {entry.id})",
                         author=entry.author,
                     )
                 )

--- a/customlists/customlist_export.py
+++ b/customlists/customlist_export.py
@@ -392,15 +392,15 @@ class CustomListExporter:
                 if link.rel == "alternate":
                     match = re.search("^(.*)/works/([^/]+)/(.*)$", link.href)
                     if match is not None:
-                        id_quoted: str = match.group(3)
-                        id_type_quoted: str = match.group(2)
-                        id: str = unquote(id_quoted)
-                        id_type: str = unquote(id_type_quoted)
+                        link_id_quoted: str = match.group(3)
+                        link_id_type_quoted: str = match.group(2)
+                        link_id: str = unquote(link_id_quoted)
+                        link_id_type: str = unquote(link_id_type_quoted)
 
                         custom_list.add_book(
                             Book(
-                                id=id,
-                                id_type=id_type,
+                                id=link_id,
+                                id_type=link_id_type,
                                 title=entry.title,
                                 author=entry.author,
                             )

--- a/customlists/customlist_export.py
+++ b/customlists/customlist_export.py
@@ -50,26 +50,34 @@ class CollectionReference:
 
 
 class Book:
-    _id: str
+    _id_value: str
     _id_type: str
+    _id_full: str
     _title: str
     _author: str
 
-    def __init__(self, id: str, id_type: str, title: str, author: str):
-        self._id = id
+    def __init__(
+        self, id_value: str, id_type: str, id_full: str, title: str, author: str
+    ):
+        self._id_value = id_value
         self._id_type = id_type
+        self._id_full = id_full
         self._title = title
         self._author = author
-        assert id
+        assert id_value
         assert id_type
+        assert id_full
         assert title
         assert author
 
     def id(self) -> str:
-        return self._id
+        return self._id_full
 
     def id_type(self) -> str:
         return self._id_type
+
+    def id_value(self) -> str:
+        return self._id_value
 
     def title(self) -> str:
         return self._title
@@ -80,8 +88,9 @@ class Book:
     def to_dict(self) -> dict:
         return {
             "%type": "book",
-            "id": self._id,
+            "id-value": self._id_value,
             "id-type": self._id_type,
+            "id-full": self._id_full,
             "title": self._title,
             "author": self._author,
         }
@@ -262,15 +271,16 @@ class CustomListExports:
             )
             for raw_book in raw_list["books"]:
                 book = Book(
-                    id=raw_book["id"],
+                    id_value=raw_book["id-value"],
                     id_type=raw_book["id-type"],
+                    id_full=raw_book["id-full"],
                     title=raw_book["title"],
                     author=raw_book["author"],
                 )
                 custom_list.add_book(book)
             for raw_book in raw_list["problematic-books"]:
                 problem_book = ProblematicBook(
-                    id=raw_book["id"],
+                    id=raw_book["id-full"],
                     message=raw_book["message"],
                     title=raw_book["title"],
                     author=raw_book["author"],
@@ -387,6 +397,7 @@ class CustomListExporter:
 
         # Now, for each book, extract the book identifier and identifier type.
         for entry in feed.entries:
+            entry_id: str = unquote(entry.id)
             added = False
             for link in entry.links:
                 if link.rel == "alternate":
@@ -399,8 +410,9 @@ class CustomListExporter:
 
                         custom_list.add_book(
                             Book(
-                                id=link_id,
+                                id_value=link_id,
                                 id_type=link_id_type,
+                                id_full=entry_id,
                                 title=entry.title,
                                 author=entry.author,
                             )
@@ -410,9 +422,9 @@ class CustomListExporter:
             if not added:
                 custom_list.add_problematic_book(
                     ProblematicBook(
-                        id=entry.id,
+                        id=entry_id,
                         title=entry.title,
-                        message=f"Could not determine the identifier type for book {entry.title} (OPDS entry ID: {entry.id})",
+                        message=f"Could not determine the identifier type for book {entry.title} (OPDS entry ID: {entry_id})",
                         author=entry.author,
                     )
                 )

--- a/customlists/customlist_import.py
+++ b/customlists/customlist_import.py
@@ -140,7 +140,7 @@ class CustomListImporter:
         )
 
         """Check that the book on the target CM has a matching ID and title."""
-        server_work_endpoint: str = f"{self._server_base}/{self._library_name}/admin/works/{book.id_type()}/{book.id()}"
+        server_work_endpoint: str = f"{self._server_base}/{self._library_name}/admin/works/{book.id_type()}/{book.id_value()}"
         response = self._session.get(server_work_endpoint)
         if response.status_code == 404:
             problem_missing = CustomListProblemBookMissing.create(

--- a/customlists/customlist_import.py
+++ b/customlists/customlist_import.py
@@ -2,7 +2,9 @@ import argparse
 import json
 import logging
 import os
+import re
 from typing import Dict, List, Set
+from urllib.parse import unquote
 
 import feedparser
 import requests
@@ -167,18 +169,25 @@ class CustomListImporter:
 
         feed = feedparser.parse(response.content)
         for entry in feed.entries:
-            if entry.id != book.id() or entry.title != book.title():
-                problem = CustomListProblemBookMismatch.create(
-                    expected_id=book.id(),
-                    expected_id_type=book.id_type(),
-                    expected_title=book.title(),
-                    received_id=entry.id,
-                    received_title=entry.title,
-                    author=book.author(),
-                )
-                self._logger.error(problem.message())
-                report.add_problem(problem)
-                rejected_books.add(book.id())
+            for link in entry.links:
+                if link.rel == "alternate":
+                    match = re.search("^(.*)/works/([^/]+)/(.*)$", link.href)
+                    if match is not None:
+                        link_id_quoted: str = match.group(3)
+                        link_id: str = unquote(link_id_quoted)
+                        if link_id != book.id() or entry.title != book.title():
+                            problem = CustomListProblemBookMismatch.create(
+                                expected_id=book.id(),
+                                expected_id_type=book.id_type(),
+                                expected_title=book.title(),
+                                received_id=entry.id,
+                                received_title=entry.title,
+                                author=book.author(),
+                            )
+                            self._logger.error(problem.message())
+                            report.add_problem(problem)
+                            rejected_books.add(book.id())
+                            break
 
     def _process_check_problematic_book(
         self,

--- a/customlists/customlist_report.py
+++ b/customlists/customlist_report.py
@@ -92,7 +92,7 @@ class CustomListProblemBookMismatch(CustomListBookProblem):
         author: str,
     ) -> "CustomListProblemBookMismatch":
         return CustomListProblemBookMismatch(
-            f"The book '{expected_title}' (id {expected_id}) appears to have title '{received_title}' (id {received_id}) on the importing CM",
+            f"Book is mismatched on the importing CM. Expected title is '{expected_title}', received title is '{received_title}'. Expected ID is '{expected_id}', received ID is '{received_id}'.",
             expected_id=expected_id,
             expected_id_type=expected_id_type,
             expected_title=expected_title,

--- a/customlists/customlists.schema.json
+++ b/customlists/customlists.schema.json
@@ -40,12 +40,16 @@
           "type": "string",
           "const": "book"
         },
-        "id": {
-          "$comment": "The primary identifier used for the book (typically an ISBN or similar)",
+        "id-value": {
+          "$comment": "The value part of an identifier (such as 614ed125-d7e5-4cff-b3de-6b6c90ff853c, in urn:librarysimplified.org/terms/id/Overdrive ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c)",
           "type": "string"
         },
         "id-type": {
           "$comment": "The type of the primary identifier",
+          "type": "string"
+        },
+        "id-full": {
+          "$comment": "The full, raw primary identifier for the book as it appeared on the exporting CM",
           "type": "string"
         },
         "title": {
@@ -60,8 +64,9 @@
       "additionalProperties": false,
       "required": [
         "%type",
-        "id",
+        "id-value",
         "id-type",
+        "id-full",
         "title",
         "author"
       ]
@@ -105,12 +110,16 @@
           "type": "string",
           "const": "problematic-book"
         },
-        "id": {
-          "$comment": "The primary identifier used for the book (typically an ISBN or similar)",
+        "id-value": {
+          "$comment": "The value part of an identifier (such as 614ed125-d7e5-4cff-b3de-6b6c90ff853c, in urn:librarysimplified.org/terms/id/Overdrive ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c)",
           "type": "string"
         },
         "id-type": {
           "$comment": "The type of the primary identifier",
+          "type": "string"
+        },
+        "id-full": {
+          "$comment": "The full, raw primary identifier for the book as it appeared on the exporting CM",
           "type": "string"
         },
         "title": {
@@ -130,8 +139,9 @@
       "required": [
         "%type",
         "author",
-        "id",
+        "id-value",
         "id-type",
+        "id-full",
         "message",
         "title"
       ]

--- a/tests/customlists/files/example-customlists.json
+++ b/tests/customlists/files/example-customlists.json
@@ -6,17 +6,35 @@
       "books": [
         {
           "%type": "book",
-          "id": "urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
+          "id-full": "urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
           "id-type": "URI",
+          "id-value": "urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
           "title": "Chameleon",
           "author": "Someone Else"
         },
         {
           "%type": "book",
-          "id": "urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+          "id-full": "urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
           "id-type": "URI",
+          "id-value": "urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
           "title": "Chameleon",
           "author": "Someone New"
+        },
+        {
+          "%type": "book",
+          "author": "Robert Crais",
+          "id-full": "urn:librarysimplified.org/terms/id/Overdrive ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c",
+          "id-type": "Overdrive ID",
+          "id-value": "614ed125-d7e5-4cff-b3de-6b6c90ff853c",
+          "title": "Suspect"
+        },
+        {
+          "%type": "book",
+          "author": "Andre Alice Norton",
+          "id-full": "http://www.feedbooks.com/book/859",
+          "id-type": "URI",
+          "id-value": "http://www.feedbooks.com/book/859",
+          "title": "The Time Traders"
         }
       ],
       "id": 90,
@@ -25,8 +43,9 @@
       "problematic-books": [
         {
           "%type": "problematic-book",
-          "id": "urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f7",
+          "id-full": "urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f7",
           "id-type": "URI",
+          "id-value": "9c9c1f5c-6742-47d4-b94c-e77f88ca55f7",
           "title": "Bad Book",
           "message": "Something went wrong on the source CM",
           "author": "Someone New"

--- a/tests/customlists/files/feed90-more-identifiers.xml
+++ b/tests/customlists/files/feed90-more-identifiers.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:schema="http://schema.org/">
+
+    <id>http://localhost:6500/HAZELNUT/admin/custom_list/90?list_name=Something+Else</id>
+    <title>Something Else</title>
+    <updated>2022-04-25T19:31:37+00:00</updated>
+    <link href="http://localhost:6500/HAZELNUT/admin/custom_list/90?list_name=Something+Else" rel="self"/>
+
+    <entry schema:additionalType="http://schema.org/EBook">
+        <title>Chameleon</title>
+        <author>
+            <name>Someone Else</name>
+        </author>
+        <summary type="html">Summary</summary>
+        <id>urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6</id>
+        <link rel="alternate"
+              href="http://localhost:6500/HAZELNUT/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6"
+              type="application/atom+xml;type=entry;profile=opds-catalog"/>
+    </entry>
+
+    <entry schema:additionalType="http://schema.org/EBook">
+        <title>Chameleon</title>
+        <author>
+            <name>Someone New</name>
+        </author>
+        <summary type="html">Summary</summary>
+        <id>urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03</id>
+        <link rel="alternate"
+              href="http://localhost:6500/HAZELNUT/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03"
+              type="application/atom+xml;type=entry;profile=opds-catalog"/>
+    </entry>
+
+    <entry schema:additionalType="http://schema.org/EBook">
+        <title>Suspect</title>
+        <author>
+            <name>Robert Crais</name>
+        </author>
+        <summary type="html">Summary</summary>
+        <id>urn:librarysimplified.org/terms/id/Overdrive%20ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c</id>
+        <link rel="alternate"
+              href="http://localhost:6500/WALNUT/works/Overdrive%20ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c"
+              type="application/atom+xml;type=entry;profile=opds-catalog"/>
+    </entry>
+
+    <entry schema:additionalType="http://schema.org/EBook">
+        <title>The Time Traders</title>
+        <author>
+            <name>Andre Alice Norton</name>
+        </author>
+        <summary type="html">Summary</summary>
+        <id>http://www.feedbooks.com/book/859</id>
+        <link rel="alternate"
+              href="http://localhost:6500/HAZELNUT/works/URI/http://www.feedbooks.com/book/859"
+              type="application/atom+xml;type=entry;profile=opds-catalog"/>
+    </entry>
+
+    <entry schema:additionalType="http://schema.org/EBook">
+        <title>Quadrant Conference, August 1943 : papers and minutes of meetings</title>
+        <author>
+            <name>Quebec Conference</name>
+        </author>
+        <summary type="html">Summary</summary>
+        <id>urn:isbn:9780160938818</id>
+        <link rel="alternate"
+              href="http://localhost:6500/HAZELNUT/works/ISBN/9780160938818"
+              type="application/atom+xml;type=entry;profile=opds-catalog"/>
+    </entry>
+
+</feed>

--- a/tests/customlists/files/feed90.xml
+++ b/tests/customlists/files/feed90.xml
@@ -10,6 +10,7 @@
     <title>Something Else</title>
     <updated>2022-04-25T19:31:37+00:00</updated>
     <link href="http://localhost:6500/HAZELNUT/admin/custom_list/90?list_name=Something+Else" rel="self"/>
+
     <entry schema:additionalType="http://schema.org/EBook">
         <title>Chameleon</title>
         <author>

--- a/tests/customlists/files/feed90_different_id.xml
+++ b/tests/customlists/files/feed90_different_id.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:app="http://www.w3.org/2007/app"
+      xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog"
+      xmlns:opf="http://www.idpf.org/2007/opf" xmlns:drm="http://librarysimplified.org/terms/drm"
+      xmlns:schema="http://schema.org/" xmlns:simplified="http://librarysimplified.org/terms/"
+      xmlns:bibframe="http://bibframe.org/vocab/" xmlns:bib="http://bib.schema.org/"
+      xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/" xmlns:lcp="http://readium.org/lcp-specs/ns">
+    <id>http://localhost:6500/HAZELNUT/admin/custom_list/90?list_name=Something+Else</id>
+    <title>Something Else</title>
+    <updated>2022-04-25T19:31:37+00:00</updated>
+    <link href="http://localhost:6500/HAZELNUT/admin/custom_list/90?list_name=Something+Else" rel="self"/>
+    <entry schema:additionalType="http://schema.org/EBook">
+        <title>Chameleon</title>
+        <author>
+            <name>Richard Hains</name>
+            <link rel="contributor" type="application/atom+xml;profile=opds-catalog;kind=acquisition"
+                  title="Richard Hains"
+                  href="http://localhost:6500/HAZELNUT/works/contributor/Richard%20Hains/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult"/>
+        </author>
+        <summary type="html">Jon Phillips is head bond trader at one of Wall Street's largest investment banks and lives
+            the American dream in the heart of New York's decadent banking community. But, after years of selfishness
+            and extravagance, he plans his exit through an unprecedented and ultimately fraudulent deal in the US
+            government bond market. A high-ranking colleague, who sits on the bank's main board, has teamed up with a
+            Russian financier in order to provide Jon with one of the key elements vital to the success of his ingenious
+            scheme. The deal goes spectacularly wrong and Jon's world collapses. As the Russians desperately attempt to
+            recover their lost millions, Jon is thrown into a deadly game of cat and mouse. From the seedy nightspots of
+            downtown NYC to the plush yacht clubs of the Hamptons, pastoral aristocratic England, and Southern
+            Australia's endless beaches, past lovers, new menaces, and numerous apparently accidental deaths line his
+            trail. Jon's survival now depends on putting the past behind him and becoming a calculated predator instead
+            of the vulnerable prey.
+        </summary>
+        <simplified:pwid>160623c4-ded3-21dc-d075-a603641b4a35</simplified:pwid>
+        <link rel="http://opds-spec.org/image"
+              href="https://library.biblioboard.com/ext/api/media/9c9c1f5c-6742-47d4-b94c-e77f88ca55f6/assets/thumbnail_full.jpg"
+              type="image/jpeg"/>
+        <link rel="http://opds-spec.org/image/thumbnail"
+              href="https://library.biblioboard.com/ext/api/media/9c9c1f5c-6742-47d4-b94c-e77f88ca55f6/assets/thumbnail.jpg"
+              type="image/jpeg"/>
+        <category scheme="http://librarysimplified.org/terms/fiction/"
+                  term="http://librarysimplified.org/terms/fiction/Fiction" label="Fiction"/>
+        <category scheme="http://librarysimplified.org/terms/genres/Simplified/"
+                  term="http://librarysimplified.org/terms/genres/Simplified/Suspense/Thriller"
+                  label="Suspense/Thriller"/>
+        <category scheme="http://schema.org/audience" term="Adult" label="Adult"/>
+        <dcterms:language>en</dcterms:language>
+        <dcterms:publisher>Beaufort Books</dcterms:publisher>
+        <dcterms:issued>2006-01-01</dcterms:issued>
+        <link rel="issues"
+              href="http://localhost:6500/HAZELNUT/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6/report"/>
+        <id>urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6</id>
+        <link rel="alternate"
+              href="http://localhost:6500/HAZELNUT/works/URI/urn:xyz"
+              type="application/atom+xml;type=entry;profile=opds-catalog"/>
+        <bibframe:distribution bibframe:ProviderName="BiblioBoard"/>
+        <published>2022-04-14T00:00:00Z</published>
+        <updated>2022-04-15T16:25:27+00:00</updated>
+        <link type="application/atom+xml;type=entry;profile=opds-catalog" rel="http://opds-spec.org/acquisition/borrow"
+              href="http://localhost:6500/HAZELNUT/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6/borrow">
+            <opds:indirectAcquisition type="application/vnd.librarysimplified.bearer-token+json">
+                <opds:indirectAcquisition type="application/epub+zip"/>
+            </opds:indirectAcquisition>
+            <opds:availability status="available"/>
+            <opds:holds total="0"/>
+            <opds:copies total="1" available="1"/>
+        </link>
+        <link rel="related" type="application/atom+xml;profile=opds-catalog;kind=acquisition" title="Recommended Works"
+              href="http://localhost:6500/HAZELNUT/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6/related_books"/>
+        <link rel="http://www.w3.org/ns/oa#annotationService"
+              type="application/ld+json; profile=&quot;http://www.w3.org/ns/anno.jsonld&quot;"
+              href="http://localhost:6500/HAZELNUT/annotations/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6"/>
+        <link rel="http://librarysimplified.org/terms/rel/analytics/open-book"
+              href="http://localhost:6500/HAZELNUT/analytics/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6/open_book"/>
+    </entry>
+    <link rel="http://opds-spec.org/auth/document" href="http://localhost:6500/HAZELNUT/authentication_document"/>
+    <link rel="search" type="application/opensearchdescription+xml" href="http://localhost:6500/HAZELNUT/search/"/>
+    <link rel="http://opds-spec.org/shelf" type="application/atom+xml;profile=opds-catalog;kind=acquisition"
+          href="http://localhost:6500/HAZELNUT/loans/"/>
+    <link rel="http://www.w3.org/ns/oa#annotationService"
+          type="application/ld+json; profile=&quot;http://www.w3.org/ns/anno.jsonld&quot;"
+          href="http://localhost:6500/HAZELNUT/annotations/"/>
+    <link rel="http://opds-spec.org/crawlable" type="application/atom+xml;profile=opds-catalog;kind=acquisition"
+          href="http://localhost:6500/HAZELNUT/lists/Something%20Else/crawlable"/>
+    <link href="mailto:someone@example.com" rel="help"/>
+</feed>

--- a/tests/customlists/files/feed92.xml
+++ b/tests/customlists/files/feed92.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:app="http://www.w3.org/2007/app"
+      xmlns:dcterms="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog"
+      xmlns:opf="http://www.idpf.org/2007/opf" xmlns:drm="http://librarysimplified.org/terms/drm"
+      xmlns:schema="http://schema.org/" xmlns:simplified="http://librarysimplified.org/terms/"
+      xmlns:bibframe="http://bibframe.org/vocab/" xmlns:bib="http://bib.schema.org/"
+      xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/" xmlns:lcp="http://readium.org/lcp-specs/ns">
+    <id>http://localhost:6500/HAZELNUT/admin/custom_list/92?list_name=Other</id>
+    <title>Other</title>
+    <updated>2022-04-25T19:31:37+00:00</updated>
+    <link href="http://localhost:6500/HAZELNUT/admin/custom_list/92?list_name=Other" rel="self"/>
+
+    <entry schema:additionalType="http://schema.org/EBook">
+        <title>Snapdragon</title>
+        <author>
+            <name>Kat Leyh</name>
+            <link rel="contributor" type="application/atom+xml;profile=opds-catalog;kind=acquisition" title="Kat Leyh" href="https://ct.thepalaceproject.org/CT0118/works/contributor/Kat%20Leyh/eng/Children"/>
+        </author>
+        <summary type="html">&lt;p&gt;&lt;b&gt;Kat Leyh's &lt;i&gt;Snapdragon&lt;/i&gt; is a magical realist graphic novel about a young girl who befriends her town’s witch and discovers the strange magic within herself.&lt;/b&gt;&lt;br&gt;&lt;br&gt;Snap's town had a witch.&lt;br&gt;&lt;br&gt;At least, that’s how the rumor goes. But in reality, Jacks is just a crocks-wearing, internet-savvy old lady who sells roadkill skeletons online—after doing a little ritual to put their spirits to rest. It’s creepy, &lt;i&gt;sure&lt;/i&gt;, but Snap thinks it’s kind of cool, too.&lt;br&gt;&lt;br&gt;They make a deal: Jacks will teach Snap how to take care of the baby opossums that Snap rescued, and Snap will help Jacks with her work. But as Snap starts to get to know Jacks, she realizes that Jacks may in fact have &lt;i&gt;real &lt;/i&gt;magic—and a connection with Snap’s family’s past.&lt;/p&gt;</summary>
+        <simplified:pwid>a04c847a-5416-7565-0eeb-fde8c6ada3bd</simplified:pwid>
+        <link rel="http://opds-spec.org/image" href="https://covers.feedbooks.net/item/3381116.jpg?size=large&amp;t=1611651306" type="image/png"/>
+        <link rel="http://opds-spec.org/image/thumbnail" href="https://covers.feedbooks.net/item/3381116.jpg?t=1611651306" type="image/png"/>
+        <category scheme="http://librarysimplified.org/terms/fiction/" term="http://librarysimplified.org/terms/fiction/Fiction" label="Fiction"/>
+        <category scheme="http://librarysimplified.org/terms/genres/Simplified/" term="http://librarysimplified.org/terms/genres/Simplified/Comics%20%26%20Graphic%20Novels" label="Comics &amp; Graphic Novels"/>
+        <category scheme="http://librarysimplified.org/terms/genres/Simplified/" term="http://librarysimplified.org/terms/genres/Simplified/Fantasy" label="Fantasy"/>
+        <category scheme="http://schema.org/audience" term="Children" label="Children"/>
+        <category scheme="http://schema.org/typicalAgeRange" term="9-13" label="9-13"/>
+        <dcterms:language>en</dcterms:language>
+        <dcterms:publisher>First Second</dcterms:publisher>
+        <dcterms:issued>2020-02-03</dcterms:issued>
+        <link rel="issues" href="https://ct.thepalaceproject.org/CT0118/works/ISBN/9781250776341/report"/>
+        <id>urn:isbn:9781250776341</id>
+        <link rel="alternate" href="https://ct.thepalaceproject.org/CT0118/works/ISBN/9781250776341" type="application/atom+xml;type=entry;profile=opds-catalog"/>
+        <bibframe:distribution bibframe:ProviderName="Palace Marketplace"/>
+        <published>2021-11-19T00:00:00Z</published>
+        <updated>2022-06-21T19:03:46+00:00</updated>
+        <link type="application/atom+xml;type=entry;profile=opds-catalog" rel="http://opds-spec.org/acquisition/borrow" href="https://ct.thepalaceproject.org/CT0118/works/ISBN/9781250776341/borrow">
+            <opds:indirectAcquisition type="application/vnd.adobe.adept+xml">
+                <opds:indirectAcquisition type="application/epub+zip"/>
+            </opds:indirectAcquisition>
+            <opds:indirectAcquisition type="application/vnd.readium.lcp.license.v1.0+json">
+                <opds:indirectAcquisition type="application/epub+zip"/>
+            </opds:indirectAcquisition>
+            <opds:availability status="available"/>
+            <opds:holds total="0"/>
+            <opds:copies total="2399977" available="25"/>
+        </link>
+        <link rel="related" type="application/atom+xml;profile=opds-catalog;kind=acquisition" title="Recommended Works" href="https://ct.thepalaceproject.org/CT0118/works/ISBN/9781250776341/related_books"/>
+        <link rel="http://www.w3.org/ns/oa#annotationService" type="application/ld+json; profile=&quot;http://www.w3.org/ns/anno.jsonld&quot;" href="https://ct.thepalaceproject.org/CT0118/annotations/ISBN/9781250776341"/>
+        <link rel="http://librarysimplified.org/terms/rel/analytics/open-book" href="https://ct.thepalaceproject.org/CT0118/analytics/ISBN/9781250776341/open_book"/>
+    </entry>
+
+    <entry schema:additionalType="http://bib.schema.org/Audiobook">
+        <title>This Town Sleeps</title>
+        <author>
+            <name>Dennis E. Staples</name>
+            <link rel="contributor" type="application/atom+xml;profile=opds-catalog;kind=acquisition" title="Dennis E. Staples" href="https://ct.thepalaceproject.org/CT0118/works/contributor/Dennis%20E.%20Staples/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult"/>
+        </author>
+        <author>
+            <name>Kaipo Schwab</name>
+            <link rel="contributor" type="application/atom+xml;profile=opds-catalog;kind=acquisition" title="Kaipo Schwab" href="https://ct.thepalaceproject.org/CT0118/works/contributor/Kaipo%20Schwab/eng/Adult%2CAdults%2BOnly%2CAll%2BAges%2CChildren%2CYoung%2BAdult"/>
+        </author>
+        <summary type="html">Set on a reservation in far northern Minnesota, This Town Sleeps explores the many ways history, culture, landscape, and lineage shape our lives, our understanding of the world we inhabit, and the stories we tell ourselves to make sense of it all.On an Ojibwe reservation called Languille Lake, within the small town of Geshig at the hub of the rez, two men enter into a secret romance. Marion Lafournier, a midtwenties gay Ojibwe man, begins a relationship with his former classmate Shannon, a heavily closeted white man. While Marion is far more open about his sexuality, neither is immune to the realities of the lives of gay men in small towns and closed societies.Then one night, while roaming the dark streets of Geshig, Marion unknowingly brings to life the spirit of a dog from beneath the elementary school playground. The mysterious revenant leads him to the grave of Kayden Kelliher, an Ojibwe basketball star who was murdered at the young age of seventeen and whose presence still lingers in the memories of the townsfolk. While investigating the fallen hero's death, Marion discovers family connections and an old Ojibwe legend that may be the secret to unraveling the mystery he has found himself in.</summary>
+        <simplified:pwid>cf784a59-4bd3-ea8a-81c3-9590492a824f</simplified:pwid>
+        <link rel="http://opds-spec.org/image" href="http://contentcafecloud.baker-taylor.com/Jacket.svc/D65D0665-050A-487B-9908-16E6D8FF5C3E/9781684578740/Large/Logo" type="image/png"/>
+        <link rel="http://opds-spec.org/image/thumbnail" href="http://contentcafecloud.baker-taylor.com/Jacket.svc/D65D0665-050A-487B-9908-16E6D8FF5C3E/9781684578740/Medium/Logo" type="image/png"/>
+        <category scheme="http://librarysimplified.org/terms/fiction/" term="http://librarysimplified.org/terms/fiction/Fiction" label="Fiction"/>
+        <category scheme="http://librarysimplified.org/terms/genres/Simplified/" term="http://librarysimplified.org/terms/genres/Simplified/Fantasy" label="Fantasy"/>
+        <category scheme="http://schema.org/audience" term="Adult" label="Adult"/>
+        <dcterms:language>en</dcterms:language>
+        <dcterms:publisher>Highbridge Co</dcterms:publisher>
+        <bib:publisherImprint>Highbridge Co</bib:publisherImprint>
+        <dcterms:issued>2020-03-03</dcterms:issued>
+        <link rel="issues" href="https://ct.thepalaceproject.org/CT0118/works/Axis%20360%20ID/0026082126/report"/>
+        <id>urn:librarysimplified.org/terms/id/Axis%20360%20ID/0026082126</id>
+        <link rel="alternate" href="https://ct.thepalaceproject.org/CT0118/works/Axis%20360%20ID/0026082126" type="application/atom+xml;type=entry;profile=opds-catalog"/>
+        <bibframe:distribution bibframe:ProviderName="Axis 360"/>
+        <published>2021-10-18T00:00:00Z</published>
+        <updated>2022-06-23T09:56:17+00:00</updated>
+        <link type="application/atom+xml;type=entry;profile=opds-catalog" rel="http://opds-spec.org/acquisition/borrow" href="https://ct.thepalaceproject.org/CT0118/works/Axis%20360%20ID/0026082126/borrow/6">
+            <opds:indirectAcquisition type="application/vnd.librarysimplified.findaway.license+json"/>
+            <opds:availability status="unavailable"/>
+            <opds:holds total="0"/>
+            <opds:copies total="1" available="0"/>
+        </link>
+        <link rel="related" type="application/atom+xml;profile=opds-catalog;kind=acquisition" title="Recommended Works" href="https://ct.thepalaceproject.org/CT0118/works/Axis%20360%20ID/0026082126/related_books"/>
+        <link rel="http://www.w3.org/ns/oa#annotationService" type="application/ld+json; profile=&quot;http://www.w3.org/ns/anno.jsonld&quot;" href="https://ct.thepalaceproject.org/CT0118/annotations/Axis%20360%20ID/0026082126"/>
+        <link rel="http://librarysimplified.org/terms/rel/analytics/open-book" href="https://ct.thepalaceproject.org/CT0118/analytics/Axis%20360%20ID/0026082126/open_book"/>
+    </entry>
+
+    <link rel="http://opds-spec.org/auth/document" href="http://localhost:6500/HAZELNUT/authentication_document"/>
+    <link rel="search" type="application/opensearchdescription+xml" href="http://localhost:6500/HAZELNUT/search/"/>
+    <link rel="http://opds-spec.org/shelf" type="application/atom+xml;profile=opds-catalog;kind=acquisition"
+          href="http://localhost:6500/HAZELNUT/loans/"/>
+    <link rel="http://www.w3.org/ns/oa#annotationService"
+          type="application/ld+json; profile=&quot;http://www.w3.org/ns/anno.jsonld&quot;"
+          href="http://localhost:6500/HAZELNUT/annotations/"/>
+    <link rel="http://opds-spec.org/crawlable" type="application/atom+xml;profile=opds-catalog;kind=acquisition"
+          href="http://localhost:6500/HAZELNUT/lists/Other/crawlable"/>
+    <link href="mailto:someone@example.com" rel="help"/>
+</feed>

--- a/tests/customlists/files/problematic-ids-customlists.json
+++ b/tests/customlists/files/problematic-ids-customlists.json
@@ -1,0 +1,16 @@
+{
+  "custom_lists": [
+    {
+      "collections": [
+        {
+          "id": 864,
+          "name": "B2",
+          "protocol": "OPDS for Distributors"
+        }
+      ],
+      "entry_count": 1,
+      "id": 92,
+      "name": "Something Else"
+    }
+  ]
+}

--- a/tests/customlists/test_export.py
+++ b/tests/customlists/test_export.py
@@ -550,11 +550,109 @@ class TestExports:
         assert "Something Else" == result_list.name()
 
         book = list(result_list.books())[0]
-        assert "9781250776341" == book.id()
+        assert "urn:isbn:9781250776341" == book.id()
+        assert "9781250776341" == book.id_value()
         assert "Snapdragon" == book.title()
         assert "ISBN" == book.id_type()
 
         book = list(result_list.books())[1]
-        assert "0026082126" == book.id()
+        assert "urn:librarysimplified.org/terms/id/Axis 360 ID/0026082126" == book.id()
+        assert "0026082126" == book.id_value()
         assert "This Town Sleeps" == book.title()
         assert "Axis 360 ID" == book.id_type()
+
+    def test_export_other_identifiers(self, mock_web_server: MockAPIServer, tmpdir):
+        """A collection with more problematic identifiers."""
+        sign_response = MockAPIServerResponse()
+        sign_response.status_code = 200
+        mock_web_server.enqueue_response(
+            "POST", "/admin/sign_in_with_password", sign_response
+        )
+
+        lists_response = MockAPIServerResponse()
+        lists_response.status_code = 200
+        lists_response.content = TestExports._test_customlists_resource_bytes(
+            "id90-customlists-response.json"
+        )
+        mock_web_server.enqueue_response(
+            "GET", "/HAZELNUT/admin/custom_lists", lists_response
+        )
+
+        list_response_0 = MockAPIServerResponse()
+        list_response_0.status_code = 200
+        with open(
+            TestExports._test_customlists_resource_path("feed90-more-identifiers.xml")
+        ) as file:
+            list_response_0.set_content(file.read().encode("utf-8"))
+        mock_web_server.enqueue_response(
+            "GET", "/HAZELNUT/admin/custom_list/90", list_response_0
+        )
+
+        schema_path = TestExports._customlists_resource_path("customlists.schema.json")
+        output_file = tmpdir.join("output.json")
+        CustomListExporter.create(
+            [
+                "--server",
+                mock_web_server.url("/"),
+                "--username",
+                "someone@example.com",
+                "--password",
+                "12345678",
+                "--library-name",
+                "HAZELNUT",
+                "--output",
+                str(output_file),
+                "--schema-file",
+                schema_path,
+                "-v",
+            ]
+        ).execute()
+
+        exports: CustomListExports
+        with open(schema_path, "rb") as schema_file:
+            schema_text = json.load(schema_file)
+            exports = CustomListExports.parse_file(file=output_file, schema=schema_text)
+
+        assert 1 == exports.size()
+        result_list = list(exports.lists())[0]
+
+        assert 5 == result_list.size()
+        assert "HAZELNUT" == result_list.library_id()
+        assert 90 == result_list.id()
+        assert "Something Else" == result_list.name()
+
+        book = list(result_list.books())[0]
+        assert "urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6" == book.id()
+        assert "urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6" == book.id_value()
+        assert "Chameleon" == book.title()
+        assert "URI" == book.id_type()
+
+        book = list(result_list.books())[1]
+        assert "urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03" == book.id()
+        assert "urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03" == book.id_value()
+        assert "Chameleon" == book.title()
+        assert "URI" == book.id_type()
+
+        book = list(result_list.books())[2]
+        assert (
+            "urn:librarysimplified.org/terms/id/Overdrive ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c"
+            == book.id()
+        )
+        assert "614ed125-d7e5-4cff-b3de-6b6c90ff853c" == book.id_value()
+        assert "Suspect" == book.title()
+        assert "Overdrive ID" == book.id_type()
+
+        book = list(result_list.books())[3]
+        assert "http://www.feedbooks.com/book/859" == book.id()
+        assert "http://www.feedbooks.com/book/859" == book.id_value()
+        assert "The Time Traders" == book.title()
+        assert "URI" == book.id_type()
+
+        book = list(result_list.books())[4]
+        assert "urn:isbn:9780160938818" == book.id()
+        assert "9780160938818" == book.id_value()
+        assert (
+            "Quadrant Conference, August 1943 : papers and minutes of meetings"
+            == book.title()
+        )
+        assert "ISBN" == book.id_type()

--- a/tests/customlists/test_import.py
+++ b/tests/customlists/test_import.py
@@ -126,6 +126,22 @@ class TestImports:
             work_response_1,
         )
 
+        work_response_2 = MockAPIServerResponse()
+        work_response_2.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/Overdrive%20ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c",
+            work_response_2,
+        )
+
+        work_response_3 = MockAPIServerResponse()
+        work_response_3.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/URI/http://www.feedbooks.com/book/859",
+            work_response_3,
+        )
+
         lists_response_0 = MockAPIServerResponse()
         lists_response_0.status_code = 404
         lists_response_0.content = b"No!"
@@ -208,6 +224,22 @@ class TestImports:
             work_response_1,
         )
 
+        work_response_2 = MockAPIServerResponse()
+        work_response_2.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/Overdrive%20ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c",
+            work_response_2,
+        )
+
+        work_response_3 = MockAPIServerResponse()
+        work_response_3.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/URI/http://www.feedbooks.com/book/859",
+            work_response_3,
+        )
+
         lists_response_0 = MockAPIServerResponse()
         lists_response_0.status_code = 404
         mock_web_server.enqueue_response(
@@ -248,7 +280,7 @@ class TestImports:
                 ]
             ).execute()
 
-        assert 5 == len(mock_web_server.requests())
+        assert 7 == len(mock_web_server.requests())
 
     def test_import_cannot_update_custom_list(
         self, mock_web_server: MockAPIServer, tmpdir
@@ -283,6 +315,22 @@ class TestImports:
             "GET",
             "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
+        )
+
+        work_response_2 = MockAPIServerResponse()
+        work_response_2.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/Overdrive%20ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c",
+            work_response_2,
+        )
+
+        work_response_3 = MockAPIServerResponse()
+        work_response_3.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/URI/http://www.feedbooks.com/book/859",
+            work_response_3,
         )
 
         lists_response_0 = MockAPIServerResponse()
@@ -351,7 +399,7 @@ class TestImports:
             == problems[1].message()
         )
 
-        assert 6 == len(mock_web_server.requests())
+        assert 8 == len(mock_web_server.requests())
 
     def emptyCustomlists(self):
         return TestImports._test_customlists_resource_bytes(
@@ -391,6 +439,22 @@ class TestImports:
             "GET",
             "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
+        )
+
+        work_response_2 = MockAPIServerResponse()
+        work_response_2.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/Overdrive%20ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c",
+            work_response_2,
+        )
+
+        work_response_3 = MockAPIServerResponse()
+        work_response_3.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/URI/http://www.feedbooks.com/book/859",
+            work_response_3,
         )
 
         lists_response_0 = MockAPIServerResponse()
@@ -461,7 +525,7 @@ class TestImports:
             == problems[1].message()
         )
 
-        assert 5 == len(mock_web_server.requests())
+        assert 7 == len(mock_web_server.requests())
 
     def test_import_dry_run(self, mock_web_server: MockAPIServer, tmpdir):
         """If --dry-run is specified, the lists aren't actually updated."""
@@ -494,6 +558,22 @@ class TestImports:
             "GET",
             "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
+        )
+
+        work_response_2 = MockAPIServerResponse()
+        work_response_2.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/Overdrive%20ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c",
+            work_response_2,
+        )
+
+        work_response_3 = MockAPIServerResponse()
+        work_response_3.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/URI/http://www.feedbooks.com/book/859",
+            work_response_3,
         )
 
         lists_response_0 = MockAPIServerResponse()
@@ -553,7 +633,7 @@ class TestImports:
             == problems[0].message()
         )
 
-        assert 5 == len(mock_web_server.requests())
+        assert 7 == len(mock_web_server.requests())
 
     def normalCollections(self):
         return TestImports._test_customlists_resource_bytes(
@@ -595,6 +675,22 @@ class TestImports:
             work_response_1,
         )
 
+        work_response_2 = MockAPIServerResponse()
+        work_response_2.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/Overdrive%20ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c",
+            work_response_2,
+        )
+
+        work_response_3 = MockAPIServerResponse()
+        work_response_3.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/URI/http://www.feedbooks.com/book/859",
+            work_response_3,
+        )
+
         lists_response_0 = MockAPIServerResponse()
         lists_response_0.status_code = 200
         lists_response_0.content = self.emptyCustomlists()
@@ -655,7 +751,7 @@ class TestImports:
             "Book 'Bad Book' (urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f7) was excluded from list updates due to a problem on the source CM: Something went wrong on the source CM"
             == problems[1].message()
         )
-        assert 5 == len(mock_web_server.requests())
+        assert 7 == len(mock_web_server.requests())
 
     def test_import_updates_and_includes_csrf(
         self, mock_web_server: MockAPIServer, tmpdir
@@ -693,6 +789,22 @@ class TestImports:
             "GET",
             "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
+        )
+
+        work_response_2 = MockAPIServerResponse()
+        work_response_2.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/Overdrive%20ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c",
+            work_response_2,
+        )
+
+        work_response_3 = MockAPIServerResponse()
+        work_response_3.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/URI/http://www.feedbooks.com/book/859",
+            work_response_3,
         )
 
         lists_response_0 = MockAPIServerResponse()
@@ -757,8 +869,8 @@ class TestImports:
             == problems[0].message()
         )
 
-        assert 6 == len(mock_web_server.requests())
-        req = mock_web_server.requests()[5]
+        assert 8 == len(mock_web_server.requests())
+        req = mock_web_server.requests()[7]
         assert "/WALNUT/admin/custom_lists" == req.path
         assert "POST" == req.method
         assert "DUZ8inJjpISkyCYjHx7PONZM8354pCu4" == req.headers["X-CSRF-Token"]
@@ -796,6 +908,22 @@ class TestImports:
             "GET",
             "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
             work_response_1,
+        )
+
+        work_response_2 = MockAPIServerResponse()
+        work_response_2.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/Overdrive%20ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c",
+            work_response_2,
+        )
+
+        work_response_3 = MockAPIServerResponse()
+        work_response_3.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/URI/http://www.feedbooks.com/book/859",
+            work_response_3,
         )
 
         lists_response_0 = MockAPIServerResponse()
@@ -864,8 +992,8 @@ class TestImports:
             == problems[1].message()
         )
 
-        assert 6 == len(mock_web_server.requests())
-        req = mock_web_server.requests()[5]
+        assert 8 == len(mock_web_server.requests())
+        req = mock_web_server.requests()[7]
         assert "/WALNUT/admin/custom_lists" == req.path
 
     def emptyCollections(self):
@@ -992,6 +1120,22 @@ class TestImports:
             work_response_1,
         )
 
+        work_response_2 = MockAPIServerResponse()
+        work_response_2.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/Overdrive%20ID/614ed125-d7e5-4cff-b3de-6b6c90ff853c",
+            work_response_2,
+        )
+
+        work_response_3 = MockAPIServerResponse()
+        work_response_3.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/URI/http://www.feedbooks.com/book/859",
+            work_response_3,
+        )
+
         lists_response_0 = MockAPIServerResponse()
         lists_response_0.status_code = 200
         lists_response_0.content = self.emptyCustomlists()
@@ -1062,6 +1206,6 @@ class TestImports:
             == problems[2].message()
         )
 
-        assert 6 == len(mock_web_server.requests())
-        req = mock_web_server.requests()[5]
+        assert 8 == len(mock_web_server.requests())
+        req = mock_web_server.requests()[7]
         assert "/WALNUT/admin/custom_lists" == req.path

--- a/tests/customlists/test_import.py
+++ b/tests/customlists/test_import.py
@@ -954,3 +954,114 @@ class TestImports:
                     "-v",
                 ]
             ).execute()
+
+    def test_import_bad_book_identifier(self, mock_web_server: MockAPIServer, tmpdir):
+        """A book with a mismatched identifier is caught."""
+        sign_response = MockAPIServerResponse()
+        sign_response.status_code = 200
+        mock_web_server.enqueue_response(
+            "POST", "/admin/sign_in_with_password", sign_response
+        )
+
+        collection_response_0 = MockAPIServerResponse()
+        collection_response_0.status_code = 200
+        collection_response_0.content = self.emptyCollections()
+        mock_web_server.enqueue_response(
+            "GET",
+            "/admin/collections",
+            collection_response_0,
+        )
+
+        work_response_0 = MockAPIServerResponse()
+        work_response_0.status_code = 200
+        with open(
+            TestImports._test_customlists_resource_path("feed90_different_id.xml"), "rb"
+        ) as f:
+            work_response_0.content = f.read()
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6",
+            work_response_0,
+        )
+
+        work_response_1 = MockAPIServerResponse()
+        work_response_1.status_code = 200
+        mock_web_server.enqueue_response(
+            "GET",
+            "/WALNUT/admin/works/URI/urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+            work_response_1,
+        )
+
+        lists_response_0 = MockAPIServerResponse()
+        lists_response_0.status_code = 200
+        lists_response_0.content = self.emptyCustomlists()
+        mock_web_server.enqueue_response(
+            "GET", "/WALNUT/admin/custom_lists", lists_response_0
+        )
+
+        update_response_0 = MockAPIServerResponse()
+        update_response_0.status_code = 200
+        mock_web_server.enqueue_response(
+            "POST", "/WALNUT/admin/custom_lists", update_response_0
+        )
+
+        schema_path = TestImports._customlists_resource_path("customlists.schema.json")
+        schema_report_path = TestImports._customlists_resource_path(
+            "customlists-report.schema.json"
+        )
+        input_file = TestImports._test_customlists_resource_path(
+            "example-customlists.json"
+        )
+        output_file = tmpdir.join("output.json")
+        CustomListImporter.create(
+            [
+                "--server",
+                mock_web_server.url("/"),
+                "--username",
+                "someone@example.com",
+                "--password",
+                "12345678",
+                "--library-name",
+                "WALNUT",
+                "--schema-file",
+                str(schema_path),
+                "--schema-report-file",
+                str(schema_report_path),
+                "--file",
+                str(input_file),
+                "--output",
+                str(output_file),
+                "-v",
+            ]
+        ).execute()
+
+        report_document: CustomListsReport
+        with open(schema_report_path, "rb") as schema_file:
+            with open(output_file, "rb") as report_file:
+                schema = json.load(schema_file)
+                document = json.load(report_file)
+                report_document = CustomListsReport.parse(
+                    schema=schema, document=document
+                )
+
+        reports: List[CustomListReport] = list(report_document.reports())
+        assert 1 == len(reports)
+        report = reports[0]
+        problems: List[CustomListProblem] = list(report.problems())
+        assert 3 == len(problems)
+        assert (
+            "The collection 'B2' appears to be missing on the importing CM"
+            == problems[0].message()
+        )
+        assert (
+            "Book is mismatched on the importing CM. Expected title is 'Chameleon', received title is 'Chameleon'. Expected ID is 'urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6', received ID is 'urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6'."
+            == problems[1].message()
+        )
+        assert (
+            "Book 'Bad Book' (urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f7) was excluded from list updates due to a problem on the source CM: Something went wrong on the source CM"
+            == problems[2].message()
+        )
+
+        assert 6 == len(mock_web_server.requests())
+        req = mock_web_server.requests()[5]
+        assert "/WALNUT/admin/custom_lists" == req.path


### PR DESCRIPTION
## Description

This adjusts the code to take book ID and ID types from the links
inside OPDS feeds, instead of depending on the value of the "id"
element (which may not be usable as a work ID on the target CM). This
also adjusts the code to remove any percent encoding that may be in
use on the identifiers.

## Motivation and Context

The scripts failed in testing on real data due to differences between the IDs that appear in OPDS links,
and the IDs that appear in OPDS `id` elements. This should fix those failures.

Affects: https://www.notion.so/lyrasis/Migrate-discrete-entries-in-client-library-lists-from-old-CM-to-new-CM-1b78b13b10234ee59830c343ef4862dc

## How Has This Been Tested?

I updated the test suite and added some specific identifiers that were problematic in testing. I also tested on a local CM.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
