### PR TITLE
Adds library name, library short name, collection name,  and medium c…

### DIFF
--- a/api/local_analytics_exporter.py
+++ b/api/local_analytics_exporter.py
@@ -6,9 +6,11 @@ from sqlalchemy.sql.expression import and_, case, join, literal_column, or_
 
 from core.model import (
     CirculationEvent,
+    Collection,
     Edition,
     Genre,
     Identifier,
+    Library,
     LicensePool,
     Work,
     WorkGenre,
@@ -40,6 +42,10 @@ class LocalAnalyticsExporter:
             "target_age",
             "genres",
             "location",
+            "collection_name",
+            "library_short_name",
+            "library_name",
+            "medium",
         ]
         output = BytesIO()
         writer = csv.writer(output, encoding="utf-8")
@@ -104,6 +110,10 @@ class LocalAnalyticsExporter:
                     Edition.imprint,
                     Edition.language,
                     CirculationEvent.location,
+                    Collection.name.label("collection_name"),
+                    Library.short_name.label("library_short_name"),
+                    Library.name.label("library_name"),
+                    Edition.medium,
                 ],
             )
             .select_from(
@@ -115,6 +125,7 @@ class LocalAnalyticsExporter:
                 .join(Identifier, LicensePool.identifier_id == Identifier.id)
                 .join(Work, Work.id == LicensePool.work_id)
                 .join(Edition, Work.presentation_edition_id == Edition.id)
+                .outerjoin(Library, CirculationEvent.library_id == Library.id)
             )
             .where(and_(*clauses))
             .order_by(CirculationEvent.start.asc())
@@ -194,6 +205,10 @@ class LocalAnalyticsExporter:
                 target_age_string.label("target_age"),
                 genres.label("genres"),
                 events.location,
+                events.collection_name,
+                events.library_short_name,
+                events.library_name,
+                events.medium,
             ]
         ).select_from(events_alias)
         return query

--- a/core/model/constants.py
+++ b/core/model/constants.py
@@ -99,9 +99,6 @@ class EditionConstants:
     IMAGE_MEDIUM = "Image"
     COURSEWARE_MEDIUM = "Courseware"
 
-    ELECTRONIC_FORMAT = "Electronic"
-    CODEX_FORMAT = "Codex"
-
     # These are all media known to the system.
     KNOWN_MEDIA = (
         BOOK_MEDIUM,

--- a/tests/api/test_local_analytics_exporter.py
+++ b/tests/api/test_local_analytics_exporter.py
@@ -19,6 +19,7 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         edition1 = w1.presentation_edition
         edition1.publisher = "A publisher"
         edition1.imprint = "An imprint"
+        edition1.medium = "Book"
         edition2 = w2.presentation_edition
         identifier1 = w1.presentation_edition.primary_identifier
         identifier2 = w2.presentation_edition.primary_identifier
@@ -42,7 +43,7 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         num = len(types)
         time = datetime.now() - timedelta(minutes=len(types))
         location = "11377"
-
+        collection_name = "Default Collection"
         # Create a bunch of circulation events of different types,
         # all with the same .location.
         for type in types:
@@ -97,9 +98,15 @@ class TestLocalAnalyticsExporter(DatabaseTest):
             w1.target_age_string or "",
             ordered_genre_string,
             location,
+            collection_name,
+            "",
+            "",
+            edition1.medium,
         ]
+
+        expected_row_count = 18
         for row in rows:
-            assert 14 == len(row)
+            assert expected_row_count == len(row)
             assert constant == row[2:]
 
         # Now run a query that includes the last event created.
@@ -115,7 +122,7 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         all_but_last_row = rows[:-1]
         assert types == [row[1] for row in all_but_last_row]
         for row in all_but_last_row:
-            assert 14 == len(row)
+            assert expected_row_count == len(row)
             assert constant == row[2:]
 
         # Now let's look at the last row. It's got metadata from a
@@ -135,6 +142,10 @@ class TestLocalAnalyticsExporter(DatabaseTest):
             w2.target_age_string or "",
             genres[1].name,
             no_location,
+            collection_name,
+            "",
+            "",
+            edition1.medium,
         ] == rows[-1][1:]
 
         output = exporter.export(self._db, today, today)
@@ -146,7 +157,10 @@ class TestLocalAnalyticsExporter(DatabaseTest):
 
         # Gather events by library - these events have an associated library id
         # but it was not passed in the exporter
-        library = self._library()
+        library_name = "Library1"
+        library_short_name = "LIB1"
+
+        library = self._library(name=library_name, short_name=library_short_name)
         library2 = self._library()
         time = datetime.now() - timedelta(minutes=num)
         for type in types:
@@ -182,11 +196,15 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         rows = [row for row in reader][1::]  # skip header row
 
         # There are five events with a library ID.
+        constant_with_library = constant.copy()
+        constant_with_library[13] = library_short_name
+        constant_with_library[14] = library_name
+
         assert num == len(rows)
         assert types == [row[1] for row in rows]
         for row in rows:
-            assert 14 == len(row)
-            assert constant == row[2:]
+            assert expected_row_count == len(row)
+            assert constant_with_library == row[2:]
 
         # We are looking for events from a different library but there
         # should be no events associated with this library.
@@ -291,5 +309,5 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         # After the start time and event type, the rest of the row is
         # the same content we've come to expect.
         for row in rows:
-            assert 14 == len(row)
+            assert expected_row_count == len(row)
             assert constant == row[2:]


### PR DESCRIPTION
…olumn to the analytics export

Resolves: https://www.notion.so/lyrasis/Add-format-patron-library-and-Collection-Source-fields-to-export-for-Palace-Manager-analytics-cf762854dc3a4cf98d278b981e2f69c3

## Description

This update adds library_name, library_short_name, collection_name, and medium to the local analytics csv export.
<!--- Describe your changes -->

## Motivation and Context

[<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
](https://www.notion.so/lyrasis/Add-format-patron-library-and-Collection-Source-fields-to-export-for-Palace-Manager-analytics-cf762854dc3a4cf98d278b981e2f69c3)


## How Has This Been Tested?
Unit tests cover the functionality. 
I have manually tested in the following way (assuming you are running local analytics):
1. Go to the dashboard.
2. Click on Download CSV.
3.  Notice the new columns at the end of the CSV:  
     collection_name | library_short_name | library_name | medium




<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
