### PR TITLE
Fixed CollectionCrawlableWorklists without a library

### DIFF
--- a/core/lane.py
+++ b/core/lane.py
@@ -1892,6 +1892,10 @@ class WorkList:
         # performance isn't a big concern -- it's just ugly.
         wl = SpecificWorkList(work_ids)
         wl.initialize(self.get_library(_db))
+        # If we are specifically targeting a collection and not a library
+        # ensure the worklist is aware of this
+        if not self.library_id and self.collection_ids:
+            wl.collection_ids = self.collection_ids
         qu = wl.works_from_database(_db, facets=facets)
         a = time.time()
         all_works = qu.all()

--- a/tests/api/test_lanes.py
+++ b/tests/api/test_lanes.py
@@ -30,7 +30,7 @@ from api.lanes import (
 from api.novelist import MockNoveListAPI
 from core.classifier import Classifier
 from core.entrypoint import AudiobooksEntryPoint
-from core.external_search import Filter
+from core.external_search import Filter, MockExternalSearchIndex
 from core.lane import DefaultSortOrderFacets, Facets, FeaturedFacets, Lane, WorkList
 from core.metadata_layer import ContributorData, Metadata
 from core.model import (
@@ -901,6 +901,23 @@ class TestCrawlableCollectionBasedLane(DatabaseTest):
         route, kwargs = lane.url_arguments
         assert CrawlableCollectionBasedLane.COLLECTION_ROUTE == route
         assert other_collection.name == kwargs.get("collection_name")
+
+    def test_works(self):
+        w1 = self._work(collection=self._default_collection)
+        w2 = self._work(collection=self._default_collection)
+        w3 = self._work(collection=self._collection())
+
+        lane = CrawlableCollectionBasedLane()
+        lane.initialize([self._default_collection])
+        search = MockExternalSearchIndex()
+        lane.works(self._db, facets=CrawlableFacets.default(None), search_engine=search)
+
+        assert len(search.queries) == 1
+        filter = search.queries[0][1]
+        # Only target a single collection
+        assert filter.collection_ids == [self._default_collection.id]
+        # without any search query
+        assert None == search.queries[0][0]
 
 
 class TestCrawlableCustomListBasedLane(DatabaseTest):


### PR DESCRIPTION
## Description
The collection_ids were missing due to no library being initialized
now we set the collection_ids directly when creating the SpecificWorklist if the library is missing
<!--- Describe your changes -->

## Motivation and Context
`/collections/<name>/crawlable` endpoint was broken due to the above issue. This functionality is required if we want to have OPDS2 feeds per collection
[Notion](https://www.notion.so/lyrasis/Fix-collections-name-crawlable-endpoint-3abd8d94d2fc44f1b21efb0167a7ba77)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated
Manually queried the `/collections/<name>/crawlable` enpoint
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
