### PR TITLE
Changed duplicate device token creation to a 200 response

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -2441,7 +2441,7 @@ class DeviceTokensController(CirculationManagerController):
         except InvalidTokenTypeError:
             return DEVICE_TOKEN_TYPE_INVALID
         except DuplicateDeviceTokenError:
-            return DEVICE_TOKEN_ALREADY_EXISTS
+            return dict(exists=True), 200
 
         return "", 201
 

--- a/core/model/devicetokens.py
+++ b/core/model/devicetokens.py
@@ -66,6 +66,7 @@ class DeviceToken(Base):
             db.add(device)
             db.commit()
         except IntegrityError as e:
+            db.rollback()
             if "device_token" in e.args[0]:
                 raise DuplicateDeviceTokenError() from e
             else:

--- a/tests/api/test_device_tokens.py
+++ b/tests/api/test_device_tokens.py
@@ -1,10 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from api.problem_details import (
-    DEVICE_TOKEN_ALREADY_EXISTS,
-    DEVICE_TOKEN_NOT_FOUND,
-    DEVICE_TOKEN_TYPE_INVALID,
-)
+from api.problem_details import DEVICE_TOKEN_NOT_FOUND, DEVICE_TOKEN_TYPE_INVALID
 from core.model.devicetokens import DeviceToken, DeviceTokenTypes
 from tests.api.test_controller import ControllerTest
 
@@ -102,7 +98,7 @@ class TestDeviceTokens(ControllerTest):
         flask.request = request
         response = self.app.manager.patron_devices.create_patron_device()
 
-        assert response == DEVICE_TOKEN_ALREADY_EXISTS
+        assert response == (dict(exists=True), 200)
 
     def test_delete_token(self, flask):
         patron = self._patron()


### PR DESCRIPTION
## Description
Instead of a `409` response which means an issue has occurred
<!--- Describe your changes -->

## Motivation and Context
The mobile devices need to know a token exists without it seeming like a error. Hence the 4xx response is now 200 response.
[Notion](https://www.notion.so/lyrasis/Push-Notifications-Http-200-for-existing-tokens-42356a53f9814d64b39e43c81c8af444)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
Unit and manual API test

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
