### PR TITLE
Made the active_license_pool method library aware

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -170,7 +170,7 @@ class CirculationManagerAnnotator(Annotator):
             _external=True,
         )
 
-    def active_licensepool_for(self, work):
+    def active_licensepool_for(self, work, library=None):
         loan = self.active_loans_by_work.get(work) or self.active_holds_by_work.get(
             work
         )
@@ -181,7 +181,7 @@ class CirculationManagerAnnotator(Annotator):
         else:
             # There is no active loan. Use the default logic for
             # determining the active license pool.
-            return super().active_licensepool_for(work)
+            return super().active_licensepool_for(work, library=library)
 
     @staticmethod
     def _prioritized_formats_for_pool(
@@ -1441,6 +1441,10 @@ class LibraryAnnotator(CirculationManagerAnnotator):
                 _external=True,
             ),
         )
+
+    def active_licensepool_for(self, work):
+        """Get an active licensepool, always within the scope of the library"""
+        return super().active_licensepool_for(work, library=self.library)
 
 
 class SharedCollectionAnnotator(CirculationManagerAnnotator):

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1,5 +1,7 @@
 # WorkGenre, Work
 
+from __future__ import annotations
+
 import logging
 from collections import Counter
 from datetime import date, datetime
@@ -1183,7 +1185,7 @@ class Work(Base):
             self, operation=WorkCoverageRecord.GENERATE_MARC_OPERATION
         )
 
-    def active_license_pool(self, library: "Library" = None) -> Optional["LicensePool"]:
+    def active_license_pool(self, library: Library = None) -> Optional[LicensePool]:
         # The active license pool is the one that *would* be
         # associated with a loan, were a loan to be issued right
         # now.

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -6,7 +6,7 @@ import logging
 from collections import Counter
 from datetime import date, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from sqlalchemy import (
     Boolean,
@@ -890,7 +890,7 @@ class Work(Base):
         )
         return changed
 
-    def _get_default_audience(self) -> Optional[str]:
+    def _get_default_audience(self) -> str | None:
         """Return the default audience.
 
         :return: Default audience
@@ -1185,7 +1185,7 @@ class Work(Base):
             self, operation=WorkCoverageRecord.GENERATE_MARC_OPERATION
         )
 
-    def active_license_pool(self, library: Library = None) -> Optional[LicensePool]:
+    def active_license_pool(self, library: Library = None) -> LicensePool | None:
         # The active license pool is the one that *would* be
         # associated with a loan, were a loan to be issued right
         # now.
@@ -1439,8 +1439,8 @@ class Work(Base):
 
     @classmethod
     def to_search_documents(
-        cls: Type[WorkTypevar], works: List[WorkTypevar]
-    ) -> List[Dict]:
+        cls: type[WorkTypevar], works: list[WorkTypevar]
+    ) -> list[dict]:
         """In app to search documents needed to ease off the burden
         of complex queries from the DB cluster
         No recursive identifier policy is taken here as using the
@@ -1457,7 +1457,7 @@ class Work(Base):
             joinedload(Work.custom_list_entries),
         )
 
-        rows: List[Work] = qu.all()
+        rows: list[Work] = qu.all()
 
         ## IDENTIFIERS START
         ## Identifiers is a house of cards, it comes crashing down if anything is changed here
@@ -1570,7 +1570,7 @@ class Work(Base):
         return results
 
     @classmethod
-    def search_doc_as_dict(cls: Type[WorkTypevar], doc: WorkTypevar):
+    def search_doc_as_dict(cls: type[WorkTypevar], doc: WorkTypevar):
         columns = {
             "work": [
                 "fiction",
@@ -1610,7 +1610,7 @@ class Work(Base):
             "custom_list_entries": ["list_id", "featured", "first_appearance"],
         }
 
-        result: Dict = {}
+        result: dict = {}
 
         def _convert(value):
             if isinstance(value, Decimal):
@@ -1654,7 +1654,7 @@ class Work(Base):
         result["contributors"] = []
         if doc.presentation_edition and doc.presentation_edition.contributions:
             for item in doc.presentation_edition.contributions:
-                contributor: Dict = {}
+                contributor: dict = {}
                 _set_value(item.contributor, "contributor", contributor)
                 _set_value(item, "contribution", contributor)
                 result["contributors"].append(contributor)
@@ -1670,7 +1670,7 @@ class Work(Base):
                 ):
                     continue
 
-                lc: Dict = {}
+                lc: dict = {}
                 _set_value(item, "licensepools", lc)
                 # lc["availability_time"] = getattr(item, "availability_time").timestamp()
                 lc["available"] = (
@@ -1702,21 +1702,21 @@ class Work(Base):
         result["identifiers"] = []
         if doc.identifiers:  # type: ignore
             for item in doc.identifiers:  # type: ignore
-                identifier: Dict = {}
+                identifier: dict = {}
                 _set_value(item, "identifiers", identifier)
                 result["identifiers"].append(identifier)
 
         result["classifications"] = []
         if doc.classifications:  # type: ignore
             for item in doc.classifications:  # type: ignore
-                classification: Dict = {}
+                classification: dict = {}
                 _set_value(item, "classifications", classification)
                 result["classifications"].append(classification)
 
         result["customlists"] = []
         if doc.custom_list_entries:
             for item in doc.custom_list_entries:  # type: ignore
-                customlist: Dict = {}
+                customlist: dict = {}
                 _set_value(item, "custom_list_entries", customlist)
                 result["customlists"].append(customlist)
 

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -50,7 +50,12 @@ from .measurement import Measurement
 
 # Import related models when doing type checking
 if TYPE_CHECKING:
-    from core.model import CachedFeed, CustomListEntry, LicensePool  # noqa: autoflake
+    from core.model import (  # noqa: autoflake
+        CachedFeed,
+        CustomListEntry,
+        Library,
+        LicensePool,
+    )
 
 
 class WorkGenre(Base):
@@ -1178,7 +1183,7 @@ class Work(Base):
             self, operation=WorkCoverageRecord.GENERATE_MARC_OPERATION
         )
 
-    def active_license_pool(self, library=None):
+    def active_license_pool(self, library: "Library" = None) -> Optional["LicensePool"]:
         # The active license pool is the one that *would* be
         # associated with a loan, were a loan to be issued right
         # now.

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -1178,12 +1178,15 @@ class Work(Base):
             self, operation=WorkCoverageRecord.GENERATE_MARC_OPERATION
         )
 
-    def active_license_pool(self):
+    def active_license_pool(self, library=None):
         # The active license pool is the one that *would* be
         # associated with a loan, were a loan to be issued right
         # now.
         active_license_pool = None
+        collections = [] if not library else [c for c in library.collections]
         for p in self.license_pools:
+            if collections and p.collection not in collections:
+                continue
             if p.superceded:
                 continue
             edition = p.presentation_edition

--- a/core/opds.py
+++ b/core/opds.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import datetime
 import logging
 from collections import defaultdict
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 from urllib.parse import quote
 
 from lxml import etree
@@ -9,8 +11,6 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.session import Session
 
 from core.external_search import QueryParseException
-from core.model.library import Library
-from core.model.licensing import LicensePool
 from core.problem_details import INVALID_INPUT
 
 from .cdn import cdnify
@@ -40,6 +40,10 @@ from .model import (
 from .util.datetime_helpers import utc_now
 from .util.flask_util import OPDSEntryResponse, OPDSFeedResponse
 from .util.opds_writer import AtomFeed, OPDSFeed, OPDSMessage
+
+# Import related models when doing type checking
+if TYPE_CHECKING:
+    from core.model import Library, LicensePool  # noqa: autoflake
 
 
 class UnfulfillableWork(Exception):

--- a/core/opds.py
+++ b/core/opds.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 from lxml import etree
@@ -196,7 +196,7 @@ class Annotator:
         return rating_tag
 
     @classmethod
-    def samples(cls, edition: Edition) -> List[Hyperlink]:
+    def samples(cls, edition: Edition) -> list[Hyperlink]:
         if not edition:
             return []
         _db = Session.object_session(edition)
@@ -460,7 +460,7 @@ class Annotator:
     @classmethod
     def active_licensepool_for(
         cls, work: Work, library: Library = None
-    ) -> Optional[LicensePool]:
+    ) -> LicensePool | None:
         """Which license pool would be/has been used to issue a license for
         this work?
         """
@@ -1272,11 +1272,11 @@ class AcquisitionFeed(OPDSFeed):
 
     def create_entry(
         self,
-        work: Optional[Union[Work, Edition]],
+        work: Work | Edition | None,
         even_if_no_license_pool=False,
         force_create=False,
         use_cache=True,
-    ) -> Union[etree.Element, OPDSMessage]:
+    ) -> etree.Element | OPDSMessage:
         """Turn a work into an entry for an acquisition feed."""
         identifier = None
         if isinstance(work, Edition):

--- a/core/opds.py
+++ b/core/opds.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 from collections import defaultdict
-from typing import List, Optional
+from typing import List, Optional, Union
 from urllib.parse import quote
 
 from lxml import etree
@@ -1268,11 +1268,11 @@ class AcquisitionFeed(OPDSFeed):
 
     def create_entry(
         self,
-        work: Optional[Work | Edition],
+        work: Optional[Union[Work, Edition]],
         even_if_no_license_pool=False,
         force_create=False,
         use_cache=True,
-    ) -> etree.Element | OPDSMessage:
+    ) -> Union[etree.Element, OPDSMessage]:
         """Turn a work into an entry for an acquisition feed."""
         identifier = None
         if isinstance(work, Edition):

--- a/core/opds.py
+++ b/core/opds.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 from collections import defaultdict
-from typing import List
+from typing import List, Optional
 from urllib.parse import quote
 
 from lxml import etree
@@ -9,6 +9,8 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.session import Session
 
 from core.external_search import QueryParseException
+from core.model.library import Library
+from core.model.licensing import LicensePool
 from core.problem_details import INVALID_INPUT
 
 from .cdn import cdnify
@@ -452,7 +454,9 @@ class Annotator:
         raise NotImplementedError()
 
     @classmethod
-    def active_licensepool_for(cls, work, library=None):
+    def active_licensepool_for(
+        cls, work: Work, library: Library = None
+    ) -> Optional[LicensePool]:
         """Which license pool would be/has been used to issue a license for
         this work?
         """
@@ -1263,8 +1267,12 @@ class AcquisitionFeed(OPDSFeed):
         return entry
 
     def create_entry(
-        self, work, even_if_no_license_pool=False, force_create=False, use_cache=True
-    ):
+        self,
+        work: Optional[Work | Edition],
+        even_if_no_license_pool=False,
+        force_create=False,
+        use_cache=True,
+    ) -> etree.Element | OPDSMessage:
         """Turn a work into an entry for an acquisition feed."""
         identifier = None
         if isinstance(work, Edition):

--- a/core/opds.py
+++ b/core/opds.py
@@ -452,14 +452,14 @@ class Annotator:
         raise NotImplementedError()
 
     @classmethod
-    def active_licensepool_for(cls, work):
+    def active_licensepool_for(cls, work, library=None):
         """Which license pool would be/has been used to issue a license for
         this work?
         """
         if not work:
             return None
 
-        return work.active_license_pool()
+        return work.active_license_pool(library=library)
 
     def sort_works_for_groups_feed(self, works, **kwargs):
         return works

--- a/tests/core/models/test_work.py
+++ b/tests/core/models/test_work.py
@@ -1723,7 +1723,6 @@ class TestWork(DatabaseTest):
             work.presentation_edition,
             collection=c1,
             unlimited_access=True,
-            open_access=True,
         )
         lp2 = self._licensepool(
             work.presentation_edition,
@@ -1735,6 +1734,8 @@ class TestWork(DatabaseTest):
             "http://example.org/"  # Unscoped calls will ALWAYS pick this pool now
         )
         lp1.calculate_work()
+        lp2.calculate_work()
+        lp1.open_access = True  # force open access
         self._db.commit()
 
         assert work.active_license_pool() == lp1

--- a/tests/core/models/test_work.py
+++ b/tests/core/models/test_work.py
@@ -1710,6 +1710,36 @@ class TestWork(DatabaseTest):
         pool2.presentation_edition.title = None
         assert pool1 == work.active_license_pool()
 
+    def test_active_license_pool_accounts_for_library(self):
+        """2 libraries, 2 collections, and 2 pools, always select the right pool in a scoped request"""
+        l1 = self._library()
+        l2 = self._library()
+        c1 = self._collection()
+        c2 = self._collection()
+        l1.collections = [c1]
+        l2.collections = [c2]
+        work: Work = self._work(presentation_edition=self._edition())
+        lp1: LicensePool = self._licensepool(
+            work.presentation_edition,
+            collection=c1,
+            unlimited_access=True,
+            open_access=True,
+        )
+        lp2 = self._licensepool(
+            work.presentation_edition,
+            collection=c2,
+            unlimited_access=True,
+            open_access=False,
+        )
+        lp1._open_access_download_url = (
+            "http://example.org/"  # Unscoped calls will ALWAYS pick this pool now
+        )
+        lp1.calculate_work()
+        self._db.commit()
+
+        assert work.active_license_pool() == lp1
+        assert work.active_license_pool(library=l2) == lp2
+
     def test_delete_work(self):
         # Search mock
         class MockSearchIndex:


### PR DESCRIPTION
## Description
Since a library is generally the base context we want to query lendable works from
the licensepool we pull for a work should also be scoped to a library
This is an optional scoping, currently only the AcquisitionFeed makes use of it
This is not an issue when borrowing, as that workflow scopes to the library already via 'best_lendable_pool'

<!--- Describe your changes -->

## Motivation and Context
The vermont deployment had 2 libraries with different collections that shared the same work and identifier.
This caused the system to get confused when pulling in an 'active license pool' for the work, and would often pick the wrong collection's pool.
[Notion](https://www.notion.so/lyrasis/Axis360-titles-are-not-able-to-be-checked-out-again-after-loan-expired-on-Android-and-iOS-b03e4f570db14acf8712acc49ab521fb)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
A new unit test has been introduced and the feed link has been manually tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
