### PR TITLE
Defensive code added for dashboard stats

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1465,6 +1465,11 @@ class DashboardController(AdminCirculationManagerController):
 
             library_collection_counts = dict()
             for collection in library.all_collections:
+                # sometimes a parent collection may be dissociated from a library
+                # in this case we may not have access to the collection as a library staff member
+                if collection.name not in collection_counts:
+                    continue
+
                 counts = collection_counts[collection.name]
                 library_collection_counts[collection.name] = counts
                 title_count += counts.get("licensed_titles", 0) + counts.get(

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -2602,6 +2602,23 @@ class TestDashboardController(AdminControllerTest):
                 assert 0 == c3_data.get("licenses")
                 assert 0 == c3_data.get("available_licenses")
 
+    def test_stats_parent_collection_permissions(self):
+        """A parent collection may be dissociated from a library"""
+        parent: Collection = self._collection()
+        child: Collection = self._collection()
+        child.parent = parent
+        library = self._library()
+        child.libraries.append(library)
+        self.admin.add_role(AdminRole.LIBRARIAN, library)
+
+        with self.request_context_with_library_and_admin("/", library=library):
+            response = self.manager.admin_dashboard_controller.stats()
+            stats = response["total"]["collections"]
+        # Child is in stats, but parent is not
+        # No exceptions were thrown
+        assert child.name in stats
+        assert parent.name not in stats
+
 
 class SettingsControllerTest(AdminControllerTest):
     """Test some part of the settings controller."""


### PR DESCRIPTION
## Description
In the case of a parent collection that is not part of a library that a child is also part of
The dashboard stats API would error out otherwise

<!--- Describe your changes -->

## Motivation and Context
Rochester Library was having this issue in their Dashboard page
[Notion](https://www.notion.so/lyrasis/Rochester-Public-Library-continually-getting-error-in-Collection-Manager-a196724ca9d04423bccb402f867c4a3d)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This has been manually tested with the VT collections
A unit test has been added for this scenario
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
