### PR TITLE
Feature/fix overdrive timeout exc

### DIFF
--- a/api/proquest/client.py
+++ b/api/proquest/client.py
@@ -561,7 +561,7 @@ class ProQuestAPIClient:
             while True:
                 try:
                     feed = self._download_feed_page(
-                        configuration, page, configuration.page_size
+                        configuration, page, int(configuration.page_size)
                     )
 
                     if self._is_feed_page_empty_or_incorrect(feed):

--- a/core/model/configuration.py
+++ b/core/model/configuration.py
@@ -1132,9 +1132,15 @@ class ConfigurationMetadata:
 
         if setting_value is None:
             setting_value = self.default
-        elif self.type == ConfigurationAttributeType.NUMBER and setting_value == "":
-            # In case we're a number, the default should take precendence over an empty value
-            setting_value = self.default
+        elif self.type == ConfigurationAttributeType.NUMBER:
+            # In case we're a number, the default should replace any incorrect formatting
+            try:
+                setting_value = float(setting_value)
+            except ValueError:
+                logging.getLogger(self.__class__.__name__).error(
+                    f"Could not typecast {self.label} value '{setting_value}'. Falling back to default"
+                )
+                setting_value = self.default
         else:
             # LIST and MENU configuration settings are stored as JSON-serialized lists in the database.
             # We need to deserialize them to get actual values.

--- a/core/model/configuration.py
+++ b/core/model/configuration.py
@@ -1137,13 +1137,10 @@ class ConfigurationMetadata:
             try:
                 setting_value = float(setting_value)
             except ValueError:
-                logging.getLogger(self.__class__.__name__).error(
-                    f"Could not typecast {self.label} value '{setting_value}'. Falling back to default"
-                )
                 if setting_value != "":
                     # A non-empty value is a "bad" value, and should raise an exception
                     raise CannotLoadConfiguration(
-                        f"Could not typecast {self.label} value '{setting_value}'. Falling back to default"
+                        f"Could not covert {self.label}'s value '{setting_value}'."
                     )
                 setting_value = self.default
         else:

--- a/core/model/configuration.py
+++ b/core/model/configuration.py
@@ -1132,6 +1132,9 @@ class ConfigurationMetadata:
 
         if setting_value is None:
             setting_value = self.default
+        elif self.type == ConfigurationAttributeType.NUMBER and setting_value == "":
+            # In case we're a number, the default should take precendence over an empty value
+            setting_value = self.default
         else:
             # LIST and MENU configuration settings are stored as JSON-serialized lists in the database.
             # We need to deserialize them to get actual values.

--- a/core/model/configuration.py
+++ b/core/model/configuration.py
@@ -1133,7 +1133,6 @@ class ConfigurationMetadata:
         if setting_value is None:
             setting_value = self.default
         elif self.type == ConfigurationAttributeType.NUMBER:
-            # In case we're a number, the default should replace any incorrect formatting
             try:
                 setting_value = float(setting_value)
             except ValueError:

--- a/core/model/configuration.py
+++ b/core/model/configuration.py
@@ -1140,6 +1140,11 @@ class ConfigurationMetadata:
                 logging.getLogger(self.__class__.__name__).error(
                     f"Could not typecast {self.label} value '{setting_value}'. Falling back to default"
                 )
+                if setting_value != "":
+                    # A non-empty value is a "bad" value, and should raise an exception
+                    raise CannotLoadConfiguration(
+                        f"Could not typecast {self.label} value '{setting_value}'. Falling back to default"
+                    )
                 setting_value = self.default
         else:
             # LIST and MENU configuration settings are stored as JSON-serialized lists in the database.

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -482,7 +482,7 @@ class OverdriveCoreAPI(HasExternalIntegration):
         payload: Dict[str, str],
         is_fulfillment=False,
         headers={},
-        **kwargs
+        **kwargs,
     ) -> Response:
         """Make an HTTP POST request for purposes of getting an OAuth token."""
         headers = dict(headers)

--- a/core/overdrive.py
+++ b/core/overdrive.py
@@ -677,14 +677,14 @@ class OverdriveCoreAPI(HasExternalIntegration):
     def _do_get(self, url: str, headers, **kwargs) -> Response:
         """This method is overridden in MockOverdriveAPI."""
         url = self.endpoint(url)
-        kwargs["max_retry_count"] = self._configuration.max_retry_count
+        kwargs["max_retry_count"] = int(self._configuration.max_retry_count)
         kwargs["timeout"] = 120
         return HTTP.get_with_timeout(url, headers=headers, **kwargs)
 
     def _do_post(self, url: str, payload, headers, **kwargs) -> Response:
         """This method is overridden in MockOverdriveAPI."""
         url = self.endpoint(url)
-        kwargs["max_retry_count"] = self._configuration.max_retry_count
+        kwargs["max_retry_count"] = int(self._configuration.max_retry_count)
         kwargs["timeout"] = 120
         return HTTP.post_with_timeout(url, payload, headers=headers, **kwargs)
 

--- a/tests/core/models/test_configuration.py
+++ b/tests/core/models/test_configuration.py
@@ -1122,7 +1122,8 @@ class TestNumberConfigurationMetadata(DatabaseTest):
         configuration = MockConfiguration(configuration_storage, self._db)
 
         configuration.setting5 = "abc"
-        assert configuration.setting5 == SETTING5_DEFAULT
+        with pytest.raises(CannotLoadConfiguration):
+            configuration.setting5
 
         configuration.setting5 = "123"
         assert configuration.setting5 == 123.0

--- a/tests/core/models/test_configuration.py
+++ b/tests/core/models/test_configuration.py
@@ -785,6 +785,14 @@ SETTING4_OPTIONS = None
 SETTING4_DEFAULT = None
 SETTING4_CATEGORY = "Settings"
 
+SETTING5_KEY = "setting5"
+SETTING5_LABEL = "Setting 5's label"
+SETTING5_DESCRIPTION = "Setting 5's description"
+SETTING5_TYPE = ConfigurationAttributeType.NUMBER
+SETTING5_REQUIRED = False
+SETTING5_DEFAULT = 12345
+SETTING5_CATEGORY = "Settings"
+
 
 class MockConfiguration(ConfigurationGrouping):
     setting1 = ConfigurationMetadata(
@@ -828,6 +836,16 @@ class MockConfiguration(ConfigurationGrouping):
         default=SETTING4_DEFAULT,
         options=SETTING4_OPTIONS,
         category=SETTING4_CATEGORY,
+    )
+
+    setting5 = ConfigurationMetadata(
+        key=SETTING5_KEY,
+        label=SETTING5_LABEL,
+        description=SETTING5_DESCRIPTION,
+        type=SETTING5_TYPE,
+        required=SETTING5_REQUIRED,
+        default=SETTING5_DEFAULT,
+        category=SETTING5_CATEGORY,
     )
 
 
@@ -977,10 +995,12 @@ class TestConfigurationGrouping:
         configuration = MockConfiguration(configuration_storage, db)
 
         # Act
-        setting_value = configuration.setting1
+        setting1_value = configuration.setting1
+        setting5_value = configuration.setting5
 
         # Assert
-        assert SETTING1_DEFAULT == setting_value
+        assert SETTING1_DEFAULT == setting1_value
+        assert SETTING5_DEFAULT == setting5_value
 
     @parameterized.expand(
         [("setting1", "setting1", 12345), ("setting2", "setting2", "12345")]
@@ -1005,7 +1025,7 @@ class TestConfigurationGrouping:
         settings = MockConfiguration.to_settings()
 
         # Assert
-        assert len(settings) == 4
+        assert len(settings) == 5
 
         assert settings[0][ConfigurationAttribute.KEY.value] == SETTING1_KEY
         assert settings[0][ConfigurationAttribute.LABEL.value] == SETTING1_LABEL

--- a/tests/core/models/test_configuration.py
+++ b/tests/core/models/test_configuration.py
@@ -1110,6 +1110,27 @@ class TestConfigurationGrouping:
         assert settings[1][ConfigurationAttribute.CATEGORY.value] == SETTING1_CATEGORY
 
 
+class TestNumberConfigurationMetadata(DatabaseTest):
+    def test_number_type_getter(self):
+        # Arrange
+        external_integration = self._external_integration("test")
+        external_integration_association = create_autospec(spec=HasExternalIntegration)
+        external_integration_association.external_integration = MagicMock(
+            return_value=external_integration
+        )
+        configuration_storage = ConfigurationStorage(external_integration_association)
+        configuration = MockConfiguration(configuration_storage, self._db)
+
+        configuration.setting5 = "abc"
+        assert configuration.setting5 == SETTING5_DEFAULT
+
+        configuration.setting5 = "123"
+        assert configuration.setting5 == 123.0
+
+        configuration.setting5 = ""
+        assert configuration.setting5 == SETTING5_DEFAULT
+
+
 class TestBooleanConfigurationMetadata(DatabaseTest):
     @parameterized.expand(
         [


### PR DESCRIPTION
## Description
Overdrive's max_retry_count was not typecast to an integer, this would break the api client for any user generated value if a retry was required.
Additionally, if we have an empty value for a NUMBER type configuration, return the default value, since typecasting an empty string would raise a ValueError

<!--- Describe your changes -->

## Motivation and Context
Exceptions in the cerberus log raised this issue
[Notion](https://www.notion.so/lyrasis/Error-retrying-OverDrive-HTTP-connection-failures-f89e498fa63b4feaa1ae7736623c9a94)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually, testing was done by reducing the timeout and pointing the overdrive API to a fake timeout server.
Unit tests have been updated to reflect the empty value typecast.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
