### PR TITLE
Add Python 3.11 support.

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         module: [Api, Core]
 
     # We want to run on external PRs, but not on our own internal PRs as they'll be run

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-![Python: 3.7,3.8,3.9,3.10](https://img.shields.io/badge/Python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue)
+![Python: 3.7,3.8,3.9,3.10,3.11](https://img.shields.io/badge/Python-3.7%20|%203.8%20|%203.9%20|%203.10%20|%203.11-blue)
 
 This is a [The Palace Project](https://thepalaceproject.org) maintained fork of the NYPL
 [Library Simplified](http://www.librarysimplified.org/) Circulation Manager.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310}-{api,core}-docker
+envlist = py{37,38,39,310,311}-{api,core}-docker
 skipsdist = true
 
 [testenv]
@@ -60,6 +60,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 MODULE =


### PR DESCRIPTION
## Description

Add Python 3.11 to CI (and local) testing.

## Motivation and Context

Keep up with new Python versions.

## How Has This Been Tested?

Tests will run in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
