### PR TITLE
Global announcement admin should get all announcements

### DIFF
--- a/api/admin/controller/announcement_service.py
+++ b/api/admin/controller/announcement_service.py
@@ -36,7 +36,7 @@ class AnnouncementSettings(SettingsController):
         settings = Configuration.ANNOUNCEMENT_SETTINGS
         return dict(
             settings=settings,
-            announcements=[ann.json_ready for ann in announcements.active],
+            announcements=[ann.json_ready for ann in announcements.announcements],
         )
 
     def post(self) -> dict | ProblemDetail:

--- a/tests/api/admin/controller/test_announcement_service.py
+++ b/tests/api/admin/controller/test_announcement_service.py
@@ -35,7 +35,7 @@ class TestAnnouncementService(AnnouncementTest, AdminControllerTest):
             response = AnnouncementSettings(self.manager).process_many()
 
         announcements = Announcements.for_all(self._db)
-        assert len(announcements.announcements) == 2
+        assert len(announcements.announcements) == 1
         assert announcements.announcements[0].id == "active"
 
     def test_post_errors(self):


### PR DESCRIPTION
## Description

Changes global announcements admin `get` API to return all global announcements, rather than just the active ones.

## Motivation and Context

The sysadmin needs to be able to manage all announces, including those that have expired and those that are upcoming.

## How Has This Been Tested?

- Updated existing test to ensure that all global announcements are returned to the admin. Rant test. Test failed.
- Fixed response. Ran test. Test passed.

## Checklist

- N/A - I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
