### PR TITLE
Aligns the item count with the number of items in the list when works…

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1053,12 +1053,7 @@ class CustomListsController(AdminCirculationManagerController):
             if isinstance(pagination, ProblemDetail):
                 return pagination
 
-            query = (
-                self._db.query(Work)
-                .join(Work.custom_list_entries)
-                .filter(CustomListEntry.list_id == list_id)
-                .order_by(Work.id)
-            )
+            query = CustomList.list_entries(self._db, list_id)
             url = self.url_for(
                 "custom_list",
                 list_name=list.name,

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -1053,7 +1053,7 @@ class CustomListsController(AdminCirculationManagerController):
             if isinstance(pagination, ProblemDetail):
                 return pagination
 
-            query = CustomList.list_entries(self._db, list_id)
+            query = CustomList.entries_having_works(self._db, list_id)
             url = self.url_for(
                 "custom_list",
                 list_name=list.name,

--- a/core/model/customlist.py
+++ b/core/model/customlist.py
@@ -113,7 +113,7 @@ class CustomList(Base):
         )
 
     @classmethod
-    def list_entries(cls, _db: Session, list_id: int):
+    def entries_having_works(cls, _db: Session, list_id: int):
         return (
             _db.query(Work)
             .join(Work.custom_list_entries)
@@ -327,7 +327,7 @@ class CustomList(Base):
         return qu
 
     def update_size(self, db: Session):
-        self.size = CustomList.list_entries(db, self.id).count()
+        self.size = CustomList.entries_having_works(db, self.id).count()
 
 
 customlist_sharedlibrary = Table(

--- a/core/model/customlist.py
+++ b/core/model/customlist.py
@@ -113,6 +113,15 @@ class CustomList(Base):
         )
 
     @classmethod
+    def list_entries(cls, _db: Session, list_id: int):
+        return (
+            _db.query(Work)
+            .join(Work.custom_list_entries)
+            .filter(CustomListEntry.list_id == list_id)
+            .order_by(Work.id)
+        )
+
+    @classmethod
     def all_from_data_sources(cls, _db, data_sources):
         """All custom lists from the given data sources."""
         if not isinstance(data_sources, list):
@@ -317,8 +326,8 @@ class CustomList(Base):
         )
         return qu
 
-    def update_size(self):
-        self.size = len(self.entries)
+    def update_size(self, db: Session):
+        self.size = CustomList.list_entries(db, self.id).count()
 
 
 customlist_sharedlibrary = Table(

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -3426,7 +3426,7 @@ class UpdateLaneSizeScript(LaneSweeperScript):
 
 class UpdateCustomListSizeScript(CustomListSweeperScript):
     def process_custom_list(self, custom_list):
-        custom_list.update_size()
+        custom_list.update_size(self._db)
 
 
 class RemovesSearchCoverage:

--- a/tests/core/models/test_customlist.py
+++ b/tests/core/models/test_customlist.py
@@ -351,7 +351,7 @@ class TestCustomList(DatabaseTest):
         list, ignore = self._customlist(num_entries=4)
         # This list has an incorrect cached size.
         list.size = 44
-        list.update_size()
+        list.update_size(self._db)
         assert 4 == list.size
 
 


### PR DESCRIPTION
… in list are no longer available.


## Description

This update ensures that the count of all items in the list uses the same query that is used to generate the list. 
## Motivation and Context
https://www.notion.so/lyrasis/Titles-missing-from-lists-lanes-in-CM-and-lanes-in-app-088f95698cdd4935898c01f0fc01f0b5


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Existing tests were updated to account for changes.  
It should be manually tested to ensure that works that have been disassociated from the list are no longer being counted.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
