### PR TITLE
Roll back buildkit version

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -69,6 +69,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
 
       - name: Create version file
         run: git rev-parse --short HEAD > .version
@@ -120,6 +123,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
 
       - name: Create version file
         run: git rev-parse --short HEAD > .version
@@ -171,6 +177,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
 
       - name: Create version file
         run: git rev-parse --short HEAD > .version

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -67,6 +67,12 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
+      # TODO: We can remove the `with` statement here once these open upstream issues are resolved
+      # https://github.com/docker/build-push-action/issues/761
+      # https://github.com/moby/buildkit/issues/3347
+      # It was added to stop an issue we saw in buildkit v0.11 where builds were failing to
+      # push with the error:
+      # failed to copy: io: read/write on closed pipe
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
@@ -121,6 +127,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
+      # TODO: See comment in the docker-image-build section for setup-buildx-action
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
@@ -175,6 +182,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
+      # TODO: See comment in the docker-image-build section for setup-buildx-action
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -69,6 +69,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: image=moby/buildkit:v0.10.6
+          buildkitd-flags: --debug
 
       - name: Create version file
         run: git rev-parse --short HEAD > .version
@@ -120,6 +123,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: image=moby/buildkit:v0.10.6
+          buildkitd-flags: --debug
 
       - name: Create version file
         run: git rev-parse --short HEAD > .version

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -69,9 +69,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
 
       - name: Create version file
         run: git rev-parse --short HEAD > .version
@@ -123,9 +120,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
 
       - name: Create version file
         run: git rev-parse --short HEAD > .version
@@ -178,8 +172,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
+          driver-opts: image=moby/buildkit:v0.10.6
+          buildkitd-flags: --debug
 
       - name: Create version file
         run: git rev-parse --short HEAD > .version


### PR DESCRIPTION
## Description

It seems like our docker builds have been failing a lot recently with the message: 
```
#33 ERROR: failed to push ghcr.io/thepalaceproject/circ-webapp:sha-blahblah: failed to copy: io: read/write on closed pipe
```

## Motivation and Context

It looks like there are two upstream issues where others are seeing this:
https://github.com/docker/build-push-action/issues/761
https://github.com/moby/buildkit/issues/3347

[One suggestion](https://github.com/docker/build-push-action/issues/761#issuecomment-1383822381) was to roll back the version of buildkit we are using temporarily. It appears this issue is correlated with the release of buildkit v11, so this may fix the issue. 

Once there is a fix for this in buildkit, we will have to revert this fix so we are getting the latest version again.

## How Has This Been Tested?

Going to let CI run and see if it works.
