### PR TITLE
Crontab entry to run the auto-updating lists script

### DIFF
--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -125,3 +125,7 @@ HOME=/var/www/circulation
 # SAML
 #
 0 5 * * * root core/bin/run saml_monitor >> /var/log/cron.log 2>&1
+
+# Auto update lists
+# Every hour between 7AM - 1AM
+5 1,7-23 * * * root core/bin/run custom_list_update_new_entries >> /var/log/cron.log 2>&1

--- a/docker/services/simplified_crontab
+++ b/docker/services/simplified_crontab
@@ -128,4 +128,4 @@ HOME=/var/www/circulation
 
 # Auto update lists
 # Every hour between 7AM - 1AM
-5 1,7-23 * * * root core/bin/run custom_list_update_new_entries >> /var/log/cron.log 2>&1
+5 0,1,7-23 * * * root core/bin/run custom_list_update_new_entries >> /var/log/cron.log 2>&1


### PR DESCRIPTION
## Description
Once an hour between 7AM and 1AM, 5 minutes past the hour (after update list size runs)
<!--- Describe your changes -->

## Motivation and Context
Now that the auto update UI is implemented and ready to be deployed, the cron job for updating the lists should be activated.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Locally by installing and checking the validity of the cron expression.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
