### PR TITLE
All outgoing requests will now have a default User Agent

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -185,6 +185,8 @@ class Configuration(ConfigurationConstants):
 
     EXCLUDED_AUDIO_DATA_SOURCES = "excluded_audio_data_sources"
 
+    DEFAULT_USER_AGENT_VERSION = "1.x.x"
+
     SITEWIDE_SETTINGS = [
         {
             "key": BASE_URL_KEY,

--- a/core/config.py
+++ b/core/config.py
@@ -9,14 +9,14 @@ from flask_babel import lazy_gettext as _
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import ArgumentError
 
+# It's convenient for other modules import IntegrationException
+# from this module, alongside CannotLoadConfiguration.
+from core.exceptions import IntegrationException
+
 from .entrypoint import EntryPoint
 from .facets import FacetConstants
 from .util import LanguageCodes
 from .util.datetime_helpers import to_utc, utc_now
-
-# It's convenient for other modules import IntegrationException
-# from this module, alongside CannotLoadConfiguration.
-from .util.http import IntegrationException
 
 
 class CannotLoadConfiguration(IntegrationException):

--- a/core/config.py
+++ b/core/config.py
@@ -186,7 +186,7 @@ class Configuration(ConfigurationConstants):
     EXCLUDED_AUDIO_DATA_SOURCES = "excluded_audio_data_sources"
 
     # In case an app version is not present, we can use this version as a fallback
-    # for all outgoing http requests with a custom user-agent
+    # for all outgoing http requests without a custom user-agent
     DEFAULT_USER_AGENT_VERSION = "1.x.x"
 
     SITEWIDE_SETTINGS = [

--- a/core/config.py
+++ b/core/config.py
@@ -185,6 +185,8 @@ class Configuration(ConfigurationConstants):
 
     EXCLUDED_AUDIO_DATA_SOURCES = "excluded_audio_data_sources"
 
+    # In case an app version is not present, we can use this version as a fallback
+    # for all outgoing http requests with a custom user-agent
     DEFAULT_USER_AGENT_VERSION = "1.x.x"
 
     SITEWIDE_SETTINGS = [

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -45,3 +45,31 @@ class BaseError(Exception):
         return "<BaseError(message={}, inner_exception={})>".format(
             (self), self.inner_exception
         )
+
+
+class IntegrationException(Exception):
+    """An exception that happens when the site's connection to a
+    third-party service is broken.
+
+    This may be because communication failed
+    (RemoteIntegrationException), or because local configuration is
+    missing or obviously wrong (CannotLoadConfiguration).
+    """
+
+    def __init__(self, message, debug_message=None):
+        """Constructor.
+
+        :param message: The normal message passed to any Exception
+        constructor.
+
+        :param debug_message: An extra human-readable explanation of the
+        problem, shown to admins but not to patrons. This may include
+        instructions on what bits of the integration configuration might need
+        to be changed.
+
+        For example, an API key might be wrong, or the API key might
+        be correct but the API provider might not have granted that
+        key enough permissions.
+        """
+        super().__init__(message)
+        self.debug_message = debug_message

--- a/core/problem_details.py
+++ b/core/problem_details.py
@@ -1,6 +1,5 @@
 from flask_babel import lazy_gettext as _
 
-from .util.http import INTEGRATION_ERROR  # noqa: autoflake
 from .util.problem_detail import ProblemDetail as pd
 
 # Generic problem detail documents that recapitulate HTTP errors.
@@ -63,4 +62,11 @@ UNRECOGNIZED_DATA_SOURCE = pd(
     400,
     _("Unrecognized data source."),
     _("I don't know anything about that data source."),
+)
+
+INTEGRATION_ERROR = pd(
+    "http://librarysimplified.org/terms/problem/remote-integration-failed",
+    502,
+    _("Third-party service failed."),
+    _("A third-party service has failed."),
 )

--- a/core/util/http.py
+++ b/core/util/http.py
@@ -252,16 +252,19 @@ class HTTP:
         if "data" in kwargs and isinstance(kwargs["data"], str):
             kwdata: str = kwargs["data"]
             kwargs["data"] = kwdata.encode("utf8")
-        if "headers" in kwargs:
-            headers = kwargs["headers"]
-            new_headers = {}
-            for k, v in list(headers.items()):
-                if isinstance(k, str):
-                    k = k.encode("utf8")
-                if isinstance(v, str):
-                    v = v.encode("utf8")
-                new_headers[k] = v
-            kwargs["headers"] = new_headers
+
+        headers = kwargs.get("headers", {})
+        # Set a user-agent if not already present
+        if "User-Agent" not in headers:
+            headers["User-Agent"] = "Palace Manager/1.x.x"
+        new_headers = {}
+        for k, v in list(headers.items()):
+            if isinstance(k, str):
+                k = k.encode("utf8")
+            if isinstance(v, str):
+                v = v.encode("utf8")
+            new_headers[k] = v
+        kwargs["headers"] = new_headers
 
         try:
             if verbose:

--- a/core/util/http.py
+++ b/core/util/http.py
@@ -8,43 +8,11 @@ from requests import sessions
 from requests.adapters import HTTPAdapter, Response
 from urllib3 import Retry
 
+from core.config import Configuration
+from core.exceptions import IntegrationException
+from core.problem_details import INTEGRATION_ERROR
+
 from .problem_detail import JSON_MEDIA_TYPE as PROBLEM_DETAIL_JSON_MEDIA_TYPE
-from .problem_detail import ProblemDetail as pd
-
-INTEGRATION_ERROR = pd(
-    "http://librarysimplified.org/terms/problem/remote-integration-failed",
-    502,
-    _("Third-party service failed."),
-    _("A third-party service has failed."),
-)
-
-
-class IntegrationException(Exception):
-    """An exception that happens when the site's connection to a
-    third-party service is broken.
-
-    This may be because communication failed
-    (RemoteIntegrationException), or because local configuration is
-    missing or obviously wrong (CannotLoadConfiguration).
-    """
-
-    def __init__(self, message, debug_message=None):
-        """Constructor.
-
-        :param message: The normal message passed to any Exception
-        constructor.
-
-        :param debug_message: An extra human-readable explanation of the
-        problem, shown to admins but not to patrons. This may include
-        instructions on what bits of the integration configuration might need
-        to be changed.
-
-        For example, an API key might be wrong, or the API key might
-        be correct but the API provider might not have granted that
-        key enough permissions.
-        """
-        super().__init__(message)
-        self.debug_message = debug_message
 
 
 class RemoteIntegrationException(IntegrationException):
@@ -256,7 +224,13 @@ class HTTP:
         headers = kwargs.get("headers", {})
         # Set a user-agent if not already present
         if "User-Agent" not in headers:
-            headers["User-Agent"] = "Palace Manager/1.x.x"
+            version = Configuration.app_version()
+            version = (
+                version
+                if version and version != Configuration.NO_APP_VERSION_FOUND
+                else "1.x.x"
+            )
+            headers["User-Agent"] = f"Palace Manager/{version}"
         new_headers = {}
         for k, v in list(headers.items()):
             if isinstance(k, str):
@@ -417,7 +391,7 @@ class HTTP:
         http_method: str,
         url: str,
         make_request_with: Optional[Callable[..., Response]] = None,
-        **kwargs
+        **kwargs,
     ) -> Response:
         """Make a request that returns a detailed problem detail document on
         error, rather than a generic "an integration error occured"
@@ -439,7 +413,7 @@ class HTTP:
             make_request_with,
             http_method,
             process_response_with=cls.process_debuggable_response,
-            **kwargs
+            **kwargs,
         )
 
     @classmethod

--- a/core/util/http.py
+++ b/core/util/http.py
@@ -228,7 +228,7 @@ class HTTP:
             version = (
                 version
                 if version and version != Configuration.NO_APP_VERSION_FOUND
-                else "1.x.x"
+                else Configuration.DEFAULT_USER_AGENT_VERSION
             )
             headers["User-Agent"] = f"Palace Manager/{version}"
         new_headers = {}

--- a/tests/core/util/test_http.py
+++ b/tests/core/util/test_http.py
@@ -1,4 +1,5 @@
 import json
+from unittest import mock
 
 import pytest
 import requests
@@ -23,8 +24,9 @@ class TestHTTP:
         assert "3xx" == m(399)
         assert "5xx" == m(500)
 
-    def test_request_with_timeout_success(self):
-
+    @mock.patch("core.util.http.Configuration")
+    def test_request_with_timeout_success(self, mock_conf):
+        mock_conf.app_version.return_value = "<VERSION>"
         called_with = None
 
         def fake_200_response(*args, **kwargs):
@@ -40,7 +42,7 @@ class TestHTTP:
             assert 20 == kwargs["timeout"]
 
             # Default header should be set
-            assert b"Palace Manager/1.x.x" == kwargs["headers"][b"User-Agent"]
+            assert b"Palace Manager/<VERSION>" == kwargs["headers"][b"User-Agent"]
             return MockRequestsResponse(200, content="Success!")
 
         response = HTTP._request_with_timeout(

--- a/tests/core/util/test_http.py
+++ b/tests/core/util/test_http.py
@@ -38,6 +38,9 @@ class TestHTTP:
 
             # A default timeout is added.
             assert 20 == kwargs["timeout"]
+
+            # Default header should be set
+            assert b"Palace Manager/1.x.x" == kwargs["headers"][b"User-Agent"]
             return MockRequestsResponse(200, content="Success!")
 
         response = HTTP._request_with_timeout(
@@ -45,6 +48,22 @@ class TestHTTP:
         )
         assert 200 == response.status_code
         assert b"Success!" == response.content
+
+    def test_request_with_timeout_with_ua(self):
+        def fake_request_method(*args, **kwargs):
+            # Non-default user agent
+            assert b"Fake Agent" == kwargs["headers"][b"User-Agent"]
+            return MockRequestsResponse(201)
+
+        assert (
+            HTTP._request_with_timeout(
+                "http://url",
+                fake_request_method,
+                "GET",
+                headers={"User-Agent": "Fake Agent"},
+            ).status_code
+            == 201
+        )
 
     def test_request_with_timeout_failure(self):
         def immediately_timeout(*args, **kwargs):


### PR DESCRIPTION
## Description
Currently set to the minimalistic Palace Manager/1.x.x

<!--- Describe your changes -->

## Motivation and Context
Overdrive have requested the CM have a custom User Agent while making requests to their endpoints.
[Notion](https://www.notion.so/lyrasis/Make-user-agent-less-generic-4820ea007b3c4e1988c569c3988f08c5)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated.
Used a mock server to inspect the user-agent manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
