### PR TITLE
Configurable setting for external search versions

### DIFF
--- a/api/admin/controller/search_service_self_tests.py
+++ b/api/admin/controller/search_service_self_tests.py
@@ -24,6 +24,6 @@ class SearchServiceSelfTestsController(SelfTestsController, ExternalSearchTest):
     def look_up_by_id(self, identifier):
         return self.look_up_service_by_id(
             identifier,
-            ExternalIntegration.OPENSEARCH,
+            ExternalIntegration.ELASTICSEARCH,
             ExternalIntegration.SEARCH_GOAL,
         )

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -5,7 +5,7 @@ import logging
 import re
 import time
 from collections import defaultdict
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from attr import define
 from elasticsearch import Elasticsearch
@@ -96,7 +96,7 @@ class ExternalSearchIndex(HasSelfTests):
     SEARCH_VERSION_OS1_2 = "Opensearch 1.2"
     DEFAULT_SEARCH_VERSION = SEARCH_VERSION_ES6_86
 
-    work_document_type = None
+    work_document_type: Optional[str] = None
     __client = None
 
     CURRENT_ALIAS_SUFFIX = "current"
@@ -115,7 +115,7 @@ class ExternalSearchIndex(HasSelfTests):
             "default": DEFAULT_WORKS_INDEX_PREFIX,
             "required": True,
             "description": _(
-                "Any Opensearch indexes needed for this application will be created with this unique prefix. In most cases, the default will work fine. You may need to change this if you have multiple application servers using a single Opensearch server."
+                "Any Search indexes needed for this application will be created with this unique prefix. In most cases, the default will work fine. You may need to change this if you have multiple application servers using a single Search server."
             ),
         },
         {
@@ -247,7 +247,7 @@ class ExternalSearchIndex(HasSelfTests):
 
         if not _db:
             raise CannotLoadConfiguration(
-                "Cannot load Opensearch configuration without a database.",
+                "Cannot load Search configuration without a database.",
             )
 
         # initialize the cached data if not already done so
@@ -292,7 +292,7 @@ class ExternalSearchIndex(HasSelfTests):
                 raise
             except ElasticsearchException as e:
                 raise CannotLoadConfiguration(
-                    "Exception communicating with Opensearch server: %s" % repr(e)
+                    "Exception communicating with Search server: %s" % repr(e)
                 )
 
         self.search = Search(using=self.__client, index=self.works_alias)
@@ -594,9 +594,7 @@ class ExternalSearchIndex(HasSelfTests):
 
         if debug:
             b = time.time()
-            self.log.debug(
-                "Opensearch query %r completed in %.3fsec", query_string, b - a
-            )
+            self.log.debug("Search query %r completed in %.3fsec", query_string, b - a)
             for results in resultset:
                 for i, result in enumerate(results):
                     self.log.debug(
@@ -814,8 +812,8 @@ class MappingDocument:
     def __init__(self, service: ExternalSearchIndex):
         self.service = service
         self.has_document_types = self.service.work_document_type is not None
-        self.properties = {}
-        self.subdocuments = {}
+        self.properties: Dict[str, Any] = {}
+        self.subdocuments: Dict[str, Any] = {}
 
     def add_property(self, name, type, **description):
         """Add a field to the list of properties.

--- a/core/testing.py
+++ b/core/testing.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from datetime import timedelta
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Set, Union
 from unittest import mock
 
 import pytest
@@ -1165,7 +1165,7 @@ class ExternalSearchTest(DatabaseTest):
         "SIMPLIFIED_TEST_ELASTICSEARCH", "http://localhost:9200"
     )
 
-    DUAL_TESTS_RUN = set()
+    DUAL_TESTS_RUN: Set[str] = set()
 
     def setup_method(self, request):
 

--- a/core/testing.py
+++ b/core/testing.py
@@ -1159,36 +1159,72 @@ class ExternalSearchTest(DatabaseTest):
     to ensure that it works well overall, with a realistic index.
     """
 
+    TESTING_VERSION = ExternalSearchIndex.SEARCH_VERSION_ES6_86
+
     SIMPLIFIED_TEST_ELASTICSEARCH = os.environ.get(
         "SIMPLIFIED_TEST_ELASTICSEARCH", "http://localhost:9200"
     )
 
-    def setup_method(self):
+    DUAL_TESTS_RUN = set()
+
+    def setup_method(self, request):
 
         super().setup_method()
+
+        # We always default to elasticsearch, unless both indices are available
+        from tests.core.conftest import DUAL_SEARCH_PRESENT
+
+        if DUAL_SEARCH_PRESENT:
+            self._setup_dual_search_test(request)
 
         # Track the indexes created so they can be torn down at the
         # end of the test.
         self.indexes = []
 
         self.integration = self._external_integration(
-            ExternalIntegration.OPENSEARCH,
+            ExternalIntegration.ELASTICSEARCH,
             goal=ExternalIntegration.SEARCH_GOAL,
             url=self.SIMPLIFIED_TEST_ELASTICSEARCH,
             settings={
                 ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY: "test_index",
                 ExternalSearchIndex.TEST_SEARCH_TERM_KEY: "test_search_term",
+                ExternalSearchIndex.SEARCH_VERSION: self.TESTING_VERSION,
             },
         )
 
         try:
-            self.search = SearchClientForTesting(self._db)
+            self.search = SearchClientForTesting(self._db, version=self.TESTING_VERSION)
         except Exception as e:
             self.search = None
             logging.error(
                 "Unable to set up elasticsearch index, search tests will be skipped.",
                 exc_info=e,
             )
+
+    def _setup_dual_search_test(self, request):
+        """In case we have dual search service testing for this test class
+        we do the following to switch around which search index we're testing against.
+        - We do not have access to the "dual_search_test" fixture so we don't know which run this is
+        - We store the method name in a list of previously run tests
+        - If it is the second run of the method, we switch the search index"""
+        # mark this test function for dual testing if required
+        name = f"{request.__self__.__class__}.{request.__name__}"
+
+        self.TESTING_VERSION = ExternalSearchIndex.SEARCH_VERSION_ES6_86
+        if getattr(self, "DUAL_SEARCH_TEST", None):
+            if name not in ExternalSearchTest.DUAL_TESTS_RUN:
+                # This is a dual run test, but it's the first run
+                ExternalSearchTest.DUAL_TESTS_RUN.add(name)
+            else:
+                # This is the second run
+                self.TESTING_VERSION = ExternalSearchIndex.SEARCH_VERSION_OS1_2
+
+        self.SIMPLIFIED_TEST_ELASTICSEARCH = os.environ.get(
+            "SIMPLIFIED_TEST_OPENSEARCH"
+            if self.TESTING_VERSION == ExternalSearchIndex.SEARCH_VERSION_OS1_2
+            else "SIMPLIFIED_TEST_ELASTICSEARCH",
+            "http://localhost:9200",
+        )
 
     def setup_index(self, new_index):
         "Create an index and register it to be destroyed during teardown."
@@ -1222,8 +1258,8 @@ class EndToEndSearchTest(ExternalSearchTest):
     search index and run searches against it.
     """
 
-    def setup_method(self):
-        super().setup_method()
+    def setup_method(self, request):
+        super().setup_method(request)
 
         # Create some works.
         if not self.search:

--- a/tests/api/admin/controller/test_search_service_self_tests.py
+++ b/tests/api/admin/controller/test_search_service_self_tests.py
@@ -29,7 +29,7 @@ class TestSearchServiceSelfTests(SettingsControllerTest):
         search_service, ignore = create(
             self._db,
             ExternalIntegration,
-            protocol=ExternalIntegration.OPENSEARCH,
+            protocol=ExternalIntegration.ELASTICSEARCH,
             goal=ExternalIntegration.SEARCH_GOAL,
         )
         # Make sure that HasSelfTest.prior_test_results() was called and that
@@ -61,7 +61,7 @@ class TestSearchServiceSelfTests(SettingsControllerTest):
         search_service, ignore = create(
             self._db,
             ExternalIntegration,
-            protocol=ExternalIntegration.OPENSEARCH,
+            protocol=ExternalIntegration.ELASTICSEARCH,
             goal=ExternalIntegration.SEARCH_GOAL,
         )
         m = (

--- a/tests/api/admin/controller/test_search_services.py
+++ b/tests/api/admin/controller/test_search_services.py
@@ -15,7 +15,9 @@ class TestSearchServices(SettingsControllerTest):
             response = self.manager.admin_search_services_controller.process_services()
             assert response.get("search_services") == []
             protocols = response.get("protocols")
-            assert ExternalIntegration.OPENSEARCH in [p.get("name") for p in protocols]
+            assert ExternalIntegration.ELASTICSEARCH in [
+                p.get("name") for p in protocols
+            ]
             assert "settings" in protocols[0]
 
             self.admin.remove_role(AdminRole.SYSTEM_ADMIN)
@@ -29,7 +31,7 @@ class TestSearchServices(SettingsControllerTest):
         search_service, ignore = create(
             self._db,
             ExternalIntegration,
-            protocol=ExternalIntegration.OPENSEARCH,
+            protocol=ExternalIntegration.ELASTICSEARCH,
             goal=ExternalIntegration.SEARCH_GOAL,
         )
         search_service.url = "search url"
@@ -85,7 +87,7 @@ class TestSearchServices(SettingsControllerTest):
         service, ignore = create(
             self._db,
             ExternalIntegration,
-            protocol=ExternalIntegration.OPENSEARCH,
+            protocol=ExternalIntegration.ELASTICSEARCH,
             goal=ExternalIntegration.SEARCH_GOAL,
         )
 
@@ -93,7 +95,7 @@ class TestSearchServices(SettingsControllerTest):
             flask.request.form = MultiDict(
                 [
                     ("name", "Name"),
-                    ("protocol", ExternalIntegration.OPENSEARCH),
+                    ("protocol", ExternalIntegration.ELASTICSEARCH),
                 ]
             )
             response = controller.process_services()
@@ -112,7 +114,7 @@ class TestSearchServices(SettingsControllerTest):
             flask.request.form = MultiDict(
                 [
                     ("name", service.name),
-                    ("protocol", ExternalIntegration.OPENSEARCH),
+                    ("protocol", ExternalIntegration.ELASTICSEARCH),
                 ]
             )
             response = controller.process_services()
@@ -121,7 +123,7 @@ class TestSearchServices(SettingsControllerTest):
         service, ignore = create(
             self._db,
             ExternalIntegration,
-            protocol=ExternalIntegration.OPENSEARCH,
+            protocol=ExternalIntegration.ELASTICSEARCH,
             goal=ExternalIntegration.SEARCH_GOAL,
         )
 
@@ -130,7 +132,7 @@ class TestSearchServices(SettingsControllerTest):
                 [
                     ("name", "Name"),
                     ("id", service.id),
-                    ("protocol", ExternalIntegration.OPENSEARCH),
+                    ("protocol", ExternalIntegration.ELASTICSEARCH),
                 ]
             )
             response = controller.process_services()
@@ -140,7 +142,7 @@ class TestSearchServices(SettingsControllerTest):
         with self.request_context_with_admin("/", method="POST"):
             flask.request.form = MultiDict(
                 [
-                    ("protocol", ExternalIntegration.OPENSEARCH),
+                    ("protocol", ExternalIntegration.ELASTICSEARCH),
                     (ExternalIntegration.URL, "search url"),
                     (ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY, "works-index-prefix"),
                 ]
@@ -152,7 +154,7 @@ class TestSearchServices(SettingsControllerTest):
             flask.request.form = MultiDict(
                 [
                     ("name", "Name"),
-                    ("protocol", ExternalIntegration.OPENSEARCH),
+                    ("protocol", ExternalIntegration.ELASTICSEARCH),
                     (ExternalIntegration.URL, "http://search_url"),
                     (ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY, "works-index-prefix"),
                     (ExternalSearchIndex.TEST_SEARCH_TERM_KEY, "sample-search-term"),
@@ -165,7 +167,7 @@ class TestSearchServices(SettingsControllerTest):
             self._db, ExternalIntegration, goal=ExternalIntegration.SEARCH_GOAL
         )
         assert service.id == int(response.response[0])
-        assert ExternalIntegration.OPENSEARCH == service.protocol
+        assert ExternalIntegration.ELASTICSEARCH == service.protocol
         assert "http://search_url" == service.url
         assert (
             "works-index-prefix"
@@ -180,7 +182,7 @@ class TestSearchServices(SettingsControllerTest):
         search_service, ignore = create(
             self._db,
             ExternalIntegration,
-            protocol=ExternalIntegration.OPENSEARCH,
+            protocol=ExternalIntegration.ELASTICSEARCH,
             goal=ExternalIntegration.SEARCH_GOAL,
         )
         search_service.url = "search url"
@@ -196,7 +198,7 @@ class TestSearchServices(SettingsControllerTest):
                 [
                     ("name", "Name"),
                     ("id", search_service.id),
-                    ("protocol", ExternalIntegration.OPENSEARCH),
+                    ("protocol", ExternalIntegration.ELASTICSEARCH),
                     (ExternalIntegration.URL, "http://new_search_url"),
                     (
                         ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY,
@@ -212,7 +214,7 @@ class TestSearchServices(SettingsControllerTest):
             assert response.status_code == 200
 
         assert search_service.id == int(response.response[0])
-        assert ExternalIntegration.OPENSEARCH == search_service.protocol
+        assert ExternalIntegration.ELASTICSEARCH == search_service.protocol
         assert "http://new_search_url" == search_service.url
         assert (
             "new-works-index-prefix"
@@ -227,7 +229,7 @@ class TestSearchServices(SettingsControllerTest):
         search_service, ignore = create(
             self._db,
             ExternalIntegration,
-            protocol=ExternalIntegration.OPENSEARCH,
+            protocol=ExternalIntegration.ELASTICSEARCH,
             goal=ExternalIntegration.SEARCH_GOAL,
         )
         search_service.url = "search url"

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,3 +1,30 @@
 # Pull in the session_fixture defined in core/testing.py
 # which does the database setup and initialization
 pytest_plugins = ["core.testing"]
+
+import os
+
+import pytest
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc):
+    _setup_dual_search_tests(metafunc)
+
+
+# Test the env variables for dual testing availability
+DUAL_SEARCH_PRESENT = None not in [
+    os.environ.get("SIMPLIFIED_TEST_ELASTICSEARCH"),
+    os.environ.get("SIMPLIFIED_TEST_OPENSEARCH"),
+]
+
+
+def _setup_dual_search_tests(metafunc: pytest.Metafunc):
+    """If dual search indexes are available, we parameterize the marked test classes
+    with 2 parameters so we have 2 runs of each method"""
+    if (
+        DUAL_SEARCH_PRESENT
+        and metafunc.cls
+        and getattr(metafunc.cls, "DUAL_SEARCH_TEST", None)
+    ):
+        metafunc.fixturenames.append("dual_search_test")
+        metafunc.parametrize("dual_search_test", ["ElasticSearch", "OpenSearch"])

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -64,6 +64,8 @@ RESEARCH = Term(audience=Classifier.AUDIENCE_RESEARCH.lower())
 
 
 class TestExternalSearch(ExternalSearchTest):
+    DUAL_SEARCH_TEST = True
+
     def test_load(self):
         # Normally, load() returns a brand new ExternalSearchIndex
         # object.
@@ -364,9 +366,11 @@ class TestExternalSearch(ExternalSearchTest):
         assert "new_long_property" not in put_mapping
 
         new_mapping = self.search.indices.get_mapping(self.search.works_index)
-        assert (
-            "new_long_property"
-            in new_mapping[self.search.works_index]["mappings"]["properties"]
+        new_mapping = new_mapping[self.search.works_index]["mappings"]
+        assert "new_long_property" in (
+            new_mapping["properties"]
+            if not self.search.work_document_type
+            else new_mapping[self.search.work_document_type]["properties"]
         )
 
 
@@ -424,6 +428,8 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
     Don't add new methods to this class - add more tests into test_query_works,
     or add a new test class.
     """
+
+    DUAL_SEARCH_TEST = True
 
     def populate_works(self):
         _work = self.default_work
@@ -1093,6 +1099,13 @@ class TestExternalSearchWithWorks(EndToEndSearchTest):
                 (None, match_nothing, first_item),
             ],
         )
+
+    def test_remove_work(self):
+        self.search.remove_work(self.moby_dick)
+        self.search.remove_work(self.moby_duck)
+        # Immediately querying never works, the search index needs a second to refresh its cache/index/data
+        time.sleep(1)
+        self._expect_results([], "Moby")
 
 
 class TestFacetFilters(EndToEndSearchTest):

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -110,7 +110,7 @@ class TestExternalSearch(ExternalSearchTest):
 
         with pytest.raises(CannotLoadConfiguration) as excinfo:
             Mock(self._db)
-        assert "Exception communicating with Opensearch server: " in str(excinfo.value)
+        assert "Exception communicating with Search server: " in str(excinfo.value)
         assert "very bad" in str(excinfo.value)
 
     def test_works_index_name(self):


### PR DESCRIPTION
## Description
The versions supported are
- Elasticsearch 6.8.6
- Opensearch 1.2

The unit tests for ExternalSearchIndex now run in 2 different modes
depending on the environment available
Both search indexes can also be tested if both environments are available
The environment availability depends on the availability of the env variables
- SIMPLIFIED_TEST_ELASTICSEARCH
- SIMPLIFIED_TEST_OPENSEARCH

A pytest hook has been written that parameterizes any test class that has
been marked with a DUAL_SEARCH_TESTS variable
Each of the tests in those classes will be run with both search indexes
if both are available
By default the tests assume only elasticsearch is available

The main difference between both the versions is the removal of the document-type
from the index APIs, this is because OS1.2 (and ES7+) have removed multiple documents per index
as an option

Pending
- README updates
- Tox updates
<!--- Describe your changes -->

## Motivation and Context
While Opensearch is the direction the CM is moving towards for the future, the current deployments
are all based on Elasticsearch, to move from one to the other we will first need to support both versions
and slowly change over on a per deployment basis
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated
Manual testing has been done of listings
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
