### PR TITLE
Use `rel="preview"` for client feed sample/preview links.

### DIFF
--- a/core/model/constants.py
+++ b/core/model/constants.py
@@ -235,6 +235,9 @@ class LinkRelations:
     AUTHOR = "http://schema.org/author"
     ALTERNATE = "alternate"
 
+    # The rel for a link we feed to clients for samples/previews.
+    CLIENT_SAMPLE = "preview"
+
     # A uri rel type for authentication documents with a vendor specific "link"
     PATRON_PASSWORD_RESET = (
         "http://librarysimplified.org/terms/rel/patron-password-reset"

--- a/core/opds.py
+++ b/core/opds.py
@@ -1434,7 +1434,7 @@ class AcquisitionFeed(OPDSFeed):
         for link in sample_links:
             links.append(
                 AtomFeed.link(
-                    rel=link.rel,
+                    rel=Hyperlink.CLIENT_SAMPLE,
                     href=link.resource.url,
                     type=link.resource.representation.media_type,
                 )

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -842,7 +842,9 @@ class TestLibraryAnnotator(VendorIDTest):
         annotator.annotate_work_entry(work, None, edition, identifier, feed, entry)
         parsed = feedparser.parse(etree.tostring(entry))
         [entry_parsed] = parsed["entries"]
-        [feed_link] = [l for l in entry_parsed["links"] if l.rel == Hyperlink.SAMPLE]
+        [feed_link] = [
+            l for l in entry_parsed["links"] if l.rel == Hyperlink.CLIENT_SAMPLE
+        ]
         assert feed_link["href"] == link.resource.url
         assert feed_link["type"] == link.resource.representation.media_type
 

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -747,7 +747,7 @@ class TestOPDS(DatabaseTest):
 
         atom_links = OPDSXMLParser._xpath(
             etree.parse(StringIO(str(feed))),
-            f"atom:entry/atom:link[@rel='{Hyperlink.SAMPLE}']",
+            f"atom:entry/atom:link[@rel='{Hyperlink.CLIENT_SAMPLE}']",
         )
 
         assert len(atom_links) == 2


### PR DESCRIPTION
## Description

Use `rel="preview"` for client feed sample/preview links, instead of the `rel` provided in the distributor feed.

## Motivation and Context

- Provide a consistent `rel` to downstream clients.
- Some already-released client apps misunderstood links with `rel="http://opds-spec.org/acquisition/sample"` as full-content (rather than sample) links.

## How Has This Been Tested?

- Updated tests for the new `rel` and all tests pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
