### PR TITLE
Fuzzy search for json type queries, eq and neq operators

### DIFF
--- a/core/external_search.py
+++ b/core/external_search.py
@@ -2029,6 +2029,8 @@ class JSONQuery(Query):
         CONTAINS = "contains"
 
     _KEYWORD_ONLY = {"keyword": True}
+    _LONG_TYPE = {"type": "long"}
+    _BOOL_TYPE = {"type": "bool"}
 
     # The fields mappings in the search DB
     FIELD_MAPPING: Dict[str, Dict] = {
@@ -2045,32 +2047,34 @@ class JSONQuery(Query):
         "fiction": _KEYWORD_ONLY,
         "genres.name": dict(path="genres"),
         "genres.scheme": dict(path="genres"),
-        "genres.term": dict(path="genres"),
-        "genres.weight": dict(path="genres"),
+        "genres.term": dict(path="genres", **_LONG_TYPE),
+        "genres.weight": dict(path="genres", **_LONG_TYPE),
         "identifiers.identifier": dict(path="identifiers"),
         "identifiers.type": dict(path="identifiers"),
         "imprint": _KEYWORD_ONLY,
         "language": dict(),
-        "licensepools.available": dict(path="licensepools"),
-        "licensepools.availability_time": dict(path="licensepools"),
-        "licensepools.collection_id": dict(path="licensepools"),
-        "licensepools.data_source_id": dict(path="licensepools", ops=[Operators.EQ]),
-        "licensepools.licensed": dict(path="licensepools"),
+        "licensepools.available": dict(path="licensepools", **_BOOL_TYPE),
+        "licensepools.availability_time": dict(path="licensepools", **_LONG_TYPE),
+        "licensepools.collection_id": dict(path="licensepools", **_LONG_TYPE),
+        "licensepools.data_source_id": dict(
+            path="licensepools", ops=[Operators.EQ], **_LONG_TYPE
+        ),
+        "licensepools.licensed": dict(path="licensepools", **_BOOL_TYPE),
         "licensepools.medium": dict(path="licensepools"),
-        "licensepools.open_access": dict(path="licensepools"),
-        "licensepools.quality": dict(path="licensepools"),
-        "licensepools.suppressed": dict(path="licensepools"),
+        "licensepools.open_access": dict(path="licensepools", **_BOOL_TYPE),
+        "licensepools.quality": dict(path="licensepools", **_LONG_TYPE),
+        "licensepools.suppressed": dict(path="licensepools", **_BOOL_TYPE),
         "medium": _KEYWORD_ONLY,
-        "presentation_ready": dict(),
+        "presentation_ready": _BOOL_TYPE,
         "publisher": _KEYWORD_ONLY,
-        "quality": dict(),
+        "quality": _LONG_TYPE,
         "series": _KEYWORD_ONLY,
         "sort_author": dict(),
         "sort_title": dict(),
         "subtitle": _KEYWORD_ONLY,
         "target_age": dict(),
         "title": _KEYWORD_ONLY,
-        "published": dict(),
+        "published": _LONG_TYPE,
     }
 
     # From the client, some field names may be abstracted
@@ -2197,10 +2201,30 @@ class JSONQuery(Query):
 
         es_query = None
 
+        # We are using "match" queries for the "equals" operator
+        # so we must keep a tight leash on the how much of a spread
+        # in the matches we want to keep
+        # The "match" is used instead of "term" in order to have some
+        # tolerance for spelling mistakes while making a query
+        match_args = dict(
+            auto_generate_synonyms_phrase_query=False,
+            max_expansions=10,
+            fuzziness="AUTO",
+        )
+
+        def _match_or_term_query():
+            """Only text type mappings get a 'match' search, others use a term search
+            All variables are used from the function closure
+            """
+            if mapping.get("type", "text") != "text":
+                return Term(**{key: value})
+            else:
+                return Match(**{key: {"query": value, **match_args}})
+
         if op == self.Operators.EQ:
-            es_query = Term(**{key: value})
+            es_query = _match_or_term_query()
         elif op == self.Operators.NEQ:
-            es_query = Bool(must_not=[Term(**{key: value})])
+            es_query = Bool(must_not=[_match_or_term_query()])
         elif op in {
             self.Operators.GT,
             self.Operators.GTE,

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -5092,18 +5092,30 @@ class TestJSONQuery:
     def _jq(query):
         return JSONQuery(dict(query=query))
 
+    match_args = dict(
+        auto_generate_synonyms_phrase_query=False,
+        max_expansions=10,
+        fuzziness="AUTO",
+    )
+
     def test_elasticsearch_query(self, external_search_fixture: ExternalSearchFixture):
         q = {"key": "medium", "value": "Book"}
         q = self._jq(q)
-        q.elasticsearch_query.to_dict() == {"term": {"medium.keyword": "Book"}}
+        q.elasticsearch_query.to_dict() == {
+            "match": {"medium.keyword": {"query": "Book", **self.match_args}}
+        }
 
         q = {"or": [self._leaf("medium", "Book"), self._leaf("medium", "Audio")]}
         q = self._jq(q)
         q.elasticsearch_query.to_dict() == {
             "bool": {
                 "should": [
-                    {"term": {"medium.keyword": "Book"}},
-                    {"term": {"medium.keyword": "Audio"}},
+                    {"match": {"medium.keyword": {"query": "Book", **self.match_args}}},
+                    {
+                        "match": {
+                            "medium.keyword": {"query": "Audio", **self.match_args}
+                        }
+                    },
                 ]
             }
         }
@@ -5113,8 +5125,12 @@ class TestJSONQuery:
         q.elasticsearch_query.to_dict() == {
             "bool": {
                 "must": [
-                    {"term": {"medium.keyword": "Book"}},
-                    {"term": {"medium.keyword": "Audio"}},
+                    {"match": {"medium.keyword": {"query": "Book", **self.match_args}}},
+                    {
+                        "match": {
+                            "medium.keyword": {"query": "Audio", **self.match_args}
+                        }
+                    },
                 ]
             }
         }
@@ -5132,12 +5148,26 @@ class TestJSONQuery:
                     {
                         "bool": {
                             "should": [
-                                {"term": {"medium.keyword": "Book"}},
-                                {"term": {"medium.keyword": "Audio"}},
+                                {
+                                    "match": {
+                                        "medium.keyword": {
+                                            "query": "Book",
+                                            **self.match_args,
+                                        }
+                                    }
+                                },
+                                {
+                                    "match": {
+                                        "medium.keyword": {
+                                            "query": "Audio",
+                                            **self.match_args,
+                                        }
+                                    }
+                                },
                             ]
                         }
                     },
-                    {"term": {"title.keyword": "Title"}},
+                    {"match": {"title.keyword": {"query": "Title", **self.match_args}}},
                 ]
             }
         }
@@ -5147,8 +5177,21 @@ class TestJSONQuery:
         assert q.elasticsearch_query.to_dict() == {
             "bool": {
                 "should": [
-                    {"term": {"medium.keyword": "Book"}},
-                    {"bool": {"must_not": [{"term": {"medium.keyword": "Audio"}}]}},
+                    {"match": {"medium.keyword": {"query": "Book", **self.match_args}}},
+                    {
+                        "bool": {
+                            "must_not": [
+                                {
+                                    "match": {
+                                        "medium.keyword": {
+                                            "query": "Audio",
+                                            **self.match_args,
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
                 ]
             }
         }
@@ -5163,8 +5206,21 @@ class TestJSONQuery:
         assert q.elasticsearch_query.to_dict() == {
             "bool": {
                 "must": [
-                    {"term": {"title.keyword": "Title"}},
-                    {"bool": {"must_not": [{"term": {"author.keyword": "Geoffrey"}}]}},
+                    {"match": {"title.keyword": {"query": "Title", **self.match_args}}},
+                    {
+                        "bool": {
+                            "must_not": [
+                                {
+                                    "match": {
+                                        "author.keyword": {
+                                            "query": "Geoffrey",
+                                            **self.match_args,
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
                 ]
             }
         }
@@ -5187,7 +5243,7 @@ class TestJSONQuery:
             ("contributors.display_name", "name", True),
             ("contributors.lc", "name", False),
             ("genres.name", "name", False),
-            ("licensepools.open_access", True, False),
+            ("licensepools.medium", "Book", False),
         ]
     )
     def test_elasticsearch_query_nested(self, key, value, is_keyword):
@@ -5195,7 +5251,10 @@ class TestJSONQuery:
         term = key if not is_keyword else f"{key}.keyword"
         root = key.split(".")[0]
         assert q.elasticsearch_query.to_dict() == {
-            "nested": {"path": root, "query": {"term": {term: value}}}
+            "nested": {
+                "path": root,
+                "query": {"match": {term: {"query": value, **self.match_args}}},
+            }
         }
 
     @parameterized.expand(
@@ -5229,7 +5288,9 @@ class TestJSONQuery:
     def test_field_transforms(self):
         q = self._jq(self._leaf("classification", "cls"))
         assert q.elasticsearch_query.to_dict() == {
-            "term": {"classifications.term.keyword": "cls"}
+            "match": {
+                "classifications.term.keyword": {"query": "cls", **self.match_args}
+            }
         }
         q = self._jq(self._leaf("open_access", True))
         assert q.elasticsearch_query.to_dict() == {
@@ -5282,6 +5343,18 @@ class TestJSONQuery:
         assert "Operator 'gt' is not allowed for 'data_source'. Only use ['eq']" == str(
             exc.value
         )
+
+    @parameterized.expand(
+        [
+            ("title", "value", True),
+            ("licensepools.open_access", True, False),
+            ("published", "1990-01-01", False),
+        ]
+    )
+    def test_type_queries(self, key, value, is_text):
+        """Bool and long types are term queries, whereas text is a match query"""
+        q = self._jq(self._leaf(key, value))
+        q.elasticsearch_query.to_dict().keys() == ["match" if is_text else "term"]
 
 
 class TestExternalSearchJSONQueryData:

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -5092,11 +5092,7 @@ class TestJSONQuery:
     def _jq(query):
         return JSONQuery(dict(query=query))
 
-    match_args = dict(
-        auto_generate_synonyms_phrase_query=False,
-        max_expansions=10,
-        fuzziness="AUTO",
-    )
+    match_args = JSONQuery.MATCH_ARGS
 
     def test_elasticsearch_query(self, external_search_fixture: ExternalSearchFixture):
         q = {"key": "medium", "value": "Book"}


### PR DESCRIPTION
## Description
Fuzzy search will only take place for text type properties.
The `contains` type operator cannot make use of this since regex's are not well suited for this kind of query, and using a `match` query for the `contains operator` turned out to be far too promiscuous with the results.
This will be achieved by replacing Term queries with Match queries for fields that have text values.
<!--- Describe your changes -->

## Motivation and Context
The current list search functionality is overly restrictive, and does not allow for slight misspellings, missing spaces, etc. (see related ticket). We need to add some fuzziness to the search fields to allow for more flexibility.
[Notion](https://www.notion.so/lyrasis/Add-fuzziness-to-list-search-queries-674c63ef3a974f59a659484519772cee)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
