### PR TITLE
Ebooks with the format 'ebook-epub-open' and 'ebook-pdf-open' are tre…

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -219,6 +219,8 @@ class FulfillmentInfo(CirculationInfo):
             `content_type`).
         :param content_expires: A time after which the "next step"
             link or content will no longer be usable.
+        :param content_link_redirect: Force the API layer to redirect the client to
+            the content_link
         """
         super().__init__(collection, data_source_name, identifier_type, identifier)
         self.content_link = content_link

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -192,6 +192,7 @@ class FulfillmentInfo(CirculationInfo):
         content_type,
         content,
         content_expires,
+        content_link_redirect=False,
     ):
         """Constructor.
 
@@ -224,6 +225,7 @@ class FulfillmentInfo(CirculationInfo):
         self.content_type = content_type
         self.content = content
         self.content_expires = content_expires
+        self.content_link_redirect = content_link_redirect
 
     def __repr__(self):
         if self.content:
@@ -231,12 +233,13 @@ class FulfillmentInfo(CirculationInfo):
         else:
             blength = 0
         return (
-            "<FulfillmentInfo: content_link: %r, content_type: %r, content: %d bytes, expires: %r>"
+            "<FulfillmentInfo: content_link: %r, content_type: %r, content: %d bytes, expires: %r, content_link_redirect: %s>"
             % (
                 self.content_link,
                 self.content_type,
                 blength,
                 self.fd(self.content_expires),
+                self.content_link_redirect,
             )
         )
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -1915,6 +1915,10 @@ class LoanController(CirculationManagerController):
                 content = etree.tostring(feed)
             status_code = 200
             headers["Content-Type"] = OPDSFeed.ACQUISITION_FEED_TYPE
+        elif fulfillment.content_link_redirect is True:
+            # Overdrive specific flow, the content link has no-drm linked to it
+            # So we should not be a proxy and instead redirect the client directly
+            return redirect(fulfillment.content_link)
         else:
             content = fulfillment.content
             if fulfillment.content_link:

--- a/api/controller.py
+++ b/api/controller.py
@@ -1916,8 +1916,7 @@ class LoanController(CirculationManagerController):
             status_code = 200
             headers["Content-Type"] = OPDSFeed.ACQUISITION_FEED_TYPE
         elif fulfillment.content_link_redirect is True:
-            # Overdrive specific flow, the content link has no-drm linked to it
-            # So we should not be a proxy and instead redirect the client directly
+            # The fulfillment API has asked us to not be a proxy and instead redirect the client directly
             return redirect(fulfillment.content_link)
         else:
             content = fulfillment.content

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -579,6 +579,7 @@ class OverdriveAPI(
 
             raise e
 
+        # In case we are a non-drm asset, we should just redirect the client to the asset directly
         fulfillment_force_redirect = internal_format in [
             "ebook-epub-open",
             "ebook-pdf-open",

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -579,6 +579,11 @@ class OverdriveAPI(
 
             raise e
 
+        fulfillment_force_redirect = internal_format in [
+            "ebook-epub-open",
+            "ebook-pdf-open",
+        ]
+
         return FulfillmentInfo(
             licensepool.collection,
             licensepool.data_source.name,
@@ -588,6 +593,7 @@ class OverdriveAPI(
             content_type=media_type,
             content=None,
             content_expires=None,
+            content_link_redirect=fulfillment_force_redirect,
         )
 
     def get_fulfillment_link(

--- a/tests/api/files/overdrive/no_drm_fulfill.json
+++ b/tests/api/files/overdrive/no_drm_fulfill.json
@@ -1,0 +1,46 @@
+{
+    "loan": {
+        "reserveId": "A4466636-34F5-495A-92EE-3A9C701F46CF",
+        "crossRefId": 432890,
+        "expires": "2022-07-27T10:38:06Z",
+        "isFormatLockedIn": false,
+        "formats": [
+            {
+                "reserveId": "A4466636-34F5-495A-92EE-3A9C701F46CF",
+                "formatType": "ebook-overdrive",
+                "links": {
+                    "self": {
+                        "href": "https://example.org/v1/patrons/me/checkouts/A4466636-34F5-495A-92EE-3A9C701F46CF/formats/ebook-overdrive",
+                        "type": "application/vnd.overdrive.circulation.api+json"
+                    }
+                },
+                "linkTemplates": {
+                    "downloadLink": {
+                        "href": "https://example.org/v1/patrons/me/checkouts/A4466636-34F5-495A-92EE-3A9C701F46CF/formats/ebook-overdrive/downloadlink?errorpageurl={errorpageurl}&odreadauthurl={odreadauthurl}",
+                        "type": "application/vnd.overdrive.circulation.api+json"
+                    },
+                    "downloadLinkV2": {
+                        "href": "https://example.org/v1/patrons/me/checkouts/A4466636-34F5-495A-92EE-3A9C701F46CF/formats/ebook-overdrive/downloadlink?errorurl={errorurl}&successurl={successurl}",
+                        "type": "application/vnd.overdrive.circulation.api+json"
+                    }
+                }
+            }
+        ],
+        "checkoutDate": "2022-07-26T10:38:06Z"
+    },
+    "lock_in": {
+        "formatType": "ebook-epub-open",
+        "reserveId": "a4466636-34f5-495a-92ee-3a9c701f46cf",
+        "crossRefId": 432890,
+        "linkTemplates": {
+            "downloadLink": {
+                "href": "https://example.org/v1/patrons/me/checkouts/a4466636-34f5-495a-92ee-3a9c701f46cf/formats/ebook-epub-open/downloadlink?errorpageurl={errorpageurl}",
+                "type": "application/vnd.overdrive.circulation.api+json"
+            },
+            "downloadLinkV2": {
+                "href": "https://example.org/v1/patrons/me/checkouts/a4466636-34f5-495a-92ee-3a9c701f46cf/formats/ebook-epub-open/downloadlink?errorurl={errorurl}&successurl={successurl}",
+                "type": "application/vnd.overdrive.circulation.api+json"
+            }
+        }
+    }
+}

--- a/tests/api/test_controller.py
+++ b/tests/api/test_controller.py
@@ -2403,10 +2403,10 @@ class TestLoanController(CirculationControllerTest):
             assert "here's your book" == response.get_data(as_text=True)
             assert [] == self._db.query(Loan).all()
 
-    def test_no_drm_overdrive_fulfill(self):
-        """A very specific flow, wherein an overdrive work does not have DRM
-        for it's fulfillment. In which case we must simply redirect the client
-        to the non-DRM'd location instead doing a proxy download"""
+    def test_no_drm_fulfill(self):
+        """In case a work does not have DRM for it's fulfillment.
+        We must simply redirect the client to the non-DRM'd location
+        instead doing a proxy download"""
         # setup the patron, work and loan
         patron = self._patron()
         work: Work = self._work(
@@ -2425,8 +2425,8 @@ class TestLoanController(CirculationControllerTest):
         lpdm.delivery_mechanism.default_client_can_fulfill = True
 
         # Mock out the flow
-        overdrive_api = MagicMock()
-        overdrive_api.fulfill.return_value = FulfillmentInfo(
+        api = MagicMock()
+        api.fulfill.return_value = FulfillmentInfo(
             self._default_collection,
             DataSource.OVERDRIVE,
             "overdrive",
@@ -2448,9 +2448,7 @@ class TestLoanController(CirculationControllerTest):
             self.manager.circulation_apis[self._default_library.id] = CirculationAPI(
                 self._db, self._default_library
             )
-            controller.circulation.api_for_collection[
-                self._default_collection.id
-            ] = overdrive_api
+            controller.circulation.api_for_collection[self._default_collection.id] = api
             response = controller.fulfill(pool.id, lpdm.delivery_mechanism.id)
 
         assert response.status_code == 302

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -1586,56 +1586,16 @@ class TestOverdriveAPI(OverdriveAPITest):
         od_api = OverdriveAPI(self._db, self._default_collection)
         od_api._server_nickname = OverdriveConfiguration.TESTING_SERVERS
 
+        # Load the mock API data
+        with open("tests/api/files/overdrive/no_drm_fulfill.json") as fp:
+            api_data = json.load(fp)
+
         # Mock out the flow
-        od_api.get_loan = MagicMock(
-            return_value={
-                "reserveId": "A4466636-34F5-495A-92EE-3A9C701F46CF",
-                "crossRefId": 432890,
-                "expires": "2022-07-27T10:38:06Z",
-                "isFormatLockedIn": False,
-                "formats": [
-                    {
-                        "reserveId": "A4466636-34F5-495A-92EE-3A9C701F46CF",
-                        "formatType": "ebook-overdrive",
-                        "links": {
-                            "self": {
-                                "href": "https://example.org/v1/patrons/me/checkouts/A4466636-34F5-495A-92EE-3A9C701F46CF/formats/ebook-overdrive",
-                                "type": "application/vnd.overdrive.circulation.api+json",
-                            }
-                        },
-                        "linkTemplates": {
-                            "downloadLink": {
-                                "href": "https://example.org/v1/patrons/me/checkouts/A4466636-34F5-495A-92EE-3A9C701F46CF/formats/ebook-overdrive/downloadlink?errorpageurl={errorpageurl}&odreadauthurl={odreadauthurl}",
-                                "type": "application/vnd.overdrive.circulation.api+json",
-                            },
-                            "downloadLinkV2": {
-                                "href": "https://example.org/v1/patrons/me/checkouts/A4466636-34F5-495A-92EE-3A9C701F46CF/formats/ebook-overdrive/downloadlink?errorurl={errorurl}&successurl={successurl}",
-                                "type": "application/vnd.overdrive.circulation.api+json",
-                            },
-                        },
-                    }
-                ],
-                "checkoutDate": "2022-07-26T10:38:06Z",
-            }
-        )
+        od_api.get_loan = MagicMock(return_value=api_data["loan"])
 
         mock_lock_in_response = create_autospec(Response)
         mock_lock_in_response.status_code = 200
-        mock_lock_in_response.json.return_value = {
-            "formatType": "ebook-epub-open",
-            "reserveId": "a4466636-34f5-495a-92ee-3a9c701f46cf",
-            "crossRefId": 432890,
-            "linkTemplates": {
-                "downloadLink": {
-                    "href": "https://example.org/v1/patrons/me/checkouts/a4466636-34f5-495a-92ee-3a9c701f46cf/formats/ebook-epub-open/downloadlink?errorpageurl={errorpageurl}",
-                    "type": "application/vnd.overdrive.circulation.api+json",
-                },
-                "downloadLinkV2": {
-                    "href": "https://example.org/v1/patrons/me/checkouts/a4466636-34f5-495a-92ee-3a9c701f46cf/formats/ebook-epub-open/downloadlink?errorurl={errorurl}&successurl={successurl}",
-                    "type": "application/vnd.overdrive.circulation.api+json",
-                },
-            },
-        }
+        mock_lock_in_response.json.return_value = api_data["lock_in"]
         od_api.lock_in_format = MagicMock(return_value=mock_lock_in_response)
 
         od_api.get_fulfillment_link_from_download_link = MagicMock(


### PR DESCRIPTION
…ated as no-drm works

## Description
The fulfill endpoint will not proxy download the files anymore, but will ask the clients to redirect to the files

For this a special property `FulfillmentInfo.content_link_redirect` has been introduced to allow
any API integration class to direct the flow of the fulfillment downstream
<!--- Describe your changes -->

## Motivation and Context
Overdrive open content package items were unable to be displayed by the frontend clients due to 
a problem with proxying chunked downloads.
The better approach is to move the burden of download to the client itself.
[Notion](https://www.notion.so/lyrasis/Investigate-and-Fix-Content-Protection-Error-from-certain-OverDrive-titles-9e032edea6424a9f8d0b6365f41a7e8c)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests were written to mock out the entire flow as described in the ticket, since production keys were not available for testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
