### PR TITLE
Adopt new GH actions environment files.

### DIFF
--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -21,5 +21,5 @@ runs:
       shell: bash
 
     - id: poetry-version
-      run: echo "::set-output name=version::$(poetry --version)"
+      run: echo "version=$(poetry --version)" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
## Description

Uses the new `$GITHUB_OUTPUT` environment file, instead of the deprecated `set-output`, for GH actions.

## Motivation and Context

The `save-state` and `set-output` workflow commands have been deprecated. [[GitHub post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)] [[Notion](https://www.notion.so/lyrasis/Use-new-GitHub-Actions-environment-files-816e94f3abfb4e73ad6bd75645f07249)]

## How Has This Been Tested?

Review CI logs from the associated branch.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
