### PR TITLE
Bump versions in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -17,7 +17,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v3.3.0
     hooks:
       - id: pyupgrade
         args:
@@ -25,7 +25,7 @@ repos:
           - --keep-mock # This can be dropped when we go to Python 3.8
 
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.0.0
     hooks:
       - id: autoflake
         args:
@@ -34,7 +34,7 @@ repos:
           - --ignore-init-module-imports
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         name: Run black
@@ -46,23 +46,29 @@ repos:
         name: Run isort
 
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.9.0
+    rev: 0.19.2
     hooks:
       - id: check-github-workflows
       - id: check-github-actions
 
   - repo: https://github.com/pappasam/toml-sort
-    rev: v0.19.0
+    rev: v0.20.1
     hooks:
       - id: toml-sort
-        args: [--all, --in-place, --ignore-case]
+        args:
+          - --all
+          - --in-place
+          - --ignore-case
         files: pyproject.toml
 
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: 0.9.3
+    rev: v0.9.8
     hooks:
       - id: pymarkdown
-        args: [--disable-version, -c, .pymarkdown.config.json, scan]
+        args:
+          - --config
+          - .pymarkdown.config.json
+          - scan
 
 # Exclude test files, since they may be intentionally malformed
 exclude: ^tests/(core|api)/files/


### PR DESCRIPTION
## Description

Changes from running `pre-commit autoupdate`. Good to make sure our linters aren't getting too out of date.
