### PR TITLE
Convert PNGs to a valid format before saving if required

### DIFF
--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -9,6 +9,7 @@ import wcag_contrast_ratio
 from flask import Response
 from flask_babel import lazy_gettext as _
 from PIL import Image
+from PIL.PngImagePlugin import _OUTMODES as PNG_MODES
 
 from api.admin.announcement_list_validator import AnnouncementListValidator
 from api.admin.geographic_validator import GeographicValidator
@@ -407,6 +408,9 @@ class LibrarySettingsController(SettingsController):
         :return: The `data` URL for the image.
         """
         buffer = BytesIO()
+        # Ensure the image is in a valid PNG format
+        if _format == "PNG" and image.mode not in PNG_MODES:
+            image = image.convert("RGBA")
         image.save(buffer, format=_format)
         b64 = base64.b64encode(buffer.getvalue())
         return "data:image/png;base64,%s" % b64.decode("utf-8")

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -9,7 +9,6 @@ import wcag_contrast_ratio
 from flask import Response
 from flask_babel import lazy_gettext as _
 from PIL import Image
-from PIL.PngImagePlugin import _OUTMODES as PNG_MODES
 
 from api.admin.announcement_list_validator import AnnouncementListValidator
 from api.admin.geographic_validator import GeographicValidator
@@ -408,8 +407,9 @@ class LibrarySettingsController(SettingsController):
         :return: The `data` URL for the image.
         """
         buffer = BytesIO()
-        # Ensure the image is in a valid PNG format
-        if _format == "PNG" and image.mode not in PNG_MODES:
+        # If the image is not RGB, RGBA or P convert it
+        # https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes
+        if image.mode not in ("RGB", "RGBA", "P"):
             image = image.convert("RGBA")
         image.save(buffer, format=_format)
         b64 = base64.b64encode(buffer.getvalue())

--- a/tests/api/admin/controller/test_library.py
+++ b/tests/api/admin/controller/test_library.py
@@ -303,6 +303,20 @@ class TestLibrarySettings(SettingsControllerTest, AnnouncementTest):
         data_url = LibrarySettingsController._data_url_for_image(image)
         assert expected_data_url == data_url
 
+        # A non PNG mode should work as RGBA
+        image = logo_properties["image"].convert("CMYK")
+        assert image.mode == "CMYK"
+
+        data_url = LibrarySettingsController._data_url_for_image(image)
+        rgba_image = image.convert("RGBA")
+        bio = BytesIO()
+        rgba_image.save(bio, "PNG")
+        bio.seek(0)
+        expected_data_url = "data:image/png;base64," + base64.b64encode(
+            bio.read()
+        ).decode("utf-8")
+        assert expected_data_url == data_url
+
     def test_libraries_post_create(self, logo_properties):
         class TestFileUpload(BytesIO):
             headers = {"Content-Type": "image/png"}


### PR DESCRIPTION
## Description
Eg. CMYK does not save as a PNG via PIL
Had to use an internal variable `_OUTMODES` from PIL since it's documentation and API aren't very expansive.
<!--- Describe your changes -->

## Motivation and Context
Some JPEG images may be in the CMYK format, so converting to PNG would fail during the upload workflow.
[Notion](https://www.notion.so/lyrasis/Collection-Manager-Error-when-attempting-to-save-a-library-logo-77f0aa914a174ef0a64e8434bc98b335)
[Related Notion](https://www.notion.so/lyrasis/Investigate-why-logos-are-not-automatically-resizing-in-the-Collection-Manager-108b38e17f074f52851bb5dbcd67111a?d=91f02f8935094b01a825cb7589b21b8b)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually uploaded the example image provided.
An additional test case was written for CMYK type images

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
