### PR TITLE
Feature/patron pwd reset link

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -151,6 +151,7 @@ class Configuration(CoreConfiguration):
     ABOUT = "about"
     LICENSE = "license"
     REGISTER = "register"
+    PATRON_PWD_RESET_LINK = "patron-password-reset-link"
 
     # A library with this many titles in a given language will be given
     # a large, detailed lane configuration for that language.
@@ -526,6 +527,16 @@ class Configuration(CoreConfiguration):
             "category": "Patron Support",
             "allowed": ["nypl.card-creator:https://patrons.librarysimplified.org/"],
             "level": CoreConfiguration.ALL_ACCESS,
+        },
+        {
+            "key": PATRON_PWD_RESET_LINK,
+            "label": _("Password Reset Link"),
+            "description": _(
+                "A link to a web page where a user can reset their virtual library card password"
+            ),
+            "format": "url",
+            "category": "Patron Support",
+            "level": CoreConfiguration.SYS_ADMIN_ONLY,
         },
         {
             "key": LARGE_COLLECTION_LANGUAGES,

--- a/api/config.py
+++ b/api/config.py
@@ -11,6 +11,7 @@ from core.config import Configuration as CoreConfiguration
 from core.config import empty_config as core_empty_config
 from core.config import temp_config as core_temp_config
 from core.model import ConfigurationSetting
+from core.model.constants import LinkRelations
 from core.util import MoneyUtility
 
 from .announcements import Announcements
@@ -151,7 +152,6 @@ class Configuration(CoreConfiguration):
     ABOUT = "about"
     LICENSE = "license"
     REGISTER = "register"
-    PATRON_PWD_RESET_LINK = "patron-password-reset-link"
 
     # A library with this many titles in a given language will be given
     # a large, detailed lane configuration for that language.
@@ -164,7 +164,7 @@ class Configuration(CoreConfiguration):
 
     # These are link relations that are valid in Authentication for
     # OPDS documents but are not registered with IANA.
-    AUTHENTICATION_FOR_OPDS_LINKS = ["register"]
+    AUTHENTICATION_FOR_OPDS_LINKS = ["register", LinkRelations.PATRON_PASSWORD_RESET]
 
     # We support three different ways of integrating help processes.
     # All three of these will be sent out as links with rel='help'
@@ -529,7 +529,7 @@ class Configuration(CoreConfiguration):
             "level": CoreConfiguration.ALL_ACCESS,
         },
         {
-            "key": PATRON_PWD_RESET_LINK,
+            "key": LinkRelations.PATRON_PASSWORD_RESET,
             "label": _("Password Reset Link"),
             "description": _(
                 "A link to a web page where a user can reset their virtual library card password"

--- a/core/model/constants.py
+++ b/core/model/constants.py
@@ -235,6 +235,11 @@ class LinkRelations:
     AUTHOR = "http://schema.org/author"
     ALTERNATE = "alternate"
 
+    # A uri rel type for authentication documents with a vendor specific "link"
+    PATRON_PASSWORD_RESET = (
+        "http://librarysimplified.org/terms/rel/patron-password-reset"
+    )
+
     # TODO: Is this the appropriate relation?
     DRM_ENCRYPTED_DOWNLOAD = "http://opds-spec.org/acquisition/"
     BORROW = "http://opds-spec.org/acquisition/borrow"

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -49,6 +49,7 @@ from core.model import (
     Session,
     create,
 )
+from core.model.constants import LinkRelations
 from core.opds import OPDSFeed
 from core.testing import DatabaseTest
 from core.user_profile import ProfileController
@@ -1203,6 +1204,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             LibraryAnnotator.ABOUT: "http://about",
             LibraryAnnotator.LICENSE: "http://license/",
             LibraryAnnotator.REGISTER: "custom-registration-hook://library/",
+            LinkRelations.PATRON_PASSWORD_RESET: "https://example.org/reset",
             Configuration.LOGO: "image data",
             Configuration.WEB_CSS_FILE: "http://style.css",
         }
@@ -1322,6 +1324,7 @@ class TestLibraryAuthenticator(AuthenticatorTest):
                 help_web,
                 help_email,
                 copyright_agent,
+                reset_link,
                 profile,
                 loans,
                 license,
@@ -1365,6 +1368,8 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             # uses a non-HTTP URI scheme.
             assert "type" not in register
             assert "custom-registration-hook://library/" == register["href"]
+
+            assert "https://example.org/reset" == reset_link["href"]
 
             # The logo link has type "image/png".
             assert "image/png" == logo["type"]


### PR DESCRIPTION
## Description
Added Patron password reset link for Library admin configuration
Authentication document now has patron password reset link
Under rel="http://librarysimplified.org/terms/rel/patron-password-reset"
<!--- Describe your changes -->
The authentication document will have the additional data as follows
![image](https://user-images.githubusercontent.com/90382027/179710002-545fd483-8099-4584-858c-dc55a24087a5.png)


## Motivation and Context
Patrons would need a way to reset forgotten passwords directly from the Palace App
This information needed to be configured per library
The authentication document links can be extended with URI type rels as per [the spec](https://drafts.opds.io/authentication-for-opds-1.0.html#232-links)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit and manual testing done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
