### PR TITLE
Avoid exceptions for commas in currency values.

### DIFF
--- a/core/util/__init__.py
+++ b/core/util/__init__.py
@@ -1,5 +1,7 @@
 """Miscellaneous utilities"""
 
+from __future__ import annotations
+
 import re
 import string
 from collections import Counter
@@ -526,15 +528,21 @@ class MoneyUtility:
     DEFAULT_CURRENCY = "USD"
 
     @classmethod
-    def parse(cls, amount):
+    def parse(cls, amount: str | float | int | None) -> Money:
         """Attempt to turn a string into a Money object."""
         currency = cls.DEFAULT_CURRENCY
         if not amount:
             amount = "0"
         amount = str(amount)
+
         if amount[0] == "$":
             currency = "USD"
             amount = amount[1:]
+
+        # `Money` does not properly handle commas in the amount, so we strip
+        # them out of US dollar amounts, since it won't change the "value."
+        if currency == "USD":
+            amount = "".join(amount.split(","))
         return Money(amount, currency)
 
 


### PR DESCRIPTION
## Description

- Fixes `MoneyUtility.parse` to avoid exceptions for commas in currency values.
- Refactors `MoneyUtility` tests and adds new test case with comma.

## Motivation and Context

`MoneyUtility.parse` raised an exception when parsing values with commas. This caused SIP2 patron authentication to fail under certain conditions. It could have an effect in other functionality, given the right conditions. [[Notion](https://www.notion.so/lyrasis/CA-Riverside-PL-patron-auth-self-test-fails-because-value-cannot-be-parsed-e6505183402d42ffb8483c62cdd93691)]

## How Has This Been Tested?

- Manual testing in development environment.
- New tests targeting the problem condition.
- CI tests. (TBD)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
