### PR TITLE
Custom list API fix

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -79,7 +79,7 @@ from core.query.customlist import CustomListQueries
 from core.s3 import S3UploaderConfiguration
 from core.selftest import HasSelfTests
 from core.util.datetime_helpers import utc_now
-from core.util.flask_util import OPDSFeedResponse
+from core.util.flask_util import OPDSFeedResponse, boolean_value
 from core.util.http import HTTP
 from core.util.problem_detail import ProblemDetail
 
@@ -1007,7 +1007,9 @@ class CustomListsController(AdminCirculationManagerController):
             )
 
             # For auto updating lists
-            auto_update = flask.request.form.get("auto_update", False)
+            auto_update = flask.request.form.get(
+                "auto_update", False, type=boolean_value
+            )
             auto_update_query = flask.request.form.get("auto_update_query")
 
             return self._create_or_update_list(

--- a/core/util/flask_util.py
+++ b/core/util/flask_util.py
@@ -175,7 +175,7 @@ class OPDSEntryResponse(Response):
         super().__init__(response, **kwargs)
 
 
-def boolean_value(value):
+def boolean_value(value: str) -> bool:
     """Convert a string request value into a boolean, used for form encoded requests
     JSON encoded requests will get automatically converted"""
-    return True if value in ["true", "True", True] else False
+    return True if value in ["true", "True", True, "1"] else False

--- a/core/util/flask_util.py
+++ b/core/util/flask_util.py
@@ -173,3 +173,9 @@ class OPDSEntryResponse(Response):
     def __init__(self, response=None, **kwargs):
         kwargs.setdefault("mimetype", OPDSFeed.ENTRY_TYPE)
         super().__init__(response, **kwargs)
+
+
+def boolean_value(value):
+    """Convert a string request value into a boolean, used for form encoded requests
+    JSON encoded requests will get automatically converted"""
+    return True if value in ["true", "True", True] else False

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -1365,6 +1365,7 @@ class TestCustomListsController(AdminControllerTest):
         # Test fails without expiring the ORM cache
         self._db.expire_all()
 
+        update_query = {"query": {"key": "title", "value": "title"}}
         with self.request_context_with_library_and_admin("/", method="POST"):
             flask.request.form = MultiDict(
                 [
@@ -1373,6 +1374,8 @@ class TestCustomListsController(AdminControllerTest):
                     ("entries", json.dumps(new_entries)),
                     ("deletedEntries", json.dumps(deletedEntries)),
                     ("collections", json.dumps([c.id for c in new_collections])),
+                    ("auto_update", "true"),
+                    ("auto_update_query", json.dumps(update_query)),
                 ]
             )
 
@@ -1394,6 +1397,8 @@ class TestCustomListsController(AdminControllerTest):
         assert "new name" == list.name
         assert {w2, w3} == {entry.work for entry in list.entries}
         assert new_collections == list.collections
+        assert True == list.auto_update_enabled
+        assert json.dumps(update_query) == list.auto_update_query
 
         # If we were using a real search engine instance, the lane's size would be set
         # to 2, since that's the number of works that would be associated with the

--- a/tests/core/util/test_flask_util.py
+++ b/tests/core/util/test_flask_util.py
@@ -5,9 +5,15 @@ import time
 from wsgiref.handlers import format_date_time
 
 from flask import Response as FlaskResponse
+from parameterized import parameterized
 
 from core.util.datetime_helpers import utc_now
-from core.util.flask_util import OPDSEntryResponse, OPDSFeedResponse, Response
+from core.util.flask_util import (
+    OPDSEntryResponse,
+    OPDSFeedResponse,
+    Response,
+    boolean_value,
+)
 from core.util.opds_writer import OPDSFeed
 
 
@@ -147,3 +153,21 @@ class TestOPDSEntryResponse:
         override_defaults = c("an entry", content_type="content/type")
         assert "content/type" == override_defaults.content_type
         assert "content/type" == override_defaults.mimetype
+
+
+class TestMethods:
+    @parameterized.expand(
+        [
+            ("true", True),
+            ("True", True),
+            (True, True),
+            ("1", True),
+            ("false", False),
+            ("False", False),
+            ("0", False),
+            ("t", False),
+            (None, False),
+        ]
+    )
+    def test_boolean_value(self, value, result):
+        assert boolean_value(value) == result


### PR DESCRIPTION
## Description
Fixed erroneous boolean type value conversion for custom_list POST request
Form requests are string values
<!--- Describe your changes -->

## Motivation and Context
The API requests would not work from actual clients because form encoded boolean values are strings
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated, also manually tested the API
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
