### PR TITLE
Feature/additional search keys

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -10,6 +10,7 @@ from werkzeug.exceptions import HTTPException
 
 from core.app_server import ErrorHandler, compressible, returns_problem_detail
 from core.model import HasSessionCache
+from core.util.cache import CachedData
 from core.util.problem_detail import ProblemDetail
 
 from .app import app, babel
@@ -34,6 +35,9 @@ def initialize_circulation_manager():
             # Make sure that any changes to the database (as might happen
             # on initial setup) are committed before continuing.
             app.manager._db.commit()
+
+            # setup the cache data object
+            CachedData.initialize(app._db)
 
 
 @babel.localeselector

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -2034,7 +2034,8 @@ class JSONQuery(Query):
 
     class ValueTransforms:
         @staticmethod
-        def data_source(value):
+        def data_source(value: str) -> int:
+            """Transform a datasource name into a datasource id"""
             sources = CachedData.cache.data_sources()
             for source in sources:
                 if source.name == value:
@@ -2044,8 +2045,8 @@ class JSONQuery(Query):
             return 0
 
         @staticmethod
-        def published(value):
-            """Expects a YYYY-MM-DD format string"""
+        def published(value: str) -> int:
+            """Expects a YYYY-MM-DD format string and returns a timestamp from epoch"""
             try:
                 values = value.split("-")
                 return datetime.datetime(

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -2045,7 +2045,7 @@ class JSONQuery(Query):
             return 0
 
         @staticmethod
-        def published(value: str) -> int:
+        def published(value: str) -> float:
             """Expects a YYYY-MM-DD format string and returns a timestamp from epoch"""
             try:
                 values = value.split("-")

--- a/core/util/cache.py
+++ b/core/util/cache.py
@@ -61,7 +61,7 @@ class CachedData:
     cache = None
 
     @classmethod
-    def initialize(cls, _db):
+    def initialize(cls, _db) -> "CachedData":
         """Initialize the cache data instance or update the _db instance for the global cache instance
         Use this method liberally in the vicinity of the usage of the cache functions so the _db instance
         is constantly being updated

--- a/core/util/cache.py
+++ b/core/util/cache.py
@@ -58,7 +58,7 @@ class CachedData:
     Always expunge objects before returning the data, to avoid stale/cross-thread session usage"""
 
     # Instance of itself
-    cache = None
+    cache: Any = None
 
     @classmethod
     def initialize(cls, _db) -> "CachedData":

--- a/core/util/cache.py
+++ b/core/util/cache.py
@@ -83,7 +83,7 @@ class CachedData:
     def data_sources(self) -> List[DataSource]:
         """List of all datasources within the system"""
         with self.lock:
-            sources = self._db.query(DataSource).all()
+            sources = self._db.query(DataSource).order_by(DataSource.id).all()
             for s in sources:
                 self._db.expunge(s)
         return sources

--- a/tests/core/util/test_cache.py
+++ b/tests/core/util/test_cache.py
@@ -36,14 +36,17 @@ class TestMemoize:
 
 class TestCacheData(DatabaseTest):
     def test_data_sources(self):
+        def to_ids(objects):
+            return [o.id for o in objects]
+
         CachedData.initialize(self._db)
-        all_sources = self._db.query(DataSource).all()
-        assert CachedData.cache.data_sources() == all_sources
+        all_sources = to_ids(self._db.query(DataSource).order_by(DataSource.id))
+        assert to_ids(CachedData.cache.data_sources()) == all_sources
 
         # Mock the db object
         CachedData.initialize(MagicMock())
         # No changes to output
-        assert CachedData.cache.data_sources() == all_sources
-        assert CachedData.cache.data_sources() == all_sources
+        assert to_ids(CachedData.cache.data_sources()) == all_sources
+        assert to_ids(CachedData.cache.data_sources()) == all_sources
         # mock object was never called due to memoize
         assert CachedData.cache._db.query.call_count == 0

--- a/tests/core/util/test_cache.py
+++ b/tests/core/util/test_cache.py
@@ -1,6 +1,9 @@
 import time
+from unittest.mock import MagicMock
 
-from core.util.cache import _signature, memoize
+from core.model.datasource import DataSource
+from core.testing import DatabaseTest
+from core.util.cache import CachedData, _signature, memoize
 
 
 class TestMemoize:
@@ -29,3 +32,18 @@ class TestMemoize:
             _signature(_func, 1, "x", o, one="one", obj=o)
             == f"{str(_func)}::1;x;{o}::one=one;obj={str(o)}"
         )
+
+
+class TestCacheData(DatabaseTest):
+    def test_data_sources(self):
+        CachedData.initialize(self._db)
+        all_sources = self._db.query(DataSource).all()
+        assert CachedData.cache.data_sources() == all_sources
+
+        # Mock the db object
+        CachedData.initialize(MagicMock())
+        # No changes to output
+        assert CachedData.cache.data_sources() == all_sources
+        assert CachedData.cache.data_sources() == all_sources
+        # mock object was never called due to memoize
+        assert CachedData.cache._db.query.call_count == 0


### PR DESCRIPTION
## Description
Added published and data_source as searchable keys in the json format
    
Both keys now transform their values before exceuting the search
A data cache has been introduced that is persistent across the application process
It has the ability to have its _db session refreshed as required and
is written to be thread-safe for _db refreshes while data is being accessed through locks

Thread safety and session safety was tested by running the app on a `uwsgi` server with 10 threads, and then hitting the search endpoint with `ab -n100 -c20`. No broken sessions or lock conflicts were detected on multiple runs with cache ttl set to 1 second.

<!--- Describe your changes -->

## Motivation and Context
The publish date and distributor are not part of the JSON search API keys, they needed to be added to the search criteria.
[Notion](https://www.notion.so/lyrasis/Add-published-date-and-datasource-name-as-search-keys-e7c408d429d04f37a41e083cb25e9c8c)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
