### PR TITLE
Share lists to all libraries

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -7,7 +7,7 @@ import sys
 import urllib.parse
 from datetime import date, datetime, timedelta
 from http.client import BAD_REQUEST
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import flask
 import jwt
@@ -773,7 +773,7 @@ class FeedController(AdminCirculationManagerController):
 
 
 class CustomListsController(AdminCirculationManagerController):
-    def _list_as_json(self, list: CustomList, is_owner=True):
+    def _list_as_json(self, list: CustomList, is_owner=True) -> Dict:
         """Transform a CustomList object into a response ready dict"""
         collections = []
         for collection in list.collections:
@@ -795,7 +795,7 @@ class CustomListsController(AdminCirculationManagerController):
             is_owner=is_owner,
         )
 
-    def custom_lists(self):
+    def custom_lists(self) -> Dict:
         library = flask.request.library
         self.require_librarian(library)
 
@@ -833,7 +833,7 @@ class CustomListsController(AdminCirculationManagerController):
                 auto_update_query=auto_update_query,
             )
 
-    def _getJSONFromRequest(self, values):
+    def _getJSONFromRequest(self, values: Optional[str]) -> Union[Dict, List]:
         if values:
             values = json.loads(values)
         else:
@@ -841,7 +841,7 @@ class CustomListsController(AdminCirculationManagerController):
 
         return values
 
-    def _get_work_from_urn(self, library, urn):
+    def _get_work_from_urn(self, library: Library, urn: str) -> Work:
         identifier, ignore = Identifier.parse_urn(self._db, urn)
         query = (
             self._db.query(Work)
@@ -864,7 +864,7 @@ class CustomListsController(AdminCirculationManagerController):
         auto_update: Optional[bool] = None,
         auto_update_query: Optional[str] = None,
         auto_update_facets: Optional[str] = None,
-    ):
+    ) -> Union[ProblemDetail, Response]:
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)
 
         old_list_with_name = CustomList.find(self._db, name, library=library)
@@ -972,7 +972,9 @@ class CustomListsController(AdminCirculationManagerController):
         else:
             return Response(str(list.id), 200)
 
-    def url_for_custom_list(self, library, list):
+    def url_for_custom_list(
+        self, library: Library, list: CustomList
+    ) -> Callable[[int], str]:
         def url_fn(after):
             return self.url_for(
                 "custom_list",
@@ -983,7 +985,7 @@ class CustomListsController(AdminCirculationManagerController):
 
         return url_fn
 
-    def custom_list(self, list_id):
+    def custom_list(self, list_id: int) -> Union[Response, Dict, ProblemDetail]:
         library = flask.request.library
         self.require_librarian(library)
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)
@@ -1082,7 +1084,7 @@ class CustomListsController(AdminCirculationManagerController):
                 lane.update_size(self._db, self.search_engine)
             return Response(str(_("Deleted")), 200)
 
-    def share_locally(self, customlist_id) -> Union[ProblemDetail, Response]:
+    def share_locally(self, customlist_id: int) -> Union[ProblemDetail, Response]:
         """Share this customlist with all libraries on this local CM"""
         if not customlist_id:
             return INVALID_INPUT

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1224,6 +1224,14 @@ class LanesController(AdminCirculationManagerController):
             for list_id in custom_list_ids:
                 list = get_one(self._db, CustomList, library=library, id=list_id)
                 if not list:
+                    # We did not find a list, is this a shared list?
+                    list = (
+                        self._db.query(CustomList)
+                        .join(CustomList.shared_locally_with_libraries)
+                        .filter(CustomList.id == list_id, Library.id == library.id)
+                        .first()
+                    )
+                if not list:
                     self._db.rollback()
                     return MISSING_CUSTOM_LIST.detailed(
                         _(

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -667,26 +667,13 @@ def custom_list(list_id):
     return app.manager.admin_custom_lists_controller.custom_list(list_id)
 
 
-@library_route("/admin/custom_list/<list_id>/share", methods=["POST"])
+@library_route("/admin/custom_list/share", methods=["POST"])
 @has_library
 @returns_json_or_response_or_problem_detail
 @requires_admin
 @requires_csrf_token
-def custom_list_share(list_id):
-    return app.manager.admin_custom_lists_controller.share_locally(list_id)
-
-
-@library_route("/admin/custom_list/<list_id>/collection/share", methods=["POST"])
-@has_library
-@returns_json_or_response_or_problem_detail
-@requires_admin
-@requires_csrf_token
-def custom_list_share_library_collection(list_id):
-    return (
-        app.manager.admin_custom_lists_controller.share_locally_with_library_collection(
-            list_id
-        )
-    )
+def custom_list_share():
+    return app.manager.admin_custom_lists_controller.share_locally()
 
 
 @library_route("/admin/lanes", methods=["GET", "POST"])

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -667,13 +667,13 @@ def custom_list(list_id):
     return app.manager.admin_custom_lists_controller.custom_list(list_id)
 
 
-@library_route("/admin/custom_list/share", methods=["POST"])
+@library_route("/admin/custom_list/<list_id>/share", methods=["POST"])
 @has_library
 @returns_json_or_response_or_problem_detail
 @requires_admin
 @requires_csrf_token
-def custom_list_share():
-    return app.manager.admin_custom_lists_controller.share_locally()
+def custom_list_share(list_id):
+    return app.manager.admin_custom_lists_controller.share_locally(list_id)
 
 
 @library_route("/admin/lanes", methods=["GET", "POST"])

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -1653,13 +1653,8 @@ class TestCustomListsController(AdminControllerTest):
             list=list,
         )
 
-    def _share_locally(self, customlist, share_with_library):
+    def _share_locally(self, customlist):
         with self.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.form = MultiDict(
-                [
-                    ("library", share_with_library.id),
-                ]
-            )
             response = self.manager.admin_custom_lists_controller.share_locally(
                 customlist.id
             )
@@ -1679,17 +1674,24 @@ class TestCustomListsController(AdminControllerTest):
 
     def test_share_locally_missing_collection(self):
         s = self._setup_share_locally()
-        response = self._share_locally(s.list, s.shared_with)
-        assert response == CUSTOMLIST_SOURCE_COLLECTION_MISSING
+        response = self._share_locally(s.list)
+        assert response["failures"] == 2
+        assert response["successes"] == 0
 
     def test_share_locally_success(self):
         s = self._setup_share_locally()
         s.shared_with.collections.append(s.collection1)
-        response = self._share_locally(s.list, s.shared_with)
-        assert response.status_code == 200
+        response = self._share_locally(s.list)
+        assert response["successes"] == 1
+        assert response["failures"] == 1  # The default library
 
         self._db.refresh(s.list)
         assert len(s.list.shared_locally_with_libraries) == 1
+
+        # Try again should have 0 more libraries as successes
+        response = self._share_locally(s.list)
+        assert response["successes"] == 0
+        assert response["failures"] == 1  # The default library
 
     def test_share_locally_with_invalid_entries(self):
         s = self._setup_share_locally()
@@ -1701,16 +1703,17 @@ class TestCustomListsController(AdminControllerTest):
         w = self._work(collection=collection2)
         s.list.add_entry(w)
 
-        response = self._share_locally(s.list, s.shared_with)
-        assert response == CUSTOMLIST_ENTRY_NOT_VALID_FOR_LIBRARY
+        response = self._share_locally(s.list)
+        assert response["failures"] == 2
+        assert response["successes"] == 0
 
     def test_share_locally_get(self):
         """Does the GET method fetch shared lists"""
         s = self._setup_share_locally()
         s.shared_with.collections.append(s.collection1)
 
-        resp = self._share_locally(s.list, s.shared_with)
-        assert resp.status_code == 200
+        resp = self._share_locally(s.list)
+        assert resp["successes"] == 1
 
         self.admin.add_role(AdminRole.LIBRARIAN, s.shared_with)
         with self.request_context_with_library_and_admin(
@@ -1718,24 +1721,20 @@ class TestCustomListsController(AdminControllerTest):
         ):
             response = self.manager.admin_custom_lists_controller.custom_lists()
             assert len(response["custom_lists"]) == 1
-            assert response["custom_lists"][0]["id"] == s.list.id
-
-    def test_share_locally_with_collection(self):
-        s = self._setup_share_locally()
-        s.shared_with.collections.append(s.collection1)
-
-        response = self._share_locally_with_collection(s.list, s.collection1)
-        assert response.status_code == 200
-
-        assert len(s.list.shared_locally_with_libraries) == 1
-        assert s.list.shared_locally_with_libraries[0].id == s.shared_with.id
-
-    def test_share_locally_with_collection_not_accessible(self):
-        s = self._setup_share_locally()
-
-        response = self._share_locally_with_collection(s.list, s.collection1)
-        assert response.status_code == 200
-        assert len(s.list.shared_locally_with_libraries) == 0
+            collections = [
+                dict(id=c.id, name=c.name, protocol=c.protocol)
+                for c in s.list.collections
+            ]
+            assert response["custom_lists"][0] == dict(
+                id=s.list.id,
+                name=s.list.name,
+                collections=collections,
+                entry_count=s.list.size,
+                auto_update=False,
+                auto_update_query=None,
+                auto_update_facets=None,
+                is_owner=False,
+            )
 
 
 class TestLanesController(AdminControllerTest):


### PR DESCRIPTION
## Description
Updated the list sharing functionality to share with all libraries on the CM
Rather than a point 2 point sharing method
Also removed the unrequired "share to libraries with collection" functionality
Added an is_owner boolean to the customlists GET endpoint so that the UI may segregate the lists

<!--- Describe your changes -->

## Motivation and Context
Most users on a CM can’t see other libraries on the same CM. Sharing a list should share it with all libraries on the same CM
[Notion](https://www.notion.so/lyrasis/Sharing-a-list-automatically-shares-it-with-all-libraries-on-the-same-CM-0a293d3d2aac480d9b24b31e85603819)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
All unit tests have been run and updated
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
