### PR TITLE
Fix license/copy accounting for OverDrive Advantage Plus shared books

### DIFF
--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -58,12 +58,6 @@ from .util.datetime_helpers import strptime_utc, utc_now
 from .util.http import HTTP, BadResponseException
 from .util.string_helpers import base64
 
-"""
-An OverDrive defined constant indicating the "main" or parent account associated
-with an OverDrive collection.
-"""
-OVERDRIVE_MAIN_ACCOUNT_ID: int = -1
-
 
 class OverdriveConfiguration(ConfigurationGrouping, BaseImporterConfiguration):
     """The basic Overdrive configuration"""
@@ -128,6 +122,10 @@ class OverdriveConfiguration(ConfigurationGrouping, BaseImporterConfiguration):
 
 
 class OverdriveCoreAPI(HasExternalIntegration):
+    # An OverDrive defined constant indicating the "main" or parent account
+    # associated with an OverDrive collection.
+    OVERDRIVE_MAIN_ACCOUNT_ID = -1
+
     log = logging.getLogger("Overdrive API")
 
     # A lock for threaded usage.
@@ -374,7 +372,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
         certain API documents served by Overdrive.
 
         For ordinary collections (ie non-Advantage) with or without associated
-        Advantage (ie child) collections shared among libraries, this will be .
+        Advantage (ie child) collections shared among libraries, this will be
         equal to the OVERDRIVE_MAIN_ACCOUNT_ID.
 
         For Overdrive Advantage accounts, this will be the numeric
@@ -385,7 +383,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
             #
             # Instead of looking for the library ID itself in these
             # documents, we should look for the constant main account id.
-            return OVERDRIVE_MAIN_ACCOUNT_ID
+            return self.OVERDRIVE_MAIN_ACCOUNT_ID
         return int(self._library_id)
 
     def check_creds(self, force_refresh=False):
@@ -1069,10 +1067,11 @@ class OverdriveRepresentationExtractor:
         we will be counting it with the parent collection.
         """
 
-        if self.library_id == OVERDRIVE_MAIN_ACCOUNT_ID:
+        if self.library_id == OverdriveCoreAPI.OVERDRIVE_MAIN_ACCOUNT_ID:
             # this is a parent collection
             filtered_result = filter(
-                lambda account: account.get("id") == OVERDRIVE_MAIN_ACCOUNT_ID
+                lambda account: account.get("id")
+                == OverdriveCoreAPI.OVERDRIVE_MAIN_ACCOUNT_ID
                 or account.get("shared", False),
                 accounts,
             )

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -1025,21 +1025,35 @@ class OverdriveRepresentationExtractor:
         elif book.get("isOwnedByCollections") is not False:
             # We own this book.
             accounts = book.get("accounts", [])
-            # consortial accounts will always contain an account with id == -1
+            # TODO: verify that the logic is correct with Overdrive.
+            #
             # This section of code is convoluted in part because I don't fully
             # understand the relationship between overdrive, overdrive
             # advantage, and overdrive consortial accounts and how related
             # information is returned by the API or not depending on the
-            # the API token used.
-            # The problem as I see it is that the response is overloaded:
-            # you need to know something about the nature of the API token
-            # in order to properly interpret the results...maybe.  I'm not sure
-            # talking to OD about it has not left me with clarity on the issue.
+            # the type of API token used.
+            # Questions: Are "shared" accounts ever returned in the feed
+            # results of  Overdrive Advantage accounts? If so should they be
+            # counted?Are "unshared" accounts ever returned in the feed
+            # results of  Overdrive Advantage accounts? If so how should they be
+            # handled?  Can a consortial account also be an Overdrive Advantage
+            # account? Can two Palace Libraries use tokens whose associated
+            # accounts overlap? What is the relationship between a token and an
+            # account? One to many? Many to many? Does it make a difference to
+            # us?
+            #
+            # The problem as I see it (if there is a problem)  is that the
+            # feed response is overloaded:
+            # you need to know what kind of API token (consortial or not) you've
+            # got in order to properly interpret the JSON response...maybe.
             is_consortium = len([a for a in accounts if a["id"] == -1]) == 1
             licenses_owned = 0
             licenses_available = 0
             if self.library_id != -1:
-                # this is an overdrive advantage account
+                # This is an Overdrive Advantage account. For the sake of
+                # making as few changes with possibly unexpected consequences
+                # as possible, just do what we were doing before I made these
+                # changes.
                 for account in accounts:
                     if account["id"] == self.library_id:
                         if "copiesOwned" in account:
@@ -1047,8 +1061,8 @@ class OverdriveRepresentationExtractor:
                         if "copiesAvailable" in account:
                             licenses_available += int(account["copiesAvailable"])
             elif not is_consortium:
-                # this is a non-consortial overdrive account
-                # just get the values from the book object
+                # This is a non-consortial, non-advantage overdrive account:
+                # just get the values from the book object.
                 licenses_owned = book.get("copiesOwned", 0)
                 licenses_available = book.get("copiesAvailable", 0)
             else:

--- a/tests/core/files/overdrive/overdrive_availability_advantage.json
+++ b/tests/core/files/overdrive/overdrive_availability_advantage.json
@@ -7,8 +7,8 @@
             "shared": false
         },
         {
-            "copiesAvailable": 2,
-            "copiesOwned": 2,
+            "copiesAvailable": 8,
+            "copiesOwned": 8,
             "id": 63,
             "shared": true
         },

--- a/tests/core/files/overdrive/overdrive_availability_advantage.json
+++ b/tests/core/files/overdrive/overdrive_availability_advantage.json
@@ -9,13 +9,19 @@
         {
             "copiesAvailable": 2,
             "copiesOwned": 2,
+            "id": 63,
+            "shared": true
+        },
+        {
+            "copiesAvailable": 2,
+            "copiesOwned": 2,
             "id": -1
         }
     ],
     "availabilityType": "Normal",
     "available": true,
-    "copiesAvailable": 3,
-    "copiesOwned": 3,
+    "copiesAvailable": 4,
+    "copiesOwned": 4,
     "links": {
         "self": {
             "href": "https://api.overdrive.com/v2/collections/v1L1B4QwAAA2O/products/776ec0c1-582f-4f7a-8d80-bdf5834de7ce/availability",

--- a/tests/core/files/overdrive/overdrive_availability_advantage.json
+++ b/tests/core/files/overdrive/overdrive_availability_advantage.json
@@ -20,8 +20,8 @@
     ],
     "availabilityType": "Normal",
     "available": true,
-    "copiesAvailable": 4,
-    "copiesOwned": 4,
+    "copiesAvailable": 11,
+    "copiesOwned": 11,
     "links": {
         "self": {
             "href": "https://api.overdrive.com/v2/collections/v1L1B4QwAAA2O/products/776ec0c1-582f-4f7a-8d80-bdf5834de7ce/availability",

--- a/tests/core/test_overdrive.py
+++ b/tests/core/test_overdrive.py
@@ -501,7 +501,7 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
         # patrons_in_hold_queue to both be nonzero; this is just to
         # verify that the test picks up whatever data is in the
         # document.
-        assert 3 == circulationdata.licenses_owned
+        assert 4 == circulationdata.licenses_owned
         assert 1 == circulationdata.licenses_available
         assert 10 == circulationdata.patrons_in_hold_queue
 
@@ -518,9 +518,11 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
         raw, info = self.sample_json("overdrive_availability_advantage.json")
 
         extractor = OverdriveRepresentationExtractor(self.api)
+        # consortial data means data that is available to a consortial account
+        # in other words, the consortial account itself + any shared accounts
         consortial_data = extractor.book_info_to_circulation(info)
-        assert 2 == consortial_data.licenses_owned
-        assert 2 == consortial_data.licenses_available
+        assert 4 == consortial_data.licenses_owned
+        assert 4 == consortial_data.licenses_available
 
         class MockAPI:
             # Pretend to be an API for an Overdrive Advantage collection with
@@ -552,8 +554,8 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
 
         extractor = OverdriveRepresentationExtractor(MockAPI())
         advantage_data = extractor.book_info_to_circulation(info)
-        assert None == advantage_data.licenses_owned
-        assert None == advantage_data.licenses_available
+        assert 0 == advantage_data.licenses_owned
+        assert 0 == advantage_data.licenses_available
         assert 0 == consortial_data.patrons_in_hold_queue
 
     def test_not_found_error_to_circulationdata(self):

--- a/tests/core/test_overdrive.py
+++ b/tests/core/test_overdrive.py
@@ -557,7 +557,6 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
         advantage_data = extractor.book_info_to_circulation(info)
         assert 0 == advantage_data.licenses_owned
         assert 0 == advantage_data.licenses_available
-        assert 0 == consortial_data.patrons_in_hold_queue
 
         class MockAPI:
             # Pretend to be an API for an Overdrive Advantage collection with
@@ -570,7 +569,6 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
         # context we do not count them here.
         assert 0 == advantage_data.licenses_owned
         assert 0 == advantage_data.licenses_available
-        assert 0 == consortial_data.patrons_in_hold_queue
 
     def test_not_found_error_to_circulationdata(self):
         raw, info = self.sample_json("overdrive_availability_not_found.json")

--- a/tests/core/test_overdrive.py
+++ b/tests/core/test_overdrive.py
@@ -501,7 +501,7 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
         # patrons_in_hold_queue to both be nonzero; this is just to
         # verify that the test picks up whatever data is in the
         # document.
-        assert 4 == circulationdata.licenses_owned
+        assert 3 == circulationdata.licenses_owned
         assert 1 == circulationdata.licenses_available
         assert 10 == circulationdata.patrons_in_hold_queue
 

--- a/tests/core/test_overdrive.py
+++ b/tests/core/test_overdrive.py
@@ -513,16 +513,17 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
         )
 
     def test_book_info_to_circulation_advantage(self):
-        # Overdrive Advantage accounts derive different information
-        # from the same API responses as regular Overdrive accounts.
+        # Overdrive Advantage accounts (a.k.a. "child" or "sub" accounts derive
+        # different information from the same API responses as "main" Overdrive
+        # accounts.
         raw, info = self.sample_json("overdrive_availability_advantage.json")
 
         extractor = OverdriveRepresentationExtractor(self.api)
-        # consortial data means data that is available to a consortial account
-        # in other words, the consortial account itself + any shared accounts
+        # Calling in the context of a main account should return a count of
+        # the main account and any shared sub account owned and available.
         consortial_data = extractor.book_info_to_circulation(info)
-        assert 4 == consortial_data.licenses_owned
-        assert 4 == consortial_data.licenses_available
+        assert 10 == consortial_data.licenses_owned
+        assert 10 == consortial_data.licenses_available
 
         class MockAPI:
             # Pretend to be an API for an Overdrive Advantage collection with
@@ -554,6 +555,19 @@ class TestOverdriveRepresentationExtractor(OverdriveTestWithAPI):
 
         extractor = OverdriveRepresentationExtractor(MockAPI())
         advantage_data = extractor.book_info_to_circulation(info)
+        assert 0 == advantage_data.licenses_owned
+        assert 0 == advantage_data.licenses_available
+        assert 0 == consortial_data.patrons_in_hold_queue
+
+        class MockAPI:
+            # Pretend to be an API for an Overdrive Advantage collection with
+            # library ID 63 which contains shared copies.
+            advantage_library_id = 63
+
+        extractor = OverdriveRepresentationExtractor(MockAPI())
+        advantage_data = extractor.book_info_to_circulation(info)
+        # since these copies are shared and counted as part of the main
+        # context we do not count them here.
         assert 0 == advantage_data.licenses_owned
         assert 0 == advantage_data.licenses_available
         assert 0 == consortial_data.patrons_in_hold_queue


### PR DESCRIPTION
## Description
This update ensures that the Overdrive API is returning the correct number of copies owned and copies available for books in consortial accounts that have related Overdrive Advantage accounts with sharing enabled.

Previously there was an assumption that if the OverdriveApi.advantage_library_id did not match the book["accounts"][n].id (ie from the feed) then the availability and ownership information was ignored.   Furthermore,  it appears that in our code when OverdriveApi.advantage_library_id resolves to -1,  it means the library is a non-overdrive advantage collection and/or it is a consortial collection.   In the case of consortial collections,  we want to include the ownership and account information that is non-consortial but shared.  

That is why the books in the BCCLS collection were not showing up: when the feed was processed, there were no copies owned by the consortial account (id=-1) and so we assumed no copies owned.  However,  there are associated AdvantagePlus accounts where shared=true, but we weren't counting those as owned or available copies.  

So I left things working just as they were with the following change:  

 If this is an overdrive parent collection, we want to return account copies owned and available associated with the main OverDrive "library" and any non-main account with sharing enabled.   If this is a child OverDrive collection, then we return only the account copies owned and available associated with that child's OverDrive Advantage "library".  Additionally, we want to exclude the account if it is "shared" since we will be counting it with the parent collection.

So my general approach was to try to leave things intact as much as possible while addressing the specific issue we're seeing in BCCLS since I'm not very confident in my understanding of the feed results.

For more details and questions see comment here: https://github.com/ThePalaceProject/circulation/pull/511/files#diff-9bfa71926822791fa4c58eb9d13fc76049bbf47a116849b986e81a8bb6821a39R1028

## Motivation and Context
https://www.notion.so/lyrasis/Investigate-discrepancy-between-BCCLS-OverDrive-materials-in-their-portal-vs-in-Palace-a46ce6541d514a1c9ca65a646f99301a

## How Has This Been Tested?

Fix covered by unit tests.  Needs manual acceptance testing.


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
