### PR TITLE
alpha3 only codes

### DIFF
--- a/core/util/languages.py
+++ b/core/util/languages.py
@@ -23,6 +23,9 @@ class LanguageCodes:
 
     The data file comes from
     http://www.loc.gov/standards/iso639-2/ISO-639-2_utf-8.txt
+    According to LOC (https://www.loc.gov/standards/iso639-2/ascii_8bits.html), the format is
+    An alpha-3 (bibliographic) code, an alpha-3 (terminologic) code (when given), an alpha-2 code (when given),
+    an English name, and a French name of a language are all separated by pipe (|) characters.
     """
 
     two_to_three = LookupTable()
@@ -588,8 +591,8 @@ zza|||Zaza; Dimili; Dimli; Kirdki; Kirmanjki; Zazaki|zaza; dimili; dimli; kirdki
         if "-" in s:
             s = s.split("-")[0]
 
-        if s in cls.three_to_two:
-            # It's already an alpha-3.
+        if s in cls.english_names and len(s) == 3:
+            # All LOC language code have an English name; it's already an alpha-3.
             return s
         elif s in cls.two_to_three:
             # It's an alpha-2.

--- a/tests/core/util/test_languages.py
+++ b/tests/core/util/test_languages.py
@@ -18,6 +18,7 @@ class TestLanguageCodes:
     def test_lookups(self):
         c = LanguageCodes
 
+        # test a simple case with all expected data
         assert "eng" == c.two_to_three["en"]
         assert "en" == c.three_to_two["eng"]
         assert ["English"] == c.english_names["en"]
@@ -25,6 +26,7 @@ class TestLanguageCodes:
         assert ["English"] == c.native_names["en"]
         assert ["English"] == c.native_names["eng"]
 
+        # test a case with multiple English and native names
         assert "spa" == c.two_to_three["es"]
         assert "es" == c.three_to_two["spa"]
         assert ["Spanish", "Castilian"] == c.english_names["es"]
@@ -32,6 +34,7 @@ class TestLanguageCodes:
         assert ["español", "castellano"] == c.native_names["es"]
         assert ["español", "castellano"] == c.native_names["spa"]
 
+        # test a case with no native names
         assert "chi" == c.two_to_three["zh"]
         assert "zh" == c.three_to_two["chi"]
         assert ["Chinese"] == c.english_names["zh"]
@@ -40,6 +43,11 @@ class TestLanguageCodes:
         assert [] == c.native_names["zh"]
         assert [] == c.native_names["chi"]
 
+        # test a case with no alpha-2 code
+        assert None == c.three_to_two["ssa"]
+        assert ["Nilo-Saharan languages"] == c.english_names["ssa"]
+
+        # test that no lookup value returned for nonexistent values
         assert None == c.two_to_three["nosuchlanguage"]
         assert None == c.three_to_two["nosuchlanguage"]
         assert [] == c.english_names["nosuchlanguage"]
@@ -60,6 +68,7 @@ class TestLanguageCodes:
         assert "eng" == m("English")
         assert "eng" == m("ENGLISH")
         assert "ssa" == m("Nilo-Saharan languages")
+        assert "ssa" == m("ssa")
         assert None == m("NO SUCH LANGUAGE")
         assert None == None
 

--- a/tests/core/util/test_languages.py
+++ b/tests/core/util/test_languages.py
@@ -67,8 +67,14 @@ class TestLanguageCodes:
         assert "eng" == m("en-GB")
         assert "eng" == m("English")
         assert "eng" == m("ENGLISH")
+        # test sparse code data where there is no alpha-2
         assert "ssa" == m("Nilo-Saharan languages")
         assert "ssa" == m("ssa")
+        # test terminologic codes
+        assert "tib" == m("bod")
+        # test reserved codes
+        assert "qab" == m("qab")
+        # test bad data
         assert None == m("NO SUCH LANGUAGE")
         assert None == None
 
@@ -79,9 +85,17 @@ class TestLanguageCodes:
         assert "English" == m(["en"])
         assert "English" == m(["eng"])
         assert "español" == m(["es"])
+        # test mixed languages
         assert "English/español" == m(["eng", "spa"])
         assert "español/English" == m("spa,eng")
         assert "español/English/Chinese" == m(["spa", "eng", "chi"])
+        # test sparse code data where there is no alpha-2
+        assert "Nilo-Saharan languages" == m("ssa")
+        # test terminologic codes
+        assert "Tibetan" == m("bod")
+        # test reserved codes
+        assert LanguageCodes.RESERVED_CODE_LABEL == m("qab")
+        # test ValueError for bad data
         pytest.raises(ValueError, m, ["eng, nxx"])
 
 


### PR DESCRIPTION
## Description

Changes two of the mapping methods in core/utils/languages to support all the ISO-639-2 alpha-3 codes, including some edge cases that raise ValueErrors and interrupt OPDS processing:
- when there is no alpha-2
- when it's a terminologic code
- when it's a code reserved for local use

## Motivation and Context

Our lane processing fails with:
```bash
Traceback (most recent call last):
  File "/var/www/circulation/core/scripts.py", line 135, in run
    timestamp_data = self.do_run()
  File "/var/www/circulation/core/scripts.py", line 617, in do_run
    self.process_libraries(parsed.libraries)
  File "/var/www/circulation/core/scripts.py", line 621, in process_libraries
    self.process_library(library)
  File "/var/www/circulation/scripts.py", line 404, in process_library
    super().process_library(library)
  File "/var/www/circulation/core/scripts.py", line 734, in process_library
    self.process_lane(l)
  File "/var/www/circulation/scripts.py", line 428, in process_lane
    feed = self.do_generate(lane, facets, pagination)
  File "/var/www/circulation/scripts.py", line 654, in do_generate
    return feed_class.groups(
  File "/var/www/circulation/core/opds.py", line 626, in groups
    return CachedFeed.fetch(
  File "/var/www/circulation/core/model/cachedfeed.py", line 149, in fetch
    feed_data = str(refresher_method())
  File "/var/www/circulation/core/opds.py", line 614, in refresh
    return cls._generate_groups(
  File "/var/www/circulation/core/opds.py", line 719, in _generate_groups
    annotator.annotate_feed(feed, worklist)
  File "/var/www/circulation/api/opds.py", line 969, in annotate_feed
    if lane and lane.search_target:
  File "/var/www/circulation/core/lane.py", line 3072, in search_target
    display_name_parts.append(LanguageCodes.name_for_languageset(languages))
  File "/var/www/circulation/core/util/languages.py", line 615, in name_for_languageset
    raise ValueError("No native or English name for %s" % l)
ValueError: No native or English name for ang
```

This is apparently because of publications - Beowulf translations - that list their languages as `eng` and `ang`. The latter is appropriate and valid (English, Old (ca.450-1100)) but because it has no alpha-2 code, it is not present in the lookup table currently used to validate and normalize alpha-3 values.

## How Has This Been Tested?

Added relevant unit test cases to tests/core/test_languages.py for `LanguageCodes.name_for_languageset` and `LanguageCodes.string_to_alpha_3`

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
