### PR TITLE
Fix s3 analytics none licensepool issue

### DIFF
--- a/api/s3_analytics_provider.py
+++ b/api/s3_analytics_provider.py
@@ -157,7 +157,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
             "series": work.series if work else None,
             "series_position": work.series_position if work else None,
             "language": work.language if work else None,
-            "open_access": license_pool.open_access,
+            "open_access": license_pool.open_access if license_pool else None,
         }
 
         return event

--- a/core/s3.py
+++ b/core/s3.py
@@ -547,6 +547,7 @@ class S3Uploader(MirrorUploader):
         self,
         library: Library,
         license_pool: LicensePool,
+        event_type: str,
         end_time: datetime,
         start_time: datetime = None,
     ):
@@ -560,9 +561,17 @@ class S3Uploader(MirrorUploader):
             time_part = str(end_time)
 
         # ensure the uniqueness of file name (in case of overlapping events)
+        collection = license_pool.collection_id if license_pool else "NONE"
         random_string = "".join(random.choices(string.ascii_lowercase, k=10))
-        parts = [time_part, license_pool.collection_id, random_string]
-        return root + self.key_join(parts) + ".json"
+        file_name = "-".join([time_part, event_type, str(collection), random_string])
+        # nest file in directories that allow for easy purging by year, month or day
+        parts = [
+            str(end_time.year),
+            str(end_time.month),
+            str(end_time.day),
+            file_name + ".json",
+        ]
+        return root + self.key_join(parts)
 
     def split_url(self, url: str, unquote: bool = True) -> Tuple[str, str]:
         """Splits the URL into the components: bucket and file path


### PR DESCRIPTION
## Description
NEW_PATRON events occur when a user tries to check out a book for the first time.  Since these events are not associated with a collection,  this PR ensures, that the license pool that is passed down to the S3 analytics provider can be None type.
Additionally, the s3 path been changed to make purging older event data more straightforward.
<!--- Describe your changes -->

## Motivation and Context

Events were not making it to S3 when the license pool for a particular event happens to be None.  The only case where this can happen is in the firing of NEW_PATRON events which are not associated with a work.   Now S3 will get NEW_PATRON events as well.  Additionally,  it is preferable that the json files containing event information are organized by year, month, and date to facilitate regular purging for already processed events.   We will likely want to keep them around in case we need to rerun the crawler/ETL process, but making it easy to script a periodic purging would be beneficial down the road.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests cover the code already.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
