### PR TITLE
Feature/holds notifications

### DIFF
--- a/bin/hold_notifications
+++ b/bin/hold_notifications
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Send out Loan Notifications to patrons"""
+"""Send out Hold Notifications to patrons"""
 import os
 import sys
 

--- a/bin/hold_notifications
+++ b/bin/hold_notifications
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+"""Send out Loan Notifications to patrons"""
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.jobs.holds_notification import HoldsNotificationMonitor
+from core.model import production_session
+
+HoldsNotificationMonitor(production_session()).run()

--- a/core/jobs/holds_notification.py
+++ b/core/jobs/holds_notification.py
@@ -1,0 +1,25 @@
+from typing import Optional, Type
+
+from core.model import Base
+from core.model.patron import Hold
+from core.monitor import SweepMonitor
+from core.util.notifications import PushNotifications
+
+
+class HoldsNotificationMonitor(SweepMonitor):
+    """Sweep across all holds that are ready to be checked out by the user"""
+
+    MODEL_CLASS: Optional[Type[Base]] = Hold
+    SERVICE_NAME: Optional[str] = "Holds Notification"
+
+    def scope_to_collection(self, qu, collection):
+        """Do not scope to collection"""
+        return qu
+
+    def item_query(self):
+        query = super().item_query()
+        query = query.filter(Hold.position == 0)
+        return query
+
+    def process_items(self, items):
+        PushNotifications.send_holds_notifications(items)

--- a/core/jobs/holds_notification.py
+++ b/core/jobs/holds_notification.py
@@ -7,7 +7,7 @@ from core.util.notifications import PushNotifications
 
 
 class HoldsNotificationMonitor(SweepMonitor):
-    """Sweep across all holds that are ready to be checked out by the user"""
+    """Sweep across all holds that are ready to be checked out by the user (position=0)"""
 
     MODEL_CLASS: Optional[Type[Base]] = Hold
     SERVICE_NAME: Optional[str] = "Holds Notification"

--- a/core/model/constants.py
+++ b/core/model/constants.py
@@ -385,3 +385,4 @@ class MediaTypes:
 class NotificationConstants:
     ACTIVITY_SYNC_TYPE = "ActivitySync"
     LOAN_EXPIRY_TYPE = "LoanExpiry"
+    HOLD_AVAILABLE_TYPE = "HoldAvailable"

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -561,10 +561,12 @@ class Hold(Base, LoanAndHoldMixin):
     __tablename__ = "holds"
     id = Column(Integer, primary_key=True)
     patron_id = Column(Integer, ForeignKey("patrons.id"), index=True)
+    patron: Patron
     integration_client_id = Column(
         Integer, ForeignKey("integrationclients.id"), index=True
     )
     license_pool_id = Column(Integer, ForeignKey("licensepools.id"), index=True)
+    license_pool: "LicensePool"
     start = Column(DateTime(timezone=True), index=True)
     end = Column(DateTime(timezone=True), index=True)
     position = Column(Integer, index=True)

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -23,7 +23,7 @@ class PushNotifications:
     VALID_TOKEN_TYPES = [DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS]
 
     @classmethod
-    def notifiable_tokens(cls, patron: Patron):
+    def notifiable_tokens(cls, patron: Patron) -> List[DeviceToken]:
         return [
             token
             for token in patron.device_tokens

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -113,6 +113,7 @@ class PushNotifications:
 
     @classmethod
     def send_holds_notifications(cls, holds: List[Hold]) -> List[str]:
+        """Send out notifcations to all patron devices that their hold is ready for checkout"""
         if not holds:
             return []
 

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -10,7 +10,8 @@ from core.model.constants import NotificationConstants
 from core.model.devicetokens import DeviceToken, DeviceTokenTypes
 from core.model.edition import Edition
 from core.model.identifier import Identifier
-from core.model.patron import Loan, Patron
+from core.model.patron import Hold, Loan, Patron
+from core.model.work import Work
 
 
 class PushNotifications:
@@ -20,6 +21,14 @@ class PushNotifications:
     _base_url = None
 
     VALID_TOKEN_TYPES = [DeviceTokenTypes.FCM_ANDROID, DeviceTokenTypes.FCM_IOS]
+
+    @classmethod
+    def notifiable_tokens(cls, patron: Patron):
+        return [
+            token
+            for token in patron.device_tokens
+            if token.token_type in cls.VALID_TOKEN_TYPES
+        ]
 
     @classmethod
     @property
@@ -73,7 +82,7 @@ class PushNotifications:
         return responses
 
     @classmethod
-    def send_activity_sync_message(cls, patrons: List[Patron]):
+    def send_activity_sync_message(cls, patrons: List[Patron]) -> List[str]:
         """Send notifications to the given patrons to sync their bookshelves
         Enough information needs to be sent to identify a patron on the mobile Apps
         and make the loans api request with the right authentication"""
@@ -84,11 +93,7 @@ class PushNotifications:
         _db = Session.object_session(patrons[0])
         url = cls.base_url(_db)
         for patron in patrons:
-            tokens = [
-                token
-                for token in patron.device_tokens
-                if token.token_type in cls.VALID_TOKEN_TYPES
-            ]
+            tokens = cls.notifiable_tokens(patron)
             loans_api = f"{url}/{patron.library.short_name}/loans"
             for token in tokens:
                 msg = messaging.Message(
@@ -98,6 +103,39 @@ class PushNotifications:
                         loans_endpoint=loans_api,
                         external_identifier=patron.external_identifier,
                         authorization_identifier=patron.authorization_identifier,
+                    ),
+                )
+                msgs.append(msg)
+        batch: messaging.BatchResponse = messaging.send_all(
+            msgs, dry_run=cls.TESTING_MODE, app=cls.fcm_app
+        )
+        return [resp.message_id for resp in batch.responses]
+
+    @classmethod
+    def send_holds_notifications(cls, holds: List[Hold]) -> List[str]:
+        if not holds:
+            return []
+
+        msgs = []
+        _db = Session.object_session(holds[0])
+        url = cls.base_url(_db)
+        for hold in holds:
+            tokens = cls.notifiable_tokens(hold.patron)
+            loans_api = f"{url}/{hold.patron.library.short_name}/loans"
+            work: Work = hold.work
+            identifier: Identifier = hold.license_pool.identifier
+            for token in tokens:
+                msg = messaging.Message(
+                    token=token.device_token,
+                    data=dict(
+                        title=f'Your hold on "{work.title}" is available!',
+                        event_type=NotificationConstants.HOLD_AVAILABLE_TYPE,
+                        loans_endpoint=loans_api,
+                        external_identifier=hold.patron.external_identifier,
+                        authorization_identifier=hold.patron.authorization_identifier,
+                        identifier=identifier.identifier,
+                        type=identifier.type,
+                        library=hold.patron.library.short_name,
                     ),
                 )
                 msgs.append(msg)

--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -129,4 +129,5 @@ HOME=/var/www/circulation
 # Notifications
 #
 10 12 * * * root core/bin/run loan_notifications >> /var/log/cron.log 2>&1
+15 12 * * * root core/bin/run hold_notifications >> /var/log/cron.log 2>&1
 0 1 * * * root core/bin/run patron_activity_sync_notifications >> /var/log/cron.log 2>&1

--- a/tests/core/test_holds_notifications.py
+++ b/tests/core/test_holds_notifications.py
@@ -1,0 +1,37 @@
+from unittest.mock import call, patch
+
+from core.jobs.holds_notification import HoldsNotificationMonitor
+from core.testing import DatabaseTest
+
+
+class TestHoldsNotifications(DatabaseTest):
+    def setup_method(self):
+        super().setup_method()
+        self.monitor = HoldsNotificationMonitor(self._db)
+
+    def test_item_query(self):
+        patron1 = self._patron()
+        work1 = self._work(with_license_pool=True)
+        work2 = self._work(with_license_pool=True)
+        work3 = self._work(with_license_pool=True)
+        work4 = self._work(with_license_pool=True)
+        hold1, _ = work1.active_license_pool().on_hold_to(patron1, position=1)
+        hold2, _ = work2.active_license_pool().on_hold_to(patron1, position=0)
+        hold3, _ = work3.active_license_pool().on_hold_to(patron1, position=0)
+        hold4, _ = work4.active_license_pool().on_hold_to(patron1, position=None)
+
+        # Only position 0 holds should be pushed queried for
+        assert self.monitor.item_query().all() == [hold2, hold3]
+
+    @patch("core.jobs.holds_notification.PushNotifications")
+    def test_script_run(self, mock_notf):
+        patron1 = self._patron()
+        work1 = self._work(with_license_pool=True)
+        work2 = self._work(with_license_pool=True)
+        hold1, _ = work1.active_license_pool().on_hold_to(patron1, position=0)
+        hold2, _ = work2.active_license_pool().on_hold_to(patron1, position=0)
+        self.monitor.run()
+        assert mock_notf.send_holds_notifications.call_count == 1
+        assert mock_notf.send_holds_notifications.call_args_list == [
+            call([hold1, hold2])
+        ]


### PR DESCRIPTION
## Description
Hold notifications for patrons
    
The script will only pick holds that have position=0
There is currently no way of telling if a notification has been sent to a user or not
So if a hold remains in reserve for a long duration the patron will receive multiple notifications
as and when the job runs
<!--- Describe your changes -->

## Motivation and Context
Patrons need to be informed when a hold is available for loan. This can be achieved through a push notification to the patron device as and when a hold is ready
[Notion](https://www.notion.so/lyrasis/Push-Notifications-Hold-available-f727cc8473bb4007b4cd8f3756b28789)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit testing is done. Manual testing is not possible without apps with FCM installed,
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
