### PR TITLE
Update how we import DeMarque Audiobook Titles

### DIFF
--- a/api/odl2.py
+++ b/api/odl2.py
@@ -200,12 +200,7 @@ class ODL2Importer(OPDS2Importer, HasExternalIntegration):
                 if parsed_license is not None:
                     licenses.append(parsed_license)
 
-                # DPLA feed doesn't have information about a DRM protection used for audiobooks.
-                # We want to try to extract that information from the License Info Document it's present there.
                 license_formats = set(odl_license.metadata.formats)
-                if parsed_license and parsed_license.content_types:
-                    license_formats |= set(parsed_license.content_types)
-
                 for license_format in license_formats:
                     if (
                         skipped_license_formats
@@ -217,8 +212,11 @@ class ODL2Importer(OPDS2Importer, HasExternalIntegration):
                         medium = Edition.medium_from_media_type(license_format)
 
                     if license_format in ODLImporter.LICENSE_FORMATS:
-                        # Special case to handle DeMarque audiobooks which
-                        # include the protection in the content type
+                        # Special case to handle DeMarque audiobooks which include the protection
+                        # in the content type. When we see a license format of
+                        # application/audiobook+json; protection=http://www.feedbooks.com/audiobooks/access-restriction
+                        # it means that this audiobook title is available through the DeMarque streaming manifest
+                        # endpoint.
                         drm_schemes = [
                             ODLImporter.LICENSE_FORMATS[license_format][
                                 ODLImporter.DRM_SCHEME

--- a/tests/api/files/odl2/feed-audiobook-no-streaming.json
+++ b/tests/api/files/odl2/feed-audiobook-no-streaming.json
@@ -1,0 +1,200 @@
+{
+  "metadata": {
+    "title": "Test",
+    "itemsPerPage": 10,
+    "currentPage": 1,
+    "numberOfItems": 100
+  },
+  "links": [
+    {
+      "type": "application/opds+json",
+      "rel": "self",
+      "href": "https://market.feedbooks.com/api/libraries/harvest.json"
+    }
+  ],
+  "publications": [
+    {
+      "metadata": {
+        "@type": "http://schema.org/Book",
+        "title": "Gun Runner",
+        "duration": 64920,
+        "language": "en",
+        "modified": "2022-10-24T19:33:47Z",
+        "published": "2021-02-02T00:00:00Z",
+        "identifier": "urn:ISBN:9781603937221",
+        "author": [
+          {
+            "name": "Larry Correia",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/store/browse/recent.json?author_id=197931&lang=en"
+              }
+            ]
+          },
+          {
+            "name": "John Brown",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/store/browse/recent.json?author_id=34808&lang=en"
+              }
+            ]
+          }
+        ],
+        "narrator": [
+          {
+            "name": "Oliver Wyman",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/store/browse/recent.json?contributor_id=133023&lang=en"
+              }
+            ]
+          }
+        ],
+        "publisher": {
+          "name": "Audible Studios",
+          "links": [
+            {
+              "type": "application/opds+json",
+              "href": "https://market.feedbooks.com/store/browse/recent.json?lang=en&publisher=Audible+Studios"
+            }
+          ]
+        },
+        "description": "<p><b>Thrilling science-fiction adventure from best-selling authors Larry Correia and John Brown.</b></p>\n<p><b>The heart of a warrior </b></p>\n<p>Once, Jackson Rook was a war hero. Raised from boyhood to pilot an exosuit mech, he&#x2019;d fought gallantly for the rebellion against the Collectivists. But that was a long time ago, on a world very far away.&#xA0;</p>\n<p>Now, Jackson Rook is a criminal, a smuggler on board the Multipurpose Supply Vehicle <i>Tar Heel</i>. His latest mission: steal a top-of-the-line mech called the Citadel and deliver it to the far-flung planet Swindle, a world so hostile even the air will kill you. The client: a man known only as the Warlord.&#xA0;</p>\n<p>Rook has been in the smuggling business long enough to know that it&#x2019;s best to take the money and not ask questions. But Rook cannot stand by and watch as the Warlord runs roughshod over the citizens of Swindle, the way the Collectivists did on his homeworld. For all his mercenary ways, Rook is not a pirate. And deep within the smuggler, the heart of a warrior still beats.</p>",
+        "subject": [
+          {
+            "code": "FBFIC000000",
+            "name": "Fiction",
+            "scheme": "http://www.feedbooks.com/categories",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/category/FBFIC000000.json?lang=en"
+              }
+            ]
+          },
+          {
+            "code": "FBFIC028000",
+            "name": "Science fiction",
+            "scheme": "http://www.feedbooks.com/categories",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/category/FBFIC028000.json?lang=en"
+              }
+            ]
+          },
+          {
+            "code": "FBFIC028010",
+            "name": "Adventure",
+            "scheme": "http://www.feedbooks.com/categories",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/category/FBFIC028010.json?lang=en"
+              }
+            ]
+          },
+          {
+            "code": "FBFIC028030",
+            "name": "Space opera and planet opera",
+            "scheme": "http://www.feedbooks.com/categories",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/category/FBFIC028030.json?lang=en"
+              }
+            ]
+          },
+          {
+            "code": "FBFIC028050",
+            "name": "Military",
+            "scheme": "http://www.feedbooks.com/categories",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/category/FBFIC028050.json?lang=en"
+              }
+            ]
+          },
+          {
+            "code": "READ0000",
+            "scheme": "http://schema.org/Audience",
+            "name": "Adult",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/top.json?age=READ0000&lang=en"
+              }
+            ]
+          }
+        ]
+      },
+      "images": [
+        {
+          "href": "https://covers.feedbooks.net/item/4699654.jpg?size=large&t=1666640027",
+          "type": "image/jpeg",
+          "width": 260,
+          "height": 420
+        },
+        {
+          "href": "https://covers.feedbooks.net/item/4699654.jpg?t=1666640027",
+          "type": "image/jpeg",
+          "width": 100,
+          "height": 180
+        }
+      ],
+      "licenses": [
+        {
+          "metadata": {
+            "identifier": "urn:uuid:a44b9e96-7ad6-42b5-a86d-786563f32b12",
+            "format": [
+              "application/audiobook+lcp"
+            ],
+            "created": "2022-10-06T18:21:36+02:00",
+            "source": "http://www.cantook.net/",
+            "price": {
+              "currency": "USD",
+              "value": 99.99
+            },
+            "terms": {
+              "concurrency": 1,
+              "length": 5097600
+            },
+            "markets": [
+              "public_library"
+            ],
+            "cap_loan_expiration_to_license": false,
+            "protection": {
+              "format": [
+                "application/vnd.readium.lcp.license.v1.0+json"
+              ],
+              "devices": 6
+            },
+            "order": {
+              "name": "Duplicate of Audible (ALL) 40x10 as of Sept. 2022",
+              "identifier": "202210-761-027824",
+              "href": "https://market.feedbooks.com/carts/27824"
+            }
+          },
+          "links": [
+            {
+              "rel": "http://opds-spec.org/acquisition/borrow",
+              "href": "https://license.feedbooks.net/loan/status/{?id,checkout_id,expires,patron_id,notification_url,passphrase,hint,hint_url}",
+              "type": "application/vnd.readium.license.status.v1.0+json",
+              "templated": true
+            },
+            {
+              "rel": "self",
+              "href": "https://license.feedbooks.net/copy/status/?uuid=a9f8b5a1-6763-4d28-9d42-1342092e1977",
+              "type": "application/vnd.odl.info+json"
+            }
+          ]
+        }
+      ],
+      "links": []
+    }
+  ]
+}

--- a/tests/api/files/odl2/feed-audiobook-streaming.json
+++ b/tests/api/files/odl2/feed-audiobook-streaming.json
@@ -109,7 +109,8 @@
             "identifier": "urn:uuid:a44b9e96-7ad6-42b5-a86d-786563f32b12",
             "format": [
               "application/audiobook+lcp",
-              "text/html"
+              "text/html",
+              "application/audiobook+json; protection=http://www.feedbooks.com/audiobooks/access-restriction"
             ],
             "created": "2021-10-07T22:23:45+02:00",
             "source": "http://www.cantook.net/",

--- a/tests/api/test_odl2.py
+++ b/tests/api/test_odl2.py
@@ -235,10 +235,10 @@ class TestODL2Importer(TestODLImporter):
         assert str(huck_finn_semantic_error) == huck_finn_failure.exception
 
     @freeze_time("2016-01-01T00:00:00+00:00")
-    def test_import_audiobook(self, importer, mock_get, datasource, db):
+    def test_import_audiobook_with_streaming(self, importer, mock_get, datasource, db):
         """Ensure that ODL2Importer2 correctly processes and imports a feed with an audiobook."""
         license = self.get_data("license-audiobook.json")
-        feed = self.get_data("feed-audiobook.json")
+        feed = self.get_data("feed-audiobook-streaming.json")
         mock_get.add(license)
 
         configuration_storage = ConfigurationStorage(importer)
@@ -289,3 +289,45 @@ class TestODL2Importer(TestODLImporter):
             )
         )
         assert feedbooks_delivery_mechanism is not None
+
+    @freeze_time("2016-01-01T00:00:00+00:00")
+    def test_import_audiobook_no_streaming(self, importer, mock_get, datasource, db):
+        """
+        Ensure that ODL2Importer2 correctly processes and imports a feed with an audiobook
+        that is not available for streaming.
+        """
+        license = self.get_data("license-audiobook.json")
+        feed = self.get_data("feed-audiobook-no-streaming.json")
+        mock_get.add(license)
+
+        imported_editions, pools, works, failures = importer.import_from_feed(feed)
+
+        # Make sure we imported one edition and it is an audiobook
+        assert isinstance(imported_editions, list)
+        assert 1 == len(imported_editions)
+
+        [edition] = imported_editions
+        assert isinstance(edition, Edition)
+        assert edition.primary_identifier.identifier == "9781603937221"
+        assert edition.primary_identifier.type == "ISBN"
+        assert EditionConstants.AUDIO_MEDIUM == edition.medium
+
+        # Make sure that license pools have correct configuration
+        assert isinstance(pools, list)
+        assert 1 == len(pools)
+
+        [license_pool] = pools
+        assert not license_pool.open_access
+        assert 1 == license_pool.licenses_owned
+        assert 1 == license_pool.licenses_available
+
+        assert 1 == len(license_pool.delivery_mechanisms)
+
+        lcp_delivery_mechanism = (
+            self._get_delivery_mechanism_by_drm_scheme_and_content_type(
+                license_pool.delivery_mechanisms,
+                MediaTypes.AUDIOBOOK_PACKAGE_LCP_MEDIA_TYPE,
+                DeliveryMechanism.LCP_DRM,
+            )
+        )
+        assert lcp_delivery_mechanism is not None


### PR DESCRIPTION
## Description

Change how we are parsing the DRM formats for DeMarque Audiobook titles available through ODL. This was done after a discussion with DeMarque about why some titles were failing in the mobile apps. 

[Notion ticket](https://www.notion.so/lyrasis/Audible-content-not-working-in-app-e6a83717a0a84de19e8fc5666f08e963)

## Motivation and Context

Some titles (notably Audible, but there are others) are only available via LCP DRM, not through the streaming endpoint. This change makes sure that we correctly set the delivery mechanisms for these titles, so the mobile apps do not choose a delivery mechanism that is unavailable.

## How Has This Been Tested?

Running the included unit tests, which include feed samples for audiobooks that are and are not available for streaming.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
