### PR TITLE
Patron activity sync scheduled job

### DIFF
--- a/bin/patron_activity_sync_notifications
+++ b/bin/patron_activity_sync_notifications
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""Send out notifications to Patrons that need their loan/hold activity synced"""
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.jobs.patron_activity_sync import PatronActivitySyncNotificationScript
+from core.model import production_session
+
+PatronActivitySyncNotificationScript(production_session()).run()

--- a/core/jobs/patron_activity_sync.py
+++ b/core/jobs/patron_activity_sync.py
@@ -1,0 +1,40 @@
+from datetime import timedelta
+from typing import List, Optional
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Query
+
+from core.model.devicetokens import DeviceToken
+from core.model.patron import Hold, Loan, Patron
+from core.monitor import PatronSweepMonitor
+from core.util.datetime_helpers import utc_now
+from core.util.notifications import PushNotifications
+
+
+class PatronActivitySyncNotificationScript(PatronSweepMonitor):
+    """Find patrons with stale last_activity_sync timestamps, and also who have loans/holds
+    and notify said patron devices to re-sync their data"""
+
+    STALE_ACTIVITY_SYNC_DAYS = 2
+    SERVICE_NAME: Optional[str] = "Patron Activity Sync Notification"
+
+    def item_query(self):
+        expired_sync = utc_now() - timedelta(days=self.STALE_ACTIVITY_SYNC_DAYS)
+        query: Query = super().item_query()
+        query = (
+            query.outerjoin(Hold)
+            .outerjoin(Loan)
+            .outerjoin(DeviceToken)
+            .filter(or_(Loan.id != None, Hold.id != None))
+            .filter(DeviceToken.id != None)
+            .filter(
+                or_(
+                    Patron._last_loan_activity_sync < expired_sync,
+                    Patron._last_loan_activity_sync == None,
+                )
+            )
+        )
+        return query
+
+    def process_items(self, items: List[Patron]):
+        PushNotifications.send_activity_sync_message(items)

--- a/core/model/constants.py
+++ b/core/model/constants.py
@@ -380,3 +380,8 @@ class MediaTypes:
             # multiple media types have the same extension, the most
             # common media type will be used.
             MEDIA_TYPE_FOR_EXTENSION[_extension] = _media_type
+
+
+class NotificationConstants:
+    ACTIVITY_SYNC_TYPE = "ActivitySync"
+    LOAN_EXPIRY_TYPE = "LoanExpiry"

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
 
 from core.model.hybrid import hybrid_property
+from core.model.library import Library
 
 from ..classifier import Classifier
 from ..user_profile import ProfileStorage
@@ -65,6 +66,7 @@ class Patron(Base):
     # individual human being may patronize multiple libraries, but
     # they will have a different patron account at each one.
     library_id = Column(Integer, ForeignKey("libraries.id"), index=True, nullable=False)
+    library: Library
 
     # The patron's permanent unique identifier in an external library
     # system, probably never seen by the patron.

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -22,7 +22,6 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
 
 from core.model.hybrid import hybrid_property
-from core.model.library import Library
 
 from ..classifier import Classifier
 from ..user_profile import ProfileStorage
@@ -33,6 +32,7 @@ from .credential import Credential
 if TYPE_CHECKING:
     from . import LicensePool
     from .devicetokens import DeviceToken
+    from .library import Library
 
 
 class LoanAndHoldMixin:
@@ -66,7 +66,7 @@ class Patron(Base):
     # individual human being may patronize multiple libraries, but
     # they will have a different patron account at each one.
     library_id = Column(Integer, ForeignKey("libraries.id"), index=True, nullable=False)
-    library: Library
+    library: "Library"
 
     # The patron's permanent unique identifier in an external library
     # system, probably never seen by the patron.

--- a/core/monitor.py
+++ b/core/monitor.py
@@ -664,6 +664,16 @@ class NotPresentationReadyWorkSweepMonitor(WorkSweepMonitor):
         return super().item_query().filter(not_presentation_ready)
 
 
+class PatronSweepMonitor(SweepMonitor):
+    """Sweep through all Patrons"""
+
+    MODEL_CLASS: Optional[Type[Base]] = Patron
+
+    def scope_to_collection(self, qu, collection):
+        """Patrons aren't scoped to a collection"""
+        return qu
+
+
 # SweepMonitors that do something specific.
 
 

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -2,18 +2,24 @@ from typing import List
 
 import firebase_admin
 from firebase_admin import credentials, messaging
+from sqlalchemy.orm import Session
 
 from core.config import Configuration
-from core.model.devicetokens import DeviceToken
+from core.model.configuration import ConfigurationSetting
+from core.model.constants import NotificationConstants
+from core.model.devicetokens import DeviceToken, DeviceTokenTypes
 from core.model.edition import Edition
 from core.model.identifier import Identifier
-from core.model.patron import Loan
+from core.model.patron import Loan, Patron
 
 
 class PushNotifications:
     # Should be set to true while unit testing
     TESTING_MODE = False
     _fcm_app = None
+    _base_url = None
+
+    VALID_TOKEN_TYPES = [DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS]
 
     @classmethod
     @property
@@ -25,10 +31,24 @@ class PushNotifications:
         return cls._fcm_app
 
     @classmethod
+    def base_url(cls, _db):
+        if not cls._base_url:
+            cls._base_url = ConfigurationSetting.sitewide(
+                _db, Configuration.BASE_URL_KEY
+            ).value
+        return cls._base_url
+
+    @classmethod
     def send_loan_expiry_message(
         cls, loan: Loan, days_to_expiry, tokens: List[DeviceToken]
     ):
+        """Send a loan expiry reminder to the mobile Apps, with enough information
+        to identify two things
+        - Which loan is being mentioned, in order to correctly deep link
+        - Which patron and make the loans api request with the right authentication"""
         responses = []
+        _db = Session.object_session(loan)
+        url = cls.base_url(_db)
         edition: Edition = loan.license_pool.presentation_edition
         identifier: Identifier = loan.license_pool.identifier
         library_short_name = loan.library and loan.library.short_name
@@ -38,6 +58,10 @@ class PushNotifications:
                 data=dict(
                     title=f"Only {days_to_expiry} {'days' if days_to_expiry != 1 else 'day'} left on your loan!",
                     body=f"Your loan on {edition.title} is expiring soon",
+                    event_type=NotificationConstants.LOAN_EXPIRY_TYPE,
+                    loans_endpoint=f"{url}/{loan.library.short_name}/loans",
+                    external_identifier=loan.patron.external_identifier,
+                    authorization_identifier=loan.patron.authorization_identifier,
                     identifier=identifier.identifier,
                     type=identifier.type,
                     library=library_short_name,
@@ -47,3 +71,37 @@ class PushNotifications:
             resp = messaging.send(msg, dry_run=cls.TESTING_MODE, app=cls.fcm_app)
             responses.append(resp)
         return responses
+
+    @classmethod
+    def send_activity_sync_message(cls, patrons: List[Patron]):
+        """Send notifications to the given patrons to sync their bookshelves
+        Enough information needs to be sent to identify a patron on the mobile Apps
+        and make the loans api request with the right authentication"""
+        if not patrons:
+            return []
+
+        msgs = []
+        _db = Session.object_session(patrons[0])
+        url = cls.base_url(_db)
+        for patron in patrons:
+            tokens = [
+                token
+                for token in patron.device_tokens
+                if token.token_type in cls.VALID_TOKEN_TYPES
+            ]
+            loans_api = f"{url}/{patron.library.short_name}/loans"
+            for token in tokens:
+                msg = messaging.Message(
+                    token=token.device_token,
+                    data=dict(
+                        event_type=NotificationConstants.ACTIVITY_SYNC_TYPE,
+                        loans_endpoint=loans_api,
+                        external_identifier=patron.external_identifier,
+                        authorization_identifier=patron.authorization_identifier,
+                    ),
+                )
+                msgs.append(msg)
+        batch: messaging.BatchResponse = messaging.send_all(
+            msgs, dry_run=cls.TESTING_MODE, app=cls.fcm_app
+        )
+        return [resp.message_id for resp in batch.responses]

--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -129,3 +129,4 @@ HOME=/var/www/circulation
 # Notifications
 #
 10 12 * * * root core/bin/run loan_notifications >> /var/log/cron.log 2>&1
+0 1 * * * root core/bin/run patron_activity_sync_notifications >> /var/log/cron.log 2>&1

--- a/tests/core/test_patron_activity_sync.py
+++ b/tests/core/test_patron_activity_sync.py
@@ -1,0 +1,76 @@
+from datetime import timedelta
+from unittest.mock import MagicMock, call, patch
+
+from core.jobs.patron_activity_sync import PatronActivitySyncNotificationScript
+from core.model import create
+from core.model.devicetokens import DeviceToken, DeviceTokenTypes
+from core.model.licensing import LicensePool
+from core.model.patron import Patron
+from core.model.work import Work
+from core.testing import DatabaseTest
+from core.util.datetime_helpers import utc_now
+
+
+class TestPatronActivitySync(DatabaseTest):
+    def setup_method(self):
+        super().setup_method()
+        self.monitor = PatronActivitySyncNotificationScript(self._db, batch_size=100)
+
+    def test_item_query(self):
+        work: Work = self._work(with_license_pool=True, with_open_access_download=True)
+        pool: LicensePool = work.active_license_pool()
+        patron1: Patron = self._patron()  # 0 loans, holds or tokens
+        patron2: Patron = self._patron()  # 0 loan, holds, 1 token
+        patron3: Patron = self._patron()  # 1 loan, 0 holds, 1 token
+        patron4: Patron = self._patron()  # 0 loan, 1 holds, 1 token
+        patron5: Patron = self._patron()  # 1 loan, 1 holds, 0 token
+
+        for info in [
+            dict(patron=patron1, loan=False, hold=False, token=False),
+            dict(patron=patron2, loan=False, hold=False, token=True),
+            dict(patron=patron3, loan=True, hold=False, token=True),
+            dict(patron=patron4, loan=False, hold=True, token=True),
+            dict(patron=patron5, loan=True, hold=True, token=False),
+        ]:
+            patron: Patron = info["patron"]
+            if info["loan"]:
+                pool.loan_to(patron)
+            if info["hold"]:
+                pool.on_hold_to(patron)
+            if info["token"]:
+                create(
+                    self._db,
+                    DeviceToken,
+                    patron=patron,
+                    token_type=DeviceTokenTypes.FCM_ANDROID,
+                    device_token=f"test-token-{patron.id}",
+                )
+            patron._last_loan_activity_sync = utc_now() - timedelta(days=30)
+
+        # Only patrons with loans/holds and tokens will appear
+        patrons = self.monitor.item_query().all()
+        assert sorted(patrons, key=lambda p: p.id) == [patron3, patron4]
+
+        # Patron3 was synced recently, so should not appear
+        patron3.last_loan_activity_sync = utc_now()
+        assert self.monitor.item_query().all() == [patron4]
+
+    @patch("core.jobs.patron_activity_sync.PushNotifications")
+    def test_run(self, mock_notf: MagicMock):
+        work = self._work(with_license_pool=True)
+        patron = self._patron()
+        patron2 = self._patron()  # no loans, should not be processed
+        pool: LicensePool = work.active_license_pool()
+        pool.loan_to(patron)
+
+        create(
+            self._db,
+            DeviceToken,
+            patron=patron,
+            token_type=DeviceTokenTypes.FCM_ANDROID,
+            device_token=f"test-token-{patron.id}",
+        )
+
+        self.monitor.run()
+        assert mock_notf.send_activity_sync_message.call_count == 1
+        assert mock_notf.send_activity_sync_message.call_args == call([patron])

--- a/tests/core/util/test_notifications.py
+++ b/tests/core/util/test_notifications.py
@@ -1,6 +1,9 @@
 from unittest import mock
 
-from core.model import get_one_or_create
+from core.config import Configuration
+from core.model import create, get_one_or_create
+from core.model.configuration import ConfigurationSetting
+from core.model.constants import NotificationConstants
 from core.model.devicetokens import DeviceToken, DeviceTokenTypes
 from core.model.work import Work
 from core.testing import DatabaseTest
@@ -9,8 +12,10 @@ from core.util.notifications import PushNotifications
 
 class TestPushNotifications(DatabaseTest):
     def setup_method(self):
+        super().setup_method()
         PushNotifications.TESTING_MODE = True
-        return super().setup_method()
+        setting = ConfigurationSetting.sitewide(self._db, Configuration.BASE_URL_KEY)
+        setting.value = "http://localhost"
 
     @mock.patch("core.util.notifications.PushNotifications.fcm_app")
     @mock.patch("core.util.notifications.messaging")
@@ -36,6 +41,8 @@ class TestPushNotifications(DatabaseTest):
                 "data": dict(
                     title="Only 1 day left on your loan!",
                     body=f"Your loan on {work.presentation_edition.title} is expiring soon",
+                    event_type=NotificationConstants.LOAN_EXPIRY_TYPE,
+                    loans_endpoint="http://localhost/default/loans",
                     identifier=work.presentation_edition.primary_identifier.identifier,
                     type=work.presentation_edition.primary_identifier.type,
                     library=loan.library.short_name,
@@ -48,3 +55,75 @@ class TestPushNotifications(DatabaseTest):
             (messaging.Message(),),
             {"dry_run": True, "app": mock_fcm},
         ]
+
+    @mock.patch("core.util.notifications.PushNotifications.fcm_app")
+    @mock.patch("core.util.notifications.messaging")
+    def test_send_activity_sync(
+        self, messaging: mock.MagicMock, fcm_app: mock.MagicMock
+    ):
+        patron1 = self._patron()
+        patron2 = self._patron()
+        patron3 = self._patron()
+
+        tokens = []
+        for patron in (patron1, patron2, patron3):
+            t, _ = create(
+                self._db,
+                DeviceToken,
+                patron=patron,
+                device_token=f"ios-token-{patron.id}",
+                token_type=DeviceTokenTypes.FCM_IOS,
+            )
+            tokens.append(t)
+            t, _ = create(
+                self._db,
+                DeviceToken,
+                patron=patron,
+                device_token=f"android-token-{patron.id}",
+                token_type=DeviceTokenTypes.FCM_ANDROID,
+            )
+            tokens.append(t)
+
+        # Notify 2 patrons of 3 total
+        PushNotifications.send_activity_sync_message([patron1, patron2])
+        assert messaging.Message.call_count == 4
+        assert messaging.Message.call_args_list == [
+            mock.call(
+                token=tokens[0].device_token,
+                data=dict(
+                    event_type=NotificationConstants.ACTIVITY_SYNC_TYPE,
+                    loans_endpoint="http://localhost/default/loans",
+                    external_identifier=patron1.external_identifier,
+                    authorization_identifier=patron1.authorization_identifier,
+                ),
+            ),
+            mock.call(
+                token=tokens[1].device_token,
+                data=dict(
+                    event_type=NotificationConstants.ACTIVITY_SYNC_TYPE,
+                    loans_endpoint="http://localhost/default/loans",
+                    external_identifier=patron1.external_identifier,
+                    authorization_identifier=patron1.authorization_identifier,
+                ),
+            ),
+            mock.call(
+                token=tokens[2].device_token,
+                data=dict(
+                    event_type=NotificationConstants.ACTIVITY_SYNC_TYPE,
+                    loans_endpoint="http://localhost/default/loans",
+                    external_identifier=patron2.external_identifier,
+                    authorization_identifier=patron2.authorization_identifier,
+                ),
+            ),
+            mock.call(
+                token=tokens[3].device_token,
+                data=dict(
+                    event_type=NotificationConstants.ACTIVITY_SYNC_TYPE,
+                    loans_endpoint="http://localhost/default/loans",
+                    external_identifier=patron2.external_identifier,
+                    authorization_identifier=patron2.authorization_identifier,
+                ),
+            ),
+        ]
+
+        assert messaging.send_all.call_count == 1

--- a/tests/core/util/test_notifications.py
+++ b/tests/core/util/test_notifications.py
@@ -43,6 +43,8 @@ class TestPushNotifications(DatabaseTest):
                     body=f"Your loan on {work.presentation_edition.title} is expiring soon",
                     event_type=NotificationConstants.LOAN_EXPIRY_TYPE,
                     loans_endpoint="http://localhost/default/loans",
+                    external_identifier=patron.external_identifier,
+                    authorization_identifier=patron.authorization_identifier,
                     identifier=work.presentation_edition.primary_identifier.identifier,
                     type=work.presentation_edition.primary_identifier.type,
                     library=loan.library.short_name,


### PR DESCRIPTION
## Description
Should send out notifications to patron mobile apps that
    - Have a device token
    - Have either a loan or hold active
    - Have potentially stale loan/hold activity data

The job is scheduled for 1AM daily
A loans endpoint has also been added to this and the loans notifications

There is an issue with the current implementation of last_activity_sync_time
wherein the getter finds the sync time to be stale in 15 minutes and clears out the
last sync time on access, we may want to change this implementation to not clear out
the information and add a has_activity_sync_expired() method, allowing each type of
workflow define when a sync is stale

<!--- Describe your changes -->

## Motivation and Context
The loans and holds information is often out of date due to out of system changes that occur. Due to this the patron must re-sync their bookshelf in a periodic fashion.
[Notion](https://www.notion.so/lyrasis/Push-Notifications-Patron-activity-sync-32fbabd6c78b4de2bf9264416ba3ee86)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit testing has been done, manual testing is not possible without device tokens
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
