### PR TITLE
JSON type search requests now ignore the scoring parameters

### DIFF
--- a/core/external_search.py
+++ b/core/external_search.py
@@ -2619,6 +2619,10 @@ class Filter(SearchBase):
             self.scoring_functions = []
             self.search_type = "default"
 
+        # JSON type searches are exact matches and do not have scoring
+        if self.search_type == "json":
+            self.min_score = None
+
     @property
     def audiences(self):
         """Return the appropriate audiences for this query.

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -4892,6 +4892,8 @@ class TestExternalSearchJSONQuery(EndToEndSearchTest):
     def test_search_with_facets_ordering(self):
         self.facets = SearchFacets(order="author", search_type="json")
         self.filter = Filter(facets=self.facets)
+        assert self.filter.min_score == None
+
         w = self.random_works
         expected = [w[1], w[2], w[0]]
         response = self.expect(


### PR DESCRIPTION
## Description
When ordering was required, the search filter would add a min_score=500
Since we do not use any dis_max queries or boost parameters we do not have
any scoring for the JSON type queries
<!--- Describe your changes -->

## Motivation and Context
A bug was discovered regarding json search and ordering
[Notion](https://www.notion.so/lyrasis/Title-and-author-sorts-for-list-search-don-t-return-results-6bfad0ab4e5c4705874f312ba13d2897)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
A unit test to cover this situation has been introduced
Manual testing on the `/search` endpoint was done
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
