### PR TITLE
Makes code compatible with elastic 7.x

### DIFF
--- a/core/external_search.py
+++ b/core/external_search.py
@@ -295,9 +295,9 @@ class ExternalSearchIndex(HasSelfTests):
     def _update_index_mapping(self, dry_run=False) -> Dict:
         """Updates the index mapping with any NEW properties added"""
 
-        current_mapping: Dict = self.indices.get_mapping(self.works_index)[
-            self.works_index
-        ]["mappings"][self.work_document_type]["properties"]
+        current_mapping: Dict = self.indices.get_mapping(
+            self.works_index, include_type_name=True
+        )[self.works_index]["mappings"][self.work_document_type]["properties"]
         new_mapping = self.mapping.body()["mappings"][self.work_document_type][
             "properties"
         ]
@@ -372,7 +372,7 @@ class ExternalSearchIndex(HasSelfTests):
         self.log.info("Creating index %s", index_name)
         body = self.mapping.body()
         body.setdefault("settings", {}).update(index_settings)
-        index = self.indices.create(index=index_name, body=body)
+        index = self.indices.create(index=index_name, body=body, include_type_name=True)
 
     def set_stored_scripts(self):
         for name, definition in self.mapping.stored_scripts():


### PR DESCRIPTION
## Description

This update adds a flag to two key elastic search calls that make it compatible with ElasticSearch 7.x.  
## Motivation and Context

There are no official docker images for users of OSX on M1 chips (ARM).  The ARM builds started after 7.x  Instead of adding a Dockerfile for ARM that we have to maintain, I've changed two lines of code which enables the circulation manager and scripts to work with ElasticSearch 7.x.  So we're effectively killing two birds with one stone:  smoothing the path for a future elastic search upgrade and allowing M1 users  to use docker to bring up ES. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
All tests pass, so we know it this change didn't break anything. 
I manually tested using ES 7.17.5

```
docker run -p 127.0.0.1:9200:9200 -d --name es-7.17.5  -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.17.5
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
