### PR TITLE
Feature/samlsettings refresh

### DIFF
--- a/core/util/cache.py
+++ b/core/util/cache.py
@@ -1,0 +1,46 @@
+import time
+from functools import wraps
+
+
+def _signature(func, *args, **kwargs):
+    """Create a hashable function signature
+    by stringifying and joining all arguments"""
+    strargs = ";".join([str(a) for a in args])
+    strkwargs = ";".join([f"{k}={v}" for k, v in kwargs.items()])
+    return str(func) + "::" + strargs + "::" + strkwargs
+
+
+def memoize(ttls: int = 3600):
+    """An in-memory cache based off the funcion and arguments
+    Usage:
+    @memoize(ttls=<seconds>)
+    def func(...):
+        ...
+
+    The `func` will be memoized and results cached based on the arguments passed in
+    When `func` is a bound-method then each instance of the object will have its own cache
+    because the first argument will always be the instance itself
+    Hence the signatures will be different for each object
+    """
+    cache = {}
+
+    def outer(func):
+        @wraps(func)
+        def inner(*args, **kwargs):
+            signature = _signature(func, *args, **kwargs)
+            cached = cache.get(signature)
+
+            # Has the cache expired?
+            if cached and time.time() - cached["last_updated"] < inner.ttls:
+                response = cached["response"]
+            else:
+                response = func(*args, **kwargs)
+                cache[signature] = dict(last_updated=time.time(), response=response)
+
+            return response
+
+        # The ttl is configurable from anywhere through the decorated function
+        inner.ttls = ttls
+        return inner
+
+    return outer

--- a/core/util/cache.py
+++ b/core/util/cache.py
@@ -1,8 +1,9 @@
 import time
 from functools import wraps
+from typing import Any, Callable, Dict
 
 
-def _signature(func, *args, **kwargs):
+def _signature(func: Callable, *args, **kwargs) -> str:
     """Create a hashable function signature
     by stringifying and joining all arguments"""
     strargs = ";".join([str(a) for a in args])
@@ -22,7 +23,7 @@ def memoize(ttls: int = 3600):
     because the first argument will always be the instance itself
     Hence the signatures will be different for each object
     """
-    cache = {}
+    cache: Dict[str, Any] = {}
 
     def outer(func):
         @wraps(func)

--- a/tests/core/util/test_cache.py
+++ b/tests/core/util/test_cache.py
@@ -1,0 +1,31 @@
+import time
+
+from core.util.cache import _signature, memoize
+
+
+class TestMemoize:
+    def test_memoize(self):
+        @memoize(ttls=10)
+        def _func():
+            return time.time()
+
+        # 10 second ttl remains the same
+        result = _func()
+        time.sleep(0.1)
+        assert _func() == result
+
+        # 0 second ttl will change the result
+        _func.ttls = 0
+        result = _func()
+        time.sleep(0.1)
+        assert _func() != result
+
+    def test_signature(self):
+        def _func():
+            pass
+
+        o = object()
+        assert (
+            _signature(_func, 1, "x", o, one="one", obj=o)
+            == f"{str(_func)}::1;x;{o}::one=one;obj={str(o)}"
+        )


### PR DESCRIPTION
## Description
Self refreshing SAMLSettings for federated IdPs

2 changes had to be made for this
- The PatronAuthServicesController needed to have its self.protocols refresh           
- The SAMLSettings needed to be able to detect a change within the DB

PatronAuthServicesController.protocols was made a cacheable callable
with 30 minute caching, so the Federated IdPs will refresh only
30 minutes after the last access

SAMLSettings queries for the last updated time for incommon SAMLFederations
and refreshes the values as needed

A memoize function was written to facilitate the time-bound caching
for PatronAuthServicesController.protocols
It currently works in-memory only, but can be extended to fit
Redis cache when required, or wholly replaced by a python library
<!--- Describe your changes -->

## Motivation and Context
The Federated IdPs list would not update unless the CM server was restarted, this needed to be rectified to be a more dynamic system.
[Ticket](https://www.notion.so/lyrasis/Make-current-list-of-SAML-federated-IdPs-appear-in-Admin-UI-without-restart-b30aa81ae65e4edeaf8ebf14aa0085de)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit and Manual testing, after running saml_import
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
