### PR TITLE
Update poetry to 1.2.1

### DIFF
--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: "Version of poetry to install"
     required: false
-    default: "1.1.12"
+    default: "1.2.1"
 
 outputs:
   version:

--- a/docker/app_setup.sh
+++ b/docker/app_setup.sh
@@ -20,7 +20,7 @@ echo "if [[ -f $SIMPLIFIED_ENVIRONMENT ]]; then \
       source $SIMPLIFIED_ENVIRONMENT; fi" >> env/bin/activate
 
 # Install Python libraries.
-poetry install --no-dev --no-root -E pg
+poetry install --only main --no-root -E pg
 poetry cache clear -n --all pypi
 
 # Install NLTK.

--- a/docker/system_setup.sh
+++ b/docker/system_setup.sh
@@ -24,7 +24,7 @@ install_clean --no-upgrade \
   pkg-config
 
 # Install Poetry
-curl -sSL https://install.python-poetry.org | POETRY_HOME="/opt/poetry" python3 - --yes --version "1.1.12"
+curl -sSL https://install.python-poetry.org | POETRY_HOME="/opt/poetry" python3 - --yes --version "1.2.1"
 ln -s /opt/poetry/bin/poetry /bin/poetry
 
 # Copy scripts that run at startup.


### PR DESCRIPTION
## Description

Update the version of Poetry we are using in Docker and CI to 1.2.1. 

Homebrew on my system updated Poetry to 1.2.1 today, then when I committed a update to a poetry lock file all of a sudden setuptools was being uninstalled by poetry. Apparently lock files generated by poetry 1.2.1 are not compatible with 1.1.x and will cause setuptools to be uninstalled 

https://github.com/python-poetry/poetry/issues/4242

## Motivation and Context

It seems reasonable to update the version of poetry we use, since 1.2 can read lock files from 1.1, but 1.1 can't correctly read lock files generated by 1.2.

## How Has This Been Tested?

Compared the packages we installed with Poetry 1.1 vs Poetry 1.2 by hand. CI running and building a docker container should show that this is working.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
