### PR TITLE
Feature/auto update with new lists

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -891,6 +891,7 @@ class CustomListsController(AdminCirculationManagerController):
             try:
                 json.loads(auto_update_query)
             except json.JSONDecodeError:
+                self._db.rollback()
                 return INVALID_INPUT.detailed(
                     "auto_update_query is not JSON serializable"
                 )
@@ -898,10 +899,12 @@ class CustomListsController(AdminCirculationManagerController):
             try:
                 json.loads(auto_update_facets)
             except json.JSONDecodeError:
+                self._db.rollback()
                 return INVALID_INPUT.detailed(
                     "auto_update_facets is not JSON serializable"
                 )
         if auto_update is True and auto_update_query is None:
+            self._db.rollback()
             return INVALID_INPUT.detailed(
                 "auto_update_query must be present when auto_update is enabled"
             )

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -7,7 +7,7 @@ import sys
 import urllib.parse
 from datetime import date, datetime, timedelta
 from http.client import BAD_REQUEST
-from typing import Optional, Union
+from typing import Dict, List, Optional, Union
 
 import flask
 import jwt
@@ -815,8 +815,21 @@ class CustomListsController(AdminCirculationManagerController):
             collections = self._getJSONFromRequest(
                 flask.request.form.get("collections")
             )
+            # For auto updating lists
+            auto_update = flask.request.form.get(
+                "auto_update", False, type=boolean_value
+            )
+            auto_update_query = flask.request.form.get("auto_update_query")
+            auto_update_facets = flask.request.form.get("auto_update_facets")
             return self._create_or_update_list(
-                library, name, entries, collections, id=id
+                library,
+                name,
+                entries,
+                collections,
+                id=id,
+                auto_update=auto_update,
+                auto_update_facets=auto_update_facets,
+                auto_update_query=auto_update_query,
             )
 
     def _getJSONFromRequest(self, values):
@@ -841,15 +854,15 @@ class CustomListsController(AdminCirculationManagerController):
 
     def _create_or_update_list(
         self,
-        library,
-        name,
-        entries,
-        collections,
-        deletedEntries=None,
-        id=None,
-        auto_update=None,
-        auto_update_query=None,
-        auto_update_facets=None,
+        library: Library,
+        name: str,
+        entries: List[Dict],
+        collections: List[int],
+        deletedEntries: List[Dict] = None,
+        id: int = None,
+        auto_update: Optional[bool] = None,
+        auto_update_query: Optional[str] = None,
+        auto_update_facets: Optional[str] = None,
     ):
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)
 

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -1252,6 +1252,24 @@ class TestCustomListsController(AdminControllerTest):
             )
             assert json.dumps({}) == list.auto_update_facets
 
+        # On an error of auto_update, rollbacks should occur
+        with self.request_context_with_library_and_admin("/", method="POST"):
+            flask.request.form = MultiDict(
+                [
+                    ("name", "400List"),
+                    (
+                        "entries",
+                        "[]",
+                    ),
+                    ("collections", "[]"),
+                    ("auto_update", True),
+                ]
+            )
+            response = self.manager.admin_custom_lists_controller.custom_lists()
+            assert 400 == response.status_code
+            # List was not created
+            assert None == get_one(self._db, CustomList, name="400List")
+
     def test_custom_list_get(self):
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)
         list, ignore = create(

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -1224,6 +1224,12 @@ class TestCustomListsController(AdminControllerTest):
                         ),
                     ),
                     ("collections", json.dumps([collection.id])),
+                    ("auto_update", True),
+                    (
+                        "auto_update_query",
+                        json.dumps({"query": {"key": "title", "value": "A Title"}}),
+                    ),
+                    ("auto_update_facets", json.dumps({})),
                 ]
             )
 
@@ -1239,6 +1245,12 @@ class TestCustomListsController(AdminControllerTest):
             assert work.presentation_edition == list.entries[0].edition
             assert True == list.entries[0].featured
             assert [collection] == list.collections
+            assert True == list.auto_update_enabled
+            assert (
+                json.dumps({"query": {"key": "title", "value": "A Title"}})
+                == list.auto_update_query
+            )
+            assert json.dumps({}) == list.auto_update_facets
 
     def test_custom_list_get(self):
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)


### PR DESCRIPTION
## Description
Custom list create API also accepts auto_update parameters
<!--- Describe your changes -->

## Motivation and Context
Initially the auto_update parameters were only accepted through the 'List edit' APIs
[Notion](https://www.notion.so/lyrasis/Can-t-create-a-new-list-with-auto_update-true-0ccfcbc0c35b4356962fc2268194945d)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated and manual testing was also done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
