### PR TITLE
Shared custom lists cannot be deleted

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -971,7 +971,9 @@ class CustomListsController(AdminCirculationManagerController):
         self.require_librarian(library)
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)
 
-        list = get_one(self._db, CustomList, id=list_id, data_source=data_source)
+        list: CustomList = get_one(
+            self._db, CustomList, id=list_id, data_source=data_source
+        )
         if not list:
             return MISSING_CUSTOM_LIST
 
@@ -1037,6 +1039,9 @@ class CustomListsController(AdminCirculationManagerController):
         elif flask.request.method == "DELETE":
             # Deleting requires a library manager.
             self.require_library_manager(flask.request.library)
+
+            if len(list.shared_locally_with_libraries) > 0:
+                return CANNOT_DELETE_SHARED_LIST
 
             # Build the list of affected lanes before modifying the
             # CustomList.

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -189,6 +189,13 @@ NO_SUCH_LIST = pd(
     _("You asked for a nonexistent list."),
 )
 
+CANNOT_DELETE_SHARED_LIST = pd(
+    "http://librarysimplified.org/terms/problem/cannot-delete-shared-list",
+    409,
+    _("Cannot delete list."),
+    _("It is not possible to delete a shared list."),
+)
+
 NO_SUCH_COLLECTION = pd(
     "http://librarysimplified.org/terms/problem/unknown-collection",
     404,

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -55,6 +55,7 @@ from core.model import (
 )
 from core.model.collection import Collection
 from core.opds_import import OPDSImporter, OPDSImportMonitor
+from core.query.customlist import CustomListQueries
 from core.s3 import S3UploaderConfiguration
 from core.selftest import HasSelfTests
 from core.util.datetime_helpers import utc_now
@@ -1584,6 +1585,13 @@ class TestCustomListsController(AdminControllerTest):
         with self.request_context_with_library_and_admin("/", method="DELETE"):
             response = self.manager.admin_custom_lists_controller.custom_list(123)
             assert MISSING_CUSTOM_LIST == response
+
+        library = self._library()
+        self.admin.add_role(AdminRole.LIBRARY_MANAGER, library)
+        CustomListQueries.share_locally_with_library(self._db, list, library)
+        with self.request_context_with_library_and_admin("/", method="DELETE"):
+            response = self.manager.admin_custom_lists_controller.custom_list(list.id)
+            assert response == CANNOT_DELETE_SHARED_LIST
 
     @define
     class ShareLocallySetup:


### PR DESCRIPTION
## Description
The API protects against deleting shared lists with a `409` response.
<!--- Describe your changes -->

## Motivation and Context
For the list sharing MVP, we do not want shared lists to be able to be deleted. This will prevent lists from being accidentally removed. In the future we will pursue a more robust solution.
[Notion](https://www.notion.so/lyrasis/Prevent-shared-lists-from-being-deleted-6b25a4f1e1254b57937f7cd7b116c2cd)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been run and updated.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
