### PR TITLE
Added the media_type of a sample link to the OPDS feed

### DIFF
--- a/core/opds.py
+++ b/core/opds.py
@@ -1432,7 +1432,13 @@ class AcquisitionFeed(OPDSFeed):
 
         sample_links = self.annotator.samples(edition)
         for link in sample_links:
-            links.append(AtomFeed.link(rel=link.rel, href=link.resource.url))
+            links.append(
+                AtomFeed.link(
+                    rel=link.rel,
+                    href=link.resource.url,
+                    type=link.resource.representation.media_type,
+                )
+            )
 
         content = self.annotator.content(work)
         if isinstance(content, bytes):

--- a/core/testing.py
+++ b/core/testing.py
@@ -1637,6 +1637,9 @@ def session_fixture():
     # Drop any existing schema. It will be recreated when
     # SessionManager.initialize() runs.
     engine = SessionManager.engine()
+    Base.metadata.reflect(
+        engine
+    )  # Required to drop table with CASCADE constriants in the right order
     Base.metadata.drop_all(engine)
 
     yield

--- a/core/testing.py
+++ b/core/testing.py
@@ -13,6 +13,8 @@ from unittest import mock
 import pytest
 from sqlalchemy.orm.session import Session
 
+from core.model.devicetokens import DeviceToken
+
 from . import external_search
 from .analytics import Analytics
 from .classifier import Classifier
@@ -1637,9 +1639,12 @@ def session_fixture():
     # Drop any existing schema. It will be recreated when
     # SessionManager.initialize() runs.
     engine = SessionManager.engine()
-    Base.metadata.reflect(
-        engine
-    )  # Required to drop table with CASCADE constriants in the right order
+    # Trying to drop all tables without reflecting first causes an issue
+    # since SQLAchemy does not know the order of cascades
+    # Adding .reflect is throwing an error locally becuase tables are imported
+    # later and hence being defined twice
+    # Deleting the problematic table first fixes the issue, in this case DeviceToken
+    DeviceToken.__table__.drop(engine, checkfirst=True)
     Base.metadata.drop_all(engine)
 
     yield

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -830,6 +830,22 @@ class TestLibraryAnnotator(VendorIDTest):
         )
         assert expect == analytics_link
 
+        # Test sample link with media types
+        link, _ = edition.primary_identifier.add_link(
+            Hyperlink.SAMPLE,
+            "http://example.org/sample",
+            edition.data_source,
+            media_type="application/epub+zip",
+        )
+        feed = AcquisitionFeed(self._db, "test", "url", [], annotator)
+        entry = feed._make_entry_xml(work, edition)
+        annotator.annotate_work_entry(work, None, edition, identifier, feed, entry)
+        parsed = feedparser.parse(etree.tostring(entry))
+        [entry_parsed] = parsed["entries"]
+        [feed_link] = [l for l in entry_parsed["links"] if l.rel == Hyperlink.SAMPLE]
+        assert feed_link["href"] == link.resource.url
+        assert feed_link["type"] == link.resource.representation.media_type
+
     def test_annotate_feed(self):
         lane = self._lane()
         linksets = []

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -699,7 +699,10 @@ class TestOPDS(DatabaseTest):
         work = self._work(with_open_access_download=True)
         edition = work.presentation_edition
 
-        resource = Resource(url="sampleurl")
+        representation, _ = self._representation(
+            "sampleurl", media_type="application/epub+zip"
+        )
+        resource = Resource(url="sampleurl", representation_id=representation.id)
         link = Hyperlink(
             rel=Hyperlink.SAMPLE,
             identifier_id=edition.primary_identifier_id,
@@ -715,7 +718,7 @@ class TestOPDS(DatabaseTest):
             identifier_id=edition1.primary_identifier_id,
             data_source_id=2,
         )
-        resource1 = Resource(url="sampleurl1")
+        resource1 = Resource(url="sampleurl1", representation_id=representation.id)
         link1.resource = resource1
 
         # unrelated work/link should not show up
@@ -727,7 +730,9 @@ class TestOPDS(DatabaseTest):
             identifier_id=edition2.primary_identifier_id,
             data_source_id=2,
         )
-        link2.resource = Resource(url="notsampleurl")
+        link2.resource = Resource(
+            url="notsampleurl", representation_id=representation.id
+        )
 
         self._db.add_all([resource, link, link1, link2])
 


### PR DESCRIPTION
## Description
The sample links in an OPDS1.2 feed will now be of the format
`<link rel="http://opds-spec.org/acquisition/sample" href="https://market.feedbooks.com/item/4152047/preview" type="application/epub+zip"/>`
<!--- Describe your changes -->

## Motivation and Context
Without the media-type in the sample link an App would only find out the kind of viewer required for the SAMPLE after downloading the content.
This way the right viewer can be opened before-hand.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
