### PR TITLE
Escape special characters in Docker environment variable values.

### DIFF
--- a/docker/startup/01_set_simplified_environment.sh
+++ b/docker/startup/01_set_simplified_environment.sh
@@ -13,10 +13,10 @@ touch $SIMPLIFIED_ENVIRONMENT
 # Move all of the environment variables with Library Simplified prefixes
 # into an environment file. This will allow the environment to be loaded when
 # cron tasks are run, since crontab doesn't load them automatically.
-printenv | \
-  grep -e SIMPLIFIED -e LIBSIMPLE | \
-  sed 's/^\(.*\)$/export \1/g' | \
-  cat > $SIMPLIFIED_ENVIRONMENT
+# The values of the variables are escaped as needed for the shell.
+for var in $(printenv | grep -e SIMPLIFIED -e LIBSIMPLE | sed -e 's/^\([^=]*\)=.*$/\1/g'); do {
+  printf "export ${var}=%q\n" $(printenv "${var}")
+} done > $SIMPLIFIED_ENVIRONMENT
 
 # Give it to the appropriate user.
 chown simplified:simplified $SIMPLIFIED_ENVIRONMENT


### PR DESCRIPTION
## Description

Changes Docker setup to escape special characters in the environment variables copied into app setup script in the scripts container.

## Motivation and Context

The variables are exported from this script with Bash, so are interpreted by the shell. Failure to escape certain special characters in these values caused errors when attempting to export the settings while activating the virtual environment. 

In addition, the way the variables were copied into the setup file could have allowed variable interpolation and created security vulnerabilities.

## How Has This Been Tested?

The changes were applied to fix a running environment that was affected by the error. More testing will be conducted after a container is built.

## Checklist

- N/A I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
