### PR TITLE
Fix search test causing issues with failures in CI.

### DIFF
--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -1306,8 +1306,10 @@ class TestExternalSearchWithWorks:
         end_to_end_search_fixture.populate_search_index()
         search.remove_work(data.moby_dick)
         search.remove_work(data.moby_duck)
-        # Immediately querying never works, the search index needs a second to refresh its cache/index/data
-        time.sleep(1)
+
+        # Immediately querying never works, the search index needs to refresh its cache/index/data
+        search.indices.refresh()
+
         end_to_end_search_fixture.expect_results([], "Moby")
 
 

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -4,7 +4,6 @@ from typing import Any, Iterable, List, Optional
 from unittest import mock
 
 import pytest
-import requests
 from _pytest.fixtures import FixtureRequest
 
 from core import external_search
@@ -103,16 +102,6 @@ class ExternalSearchFixture:
         work.set_presentation_ready()
         return work
 
-    def refresh_and_wait(self):
-        target = self.url + "/_refresh"
-        logging.info("sending request to " + target)
-        response = requests.get(target)
-        if response.status_code >= 400:
-            raise RuntimeError(
-                "Attempting to refresh Elasticsearch index resulted in status "
-                + str(response.status_code)
-            )
-
 
 @pytest.fixture(
     scope="function",
@@ -160,7 +149,7 @@ class EndToEndSearchFixture:
             self.external_search.db.session,
             search_index_client=self.external_search.search,
         ).run_once_and_update_timestamp()
-        self.external_search.refresh_and_wait()
+        self.external_search.search.indices.refresh()
 
     @staticmethod
     def assert_works(description, expect, actual, should_be_ordered=True):


### PR DESCRIPTION
## Description

Use the `refresh()` method, instead of a fixed wait, to reduce CI failures.

## Motivation and Context

We are seeing a number of random CI failures for a test that was added in #411. This is likely a timing issue, with making sure the elastic search index is up to date before doing the query.

## How Has This Been Tested?

Ran tests locally.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
