### PR TITLE
Open access fulfillment links

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -261,7 +261,6 @@ class CirculationManagerAnnotator(Annotator):
         feed,
         entry,
         updated=None,
-        add_open_access_links=True,
     ):
         # If ElasticSearch included a more accurate last_update_time,
         # use it instead of Work.last_update_time

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -42,10 +42,8 @@ from core.model import (
     Representation,
     RightsStatus,
     Work,
-    get_one_or_create,
 )
 from core.model.formats import FormatPriorities
-from core.model.library import Library
 from core.model.licensing import LicensePool
 from core.opds import AcquisitionFeed, MockAnnotator, UnfulfillableWork
 from core.opds_import import OPDSXMLParser
@@ -494,24 +492,6 @@ class TestLibraryAnnotator(VendorIDTest):
         # 'open-access' link relation.
         link = self.annotator.fulfill_link(pool, None, lpdm, OPDSFeed.OPEN_ACCESS_REL)
         assert OPDSFeed.OPEN_ACCESS_REL == link.attrib["rel"]
-
-    def test_add_open_access_links(self):
-        library: Library = self._library()
-        integration, _ = get_one_or_create(
-            self._db,
-            ExternalIntegration,
-            goal=ExternalIntegration.PATRON_AUTH_GOAL,
-            name="Name",
-            protocol="protocol",
-        )
-
-        library.integrations.append(integration)
-        annotator = LibraryAnnotator(None, None, library)
-        assert annotator.add_open_access_links == False
-
-        library.integrations.remove(integration)
-        annotator = LibraryAnnotator(None, None, library)
-        assert annotator.add_open_access_links == True
 
     # We freeze the test time here, because this test checks that the client token
     # in the feed matches a generated client token. The client token contains an
@@ -1701,36 +1681,40 @@ class TestLibraryAnnotator(VendorIDTest):
         # Book with no loans or holds yet.
         work4 = self._work(with_license_pool=True)
 
+        # Ensure the state variable
+        assert annotator.identifies_patrons == True
+
         loan1_links = annotator.acquisition_links(
             loan1.license_pool, loan1, None, None, feed, loan1.license_pool.identifier
         )
-        # Fulfill, open access, and revoke.
-        [revoke, fulfill, open_access] = sorted(
-            loan1_links, key=lambda x: x.attrib.get("rel")
-        )
+        # Fulfill, and revoke.
+        [revoke, fulfill] = sorted(loan1_links, key=lambda x: x.attrib.get("rel"))
         assert "revoke_loan_or_hold" in revoke.attrib.get("href")
         assert "http://librarysimplified.org/terms/rel/revoke" == revoke.attrib.get(
             "rel"
         )
         assert "fulfill" in fulfill.attrib.get("href")
         assert "http://opds-spec.org/acquisition" == fulfill.attrib.get("rel")
-        assert "fulfill" in open_access.attrib.get("href")
-        assert "http://opds-spec.org/acquisition/open-access" == open_access.attrib.get(
-            "rel"
-        )
 
-        # Remove direct open-access downloads
-        annotator.add_open_access_links = False
+        # Allow direct open-access downloads
+        # This will also filter out loan revoke links
+        annotator.identifies_patrons = False
         loan1_links = annotator.acquisition_links(
             loan1.license_pool, loan1, None, None, feed, loan1.license_pool.identifier
         )
-        assert len(loan1_links) == 2
-        assert {"http://host/revoke_loan_or_hold", "http://host/fulfill"} == {
-            link.attrib.get("href").split("?")[0] for link in loan1_links
+        assert len(loan1_links) == 1
+        assert {"http://opds-spec.org/acquisition/open-access"} == {
+            link.attrib.get("rel") for link in loan1_links
         }
 
+        # Work 2 has no open access links
+        loan2_links = annotator.acquisition_links(
+            loan2.license_pool, loan2, None, None, feed, loan2.license_pool.identifier
+        )
+        assert len(loan2_links) == 0
+
         # Revert the annotator state
-        annotator.add_open_access_links = True
+        annotator.identifies_patrons = True
 
         loan2_links = annotator.acquisition_links(
             loan2.license_pool, loan2, None, None, feed, loan2.license_pool.identifier


### PR DESCRIPTION
## Description
Library based acquisition feeds will only send open-access fulfillment links if the library has no auth

Otherwise it will expect the patron to go through the regular borrow workflow

<!--- Describe your changes -->

## Motivation and Context
The CM acts differently depending if it has patron authentication enabled or not. If a CM is configured without Patron authentication (Like the Palace Bookshelf CM) then users can borrow open access content without authentication. However if Patron authentication is enabled, then we require patrons to checkout the content, so we can keep the correct bookshelf entries for them. 

[Notion](https://www.notion.so/lyrasis/Investigate-why-the-CM-is-sending-an-unfulfillable-fulfillment-acquisition-link-in-the-results-of-an-5f391fa052a745cebd5ba9b81125fe20)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested the catalog and search feed, with and without patron authentication.
Updated the unit tests to cover the use case
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
