### PR TITLE
Run `update_lane_size` overnight to avoid daytime performance issues.

### DIFF
--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -15,7 +15,7 @@ HOME=/var/www/circulation
 */30 * * * * root core/bin/run -d 15 search_index_refresh >> /var/log/cron.log 2>&1
 10 0 * * * root core/bin/run search_index_clear >> /var/log/cron.log 2>&1
 0 0 * * * root core/bin/run update_custom_list_size >> /var/log/cron.log 2>&1
-0 10 * * * root core/bin/run update_lane_size >> /var/log/cron.log 2>&1
+0 2 * * * root core/bin/run update_lane_size >> /var/log/cron.log 2>&1
 */30 * * * * root core/bin/run -d 5 equivalent_identifiers_refresh >> /var/log/cron.log 2>&1
 
 # These scripts improve the bibliographic information associated with


### PR DESCRIPTION
## Description

Modify the script schedule to run `update_lane_size` overnight.

## Motivation and Context

When `update_lane_size` runs during the morning hours, it interacts with (an)other script(s) and causes response time issue. Killing the process associated with that script leads to an almost immediate return to responsiveness. It is possible that `update_lane_size` will continue to cause similar performance problems, just in the overnight hours, instead of the morning. But at least in that case, it will affect fewer patrons.

## How Has This Been Tested?

Carefully reviewed the change to the `crontab`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
  - We will need to update scripts page, once this change is deployed. 
- [X] All new and existing tests passed.
