### PR TITLE
Auto update custom lists with automatic back population of titles

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -865,7 +865,7 @@ class CustomListsController(AdminCirculationManagerController):
         name: str,
         entries: List[Dict],
         collections: List[int],
-        deletedEntries: List[Dict] = None,
+        deleted_entries: List[Dict] = None,
         id: int = None,
         auto_update: Optional[bool] = None,
         auto_update_query: Optional[str] = None,
@@ -909,7 +909,7 @@ class CustomListsController(AdminCirculationManagerController):
 
                 if entries and len(entries) > 0:
                     raise Exception(AUTO_UPDATE_CUSTOM_LIST_CANNOT_HAVE_ENTRIES)
-                if deletedEntries and len(deletedEntries) > 0:
+                if deleted_entries and len(deleted_entries) > 0:
                     raise Exception(AUTO_UPDATE_CUSTOM_LIST_CANNOT_HAVE_ENTRIES)
 
             if auto_update_facets:
@@ -988,8 +988,8 @@ class CustomListsController(AdminCirculationManagerController):
                     works_to_update_in_search.add(work)
                     membership_change = True
 
-        if deletedEntries:
-            for entry in deletedEntries:
+        if deleted_entries:
+            for entry in deleted_entries:
                 urn = entry.get("id")
                 work = self._get_work_from_urn(library, urn)
 
@@ -1084,7 +1084,7 @@ class CustomListsController(AdminCirculationManagerController):
             collections = self._getJSONFromRequest(
                 flask.request.form.get("collections")
             )
-            deletedEntries = self._getJSONFromRequest(
+            deleted_entries = self._getJSONFromRequest(
                 flask.request.form.get("deletedEntries")
             )
 
@@ -1100,7 +1100,7 @@ class CustomListsController(AdminCirculationManagerController):
                 name,
                 entries,
                 collections,
-                deletedEntries=deletedEntries,
+                deleted_entries=deleted_entries,
                 id=list_id,
                 auto_update=auto_update,
                 auto_update_query=auto_update_query,

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -796,6 +796,7 @@ class CustomListsController(AdminCirculationManagerController):
             auto_update=list.auto_update_enabled,
             auto_update_query=list.auto_update_query,
             auto_update_facets=list.auto_update_facets,
+            auto_update_status=list.auto_update_status,
             is_owner=is_owner,
             is_shared=len(list.shared_locally_with_libraries) > 0,
         )

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -428,6 +428,13 @@ CUSTOM_LIST_NAME_ALREADY_IN_USE = pd(
     detail=_("The library already has a custom list with that name."),
 )
 
+AUTO_UPDATE_CUSTOM_LIST_CANNOT_HAVE_ENTRIES = pd(
+    "http://librarysimplified.org/terms/problem/auto-update-custom-list-cannot-have-entries",
+    status_code=400,
+    title=_("An auto update custom list cannot have entries"),
+    detail=_("Entries are automatically managed for auto update custom lists"),
+)
+
 COLLECTION_NOT_ASSOCIATED_WITH_LIBRARY = pd(
     "http://librarysimplified.org/terms/problem/collection-not-associated-with-library",
     status_code=400,

--- a/core/model/customlist.py
+++ b/core/model/customlist.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     Boolean,
     Column,
     DateTime,
+    Enum,
     ForeignKey,
     Index,
     Integer,
@@ -35,6 +36,11 @@ class CustomList(Base):
     """A custom grouping of Editions."""
 
     STAFF_PICKS_NAME = "Staff Picks"
+
+    INIT = "init"
+    UPDATED = "updated"
+    REPOPULATE = "repopulate"
+    auto_update_status_enum = Enum(INIT, UPDATED, REPOPULATE, name="auto_update_status")
 
     __tablename__ = "customlists"
     id = Column(Integer, primary_key=True)
@@ -66,6 +72,7 @@ class CustomList(Base):
     auto_update_query = Column(Unicode, nullable=True)  # holds json data
     auto_update_facets = Column(Unicode, nullable=True)  # holds json data
     auto_update_last_update = Column(DateTime, nullable=True)
+    auto_update_status = Column(auto_update_status_enum, default=INIT)
 
     # Typing specific
     collections: List["Collection"]

--- a/core/query/customlist.py
+++ b/core/query/customlist.py
@@ -67,6 +67,12 @@ class CustomListQueries:
         log = logging.getLogger("Auto Update Custom List")
         search = ExternalSearchIndex(_db)
 
+        if not custom_list.auto_update_query:
+            log.info(
+                f"Cannot populate entries: Custom list {custom_list.name} is missing an auto update query"
+            )
+            return 0
+
         if not json_query:
             json_query = json.loads(custom_list.auto_update_query)
 

--- a/core/query/customlist.py
+++ b/core/query/customlist.py
@@ -1,20 +1,30 @@
-from typing import Union
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+from typing import TYPE_CHECKING
 
 from api.admin.problem_details import (
     CUSTOMLIST_ENTRY_NOT_VALID_FOR_LIBRARY,
     CUSTOMLIST_SOURCE_COLLECTION_MISSING,
 )
+from core.external_search import ExternalSearchIndex
+from core.lane import Pagination, SearchFacets, WorkList
 from core.model.customlist import CustomList, CustomListEntry
 from core.model.library import Library
 from core.model.licensing import LicensePool
 from core.util.problem_detail import ProblemDetail
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 
 class CustomListQueries:
     @classmethod
     def share_locally_with_library(
         cls, _db, customlist: CustomList, library: Library
-    ) -> Union[ProblemDetail, bool]:
+    ) -> ProblemDetail | bool:
         # All customlist collections must be present in the library
         for collection in customlist.collections:
             if collection not in library.collections:
@@ -37,3 +47,65 @@ class CustomListQueries:
 
         customlist.shared_locally_with_libraries.append(library)
         return True
+
+    @classmethod
+    def populate_query_pages(
+        self,
+        _db: Session,
+        custom_list: CustomList,
+        start_page: int = 1,
+        max_pages: int = 1000,
+        page_size: int = 100,
+        json_query: dict = None,
+    ) -> int:
+        """Populate the custom list while paging through the search query results
+        :param start_page: Offset of the search will be used from here (based on page_size)
+        :param page_size: Page size to use for the search iteration
+        :param max_pages: Maximum number of pages to search through
+        :param json_query: If provided, use this json query rather than that of the custom list"""
+
+        log = logging.getLogger("Auto Update Custom List")
+        search = ExternalSearchIndex(_db)
+
+        if not json_query:
+            json_query = json.loads(custom_list.auto_update_query)
+
+        if custom_list.auto_update_facets:
+            facets = SearchFacets(
+                search_type="json", **json.loads(custom_list.auto_update_facets)
+            )
+        else:
+            facets = SearchFacets(search_type="json")
+
+        total_works_updated = 0
+        start_page -= 1  # 0 based offset, so page 1 == 0
+        for page_num in range(start_page, start_page + max_pages):
+            ## Query for the works with the search query
+            pagination = Pagination(offset=page_size * page_num, size=page_size)
+            wl = WorkList()
+            wl.initialize(custom_list.library)
+            works = wl.search(
+                _db, json_query, search, pagination=pagination, facets=facets
+            )
+
+            ## No more works
+            if not len(works):
+                log.info(
+                    f"{custom_list.name} customlist updated with {total_works_updated} works, moving on..."
+                )
+                break
+
+            total_works_updated += len(works)
+
+            ## Now update works into the list
+            for work in works:
+                custom_list.add_entry(work, update_external_index=True)
+
+            log.info(
+                f"Updated customlist {custom_list.name} with {total_works_updated} works"
+            )
+
+        # update this lists last updated time
+        custom_list.auto_update_last_update = datetime.datetime.now()
+
+        return total_works_updated

--- a/core/query/customlist.py
+++ b/core/query/customlist.py
@@ -113,5 +113,7 @@ class CustomListQueries:
 
         # update this lists last updated time
         custom_list.auto_update_last_update = datetime.datetime.now()
+        # update the list size
+        custom_list.size = len(custom_list.entries)
 
         return total_works_updated

--- a/core/query/customlist.py
+++ b/core/query/customlist.py
@@ -59,9 +59,11 @@ class CustomListQueries:
         json_query: dict = None,
     ) -> int:
         """Populate the custom list while paging through the search query results
+        :param _db: The database conenction
+        :param custom_list: The list to be populated
         :param start_page: Offset of the search will be used from here (based on page_size)
-        :param page_size: Page size to use for the search iteration
         :param max_pages: Maximum number of pages to search through
+        :param page_size: Page size to use for the search iteration
         :param json_query: If provided, use this json query rather than that of the custom list"""
 
         log = logging.getLogger("Auto Update Custom List")

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -3519,7 +3519,15 @@ class CustomListUpdateEntriesScript(CustomListSweeperScript):
             # We're in the init phase, we need to back-populate all titles
             # starting from page 2, since page 1 should be already populated
             start_page = 2
+        elif custom_list.auto_update_status == CustomList.REPOPULATE:
+            # During a repopulate phase we must empty the list
+            # and start population from page 1
+            for entry in custom_list.entries:
+                self._db.delete(entry)
+            custom_list.entries = []
         else:
+            # Otherwise we are a update type process, which means we only search for
+            # "newer" books from the last time we updated the list
             try:
                 if custom_list.auto_update_query:
                     json_query = json.loads(custom_list.auto_update_query)

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -3526,7 +3526,7 @@ class CustomListUpdateEntriesScript(CustomListSweeperScript):
                 self._db.delete(entry)
             custom_list.entries = []
         else:
-            # Otherwise we are a update type process, which means we only search for
+            # Otherwise we are in an update type process, which means we only search for
             # "newer" books from the last time we updated the list
             try:
                 if custom_list.auto_update_query:

--- a/migration/20220913-customlists-add-status.sql
+++ b/migration/20220913-customlists-add-status.sql
@@ -1,0 +1,10 @@
+DO $$
+ BEGIN
+  BEGIN
+   CREATE TYPE auto_update_status AS ENUM ('init', 'updated', 'populated');
+  EXCEPTION
+   WHEN duplicate_object THEN RAISE NOTICE 'type auto_update_status already exists.';
+  END;
+  ALTER TABLE customlists ADD COLUMN IF NOT EXISTS auto_update_status auto_update_status DEFAULT 'init';
+ END;
+$$;

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -1099,7 +1099,9 @@ class TestCustomListsController(AdminControllerTest):
             assert collection.protocol == c.get("protocol")
             assert True == l1.get("auto_update")
             assert auto_update_query == l1.get("auto_update_query")
+            assert CustomList.INIT == l1.get("auto_update_status")
             assert False == l1.get("is_shared")
+            assert True == l1.get("is_owner")
 
             assert no_entries.id == l2.get("id")
             assert no_entries.name == l2.get("name")
@@ -1107,7 +1109,9 @@ class TestCustomListsController(AdminControllerTest):
             assert 0 == len(l2.get("collections"))
             assert False == l2.get("auto_update")
             assert None == l2.get("auto_update_query")
+            assert CustomList.INIT == l2.get("auto_update_status")
             assert True == l2.get("is_shared")
+            assert True == l2.get("is_owner")
 
         self.admin.remove_role(AdminRole.LIBRARIAN, self._default_library)
         with self.request_context_with_library_and_admin("/"):
@@ -1801,6 +1805,7 @@ class TestCustomListsController(AdminControllerTest):
                 auto_update=False,
                 auto_update_query=None,
                 auto_update_facets=None,
+                auto_update_status=CustomList.INIT,
                 is_owner=False,
                 is_shared=True,
             )

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -1822,8 +1822,6 @@ class TestCustomListsController(AdminControllerTest):
         custom_list.auto_update_status = CustomList.UPDATED
         self._db.commit()
 
-        print(custom_list.library, self._default_library)
-
         response = self.manager.admin_custom_lists_controller._create_or_update_list(
             custom_list.library,
             custom_list.name,

--- a/tests/core/test_customlist_queries.py
+++ b/tests/core/test_customlist_queries.py
@@ -1,0 +1,44 @@
+from unittest import mock
+
+from core.query.customlist import CustomListQueries
+from core.testing import DatabaseTest
+
+
+@mock.patch("core.query.customlist.ExternalSearchIndex")
+@mock.patch("core.query.customlist.WorkList")
+class TestCustomListQueries(DatabaseTest):
+    def test_populate_query_pages_single(self, mock_wl, mock_search):
+        w1 = self._work()
+        mock_wl().search.side_effect = [[w1], []]
+        custom_list, _ = self._customlist(num_entries=0)
+        custom_list.auto_update_query = "{}"
+
+        assert 1 == CustomListQueries.populate_query_pages(self._db, custom_list)
+        assert mock_wl().search.call_count == 2
+        assert [e.work_id for e in custom_list.entries] == [w1.id]
+
+    def test_populate_query_multi_page(self, mock_wl, mock_search):
+        w1 = self._work()
+        w2 = self._work()
+        mock_wl().search.side_effect = [[w1], [w2], []]
+        custom_list, _ = self._customlist(num_entries=0)
+        custom_list.auto_update_query = "{}"
+
+        assert 2 == CustomListQueries.populate_query_pages(self._db, custom_list)
+        assert mock_wl().search.call_count == 3
+        assert [e.work_id for e in custom_list.entries] == [w1.id, w2.id]
+
+    def test_populate_query_pages(self, mock_wl, mock_search):
+        w1 = self._work()
+        w2 = self._work()
+        w3 = self._work()
+        mock_wl().search.side_effect = [[w1], [w2], [w3], []]
+        custom_list, _ = self._customlist(num_entries=0)
+        custom_list.auto_update_query = "{}"
+
+        assert 1 == CustomListQueries.populate_query_pages(
+            self._db, custom_list, max_pages=1, start_page=2, page_size=10
+        )
+        assert mock_wl().search.call_count == 1
+        assert [e.work_id for e in custom_list.entries] == [w1.id]
+        assert mock_wl().search.call_args_list[0][1]["pagination"].offset == 10

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -40,6 +40,7 @@ from core.model import (
 )
 from core.model.classification import Subject
 from core.model.configuration import ExternalIntegrationLink
+from core.model.customlist import CustomList
 from core.monitor import CollectionMonitor, Monitor, ReaperMonitor
 from core.opds_import import OPDSImportMonitor
 from core.s3 import MinIOUploader, MinIOUploaderConfiguration, S3Uploader
@@ -3106,6 +3107,11 @@ class TestCustomListUpdateEntriesScript(EndToEndSearchTest):
         self.unpopular_books: list[Work] = [
             self._work(with_license_pool=True, title="Unpopular Book") for _ in range(3)
         ]
+        # This is for back population only
+        self.populated_books[0].license_pools[0].availability_time = datetime.datetime(
+            1900, 1, 1
+        )
+        self._db.commit()
 
     def test_process_custom_list(self):
         last_updated = datetime.datetime.now() - datetime.timedelta(hours=1)
@@ -3116,6 +3122,7 @@ class TestCustomListUpdateEntriesScript(EndToEndSearchTest):
             dict(query=dict(key="title", value="Populated Book"))
         )
         custom_list.auto_update_last_update = last_updated
+        custom_list.auto_update_status = CustomList.UPDATED
 
         custom_list1, _ = self._customlist()
         custom_list1.library = self._default_library
@@ -3124,6 +3131,7 @@ class TestCustomListUpdateEntriesScript(EndToEndSearchTest):
             dict(query=dict(key="title", value="Unpopular Book"))
         )
         custom_list1.auto_update_last_update = last_updated
+        custom_list1.auto_update_status = CustomList.UPDATED
 
         # Do the process
         script = CustomListUpdateEntriesScript(self._db)
@@ -3136,9 +3144,9 @@ class TestCustomListUpdateEntriesScript(EndToEndSearchTest):
 
         self._db.refresh(custom_list)
         self._db.refresh(custom_list1)
-        assert len(custom_list.entries) == 1 + len(
-            self.populated_books
-        )  # default + new
+        assert (
+            len(custom_list.entries) == 1 + len(self.populated_books) - 1
+        )  # default + new - one past availability time
         assert len(custom_list1.entries) == 1 + len(
             self.unpopular_books
         )  # default + new
@@ -3146,7 +3154,7 @@ class TestCustomListUpdateEntriesScript(EndToEndSearchTest):
         assert custom_list.auto_update_last_update == frozen_time.time_to_freeze
         assert custom_list1.auto_update_last_update == frozen_time.time_to_freeze
 
-    @patch("core.scripts.ExternalSearchIndex")
+    @patch("core.query.customlist.ExternalSearchIndex")
     def test_search_facets(self, mock_index):
         last_updated = datetime.datetime.now() - datetime.timedelta(hours=1)
         custom_list, _ = self._customlist()
@@ -3183,6 +3191,22 @@ class TestCustomListUpdateEntriesScript(EndToEndSearchTest):
         script = CustomListUpdateEntriesScript(self._db)
         script.process_custom_list(custom_list)
         assert custom_list.auto_update_last_update == frozen_time.time_to_freeze
+
+    @patch("core.scripts.CustomListQueries")
+    def test_init_backpopulates(self, mock_queries):
+        custom_list, _ = self._customlist()
+        custom_list.library = self._default_library
+        custom_list.auto_update_enabled = True
+        custom_list.auto_update_query = json.dumps(
+            dict(query=dict(key="title", value="Populated Book"))
+        )
+        script = CustomListUpdateEntriesScript(self._db)
+        script.process_custom_list(custom_list)
+
+        args = mock_queries.populate_query_pages.call_args_list[0]
+        assert args[1]["json_query"] == None
+        assert args[1]["start_page"] == 2
+        assert custom_list.auto_update_status == CustomList.UPDATED
 
 
 class TestWorkConsolidationScript:


### PR DESCRIPTION
## Description
- The first time the list is created we populate only page 1 of the search
- The first time the script runs we back populate all titles from page 2
- Thereafter we only query for availability time > last updated time

Custom list auto update statuses have been added to track
- INIT: The initial phase of the auto update for back population
- UPDATED: The running phase of the script for future population
- REPOPULATE: To be used when a list query is edited

Some refactoring has been done to allow code reuse

---
Once the `auto_update_query` is edited through the API 
- Auto update status is set to `repopulate`
- The scheduled task will delete all entries in the list
- And proceed to repopulate the list from page 1

<!--- Describe your changes -->

## Motivation and Context
The previous implementation of the auto update initial state was not in line with the UX.
Auto update lists should be completely auto managed lists, with no ability to edit the entries manually
[Notion](https://www.notion.so/lyrasis/Custom-List-Auto-Update-Initial-entries-population-39796139c3654603a3f2d9c7dd972687)
[Notion 2](https://www.notion.so/lyrasis/Custom-List-Auto-Update-Update-auto-update-query-ea667680474f46ebb02149708c6a3752)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested the API changes with Postman
The unit tests have been updated to match the expectations

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
