### PR TITLE
Switched the OPDS2 feed pagination to be sortkey based

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1398,7 +1398,7 @@ class OPDS2FeedController(CirculationManagerController):
     def _parse_feed_request(self):
         """Parse the request to get frequently used request parameters for the feeds"""
         library = getattr(flask.request, "library", None)
-        pagination = load_pagination_from_request()
+        pagination = load_pagination_from_request(SortKeyPagination)
         if isinstance(pagination, ProblemDetail):
             return FeedRequestParameters(problem=pagination)
 

--- a/core/opds2.py
+++ b/core/opds2.py
@@ -1,7 +1,8 @@
 import json
-import math
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode
 
+from core.cdn import cdnify
 from core.external_search import ExternalSearchIndex
 from core.lane import Facets, Pagination, WorkList
 from core.model.cachedfeed import CachedFeed
@@ -176,14 +177,22 @@ class OPDS2Annotator:
 
     def feed_links(self):
         """Create links for a publication feed"""
-        next_query_string = (
-            f"{self.pagination.next_page.query_string}&{self.facets.query_string}"
-        )
-        next_url = self.url.split("?", 1)[0] + "?" + next_query_string
         links = [
-            {"href": self.url, "rel": "self", "type": self.OPDS2_TYPE},
-            {"href": next_url, "rel": "next", "type": self.OPDS2_TYPE},
+            {"href": cdnify(self.url), "rel": "self", "type": self.OPDS2_TYPE},
         ]
+        # If another page is present, then add the next link
+        if self.pagination.has_next_page:
+            next_query_string = urlencode(
+                {
+                    **dict(self.pagination.next_page.items()),
+                    **dict(self.facets.items()),
+                },
+                doseq=True,
+            )
+            next_url = self.url.split("?", 1)[0] + "?" + next_query_string
+            links.append(
+                {"href": cdnify(next_url), "rel": "next", "type": self.OPDS2_TYPE}
+            )
 
         return links
 
@@ -192,8 +201,6 @@ class OPDS2Annotator:
         return {
             "title": self.title,
             "itemsPerPage": self.pagination.size,
-            "currentPage": math.ceil(self.pagination.offset / self.pagination.size)
-            + 1,  # start from 1
         }
 
 

--- a/tests/api/test_opds2.py
+++ b/tests/api/test_opds2.py
@@ -16,7 +16,8 @@ from api.opds2 import (
     OPDS2PublicationsAnnotator,
     TokenAuthenticationFulfillmentProcessor,
 )
-from core.lane import Facets, Pagination
+from core.external_search import SortKeyPagination
+from core.lane import Facets
 from core.model.collection import Collection
 from core.model.configuration import ConfigurationSetting, ExternalIntegration
 from core.model.datasource import DataSource
@@ -34,7 +35,7 @@ class TestOPDS2FeedController(CirculationControllerTest):
         self.annotator = OPDS2PublicationsAnnotator(
             "https://example.org/opds2",
             Facets.default(self._default_library),
-            Pagination.default(),
+            SortKeyPagination(),
             self._default_library,
         )
         self.controller = self.manager.opds2_feeds
@@ -55,7 +56,7 @@ class TestOPDS2PublicationAnnotator(DatabaseTest):
         self.annotator = OPDS2PublicationsAnnotator(
             "https://example.org/opds2",
             Facets.default(self._default_library),
-            Pagination.default(),
+            SortKeyPagination(),
             self._default_library,
         )
 
@@ -92,7 +93,7 @@ class TestOPDS2NavigationAnnotator(DatabaseTest):
         self.annotator = OPDS2NavigationsAnnotator(
             "/",
             Facets.default(self._default_library),
-            Pagination.default(),
+            SortKeyPagination(),
             self._default_library,
             title="Navigation",
         )


### PR DESCRIPTION
## Description
This is to overcome the 10K limitation elasticsearch has on index based pagination.
As a result the "currentPage" is no longer tracked in the OPDS2 feed
<!--- Describe your changes -->

## Motivation and Context
When trying to inspect and test the feed, the “next” link in the page metadata stopped at about the 200th page or 10,000 publication mark.  
If changing the url query parameter ?after=50 to ?after=9950, the query returns the page.  However, following the next link results in an “internal error” message.   Sometimes the query has functioned upto setting ?after=9990 but anything more results in an internal error.

[Notion](https://www.notion.so/lyrasis/OPDS-2-Crawlable-feed-stops-at-10K-titles-133224082b62423298fa541eb88147e0)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated
The local feed was pulled till it's end, which exceeded 54K entries
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
