### PR TITLE
Opensearch in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ skipsdist = true
 
 [testenv]
 commands_pre =
+    docker: docker exec os-circ /usr/share/opensearch/bin/opensearch-plugin -s install analysis-icu
+    docker: docker restart os-circ
     docker: docker exec es-circ elasticsearch-plugin -s install analysis-icu
     docker: docker restart es-circ
     poetry install --no-root -E pg-binary -v
@@ -15,10 +17,12 @@ passenv = SIMPLIFIED_* CI
 setenv =
     docker: SIMPLIFIED_TEST_DATABASE=postgresql://simplified_test:test@localhost:9005/simplified_circulation_test
     docker: SIMPLIFIED_TEST_ELASTICSEARCH=http://localhost:9006
+    docker: SIMPLIFIED_TEST_OPENSEARCH=http://localhost:9007
     core-docker: SIMPLIFIED_TEST_MINIO_ENDPOINT_URL=http://localhost:9004
     core-docker: SIMPLIFIED_TEST_MINIO_USER=simplified
     core-docker: SIMPLIFIED_TEST_MINIO_PASSWORD=12345678901234567890
 docker =
+    docker: os-circ
     docker: es-circ
     docker: db-circ
     core-docker: minio-circ
@@ -45,6 +49,14 @@ environment =
     discovery.type=single-node
 ports =
     9006:9200/tcp
+
+[docker:os-circ]
+image = opensearchproject/opensearch:1.2.0
+environment =
+    discovery.type=single-node
+    DISABLE_SECURITY_PLUGIN=true
+ports =
+    9007:9200/tcp
 
 [docker:minio-circ]
 image = bitnami/minio:2022.3.3


### PR DESCRIPTION
## Description
Added opensearch to the tox environment
    
opensearch-security is disabled for the testing environment to remove the requirement of having an SSL certificate during the testing phase
<!--- Describe your changes -->

## Motivation and Context
Opensearch and elasticsearch will both be supported in the near future, so we must have opensearch as a testable backend

[Notion](https://www.notion.so/lyrasis/Update-tox-to-use-Opensearch-1-2-b33eaa8df5034de1b4899a6928576d86)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually ran the tox commands
`tox -e py310-core-docker`
`tox -e py310-api-docker`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
