### PR TITLE
Adds distributor to local analytics exporter.

### DIFF
--- a/api/local_analytics_exporter.py
+++ b/api/local_analytics_exporter.py
@@ -7,6 +7,7 @@ from sqlalchemy.sql.expression import and_, case, join, literal_column, or_
 from core.model import (
     CirculationEvent,
     Collection,
+    DataSource,
     Edition,
     Genre,
     Identifier,
@@ -46,6 +47,7 @@ class LocalAnalyticsExporter:
             "library_short_name",
             "library_name",
             "medium",
+            "distributor",
         ]
         output = BytesIO()
         writer = csv.writer(output, encoding="utf-8")
@@ -114,6 +116,7 @@ class LocalAnalyticsExporter:
                     Library.short_name.label("library_short_name"),
                     Library.name.label("library_name"),
                     Edition.medium,
+                    DataSource.name.label("distributor"),
                 ],
             )
             .select_from(
@@ -126,6 +129,7 @@ class LocalAnalyticsExporter:
                 .join(Work, Work.id == LicensePool.work_id)
                 .join(Edition, Work.presentation_edition_id == Edition.id)
                 .join(Collection, LicensePool.collection_id == Collection.id)
+                .join(DataSource, LicensePool.data_source_id == DataSource.id)
                 .outerjoin(Library, CirculationEvent.library_id == Library.id)
             )
             .where(and_(*clauses))
@@ -210,6 +214,7 @@ class LocalAnalyticsExporter:
                 events.library_short_name,
                 events.library_name,
                 events.medium,
+                events.distributor,
             ]
         ).select_from(events_alias)
         return query

--- a/tests/api/test_local_analytics_exporter.py
+++ b/tests/api/test_local_analytics_exporter.py
@@ -19,6 +19,7 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         [lp2] = w2.license_pools
         lp1.collection = c1
         lp2.collection = c2
+
         edition1 = w1.presentation_edition
         edition1.publisher = "A publisher"
         edition1.imprint = "An imprint"
@@ -104,11 +105,12 @@ class TestLocalAnalyticsExporter(DatabaseTest):
             "",
             "",
             edition1.medium,
+            lp1.data_source.name,
         ]
 
-        expected_row_count = 18
+        expected_column_count = 19
         for row in rows:
-            assert expected_row_count == len(row)
+            assert expected_column_count == len(row)
             assert constant == row[2:]
 
         # Now run a query that includes the last event created.
@@ -124,7 +126,7 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         all_but_last_row = rows[:-1]
         assert types == [row[1] for row in all_but_last_row]
         for row in all_but_last_row:
-            assert expected_row_count == len(row)
+            assert expected_column_count == len(row)
             assert constant == row[2:]
 
         # Now let's look at the last row. It's got metadata from a
@@ -148,6 +150,7 @@ class TestLocalAnalyticsExporter(DatabaseTest):
             "",
             "",
             edition1.medium,
+            lp2.data_source.name,
         ] == rows[-1][1:]
 
         output = exporter.export(self._db, today, today)
@@ -205,7 +208,7 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         assert num == len(rows)
         assert types == [row[1] for row in rows]
         for row in rows:
-            assert expected_row_count == len(row)
+            assert expected_column_count == len(row)
             assert constant_with_library == row[2:]
 
         # We are looking for events from a different library but there
@@ -311,5 +314,5 @@ class TestLocalAnalyticsExporter(DatabaseTest):
         # After the start time and event type, the rest of the row is
         # the same content we've come to expect.
         for row in rows:
-            assert expected_row_count == len(row)
+            assert expected_column_count == len(row)
             assert constant == row[2:]


### PR DESCRIPTION
## Description

Adds distributor to local analytics exporter.  As it turns out,  license type and new patron info does not belong in this export.  See ticket below for details.

## Motivation and Context

https://www.notion.so/lyrasis/Add-license-type-distributor-and-count-of-new-patron-logins-to-export-for-Palace-Manager-analytics-a2f3042bb11d4976aee9e4248faefcf1


## How Has This Been Tested?

Manually tested by downloading the stats from the Dashboard and verifying the distributor column is there.  
A existing unit test was updated to cover new field.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
