### PR TITLE
Fix flakey OPDS API test

### DIFF
--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -7,6 +7,7 @@ from unittest.mock import create_autospec
 import dateutil
 import feedparser
 import pytest
+from freezegun import freeze_time
 from lxml import etree
 
 from api.adobe_vendor_id import AuthdataUtility
@@ -492,6 +493,12 @@ class TestLibraryAnnotator(VendorIDTest):
         link = self.annotator.fulfill_link(pool, None, lpdm, OPDSFeed.OPEN_ACCESS_REL)
         assert OPDSFeed.OPEN_ACCESS_REL == link.attrib["rel"]
 
+    # We freeze the test time here, because this test checks that the client token
+    # in the feed matches a generated client token. The client token contains an
+    # expiry date based on the current time, so this test can be flaky in a slow
+    # integration environment unless we make sure the clock does not change as this
+    # test is being performed.
+    @freeze_time("1867-07-01")
     def test_fulfill_link_includes_device_registration_tags(self):
         """Verify that when Adobe Vendor ID delegation is included, the
         fulfill link for an Adobe delivery mechanism includes instructions


### PR DESCRIPTION
## Description

I'm trying to reduce our random test failures when I see them.

Saw this test failure [today](https://github.com/ThePalaceProject/circulation/actions/runs/3090239014/jobs/4998784014#step:7:476): 
```
          # The drm:licensor tag is the one we get by calling
          # adobe_id_tags() on that identifier.
          [expect] = self.annotator.adobe_id_tags(adobe_id_identifier.credential)
  >       assert etree.tostring(expect, method="c14n2") == etree.tostring(
              licensor, method="c14n2"
          )
  E       assert b'<ns0:licens...ns0:licensor>' == b'<ns0:licens...ns0:licensor>'
  E         At index 127 diff: b'7' != b'6'
  E         Full diff:
  E           (
  E            b'<ns0:licensor xmlns:ns0="http://librarysimplified.org/terms/drm" ns0:vendor='
  E         -  b'"vendor id"><ns0:clientToken>DEFAULTTOKEN|1663682426|328a4b64-38e4-11ed-8707'
  E         ?                                                       ^
  E         +  b'"vendor id"><ns0:clientToken>DEFAULTTOKEN|1663682427|328a4b64-38e4-11ed-8707'
  E         ?                                                       ^
  E         -  b'-e1b5ef77cc37|wGWovL12QzN2JlpDWmLiUvZLrPsYpgWxCEdQae7oDbs@</ns0:clientToken>'
  E         +  b'-e1b5ef77cc37|:8:fl3klsk4JbWot:KYltWuk23OmDji:7het10eHcwQ@</ns0:clientToken>'
  E            b'<link href="http://host/adobe_drm_devices?library_short_name=default" rel="h'
  E            b'ttp://librarysimplified.org/terms/drm/rel/devices"></link></ns0:licensor>',
  E           )
```

Looks like it failed because the time changed from when the first token and second token were generated.

## Motivation and Context

Adding a `freeze_time` to this test should make sure we get less random failures due to the tests running slower in CI.

## How Has This Been Tested?

Ran units tests.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
