### PR TITLE
Search field values for search autocomplete

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -6,14 +6,12 @@ import os
 import sys
 import urllib.parse
 from datetime import date, datetime, timedelta
-from http.client import BAD_REQUEST
 from typing import Callable, Dict, List, Optional, Union
 
 import flask
 import jwt
 from flask import Response, redirect
 from flask_babel import lazy_gettext as _
-from sqlalchemy.orm import lazyload_all
 from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import and_, desc, distinct, join, nullslast, select
 

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -738,6 +738,15 @@ def change_lane_order():
     return app.manager.admin_lanes_controller.change_order()
 
 
+@library_route("/admin/search_field_values", methods=["GET"])
+@has_library
+@returns_json_or_response_or_problem_detail
+@requires_admin
+@requires_csrf_token
+def search_field_values():
+    return app.manager.admin_search_controller.search_field_values()
+
+
 @app.route("/admin/diagnostics")
 @requires_admin
 @returns_json_or_response_or_problem_detail

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -742,7 +742,6 @@ def change_lane_order():
 @has_library
 @returns_json_or_response_or_problem_detail
 @requires_admin
-@requires_csrf_token
 def search_field_values():
     return app.manager.admin_search_controller.search_field_values()
 

--- a/tests/api/admin/controller/test_admin_search_controller.py
+++ b/tests/api/admin/controller/test_admin_search_controller.py
@@ -1,0 +1,88 @@
+from core.model.classification import Subject
+from core.model.datasource import DataSource
+from core.model.work import Work
+from tests.api.admin.controller.test_controller import AdminControllerTest
+
+
+class TestAdminSearchController(AdminControllerTest):
+    def setup_method(self):
+        super().setup_method()
+
+        # Setup works with subjects, languages, audiences etc...
+        gutenberg = DataSource.lookup(self._db, DataSource.GUTENBERG)
+        w: Work = self._work(
+            title="work1",
+            genre="Education",
+            language="eng",
+            audience="Adult",
+            with_license_pool=True,
+        )
+        w.presentation_edition.publisher = "Publisher 1"
+        s: Subject = self._subject("subject1", "subjectid1")
+        s.genre = w.genres[0]
+        s.name = "subject 1"
+        s.audience = "Adult"
+        self._classification(w.presentation_edition.primary_identifier, s, gutenberg)
+
+        w = self._work(
+            title="work2",
+            genre="Education",
+            language="eng",
+            audience="Adult",
+            with_license_pool=True,
+        )
+        w.presentation_edition.publisher = "Publisher 1"
+        s: Subject = self._subject("subject2", "subjectid2")
+        s.genre = w.genres[0]
+        s.name = "subject 2"
+        s.audience = "Adult"
+        self._classification(w.presentation_edition.primary_identifier, s, gutenberg)
+
+        w = self._work(
+            title="work3",
+            genre="Horror",
+            language="spa",
+            audience="Adult",
+            with_license_pool=True,
+        )
+        w.presentation_edition.publisher = "Publisher 1"
+        s: Subject = self._subject("subject3", "subjectid3")
+        s.genre = w.genres[0]
+        s.name = "subject 3"
+        s.audience = "Adult"
+        self._classification(w.presentation_edition.primary_identifier, s, gutenberg)
+
+        for _ in range(10):
+            w = self._work(
+                genre="Drama",
+                language="man",
+                audience="Young Adult",
+                data_source_name=DataSource.GUTENBERG,
+                with_license_pool=True,
+            )
+            w.presentation_edition.publisher = "Publisher 10"
+            s: Subject = self._subject("subject10", "subjectid10")
+            s.genre = w.genres[0]
+            s.name = "subject 10"
+            s.audience = "Young Adult"
+            self._classification(
+                w.presentation_edition.primary_identifier, s, gutenberg
+            )
+
+    def test_search_field_values(self):
+        with self.request_context_with_library_and_admin(
+            "/", library=self._default_library
+        ):
+            response = self.manager.admin_search_controller.search_field_values()
+
+        assert response["subjects"] == {
+            "subject 1": 1,
+            "subject 2": 1,
+            "subject 3": 1,
+            "subject 10": 10,
+        }
+        assert response["audiences"] == {"Adult": 3, "Young Adult": 10}
+        assert response["genres"] == {"Education": 2, "Horror": 1, "Drama": 10}
+        assert response["languages"] == {"eng": 2, "spa": 1, "man": 10}
+        assert response["publishers"] == {"Publisher 1": 3, "Publisher 10": 10}
+        assert response["distributors"] == {"Gutenberg": 13}


### PR DESCRIPTION
## Description
Provides values for the following search fields
- Language
- Publisher
- Audience
- Genre
- Subject
- Distributor

Field values are cached in-memory for 1 hour on a collection_ids basis

API endpoint `GET <library>/admin/search_field_values` has been added
Returns
```
{
  "subjects": {
    "<name>": <works count>,
    ...
  },
  "languages": {
    ...
  },
  ...
}
```
<!--- Describe your changes -->

## Motivation and Context
Currently, when constructing a filtered search for a list in the Admin UI, each search filter must be entered manually as a text string. This makes sense for fields like Title, but for other fields there is a limited set of values that are stored in the database/index.
[Notion](https://www.notion.so/lyrasis/Provide-list-of-values-to-Admin-UI-for-relevant-search-filters-3e0c03c2cd23473fa7a88ca9db6510fc)

**Question:** This has been implemented as an Admin endpoint, is there a reason to have this information as a public endpoint? Eg. This [ticket](https://www.notion.so/lyrasis/Add-Advanced-Search-facets-to-the-Collection-Manager-cfcb41b38beb4bdfbfc485c8bfba17fe) might require it in the mobile apps

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manual API endpoint testing
Unit tests have been added

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
