### PR TITLE
Global announcements

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -204,6 +204,10 @@ def setup_admin_controllers(manager):
 
     manager.admin_catalog_services_controller = CatalogServicesController(manager)
 
+    from api.admin.controller.announcement_service import AnnouncementSettings
+
+    manager.admin_announcement_service = AnnouncementSettings(manager)
+
 
 class AdminController:
     def __init__(self, manager):

--- a/api/admin/controller/announcement_service.py
+++ b/api/admin/controller/announcement_service.py
@@ -1,0 +1,51 @@
+import json
+
+import flask
+
+from api.admin.announcement_list_validator import AnnouncementListValidator
+from api.announcements import Announcements
+from api.config import Configuration
+from core.model.configuration import ConfigurationSetting
+from core.problem_details import INVALID_INPUT
+
+from . import SettingsController
+
+
+class AnnouncementSettings(SettingsController):
+    """Controller that manages global announcements for all libraries"""
+
+    def _action(self):
+        method = flask.request.method.lower()
+        return getattr(self, method)
+
+    def process_many(self):
+        return self._action()()
+
+    def process_one(self, key):
+        return self._action()(key=key)
+
+    def get(self):
+        """Respond with settings and all global announcements"""
+        announcements = Announcements.for_all(self._db)
+        settings = Configuration.ANNOUNCEMENT_SETTINGS
+        return dict(
+            settings=settings,
+            announcements=[ann.json_ready for ann in announcements.active],
+        )
+
+    def post(self):
+        """POST multiple announcements to the global namespace, all announcements are overwritten"""
+        announcements = AnnouncementListValidator()
+        try:
+            announcements = Announcements(flask.request.form["announcements"])
+            if announcements.problem:
+                return announcements.problem
+        except (KeyError, TypeError):
+            return INVALID_INPUT
+
+        conf = ConfigurationSetting.sitewide(
+            self._db, Announcements.GLOBAL_SETTING_NAME
+        )
+        conf.value = json.dumps([ann.json_ready for ann in announcements.announcements])
+
+        return dict(success=True)

--- a/api/admin/controller/announcement_service.py
+++ b/api/admin/controller/announcement_service.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING, Callable
 
 import flask
 
@@ -10,21 +13,24 @@ from core.problem_details import INVALID_INPUT
 
 from . import SettingsController
 
+if TYPE_CHECKING:
+    from core.util.problem_detail import ProblemDetail
+
 
 class AnnouncementSettings(SettingsController):
     """Controller that manages global announcements for all libraries"""
 
-    def _action(self):
+    def _action(self) -> Callable:
         method = flask.request.method.lower()
         return getattr(self, method)
 
-    def process_many(self):
+    def process_many(self) -> dict | ProblemDetail:
         return self._action()()
 
-    def process_one(self, key):
+    def process_one(self, key) -> dict | ProblemDetail:
         return self._action()(key=key)
 
-    def get(self):
+    def get(self) -> dict | ProblemDetail:
         """Respond with settings and all global announcements"""
         announcements = Announcements.for_all(self._db)
         settings = Configuration.ANNOUNCEMENT_SETTINGS
@@ -33,7 +39,7 @@ class AnnouncementSettings(SettingsController):
             announcements=[ann.json_ready for ann in announcements.active],
         )
 
-    def post(self):
+    def post(self) -> dict | ProblemDetail:
         """POST multiple announcements to the global namespace, all announcements are overwritten"""
         announcements = AnnouncementListValidator()
         try:

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -623,6 +623,14 @@ def sitewide_setting(key):
     )
 
 
+@app.route("/admin/announcements", methods=["GET", "POST"])
+@returns_json_or_response_or_problem_detail
+@requires_admin
+@requires_csrf_token
+def announcements_for_all():
+    return app.manager.admin_announcement_service.process_many()
+
+
 @app.route("/admin/logging_services", methods=["GET", "POST"])
 @returns_json_or_response_or_problem_detail
 @requires_admin

--- a/api/announcements.py
+++ b/api/announcements.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Generator
 
 from core.model.configuration import ConfigurationSetting
 from core.util.problem_detail import ProblemDetail
@@ -19,7 +20,7 @@ class Announcements:
     GLOBAL_SETTING_NAME = "global_announcements"
 
     @classmethod
-    def for_all(cls, _db):
+    def for_all(cls, _db) -> "Announcements":
         """Load announcements that are not bound to any library"""
         announcement = (
             ConfigurationSetting.sitewide(_db, cls.GLOBAL_SETTING_NAME).json_value or []
@@ -27,7 +28,7 @@ class Announcements:
         return cls(announcement)
 
     @classmethod
-    def for_library(cls, library):
+    def for_library(cls, library) -> "Announcements":
         """Load an Announcements object for the given Library.
 
         :param library: A Library
@@ -56,7 +57,7 @@ class Announcements:
         self.announcements = [Announcement(**data) for data in validated]
 
     @property
-    def active(self):
+    def active(self) -> Generator["Announcement", None, None]:
         """Yield only the active announcements."""
         for a in self.announcements:
             if a.is_active:

--- a/api/announcements.py
+++ b/api/announcements.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from typing import Generator
 
@@ -20,7 +22,7 @@ class Announcements:
     GLOBAL_SETTING_NAME = "global_announcements"
 
     @classmethod
-    def for_all(cls, _db) -> "Announcements":
+    def for_all(cls, _db) -> Announcements:
         """Load announcements that are not bound to any library"""
         announcement = (
             ConfigurationSetting.sitewide(_db, cls.GLOBAL_SETTING_NAME).json_value or []
@@ -28,7 +30,7 @@ class Announcements:
         return cls(announcement)
 
     @classmethod
-    def for_library(cls, library) -> "Announcements":
+    def for_library(cls, library) -> Announcements:
         """Load an Announcements object for the given Library.
 
         :param library: A Library
@@ -57,7 +59,7 @@ class Announcements:
         self.announcements = [Announcement(**data) for data in validated]
 
     @property
-    def active(self) -> Generator["Announcement", None, None]:
+    def active(self) -> Generator[Announcement, None, None]:
         """Yield only the active announcements."""
         for a in self.announcements:
             if a.is_active:

--- a/api/announcements.py
+++ b/api/announcements.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import datetime
-from typing import Generator
+from typing import TYPE_CHECKING, Generator
 
 from core.model.configuration import ConfigurationSetting
 from core.util.problem_detail import ProblemDetail
 
 from .admin.announcement_list_validator import AnnouncementListValidator
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from core.model import Library
 
 
 class Announcements:
@@ -22,7 +27,7 @@ class Announcements:
     GLOBAL_SETTING_NAME = "global_announcements"
 
     @classmethod
-    def for_all(cls, _db) -> Announcements:
+    def for_all(cls, _db: Session) -> Announcements:
         """Load announcements that are not bound to any library"""
         announcement = (
             ConfigurationSetting.sitewide(_db, cls.GLOBAL_SETTING_NAME).json_value or []
@@ -30,7 +35,7 @@ class Announcements:
         return cls(announcement)
 
     @classmethod
-    def for_library(cls, library) -> Announcements:
+    def for_library(cls, library: Library) -> Announcements:
         """Load an Announcements object for the given Library.
 
         :param library: A Library

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1179,7 +1179,12 @@ class LibraryAuthenticator:
             x.for_authentication_document
             for x in Announcements.for_library(library).active
         ]
-        doc["announcements"] = announcements
+        # Add any global announcements
+        announcements_for_all = [
+            x.for_authentication_document
+            for x in Announcements.for_all(self._db).active
+        ]
+        doc["announcements"] = announcements_for_all + announcements
 
         # Finally, give the active annotator a chance to modify the document.
 

--- a/api/config.py
+++ b/api/config.py
@@ -574,6 +574,19 @@ class Configuration(CoreConfiguration):
         },
     ]
 
+    ANNOUNCEMENT_SETTINGS = [
+        {
+            "key": Announcements.GLOBAL_SETTING_NAME,
+            "label": _("Scheduled announcements"),
+            "description": _(
+                "Announcements will be displayed to authenticated patrons."
+            ),
+            "category": "Announcements",
+            "type": "announcements",
+            "level": CoreConfiguration.ALL_ACCESS,
+        },
+    ]
+
     @classmethod
     def lending_policy(cls):
         return cls.policy(cls.LENDING_POLICY)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -64,7 +64,7 @@ paths:
                 announcements:
                   type: string
                   description: JSON stringified list of announcements
-                  example: [{"id": "xxxx-xxx-xxxxx", "message": "An announcement for all to see", start: "1990-01-01"}, {"message": "This is a new announcement without an id yet"}]
+                  example: [{"id": "xxxx-xxx-xxxxx", "content": "An announcement for all to see", start: "1990-01-01"}, {"content": "This is a new announcement without an id yet"}]
       responses:
         '200':
           description: OK

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -31,6 +31,61 @@ paths:
       tags:
         - admin
 
+  /admin/announcements:
+    summary: >
+      Create/Edit/Read global announcements meant for every library. \
+      The announcements will show up in the authentication documents.
+    get:
+      summary: Fetch all global announcements
+      tags:
+        - admin
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  settings:
+                    type: object
+                  announcements:
+                    type: object
+    post:
+      summary: Edit the list of global announcements in its entirety.
+      tags:
+        - admin
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                announcements:
+                  type: string
+                  description: JSON stringified list of announcements
+                  example: [{"id": "xxxx-xxx-xxxxx", "message": "An announcement for all to see", start: "1990-01-01"}, {"message": "This is a new announcement without an id yet"}]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/invalid_input"
+
+
+
+
 components:
   requestBodies:
     custom_list:
@@ -57,3 +112,16 @@ components:
                   type: object
                 auto_update_facets:
                   type: object
+  schemas:
+    invalid_input:
+      type: object
+      properties:
+        message:
+          type: string
+          example: You provided invalid or unrecognized input
+        type:
+          type: string
+          example: http://librarysimplified.org/terms/problem/invalid-input
+        title:
+          type: string
+          example: Invalid input.

--- a/tests/api/admin/controller/test_announcement_service.py
+++ b/tests/api/admin/controller/test_announcement_service.py
@@ -1,0 +1,50 @@
+import json
+
+from werkzeug.datastructures import MultiDict
+
+from api.admin.controller.announcement_service import AnnouncementSettings
+from api.announcements import Announcements
+from api.testing import AnnouncementTest
+from core.model.configuration import ConfigurationSetting
+from core.problem_details import INVALID_INPUT
+from tests.api.admin.controller.test_controller import AdminControllerTest
+
+
+class TestAnnouncementService(AnnouncementTest, AdminControllerTest):
+    def test_get(self):
+        setting = ConfigurationSetting.sitewide(
+            self._db, Announcements.GLOBAL_SETTING_NAME
+        )
+        setting.value = json.dumps([self.expired, self.active])
+
+        with self.request_context_with_admin("/", method="GET") as ctx:
+            response = AnnouncementSettings(self.manager).process_many()
+
+        assert set(response.keys()) == {"settings", "announcements"}
+        assert len(response["announcements"]) == 1
+        assert response["announcements"][0]["id"] == "active"
+
+    def test_post(self):
+        with self.request_context_with_admin("/", method="POST") as ctx:
+            ctx.request.form = MultiDict([("announcements", json.dumps([self.active]))])
+            response = AnnouncementSettings(self.manager).process_many()
+
+        announcements = Announcements.for_all(self._db)
+        assert len(announcements.announcements) == 1
+        assert announcements.announcements[0].id == "active"
+
+    def test_post_errors(self):
+        with self.request_context_with_admin("/", method="POST") as ctx:
+            ctx.request.form = None
+            response = AnnouncementSettings(self.manager).process_many()
+            assert response == INVALID_INPUT
+
+            ctx.request.form = MultiDict([("somethingelse", json.dumps([self.active]))])
+            response = AnnouncementSettings(self.manager).process_many()
+            assert response == INVALID_INPUT
+
+            ctx.request.form = MultiDict(
+                [("announcements", json.dumps([{"id": "xxx"}]))]
+            )
+            response = AnnouncementSettings(self.manager).process_many()
+            assert "Missing required field: content" == response.detail

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -1280,6 +1280,25 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             Announcements.SETTING_NAME, library
         )
         announcement_setting.value = json.dumps(announcements)
+        announcement_for_all_setting = ConfigurationSetting.sitewide(
+            self._db, Announcements.GLOBAL_SETTING_NAME
+        )
+        announcement_for_all_setting.value = json.dumps(
+            [
+                dict(
+                    id="all1",
+                    content="test announcement",
+                    start=yesterday,
+                    finish=today,
+                ),
+                dict(
+                    id="all2",
+                    content="test announcement",
+                    start=two_days_ago,
+                    finish=yesterday,
+                ),
+            ]
+        )
 
         with self.app.test_request_context("/"):
             url = authenticator.authentication_document_url(library)
@@ -1400,9 +1419,10 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             )
 
             # Active announcements are published; inactive announcements are not.
-            a1, a3 = doc["announcements"]
+            all1, a1, a3 = doc["announcements"]
             assert dict(id="a1", content="this is announcement 1") == a1
             assert dict(id="a3", content="this is announcement 3") == a3
+            assert dict(id="all1", content="test announcement") == all1
 
             # Features that are enabled for this library are communicated
             # through the 'features' item.
@@ -1427,9 +1447,15 @@ class TestLibraryAuthenticator(AuthenticatorTest):
             for key in ("focus_area", "service_area"):
                 assert key not in doc
 
+            # Only global anouncements
+            announcement_setting.value = None
+            doc = json.loads(authenticator.create_authentication_document())
+            assert [dict(id="all1", content="test announcement")] == doc[
+                "announcements"
+            ]
             # If there are no announcements, the list of announcements is present
             # but empty.
-            announcement_setting.value = None
+            announcement_for_all_setting.value = None
             doc = json.loads(authenticator.create_authentication_document())
             assert [] == doc["announcements"]
 


### PR DESCRIPTION
## Description
Added a global announcements feature and admin endpoint /admin/announcements

The global announcements have a "global_announcements" settings name
to avoid configuration inheritance with the "announcements" settings name

Pending: Update the openapi documentation once the rebase is possible
<!--- Describe your changes -->

## Motivation and Context
When there is an emergency in the app that impacts all libraries, we need an easy way to notify all libraries quickly.
[Notion](https://www.notion.so/lyrasis/Add-to-back-end-Add-ability-for-super-admins-to-send-mass-announcements-to-all-libraries-configured-283d341d4e3f405a92ffaf1880acf71c)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manual API testing and Unit Testing done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
