### PR TITLE
Correct a possible mistake in import id checking

### DIFF
--- a/customlists/customlist_export.py
+++ b/customlists/customlist_export.py
@@ -408,6 +408,14 @@ class CustomListExporter:
                         link_id: str = unquote(link_id_quoted)
                         link_id_type: str = unquote(link_id_type_quoted)
 
+                        self._logger.debug(f"storing link id (id_value) {link_id}")
+                        self._logger.debug(
+                            f"storing link id type (id_type) {link_id_type}"
+                        )
+                        self._logger.debug(f"storing entry id (id_full) {entry_id}")
+                        self._logger.debug(f"storing entry title {entry.title}")
+                        self._logger.debug(f"storing entry author {entry.author}")
+
                         custom_list.add_book(
                             Book(
                                 id_value=link_id,

--- a/customlists/customlist_import.py
+++ b/customlists/customlist_import.py
@@ -173,14 +173,22 @@ class CustomListImporter:
                 if link.rel == "alternate":
                     match = re.search("^(.*)/works/([^/]+)/(.*)$", link.href)
                     if match is not None:
-                        link_id_quoted: str = match.group(3)
-                        link_id: str = unquote(link_id_quoted)
-                        if link_id != book.id() or entry.title != book.title():
+                        entry_id_unquoted = unquote(entry.id)
+                        matches_id = entry_id_unquoted == book.id()
+                        matches_title = entry.title == book.title()
+                        self._logger.debug(
+                            f"comparing id '{entry_id_unquoted}' with '{book.id()}' -> {matches_id}"
+                        )
+                        self._logger.debug(
+                            f"comparing title '{entry.title}' with '{book.title()}' -> {matches_title}"
+                        )
+
+                        if not (matches_id and matches_title):
                             problem = CustomListProblemBookMismatch.create(
                                 expected_id=book.id(),
                                 expected_id_type=book.id_type(),
                                 expected_title=book.title(),
-                                received_id=entry.id,
+                                received_id=entry_id_unquoted,
                                 received_title=entry.title,
                                 author=book.author(),
                             )

--- a/tests/customlists/files/feed90_different_id.xml
+++ b/tests/customlists/files/feed90_different_id.xml
@@ -48,7 +48,7 @@
         <dcterms:issued>2006-01-01</dcterms:issued>
         <link rel="issues"
               href="http://localhost:6500/HAZELNUT/works/URI/urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6/report"/>
-        <id>urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6</id>
+        <id>urn:uuid:eff86500-009d-4e64-b675-0c0b1b6f243d</id>
         <link rel="alternate"
               href="http://localhost:6500/HAZELNUT/works/URI/urn:xyz"
               type="application/atom+xml;type=entry;profile=opds-catalog"/>

--- a/tests/customlists/test_import.py
+++ b/tests/customlists/test_import.py
@@ -1198,7 +1198,7 @@ class TestImports:
             == problems[0].message()
         )
         assert (
-            "Book is mismatched on the importing CM. Expected title is 'Chameleon', received title is 'Chameleon'. Expected ID is 'urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6', received ID is 'urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6'."
+            "Book is mismatched on the importing CM. Expected title is 'Chameleon', received title is 'Chameleon'. Expected ID is 'urn:uuid:9c9c1f5c-6742-47d4-b94c-e77f88ca55f6', received ID is 'urn:uuid:eff86500-009d-4e64-b675-0c0b1b6f243d'."
             == problems[1].message()
         )
         assert (


### PR DESCRIPTION
## Description

This adjusts the comparison for import IDs so that the _unquoted_ OPDS entry ID is compared with the full book ID. My kingdom for a stronger type system.

## Motivation and Context

It appears that the code was comparing the wrong id elements, leading
to an import failure and a misleading error message. This should fix
that. This also introduces more debug logging, so we can see what's
gone wrong on the next inevitable failure.

Affects: https://www.notion.so/lyrasis/Migrate-discrete-entries-in-client-library-lists-from-old-CM-to-new-CM-1b78b13b10234ee59830c343ef4862dc

## How Has This Been Tested?

I ran through the usual "try it on a local CM" process, and updated the test suite again.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
