### PR TITLE
Removed the uniqueness on device_tokens

### DIFF
--- a/core/model/devicetokens.py
+++ b/core/model/devicetokens.py
@@ -1,6 +1,6 @@
 from typing import Type, TypeVar, Union
 
-from sqlalchemy import Column, Enum, ForeignKey, Integer, Unicode
+from sqlalchemy import Column, Enum, ForeignKey, Index, Integer, Unicode
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import backref, relationship
 
@@ -39,7 +39,13 @@ class DeviceToken(Base):
     )
     token_type = Column(token_type_enum, nullable=False)
 
-    device_token = Column(Unicode, nullable=False, unique=True, index=True)
+    device_token = Column(Unicode, nullable=False, index=True)
+
+    __table_args__ = (
+        Index(
+            "ix_devicetokens_device_token_patron", device_token, patron_id, unique=True
+        ),
+    )
 
     @classmethod
     def create(

--- a/migration/20220722-replace-devicetoken-unique.sql
+++ b/migration/20220722-replace-devicetoken-unique.sql
@@ -1,0 +1,8 @@
+-- Drop the basic unique device_token index
+-- And add a device_token and patron unique index
+DO $$
+BEGIN
+    DROP INDEX IF EXISTS ix_devicetokens_device_token;
+    CREATE UNIQUE INDEX IF NOT EXISTS ix_devicetokens_device_token_patron on devicetokens using btree (device_token ASC, patron_id ASC);
+END;
+$$;

--- a/tests/core/models/test_devicetoken.py
+++ b/tests/core/models/test_devicetoken.py
@@ -34,6 +34,17 @@ class TestDeviceToken(DatabaseTest):
         with pytest.raises(DuplicateDeviceTokenError):
             DeviceToken.create(self._db, DeviceTokenTypes.FCM_IOS, "xxxx", patron)
 
+    def test_duplicate_different_patron(self):
+        patron = self._patron()
+        device = DeviceToken.create(
+            self._db, DeviceTokenTypes.FCM_ANDROID, "xxxx", patron
+        )
+        patron1 = self._patron()
+        device = DeviceToken.create(
+            self._db, DeviceTokenTypes.FCM_ANDROID, "xxxx", patron1
+        )
+        assert device.id is not None
+
     def test_invalid_type(self):
         patron = self._patron()
         with pytest.raises(InvalidTokenTypeError):


### PR DESCRIPTION
## Description
Introduced device_token, patron_id uniqueness

<!--- Describe your changes -->

## Motivation and Context
Every User with multiple Libraries on their App will have multiple Patrons attached to the same device.
These Patrons may be on the same CM backend, which means they would share device tokens in the same DB.
The device_token uniqueness constraint would prevent this, so we change the device_token uniqueness to include the patron_id as well
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
Manual and Unit testing done

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
