### PR TITLE
Device token DELETE endpoint added

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -517,6 +517,15 @@ def put_patron_devices():
     return app.manager.patron_devices.create_patron_device()
 
 
+@library_dir_route("/patrons/me/devices", methods=["DELETE"])
+@has_library
+@allows_patron_web
+@requires_auth
+@returns_problem_detail
+def delete_patron_devices():
+    return app.manager.patron_devices.delete_patron_device()
+
+
 @library_dir_route("/loans", methods=["GET", "HEAD"])
 @has_library
 @allows_patron_web

--- a/tests/api/test_device_tokens.py
+++ b/tests/api/test_device_tokens.py
@@ -103,3 +103,36 @@ class TestDeviceTokens(ControllerTest):
         response = self.app.manager.patron_devices.create_patron_device()
 
         assert response == DEVICE_TOKEN_ALREADY_EXISTS
+
+    def test_delete_token(self, flask):
+        patron = self._patron()
+        device = DeviceToken.create(self._db, DeviceTokenTypes.FCM_IOS, "xxx", patron)
+
+        request = MagicMock()
+        request.patron = patron
+        request.json = {
+            "device_token": "xxx",
+            "token_type": DeviceTokenTypes.FCM_IOS,
+        }
+        flask.request = request
+
+        response = self.app.manager.patron_devices.delete_patron_device()
+        self._db.commit()
+
+        assert response.status_code == 204
+        assert self._db.query(DeviceToken).get(device.id) == None
+
+    def test_delete_no_token(self, flask):
+        patron = self._patron()
+        device = DeviceToken.create(self._db, DeviceTokenTypes.FCM_IOS, "xxx", patron)
+
+        request = MagicMock()
+        request.patron = patron
+        request.json = {
+            "device_token": "xxxy",
+            "token_type": DeviceTokenTypes.FCM_IOS,
+        }
+        flask.request = request
+
+        response = self.app.manager.patron_devices.delete_patron_device()
+        assert response == DEVICE_TOKEN_NOT_FOUND


### PR DESCRIPTION
## Description
Returns a `204` in case of a successful delete or a `404` in case of a Device Token Not Found

<!--- Describe your changes -->
## Motivation and Context
In case a user removes a library from their App
The App should DELETE the token for that library from their App

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manual and Unit testing has been done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
