### PR TITLE
Added auto_update_facets form parameter for /custom_list edit API

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -773,6 +773,27 @@ class FeedController(AdminCirculationManagerController):
 
 
 class CustomListsController(AdminCirculationManagerController):
+    def _list_as_json(self, list: CustomList):
+        """Transform a CustomList object into a response ready dict"""
+        collections = []
+        for collection in list.collections:
+            collections.append(
+                dict(
+                    id=collection.id,
+                    name=collection.name,
+                    protocol=collection.protocol,
+                )
+            )
+        return dict(
+            id=list.id,
+            name=list.name,
+            collections=collections,
+            entry_count=list.size,
+            auto_update=list.auto_update_enabled,
+            auto_update_query=list.auto_update_query,
+            auto_update_facets=list.auto_update_facets,
+        )
+
     def custom_lists(self):
         library = flask.request.library
         self.require_librarian(library)
@@ -780,48 +801,10 @@ class CustomListsController(AdminCirculationManagerController):
         if flask.request.method == "GET":
             custom_lists = []
             for list in library.custom_lists:
-                collections = []
-                for collection in list.collections:
-                    collections.append(
-                        dict(
-                            id=collection.id,
-                            name=collection.name,
-                            protocol=collection.protocol,
-                        )
-                    )
-                custom_lists.append(
-                    dict(
-                        id=list.id,
-                        name=list.name,
-                        collections=collections,
-                        entry_count=list.size,
-                        auto_update=list.auto_update_enabled,
-                        auto_update_query=list.auto_update_query,
-                        auto_update_facets=list.auto_update_facets,
-                    )
-                )
+                custom_lists.append(self._list_as_json(list))
 
             for list in library.shared_custom_lists:
-                collections = []
-                for collection in list.collections:
-                    collections.append(
-                        dict(
-                            id=collection.id,
-                            name=collection.name,
-                            protocol=collection.protocol,
-                        )
-                    )
-                custom_lists.append(
-                    dict(
-                        id=list.id,
-                        name=list.name,
-                        collections=collections,
-                        entry_count=list.size,
-                        auto_update=list.auto_update_enabled,
-                        auto_update_query=list.auto_update_query,
-                        auto_update_facets=list.auto_update_facets,
-                    )
-                )
+                custom_lists.append(self._list_as_json(list))
 
             return dict(custom_lists=custom_lists)
 

--- a/core/model/customlist.py
+++ b/core/model/customlist.py
@@ -63,7 +63,8 @@ class CustomList(Base):
     )
 
     auto_update_enabled = Column(Boolean, default=False)
-    auto_update_query = Column(Unicode, nullable=True)
+    auto_update_query = Column(Unicode, nullable=True)  # holds json data
+    auto_update_facets = Column(Unicode, nullable=True)  # holds json data
     auto_update_last_update = Column(DateTime, nullable=True)
 
     # Typing specific

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -3542,7 +3542,13 @@ class CustomListUpdateEntriesScript(CustomListSweeperScript):
         json_query["query"] = query_part
 
         search = ExternalSearchIndex(self._db)
-        facets = SearchFacets(search_type="json")
+        if custom_list.auto_update_facets:
+            facets = SearchFacets(
+                search_type="json", **json.loads(custom_list.auto_update_facets)
+            )
+        else:
+            facets = SearchFacets(search_type="json")
+
         page_size = 100
         total_works_updated = 0
         for page in range(10000):  # failsafe max loops

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,67 @@
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>The Palace CM API</title>
+
+    <!-- Elements: Web Component -->
+    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+
+    <!-- Twitter Bootstrap -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- Twitter Bootstrap: Sticky Footer Example -->
+    <link rel="stylesheet" href="https://getbootstrap.com/docs/4.5/examples/sticky-footer-navbar/sticky-footer-navbar.css">
+
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+      }
+
+      main {
+        flex: 1 0 0;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+
+  <body>
+
+    <header>
+      <!-- Fixed navbar -->
+      <nav class="navbar navbar-expand-md navbar-dark bg-dark">
+        <a class="navbar-brand" href="#">The Palace Project</a>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarCollapse">
+          <ul class="navbar-nav mr-auto">
+            <li class="nav-item active">
+              <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
+            </li>
+          </ul>
+        </div>
+      </nav>
+    </header>
+
+    <!-- Begin page content -->
+    <main role="main">
+      <elements-api
+        apiDescriptionUrl="openapi.yaml"
+        router="hash"
+      />
+    </main>
+
+    <footer class="footer">
+      <div class="container">
+      </div>
+    </footer>
+  </body>
+</html>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,59 @@
+openapi: "3.0.0"
+info:
+  version: "0.1"
+  title: Circulation API
+paths:
+  /{library}/admin/custom_list/{list_id}:
+    summary: Edit/Delete a custom list as required
+    post:
+      summary: Edit a custom list
+      requestBody:
+        $ref: "#/components/requestBodies/custom_list"
+      responses:
+        '200':
+          description: Custom list was edited successfully
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: 5
+        '400':
+          description: Bad input was provided
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    properties:
+                      message:
+                        type: string
+                        example: auto_update_query is required when auto_update is enabled
+      tags:
+        - admin
+
+components:
+  requestBodies:
+    custom_list:
+      content:
+        multipart/form-data:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                entries:
+                  type: object
+                collections:
+                  type: array
+                  items:
+                    type: number
+                deletedEntries:
+                  type: array
+                  items:
+                    type: number
+                auto_update:
+                  type: boolean
+                auto_update_query:
+                  type: object
+                auto_update_facets:
+                  type: object

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -3164,7 +3164,7 @@ class TestCustomListUpdateEntriesScript(EndToEndSearchTest):
         script.process_custom_list(custom_list)
 
         assert mock_index().query_works.call_count == 1
-        filter: Filter = mock_index().query_works.call_args_list[0].args[1]
+        filter: Filter = mock_index().query_works.call_args_list[0][0][1]
         assert filter.sort_order[0] == {
             "sort_title": "asc"
         }  # since we asked for title ordering this should come up first


### PR DESCRIPTION
## Description
Accepts a JSON of attributes that would generally go into a Facet object
Eg.
- order
- language
- media
- author

Added open API documentation for the modified endpoint which can be rendered using the index.html
![image](https://user-images.githubusercontent.com/90382027/184351908-a96d37e7-02c7-4bbb-90c6-450c04a2018c.png)

<!--- Describe your changes -->

## Motivation and Context
The auto update feature for custom lists was missing the facets which are a part of the search criteria. 
This is an important set of attributes which affect the results of the search and hence what may or may not be part of a list.
[Notion](https://www.notion.so/lyrasis/Enable-list-sharing-for-advanced-search-lists-35694eda31bd43f8a4b0b498dd8c2094)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
API and facets have been unit tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
