### PR TITLE
Blank values in the Library settings are now considered as valid values

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -356,7 +356,9 @@ class LibrarySettingsController(SettingsController):
             if type == "image":
                 value = self.image_setting(setting) or default_value
             else:
-                value = self.scalar_setting(setting) or default_value
+                value = self.scalar_setting(setting)
+                # An empty "" value or 0 value is valid, hence check for None
+                value = default_value if value is None else value
         return value
 
     def scalar_setting(self, setting):

--- a/tests/api/admin/controller/test_library.py
+++ b/tests/api/admin/controller/test_library.py
@@ -6,6 +6,7 @@ from io import BytesIO
 import flask
 import pytest
 from PIL import Image
+from werkzeug import Response
 from werkzeug.datastructures import MultiDict
 
 from api.admin.announcement_list_validator import AnnouncementListValidator
@@ -556,6 +557,72 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
         assert (
             "A tiny image"
             == ConfigurationSetting.for_library(Configuration.LOGO, library).value
+        )
+
+    def test_library_post_empty_values_edit(self):
+        library = self._library("New York Public Library", "nypl")
+        ConfigurationSetting.for_library(
+            Configuration.LIBRARY_DESCRIPTION, library
+        ).value = "description"
+
+        with self.request_context_with_admin("/", method="POST"):
+            flask.request.form = MultiDict(
+                [
+                    ("uuid", library.uuid),
+                    ("name", "The New York Public Library"),
+                    ("short_name", "nypl"),
+                    (Configuration.LIBRARY_DESCRIPTION, ""),  # empty value
+                    (Configuration.WEBSITE_URL, "https://library.library/"),
+                    (Configuration.HELP_EMAIL, "help@example.com"),
+                ]
+            )
+            response = self.manager.admin_library_settings_controller.process_post()
+            assert response.status_code == 200
+
+        assert (
+            ConfigurationSetting.for_library(
+                Configuration.LIBRARY_DESCRIPTION, library
+            )._value
+            == ""
+        )
+        # ConfigurationSetting.value property.getter sets "" to None
+        assert (
+            ConfigurationSetting.for_library(
+                Configuration.LIBRARY_DESCRIPTION, library
+            ).value
+            == None
+        )
+
+    def test_library_post_empty_values_create(self):
+        with self.request_context_with_admin("/", method="POST"):
+            flask.request.form = MultiDict(
+                [
+                    ("name", "The New York Public Library"),
+                    ("short_name", "nypl"),
+                    (Configuration.LIBRARY_DESCRIPTION, ""),  # empty value
+                    (Configuration.WEBSITE_URL, "https://library.library/"),
+                    (Configuration.HELP_EMAIL, "help@example.com"),
+                ]
+            )
+            response: Response = (
+                self.manager.admin_library_settings_controller.process_post()
+            )
+            assert response.status_code == 201
+            uuid = response.get_data(as_text=True)
+
+        library = get_one(self._db, Library, uuid=uuid)
+        assert (
+            ConfigurationSetting.for_library(
+                Configuration.LIBRARY_DESCRIPTION, library
+            )._value
+            == ""
+        )
+        # ConfigurationSetting.value property.getter sets "" to None
+        assert (
+            ConfigurationSetting.for_library(
+                Configuration.LIBRARY_DESCRIPTION, library
+            ).value
+            == None
         )
 
     def test_library_delete(self):


### PR DESCRIPTION
## Description
Only NoneType values are ignored now

## Motivation and Context
Blank values are still valid values when optional fields are deleted, however, these values were being ignored as "falsey" values.

[Notion ticket](https://www.notion.so/lyrasis/Removing-a-value-from-an-Admin-UI-field-does-not-save-the-blank-value-55dacb3de5e94e34a1fdad6e450b64c5).

## How Has This Been Tested?

- New tests added.
- All tests ran successfully.

## Checklist
Unit and Manual testing was done

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
