### PR TITLE
Fixes problem of duplicate events appearing in the local analytics ex…

### DIFF
--- a/api/local_analytics_exporter.py
+++ b/api/local_analytics_exporter.py
@@ -125,6 +125,7 @@ class LocalAnalyticsExporter:
                 .join(Identifier, LicensePool.identifier_id == Identifier.id)
                 .join(Work, Work.id == LicensePool.work_id)
                 .join(Edition, Work.presentation_edition_id == Edition.id)
+                .join(Collection, LicensePool.collection_id == Collection.id)
                 .outerjoin(Library, CirculationEvent.library_id == Library.id)
             )
             .where(and_(*clauses))

--- a/tests/api/test_local_analytics_exporter.py
+++ b/tests/api/test_local_analytics_exporter.py
@@ -11,11 +11,14 @@ class TestLocalAnalyticsExporter(DatabaseTest):
 
     def test_export(self):
         exporter = LocalAnalyticsExporter()
-
+        c1 = self._collection(name="c1")
+        c2 = self._collection(name="c2")
         w1 = self._work(with_open_access_download=True)
         w2 = self._work(with_open_access_download=True)
         [lp1] = w1.license_pools
         [lp2] = w2.license_pools
+        lp1.collection = c1
+        lp2.collection = c2
         edition1 = w1.presentation_edition
         edition1.publisher = "A publisher"
         edition1.imprint = "An imprint"
@@ -43,7 +46,6 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         num = len(types)
         time = datetime.now() - timedelta(minutes=len(types))
         location = "11377"
-        collection_name = "Default Collection"
         # Create a bunch of circulation events of different types,
         # all with the same .location.
         for type in types:
@@ -98,7 +100,7 @@ class TestLocalAnalyticsExporter(DatabaseTest):
             w1.target_age_string or "",
             ordered_genre_string,
             location,
-            collection_name,
+            c1.name,
             "",
             "",
             edition1.medium,
@@ -142,7 +144,7 @@ class TestLocalAnalyticsExporter(DatabaseTest):
             w2.target_age_string or "",
             genres[1].name,
             no_location,
-            collection_name,
+            c2.name,
             "",
             "",
             edition1.medium,


### PR DESCRIPTION
## Description

Fixes problem of duplicate events appearing in the local analytics export.

This PR fixes a problem introduced when we added the library and collection to the local analytics export.  The problem is that I didn't specify explicitly how to join to the Collection table. As a result,  the join was occurring by default on the library  resulting in a row for each collection in the library, rather than the collection associated with the license pool (which has a 1 to 1 relationship with a collection.


## Motivation and Context
 https://www.notion.so/lyrasis/CSV-export-includes-duplicate-events-for-every-collection-on-the-CM-513bb0974cce46e399cd610c0cd7e9d9
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I updated the test to use two collections rather than a single collection to ensure that the resulting row counts are correct.

I also manually checked it.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
