### PR TITLE
Added CASCADE on devicetoken fkey patron_id

### DIFF
--- a/core/model/devicetokens.py
+++ b/core/model/devicetokens.py
@@ -2,7 +2,7 @@ from typing import Type, TypeVar, Union
 
 from sqlalchemy import Column, Enum, ForeignKey, Integer, Unicode
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import backref, relationship
 
 from core.model.patron import Patron
 
@@ -24,8 +24,15 @@ class DeviceToken(Base):
     __tablename__ = "devicetokens"
 
     id = Column("id", Integer, primary_key=True)
-    patron_id = Column(Integer, ForeignKey("patrons.id"), index=True, nullable=False)
-    patron = relationship("Patron", backref="device_tokens", cascade="delete")
+    patron_id = Column(
+        Integer,
+        ForeignKey("patrons.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    patron = relationship(
+        "Patron", backref=backref("device_tokens", passive_deletes=True)
+    )
 
     token_type_enum = Enum(
         DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS, name="token_types"

--- a/migration/20220701-add-devicetoken-cascade.sql
+++ b/migration/20220701-add-devicetoken-cascade.sql
@@ -1,0 +1,12 @@
+-- Add a CASCADE on the patron_id fkey
+DO $$
+BEGIN
+    ALTER TABLE IF EXISTS devicetokens
+        add constraint devicetokens_patron_fkey
+        foreign key (patron_id)
+        references patrons(id)
+        on delete cascade;
+EXCEPTION when DUPLICATE_OBJECT THEN
+    RAISE NOTICE 'devicetokens_patron_fkey already exists, no need to create';
+END;
+$$;


### PR DESCRIPTION
## Description
This was missing and an in-code reverse CASCADE existed
<!--- Describe your changes -->

## Motivation and Context
This CASCADE was missing and a dangerous in-code reverse CASCADE existed.
Whenever a devicetoken would get deleted the corresponding patron would too.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
