### PR TITLE
Feature/maintain patron last activity

### DIFF
--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -249,7 +249,8 @@ class Patron(Base):
         """
         return 15 * 60
 
-    def has_last_loan_activity_expired(self):
+    def is_last_loan_activity_stale(self) -> bool:
+        """Has the last_loan_activity_sync timestamp outlived the loan_activity_max_age seconds"""
         if not self._last_loan_activity_sync:
             return True
 
@@ -265,7 +266,7 @@ class Patron(Base):
         :return: A datetime, or None if we know our loan data is
             stale.
         """
-        if self.has_last_loan_activity_expired():
+        if self.is_last_loan_activity_stale():
             return None
         return self._last_loan_activity_sync
 

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -249,6 +249,14 @@ class Patron(Base):
         """
         return 15 * 60
 
+    def has_last_loan_activity_expired(self):
+        if not self._last_loan_activity_sync:
+            return True
+
+        return utc_now() > self._last_loan_activity_sync + datetime.timedelta(
+            seconds=self.loan_activity_max_age
+        )
+
     @hybrid_property
     def last_loan_activity_sync(self):
         """When was the last time we asked the vendors about
@@ -257,19 +265,9 @@ class Patron(Base):
         :return: A datetime, or None if we know our loan data is
             stale.
         """
-        value = self._last_loan_activity_sync
-        if not value:
-            return value
-
-        # We have an answer, but it may be so old that we should clear
-        # it out.
-        now = utc_now()
-        expires = value + datetime.timedelta(seconds=self.loan_activity_max_age)
-        if now > expires:
-            # The value has expired. Clear it out.
-            value = None
-            self._last_loan_activity_sync = value
-        return value
+        if self.has_last_loan_activity_expired():
+            return None
+        return self._last_loan_activity_sync
 
     @last_loan_activity_sync.setter
     def last_loan_activity_sync(self, value):

--- a/tests/core/models/test_patron.py
+++ b/tests/core/models/test_patron.py
@@ -550,11 +550,11 @@ class TestPatron(DatabaseTest):
         assert recently == patron.last_loan_activity_sync
 
         # If it's _not_ relatively recent, attempting to access it
-        # clears it out.
+        # doesn't clear it out, but accessor returns None
         patron.last_loan_activity_sync = long_ago
         assert long_ago == patron._last_loan_activity_sync
         assert None == patron.last_loan_activity_sync
-        assert None == patron._last_loan_activity_sync
+        assert long_ago == patron._last_loan_activity_sync
 
     def test_root_lane(self):
         root_1 = self._lane()


### PR DESCRIPTION
## Description
last_loan_activity_sync accessor no longer clears out the underlying DB property
    
It continues to return None on an expired value, but the underlying property is still
queryable in the database

<!--- Describe your changes -->

## Motivation and Context
The patron activity sync job needs the underlying _last_loan_activity_sync property to remain intact within the DB
in order to query for it in the future, beyond the hard coded staleness check
So we maintain the contract of the accessor, but do not clear out the property
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit testing has been done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
