### PR TITLE
Failsafe redirect during admin sign in

### DIFF
--- a/api/admin/password_admin_authentication_provider.py
+++ b/api/admin/password_admin_authentication_provider.py
@@ -31,6 +31,8 @@ class PasswordAdminAuthenticationProvider(AdminAuthenticationProvider):
         email = request.get("email")
         password = request.get("password")
         redirect_url = request.get("redirect")
+        if redirect_url in (None, "None", "null"):
+            redirect_url = "/admin/web"
 
         if email and password:
             match = Admin.authenticate(_db, email, password)

--- a/tests/api/admin/test_password_admin_authentication_provider.py
+++ b/tests/api/admin/test_password_admin_authentication_provider.py
@@ -63,6 +63,14 @@ class TestPasswordAdminAuthenticationProvider(DatabaseTest):
         assert INVALID_ADMIN_CREDENTIALS == admin_details
         assert None == redirect
 
+        # Test with "empty" redirect urls, should redirect to admin home page
+        for redirect in (None, "None", "null"):
+            admin_details, redirect = password_auth.sign_in(
+                self._db,
+                dict(email="admin1@nypl.org", password="pass1", redirect=redirect),
+            )
+            assert redirect == "/admin/web"
+
     def test_sign_in_case_insensitive(self):
         password_auth = PasswordAdminAuthenticationProvider(None)
 


### PR DESCRIPTION
## Description
In case the redirect url is a "none" tyoe string we redirect to the admin home page
<!--- Describe your changes -->

## Motivation and Context
If the sign in page is gotten to by direct typing it into the url bar of the browser then the redirect url sent to the backend would be a "None" string. Which would in turn redirect to a non-existent "/None" page

[Notion](https://www.notion.so/lyrasis/URL-redirect-error-when-logging-into-CM-0f1fc0863a9e4769b7928b7fb1cab29e)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested this in the browser.
Unit tests have been updated for this use case.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
