### PR TITLE
JSON search field transforms fix

### DIFF
--- a/core/external_search.py
+++ b/core/external_search.py
@@ -2089,7 +2089,7 @@ class JSONQuery(Query):
 
         nested_path = self._nested_path(key)
         if self._is_keyword(key):
-            key = query[self.QueryLeaf.KEY] + ".keyword"
+            key = key + ".keyword"
 
         value = query[self.QueryLeaf.VALUE]
 

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -4745,6 +4745,19 @@ class TestJSONQuery(ExternalSearchTest):
             }
         }
 
+    def test_field_transforms(self):
+        q = self._jq(self._leaf("classification", "cls"))
+        assert q.elasticsearch_query.to_dict() == {
+            "term": {"classifications.term.keyword": "cls"}
+        }
+        q = self._jq(self._leaf("open_access", True))
+        assert q.elasticsearch_query.to_dict() == {
+            "nested": {
+                "path": "licensepools",
+                "query": {"term": {"licensepools.open_access": True}},
+            }
+        }
+
 
 class TestExternalSearchJSONQuery(EndToEndSearchTest):
     def _leaf(self, key, value, op="eq"):


### PR DESCRIPTION
## Description
Keyword type fields were not being transformed correctly, this fixes the issue
<!--- Describe your changes -->

## Motivation and Context
Specifically `Classification` was not transforming correctly to `Classifications.term.keyword`
[Notion](https://www.notion.so/lyrasis/JSON-search-field-transforms-do-not-work-as-intended-7b65081579124900a4e0944c6eeaff04)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit and manual api testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
