### PR TITLE
Use zoned UTC when comparing search doc and edition publication dates.

### DIFF
--- a/tests/core/models/test_work.py
+++ b/tests/core/models/test_work.py
@@ -1145,7 +1145,12 @@ class TestWork(DatabaseTest):
         assert edition.publisher == search_doc["publisher"]
         assert edition.imprint == search_doc["imprint"]
         assert edition.permanent_work_id == search_doc["permanent_work_id"]
-        assert edition.published == datetime.date.fromtimestamp(search_doc["published"])
+        assert (
+            edition.published
+            == datetime.datetime.fromtimestamp(
+                search_doc["published"], tz=pytz.UTC
+            ).date()
+        )
         assert "Nonfiction" == search_doc["fiction"]
         assert "YoungAdult" == search_doc["audience"]
         assert work.summary_text == search_doc["summary"]


### PR DESCRIPTION
## Description

Fixes an [assertion in `tests/core/models/test_work.py::TestWork::test_to_search_document`](https://github.com/ThePalaceProject/circulation/blob/b30cf5a2803403095918302a685bd76fd505dc3a/tests/core/models/test_work.py#L1148), so that both sides of the comparison are based on UTC-zoned `datetime`s.

## Motivation and Context

Test was failing depending on the timezone and time configured for the test environment.

## How Has This Been Tested?

- Manually ran tests with different time zones configured in the test environment.
  - TZ = UTC: Test always passed -- both before and after the change.
  - EST: Before the fix, test always failed.
  - EST: After the fix, test always passed.
- CI tests.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
