### PR TITLE
Axis360FulfillmentInfo fix

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -1725,8 +1725,6 @@ class Axis360FulfillmentInfo(APIAwareFulfillmentInfo):
         self._content = str(manifest)
         self._content_type = manifest.MEDIA_TYPE
         self._content_expires = expires
-        # Never used in this object, required for consistency
-        self.content_link_redirect = False
 
 
 class Axis360AcsFulfillmentInfo(FulfillmentInfo):

--- a/api/axis.py
+++ b/api/axis.py
@@ -1725,6 +1725,8 @@ class Axis360FulfillmentInfo(APIAwareFulfillmentInfo):
         self._content = str(manifest)
         self._content_type = manifest.MEDIA_TYPE
         self._content_expires = expires
+        # Never used in this object, required for consistency
+        self.content_link_redirect = False
 
 
 class Axis360AcsFulfillmentInfo(FulfillmentInfo):

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -288,6 +288,8 @@ class APIAwareFulfillmentInfo(FulfillmentInfo):
         self._content_type = None
         self._content = None
         self._content_expires = None
+        # Never used in this object, required for consistency
+        self.content_link_redirect = False
 
     def fetch(self):
         """It's time to tell the API that we want to fulfill this book."""

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -288,7 +288,6 @@ class APIAwareFulfillmentInfo(FulfillmentInfo):
         self._content_type = None
         self._content = None
         self._content_expires = None
-        # Never used in this object, required for consistency
         self.content_link_redirect = False
 
     def fetch(self):


### PR DESCRIPTION
## Description
Axis360's variant of FulfillmentInfo did not have the content_link_redirect attribute

Added with tests for the same workflow

## Motivation and Context
QA systems were down because of this

## How Has This Been Tested?
A Unit tests was written to cover this flow

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
