### PR TITLE
Feature/crawlable opds2 feed

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1383,6 +1383,8 @@ class OPDSFeedController(CirculationManagerController):
 
 @define
 class FeedRequestParameters:
+    """Frequently used request parameters for feed requests"""
+
     library: Optional[Library] = None
     pagination: Optional[Pagination] = None
     facets: Optional[Facets] = None
@@ -1390,7 +1392,10 @@ class FeedRequestParameters:
 
 
 class OPDS2FeedController(CirculationManagerController):
+    """All OPDS2 type feeds are served through this controller"""
+
     def _parse_feed_request(self):
+        """Parse the request to get frequently used request parameters for the feeds"""
         library = getattr(flask.request, "library", None)
         pagination = load_pagination_from_request()
         if isinstance(pagination, ProblemDetail):
@@ -1409,6 +1414,7 @@ class OPDS2FeedController(CirculationManagerController):
         )
 
     def publications(self):
+        """OPDS2 publications feed"""
         params: FeedRequestParameters = self._parse_feed_request()
         if params.problem:
             return params.problem
@@ -1430,6 +1436,7 @@ class OPDS2FeedController(CirculationManagerController):
         )
 
     def navigation(self):
+        """OPDS2 navigation links"""
         params: FeedRequestParameters = self._parse_feed_request()
         annotator = OPDS2NavigationsAnnotator(
             flask.request.url,

--- a/api/opds2.py
+++ b/api/opds2.py
@@ -1,0 +1,32 @@
+from typing import Dict
+
+from flask import url_for
+
+from core.model.edition import Edition
+from core.model.identifier import Identifier
+from core.model.resource import Hyperlink
+from core.opds2 import OPDS2Annotator
+
+
+class OPDS2PublicationsAnnotator(OPDS2Annotator):
+    def loan_link(self, edition: Edition) -> Dict:
+        identifier: Identifier = edition.primary_identifier
+        return {
+            "href": url_for(
+                "borrow",
+                identifier_type=identifier.type,
+                identifier=identifier.identifier,
+            ),
+            "rel": Hyperlink.BORROW,
+        }
+
+    def self_link(self, edition: Edition) -> Dict:
+        identifier: Identifier = edition.primary_identifier
+        return {
+            "href": url_for(
+                "permalink",
+                identifier_type=identifier.type,
+                identifier=identifier.identifier,
+            ),
+            "rel": "self",
+        }

--- a/api/opds2.py
+++ b/api/opds2.py
@@ -9,6 +9,8 @@ from core.opds2 import OPDS2Annotator
 
 
 class OPDS2PublicationsAnnotator(OPDS2Annotator):
+    """API level implementation for the publications feed OPDS2 annotator"""
+
     def loan_link(self, edition: Edition) -> Dict:
         identifier: Identifier = edition.primary_identifier
         return {
@@ -35,7 +37,10 @@ class OPDS2PublicationsAnnotator(OPDS2Annotator):
 
 
 class OPDS2NavigationsAnnotator(OPDS2Annotator):
+    """API level implementation for the navigation feed OPDS2 annotator"""
+
     def navigation_collection(self) -> Dict:
+        """The OPDS2 navigation collection, currently only serves the publications link"""
         return [
             {
                 "href": url_for(

--- a/api/opds2.py
+++ b/api/opds2.py
@@ -16,6 +16,7 @@ class OPDS2PublicationsAnnotator(OPDS2Annotator):
                 "borrow",
                 identifier_type=identifier.type,
                 identifier=identifier.identifier,
+                library_short_name=self.library.short_name,
             ),
             "rel": Hyperlink.BORROW,
         }
@@ -27,6 +28,28 @@ class OPDS2PublicationsAnnotator(OPDS2Annotator):
                 "permalink",
                 identifier_type=identifier.type,
                 identifier=identifier.identifier,
+                library_short_name=self.library.short_name,
             ),
             "rel": "self",
         }
+
+
+class OPDS2NavigationsAnnotator(OPDS2Annotator):
+    def navigation_collection(self) -> Dict:
+        return [
+            {
+                "href": url_for(
+                    "opds2_publications", library_short_name=self.library.short_name
+                ),
+                "title": "OPDS2 Publications Feed",
+                "type": self.OPDS2_TYPE,
+            }
+        ]
+
+    def feed_metadata(self):
+        return {"title": self.title}
+
+    def feed_links(self):
+        return [
+            {"href": self.url, "rel": "self", "type": self.OPDS2_TYPE},
+        ]

--- a/api/routes.py
+++ b/api/routes.py
@@ -385,6 +385,24 @@ def crawlable_collection_feed(collection_name):
     return app.manager.opds_feeds.crawlable_collection_feed(collection_name)
 
 
+@library_route("/opds2/publications")
+@has_library
+@allows_patron_web
+@returns_problem_detail
+@compressible
+def opds2_publications():
+    return app.manager.opds2_feeds.publications()
+
+
+@library_route("/opds2/navigation")
+@has_library
+@allows_patron_web
+@returns_problem_detail
+@compressible
+def opds2_navigation():
+    return app.manager.opds2_feeds.navigation()
+
+
 @app.route("/collections/<collection_name>")
 @returns_problem_detail
 def shared_collection_info(collection_name):

--- a/core/model/contributor.py
+++ b/core/model/contributor.py
@@ -474,5 +474,6 @@ class Contribution(Base):
     contributor_id = Column(
         Integer, ForeignKey("contributors.id"), index=True, nullable=False
     )
+    contributor: Contributor  # for typing
     role = Column(Unicode, index=True, nullable=False)
     __table_args__ = (UniqueConstraint("edition_id", "contributor_id", "role"),)

--- a/core/model/edition.py
+++ b/core/model/edition.py
@@ -51,6 +51,7 @@ class Edition(Base, EditionConstants):
     # it. Through the Equivalency class, it is associated with a
     # (probably huge) number of other identifiers.
     primary_identifier_id = Column(Integer, ForeignKey("identifiers.id"), index=True)
+    primary_identifier: Identifier  # for typing
 
     # An Edition may be the presentation edition for a single Work. If it's not
     # a presentation edition for a work, work will be None.
@@ -77,7 +78,7 @@ class Edition(Base, EditionConstants):
     author = Column(Unicode, index=True)
     sort_author = Column(Unicode, index=True)
 
-    contributions = relationship("Contribution", backref="edition")
+    contributions = relationship("Contribution", backref="edition", uselist=True)
 
     language = Column(Unicode, index=True)
     publisher = Column(Unicode, index=True)

--- a/core/model/identifier.py
+++ b/core/model/identifier.py
@@ -107,7 +107,7 @@ class Identifier(Base, IdentifierConstants):
     )
 
     # One Identifier may have many Links.
-    links = relationship("Hyperlink", backref="identifier")
+    links = relationship("Hyperlink", backref="identifier", uselist=True)
 
     # One Identifier may be the subject of many Measurements.
     measurements = relationship("Measurement", backref="identifier")

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1445,7 +1445,7 @@ class Work(Base):
         qu = qu.options(
             joinedload(Work.presentation_edition)
             .joinedload(Edition.contributions)
-            .joinedload(Contribution.contributor),  # type: ignore
+            .joinedload(Contribution.contributor),
             joinedload(Work.work_genres).joinedload(WorkGenre.genre),  # type: ignore
             joinedload(Work.custom_list_entries),
         )

--- a/core/opds2.py
+++ b/core/opds2.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from core.external_search import ExternalSearchIndex
 from core.lane import Facets, Pagination, WorkList
+from core.model.cachedfeed import CachedFeed
 from core.model.classification import Genre, Subject
 from core.model.contributor import Contribution, Contributor
 from core.model.edition import Edition
@@ -202,12 +203,22 @@ class AcquisitonFeedOPDS2(OPDS2Feed):
         pagination: Pagination,
         search_engine: ExternalSearchIndex,
         annotator: OPDS2Annotator,
+        max_age: int = None,
     ):
         # do some caching magic
         # then do the publication
+        def refresh():
+            return cls._generate_publications(
+                _db, worklist, facets, pagination, search_engine, annotator
+            )
 
-        return cls._generate_publications(
-            _db, worklist, facets, pagination, search_engine, annotator
+        return CachedFeed.fetch(
+            _db,
+            worklist=worklist,
+            facets=facets,
+            pagination=pagination,
+            refresher_method=refresh,
+            max_age=max_age,
         )
 
     @classmethod

--- a/core/opds2.py
+++ b/core/opds2.py
@@ -1,0 +1,157 @@
+from typing import Dict, List
+
+from core.external_search import ExternalSearchIndex
+from core.lane import SearchFacets, WorkList
+from core.model.collection import Collection
+from core.model.contributor import Contribution, Contributor
+from core.model.edition import Edition
+from core.model.work import Work
+
+
+class OPDS2Feed:
+    pass
+
+
+class FeedTypes:
+    PUBLICATIONS = "publications"
+
+
+class AcquisitonFeedOPDS2(OPDS2Feed):
+    @classmethod
+    def publications(
+        cls,
+        _db,
+        worklist: WorkList,
+        facets: SearchFacets,
+        search_engine: ExternalSearchIndex,
+    ):
+        # do some caching magic
+        # then do the publication
+
+        return cls._generate_publications(_db, worklist, facets, search_engine)
+
+    @classmethod
+    def _generate_publications(
+        cls,
+        _db,
+        worklist: WorkList,
+        facets: SearchFacets,
+        search_engine: ExternalSearchIndex,
+    ):
+        publications = []
+
+        for work in worklist.works(_db, facets=facets, search_engine=search_engine):
+            publications.append(work)
+
+        return cls(_db, "publications", publications, worklist.get_library(_db))
+
+    def __init__(
+        self, _db, title, works: List[Work], library, feed_type=FeedTypes.PUBLICATIONS
+    ):
+        self._db = _db
+        self.works = works
+        self.library = library
+        self.feed_type = feed_type
+
+    def json(self):
+        if self.feed_type == FeedTypes.PUBLICATIONS:
+            return self.publications_json()
+
+    def publications_json(self):
+        result = {}
+
+        entries = []
+        for work in self.works:
+            entries.append(self._metadata_for_work(work))
+
+        result["publications"] = entries
+        return result
+
+    # Should this be in an annotator??
+    def _metadata_for_work(self, work: Work):
+        """Create the metadata json for a work item
+        using the schema https://readium.org/webpub-manifest/context.jsonld"""
+        # TODO: What happens when there is not presentation edition?
+        edition: Edition = work.presentation_edition
+        result = {}
+        # Palace marketplace has this as '@type'
+        result["type"] = Edition.medium_to_additional_type.get(edition.medium)
+        result["title"] = edition.title
+        result["subtitle"] = edition.subtitle
+        result["identifier"] = edition.primary_identifier.identifier
+        result["sortAs"] = edition.sort_title
+        result.update(self._contributors(edition))
+        result["language"] = edition.language
+        # TODO: subject is meant to be http://schema.org/about,
+        # however Palace marketplace uses this to provide genre subjects
+        # TODO: numberOfPages. we don't store this
+        # TODO: duration. we don't store this
+        # TODO: abridged. we don't store this
+        if edition.publisher:
+            result["publisher"] = {"name": edition.publisher}
+        if edition.imprint:
+            result["imprint"] = {"name": edition.imprint}
+        result["modified"] = work.last_update_time
+        result["description"] = work.summary_text
+        # TODO: belongsTo. Palace marketplace has series and collection within this,
+        # which shouldn't be the case because it is a https://schema.org/CreativeWork
+        # Even the OPDS example uses it in this way https://drafts.opds.io/opds-2.0.html#42-metadata
+        if work.series:
+            result["series"] = {
+                "name": work.series,
+            }
+            # Palace marketplace has this within the "series" object
+            result["position"] = (
+                work.series_position if work.series_position is not None else 1
+            )
+        collection = self._collection(edition)
+        if collection:
+            result["collection"] = collection
+        # TODO: add acquisition links
+
+        return dict(metadata=result)
+
+    def _collection(self, edition: Edition) -> Dict:
+        """The first collection of this edition that is part of the library of this feed"""
+        collection = None
+        collection_ids = [c.id for c in self.library.all_collections]
+        this_collection: Collection = None
+        for pool in edition.license_pools:
+            if pool.collection_id in collection_ids:
+                this_collection = pool.collection
+                break
+        if this_collection:
+            collection = {"name": this_collection.name}
+        return collection
+
+    def _contributors(self, edition: Edition) -> Dict:
+        authors = {}
+        contribution: Contribution
+        key_mapping = {
+            Contributor.AUTHOR_ROLE: "author",
+            Contributor.TRANSLATOR_ROLE: "translator",
+            Contributor.EDITOR_ROLE: "editor",
+            Contributor.ILLUSTRATOR_ROLE: "illustrator",
+            Contributor.ARTIST_ROLE: "artist",
+            Contributor.COLORIST_ROLE: "colorist",
+            Contributor.INKER_ROLE: "inker",
+            Contributor.PENCILER_ROLE: "pencilor",
+            Contributor.LETTERER_ROLE: "letterer",
+            Contributor.NARRATOR_ROLE: "narrator",
+            Contributor.CONTRIBUTOR_ROLE: "contributor",
+        }
+        for contribution in edition.contributions:
+            if contribution.role in key_mapping:
+                contributor = contribution.contributor
+                meta = {"name": contributor.display_name}
+                if len(contributor.aliases) > 0:
+                    meta["additionalName"] = contributor.aliases[0]
+
+                # TODO: Marketplace adds links for the author based search
+                # should we do the same?
+
+                authors[key_mapping[contribution.role]] = meta
+        return authors
+
+    def __str__(self):
+        """Make the serialized OPDS2 feed"""

--- a/core/opds2.py
+++ b/core/opds2.py
@@ -1,7 +1,8 @@
+import math
 from typing import Dict, List
 
 from core.external_search import ExternalSearchIndex
-from core.lane import SearchFacets, WorkList
+from core.lane import Facets, Pagination, SearchFacets, WorkList
 from core.model.classification import Genre, Subject
 from core.model.contributor import Contribution, Contributor
 from core.model.edition import Edition
@@ -17,10 +18,12 @@ class OPDS2Feed:
 class OPDS2Annotator:
     """Annotate a feed following the OPDS2 spec"""
 
-    def __init__(self, url, facets, library) -> None:
+    def __init__(self, url, facets, pagination, library, title="OPDS2 Feed") -> None:
         self.url = url
-        self.facets = facets
+        self.facets: Facets = facets
         self.library = library
+        self.title = title
+        self.pagination = pagination or Pagination()
 
     # Should this be in an annotator??
     def metadata_for_work(self, work: Work) -> Dict:
@@ -166,6 +169,14 @@ class OPDS2Annotator:
 
         return links
 
+    def feed_metadata(self):
+        return {
+            "title": self.title,
+            "itemsPerPage": self.pagination.size,
+            "currentPage": math.ceil(self.pagination.offset / self.pagination.size)
+            + 1,  # start from 1
+        }
+
 
 class FeedTypes:
     PUBLICATIONS = "publications"
@@ -179,6 +190,7 @@ class AcquisitonFeedOPDS2(OPDS2Feed):
         url: str,
         worklist: WorkList,
         facets: SearchFacets,
+        pagination: Pagination,
         search_engine: ExternalSearchIndex,
         annotator: OPDS2Annotator,
     ):
@@ -186,7 +198,7 @@ class AcquisitonFeedOPDS2(OPDS2Feed):
         # then do the publication
 
         return cls._generate_publications(
-            _db, url, worklist, facets, search_engine, annotator
+            _db, url, worklist, facets, pagination, search_engine, annotator
         )
 
     @classmethod
@@ -196,6 +208,7 @@ class AcquisitonFeedOPDS2(OPDS2Feed):
         url: str,
         worklist: WorkList,
         facets: SearchFacets,
+        pagination: Pagination,
         search_engine: ExternalSearchIndex,
         annotator: OPDS2Annotator,
     ):

--- a/tests/api/test_opds2.py
+++ b/tests/api/test_opds2.py
@@ -1,0 +1,57 @@
+import json
+from urllib.parse import quote
+
+from api.app import app
+from api.opds2 import OPDS2PublicationsAnnotator
+from core.lane import Facets, Pagination
+from core.model.resource import Hyperlink
+from core.testing import DatabaseTest
+from tests.api.test_controller import CirculationControllerTest
+
+
+class TestOPDS2FeedController(CirculationControllerTest):
+    def setup_method(self):
+        super().setup_method()
+        self.annotator = OPDS2PublicationsAnnotator(
+            "https://example.org/opds2",
+            Facets.default(self._default_library),
+            Pagination.default(),
+            self._default_library,
+        )
+        self.controller = self.manager.opds2_feeds
+
+    def test_publications_feed(self):
+        with self.request_context_with_library("/"):
+            response = self.controller.publications()
+            assert response.status_code == 200
+            feed = json.loads(response.data)
+            assert "metadata" in feed
+            assert "links" in feed
+            assert "publications" in feed
+
+
+class TestOPDS2PublicationAnnotator(DatabaseTest):
+    def setup_method(self):
+        super().setup_method()
+        self.annotator = OPDS2PublicationsAnnotator(
+            "https://example.org/opds2",
+            Facets.default(self._default_library),
+            Pagination.default(),
+            self._default_library,
+        )
+
+    def test_loan_link(self):
+        work = self._work()
+        idn = work.presentation_edition.primary_identifier
+        with app.test_request_context("/"):
+            link = self.annotator.loan_link(work.presentation_edition)
+            assert Hyperlink.BORROW == link["rel"]
+            assert quote(f"/works/{idn.type}/{idn.identifier}/borrow") == link["href"]
+
+    def test_self_link(self):
+        work = self._work()
+        idn = work.presentation_edition.primary_identifier
+        with app.test_request_context("/"):
+            link = self.annotator.self_link(work.presentation_edition)
+            assert link["rel"] == "self"
+            assert quote(f"/works/{idn.type}/{idn.identifier}") == link["href"]

--- a/tests/core/test_opds2.py
+++ b/tests/core/test_opds2.py
@@ -97,7 +97,7 @@ class TestOPDS2Annotator(DatabaseTest):
         self.fiction.fiction = True
         self.fiction.audiences = [Classifier.AUDIENCE_ADULT]
         self.annotator = OPDS2Annotator(
-            "http://example.org/feed?page=2",
+            "http://example.org/feed",
             Facets.default(self._default_library),
             Pagination(),
             self._default_library,
@@ -105,12 +105,13 @@ class TestOPDS2Annotator(DatabaseTest):
 
     def test_feed_links(self):
         links = self.annotator.feed_links()
-        assert len(links) == 1
+        assert len(links) == 2
         assert links[0] == {
             "rel": "self",
-            "href": "http://example.org/feed?page=2",
+            "href": "http://example.org/feed",
             "type": "application/opds+json",
         }
+        assert "after=50" in links[1]["href"]
 
     def test_image_links(self):
         work = self._work()

--- a/tests/core/test_opds2.py
+++ b/tests/core/test_opds2.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 
 from core.classifier import Classifier
@@ -9,6 +10,7 @@ from core.model.identifier import Identifier
 from core.model.resource import Hyperlink
 from core.opds2 import AcquisitonFeedOPDS2, OPDS2Annotator
 from core.testing import DatabaseTest
+from core.util.flask_util import OPDSFeedResponse
 
 
 class TestOPDS2Feed(DatabaseTest):
@@ -37,8 +39,8 @@ class TestOPDS2Feed(DatabaseTest):
             ),
         )
 
-        assert type(result) == AcquisitonFeedOPDS2
-        assert result.works == [work]
+        assert type(result) == OPDSFeedResponse
+        # assert result.works == [work]
 
     def test_publications_feed_json(self):
         works = [
@@ -74,7 +76,7 @@ class TestOPDS2Feed(DatabaseTest):
             Pagination.default(),
             self._default_library,
         )
-        result = AcquisitonFeedOPDS2.publications(
+        result: OPDSFeedResponse = AcquisitonFeedOPDS2.publications(
             self._db,
             self.fiction,
             SearchFacets(),
@@ -82,7 +84,7 @@ class TestOPDS2Feed(DatabaseTest):
             self.search_engine,
             annotator,
         )
-        result = result.json()
+        result = json.loads(result.data)
 
         assert len(result["publications"]) == len(works)
 

--- a/tests/core/test_opds2.py
+++ b/tests/core/test_opds2.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+from core.classifier import Classifier
+from core.external_search import MockExternalSearchIndex
+from core.lane import SearchFacets
+from core.opds2 import AcquisitonFeedOPDS2
+from core.testing import DatabaseTest
+
+
+class TestOPDS2Feed(DatabaseTest):
+    def setup_method(self):
+        super().setup_method()
+
+        self.search_engine = MockExternalSearchIndex()
+
+        self.fiction = self._lane("Fiction")
+        self.fiction.fiction = True
+        self.fiction.audiences = [Classifier.AUDIENCE_ADULT]
+
+    def test_publications_feed(self):
+        work = self._work(
+            with_open_access_download=True, authors="Author Name", fiction=True
+        )
+        self.search_engine.bulk_update([work])
+        result = AcquisitonFeedOPDS2.publications(
+            self._db, self.fiction, SearchFacets(), self.search_engine
+        )
+
+        assert type(result) == AcquisitonFeedOPDS2
+        assert result.works == [work]
+
+    def test_publications_feed_json(self):
+        works = [
+            self._work(
+                with_open_access_download=True,
+                title="title1",
+                authors="Author Name1",
+                fiction=True,
+            ),
+            self._work(
+                with_open_access_download=True,
+                title="title2",
+                authors="Author Name2",
+                fiction=True,
+            ),
+            self._work(
+                with_open_access_download=True,
+                title="title3",
+                authors="Author Name3",
+                fiction=True,
+            ),
+            self._work(
+                with_open_access_download=True,
+                title="title4",
+                authors="Author Name4",
+                fiction=True,
+            ),
+        ]
+        last_ix = len(works) - 1
+        modified = datetime.now()
+        works[-1].last_update_time = modified
+        works[-1].presentation_edition.series = "A series"
+
+        self.search_engine.bulk_update(works)
+        result = AcquisitonFeedOPDS2.publications(
+            self._db, self.fiction, SearchFacets(), self.search_engine
+        )
+        result = result.json()
+
+        assert len(result["publications"]) == len(works)
+        for ix, pub in enumerate(result["publications"]):
+            work = works[ix]
+            metadata = pub["metadata"]
+            assert metadata["collection"]["name"] == self._default_collection.name
+            assert (
+                metadata["identifier"]
+                == work.presentation_edition.primary_identifier.identifier
+            )
+            assert metadata["title"] == work.presentation_edition.title
+
+            if ix == last_ix:
+                assert metadata["series"] == {"name": "A series"}
+                assert metadata["position"] == 1
+                assert metadata["modified"] == modified

--- a/tests/core/test_opds2.py
+++ b/tests/core/test_opds2.py
@@ -28,7 +28,6 @@ class TestOPDS2Feed(DatabaseTest):
         self.search_engine.bulk_update([work])
         result = AcquisitonFeedOPDS2.publications(
             self._db,
-            "/",
             self.fiction,
             SearchFacets(),
             Pagination.default(),
@@ -77,7 +76,6 @@ class TestOPDS2Feed(DatabaseTest):
         )
         result = AcquisitonFeedOPDS2.publications(
             self._db,
-            "/",
             self.fiction,
             SearchFacets(),
             Pagination.default(),
@@ -168,8 +166,8 @@ class TestOPDS2Annotator(DatabaseTest):
         assert meta["title"] == work.title
         assert meta["subtitle"] == work.subtitle
         assert meta["identifier"] == idn.identifier
-        assert meta["modified"] == modified
-        assert meta["published"] == modified
+        assert meta["modified"] == modified.isoformat()
+        assert meta["published"] == modified.isoformat()
         assert meta["language"] == "en"
         assert meta["sortAs"] == work.sort_title
         assert meta["author"] == {"name": "Author Person"}


### PR DESCRIPTION
## Description
OPDS 2 Publications and navigation feed following https://drafts.opds.io/opds-2.0
The navigation collection only has one link right now, the publication feed
Eg. `http://localhost:6500/localtest/opds2/navigation` responds with
```
{
    "metadata": {
        "title": "OPDS2 Navigation"
    },
    "links": [
        {
            "href": "http://localhost:6500/localtest/opds2/navigation",
            "rel": "self",
            "type": "application/opds+json"
        }
    ],
    "navigation": [
        {
            "href": "/localtest/opds2/publications",
            "title": "OPDS2 Publications Feed",
            "type": "application/opds+json"
        }
    ]
}
```

The Publication feed has entries of the form:
```
{
    "metadata": {
        "@type": "http://schema.org/EBook",
        "title": "Sea of Stars Vol. 2: The People of the Broken Moon",
        "subtitle": null,
        "identifier": "9781534322820",
        "sortAs": "Sea of Stars Vol. 2: The People of the Broken Moon",
        "language": "en",
        "publisher": {
            "name": "Image Comics, Inc."
        },
        "modified": "2022-06-22T04:45:16.164734+00:00",
        "published": "2022-06-08T10:22:08.303949+00:00",
        "description": "From writing duo JASON AARON (SOUTHERN BASTARDS, Thor) and\nDENNIS HALLUM (Cloak and Dagger, Vader: Dark Visions) comes an all-ages science fiction series, featuring dazzling art by STEPHEN GREEN (Hellboy and the B.P.R.D.) and cosmic colors by RICO RENZI (Spider-Gwen)!\n\nYoung Kadyn thought being lost in the wild heavens was the most fun a kid could have. But now he’s beginning to see the true face of the deep-space danger all around him. Meanwhile, his father Gil, who’s been fighting every step of the way to find his son, may have finally hit his breaking point...and completely lost his mind.\n\nThe tender heart of the The Neverending Story meets the space-faring scope of Star Wars in the stunning conclusion to this galaxy-spanning adventure!\n\nCollects SEA OF STARS #6-11"
    },
    "links": [
        {
            "href": "/localtest/works/ISBN/9781534322820/borrow",
            "rel": "http://opds-spec.org/acquisition/borrow"
        },
        {
            "href": "/localtest/works/ISBN/9781534322820",
            "rel": "self"
        }
    ],
    "images": [
        {
            "href": "https://covers.feedbooks.net/item/4378658.jpg?size=large&t=1652686868",
            "rel": "http://opds-spec.org/image",
            "type": "image/jpeg"
        },
        {
            "href": "https://covers.feedbooks.net/item/4378658.jpg?t=1652686868",
            "rel": "http://opds-spec.org/image/thumbnail",
            "type": "image/jpeg"
        }
    ]
},
```

with a crawlable link to the next page
```
"links": [
    {
        "href": "http://localhost:6500/localtest/opds2/publications",
        "rel": "self",
        "type": "application/opds+json"
    },
    {
        "href": "http://localhost:6500/localtest/opds2/publications?after=50&size=50&available=all&collection=full&entrypoint=Book&order=author",
        "rel": "next",
        "type": "application/opds+json"
    }
],
```

<!--- Describe your changes -->

## Motivation and Context
The OPDS2 implementation is easier to understand and parse, and hence a desirable feed to have on the CM.
[Notion](https://www.notion.so/lyrasis/Implement-OPDS-2-0-Catalog-Crawable-feed-08b34bb000c04cf4bda8270df999ff0b)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manual and unit testing has been done

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

## Issues
- The ticket calls for a way to pull feeds "by collection", unfortunately, the `/collections/<name>/crawlable` endpoint for OPDS1.2 is broken, due to a bug in the underlying engine. To implement a `/opds2/collections/<name>/crawlable` endpoint we would need to fix the issue first.
- The `belongsTo.collection` attribute has not been implemented, because I'm not sure what value needs to go in there
