### PR TITLE
Use Admin UI v0.3.0.

### DIFF
--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -12,7 +12,7 @@ class Configuration:
 
     APP_NAME = "Palace Collection Manager"
     PACKAGE_NAME = "@thepalaceproject/circulation-admin"
-    PACKAGE_VERSION = "0.2.0"
+    PACKAGE_VERSION = "0.3.0"
 
     STATIC_ASSETS = {
         "admin_js": "circulation-admin.js",


### PR DESCRIPTION
## Description

Updates default Admin UI version to 0.3.0.

## Motivation and Context

Pick up changes in new version. For details, see [Admin UI v0.3.0 release notes](https://github.com/ThePalaceProject/circulation-admin/releases/tag/0.3.0).

## How Has This Been Tested?

All CI tests/validations pass.

Manually tested the changes in a local development environment to ensure that version 0.3.0 was pulled from the CDN and that the site-wide announcement configuration appears to work properly.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
