### PR TITLE
Added an is_shared to the /custom_lists admin route

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -797,6 +797,7 @@ class CustomListsController(AdminCirculationManagerController):
             auto_update_query=list.auto_update_query,
             auto_update_facets=list.auto_update_facets,
             is_owner=is_owner,
+            is_shared=len(list.shared_locally_with_libraries) > 0,
         )
 
     def custom_lists(self) -> Dict:

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -1073,6 +1073,15 @@ class TestCustomListsController(AdminControllerTest):
             auto_update_enabled=False,
         )
 
+        # This will set the is_shared attribute
+        shared_library = self._library()
+        assert (
+            CustomListQueries.share_locally_with_library(
+                self._db, no_entries, shared_library
+            )
+            == True
+        )
+
         with self.request_context_with_library_and_admin("/"):
             response = self.manager.admin_custom_lists_controller.custom_lists()
             assert 2 == len(response.get("custom_lists"))
@@ -1089,6 +1098,7 @@ class TestCustomListsController(AdminControllerTest):
             assert collection.protocol == c.get("protocol")
             assert True == l1.get("auto_update")
             assert auto_update_query == l1.get("auto_update_query")
+            assert False == l1.get("is_shared")
 
             assert no_entries.id == l2.get("id")
             assert no_entries.name == l2.get("name")
@@ -1096,6 +1106,7 @@ class TestCustomListsController(AdminControllerTest):
             assert 0 == len(l2.get("collections"))
             assert False == l2.get("auto_update")
             assert None == l2.get("auto_update_query")
+            assert True == l2.get("is_shared")
 
         self.admin.remove_role(AdminRole.LIBRARIAN, self._default_library)
         with self.request_context_with_library_and_admin("/"):
@@ -1734,6 +1745,7 @@ class TestCustomListsController(AdminControllerTest):
                 auto_update_query=None,
                 auto_update_facets=None,
                 is_owner=False,
+                is_shared=True,
             )
 
 


### PR DESCRIPTION
## Description
Will be True in case a list is shared with any other library

<!--- Describe your changes -->

## Motivation and Context
The UI needs to be aware if a list is shared to any other library to make appropriate changes in the view
[Notion](https://www.notion.so/lyrasis/Need-a-way-to-tell-if-a-custom-list-is-shared-when-you-are-the-owner-a8101f9aa97e47c381a99346a0318842)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit test has been updated
Manually tested with the admin panel "list editing" page
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
