### PR TITLE
Rename easy readers lane

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -635,11 +635,11 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
     children_priority += 1
     children.sublanes.append(picture_books)
 
-    easy_readers, ignore = create(
+    early_readers, ignore = create(
         _db,
         Lane,
         library=library,
-        display_name="Easy Readers",
+        display_name="Early Readers",
         target_age=(5, 8),
         genres=[],
         fiction=None,
@@ -647,7 +647,7 @@ def create_lanes_for_large_collection(_db, library, languages, priority=0):
         languages=languages,
     )
     children_priority += 1
-    children.sublanes.append(easy_readers)
+    children.sublanes.append(early_readers)
 
     chapter_books, ignore = create(
         _db,

--- a/core/classifier/__init__.py
+++ b/core/classifier/__init__.py
@@ -325,7 +325,7 @@ class GradeLevelClassifier(Classifier):
         "pre-school": 3,
         "p": 3,
         "pk": 4,
-        # Easy readers
+        # Early readers
         "kindergarten": 5,
         "k": 5,
         "0": 5,

--- a/core/classifier/age.py
+++ b/core/classifier/age.py
@@ -11,7 +11,7 @@ class GradeLevelClassifier(Classifier):
         "pre-school": 3,
         "p": 3,
         "pk": 4,
-        # Easy readers
+        # Early readers
         "kindergarten": 5,
         "k": 5,
         "0": 5,

--- a/migration/20230118-rename-easy-reader-lane.sql
+++ b/migration/20230118-rename-easy-reader-lane.sql
@@ -1,0 +1,3 @@
+-- Change the name of the "Easy Readers" lane to "Early Readers" in accordance with
+-- https://www.notion.so/lyrasis/Rename-the-default-lane-Easy-Readers-to-Early-Readers-e2df6515cb644064b4cd2b65556f186d
+UPDATE lanes SET display_name = 'Early Readers' WHERE display_name= 'Easy Readers';


### PR DESCRIPTION
## Description
* Renames the "Easy Readers" default lane to "Early Readers" in accordance with new library conventions.
* Provides a migration script for existing lanes.
## Motivation and Context
https://www.notion.so/lyrasis/Rename-the-default-lane-Easy-Readers-to-Early-Readers-e2df6515cb644064b4cd2b65556f186d
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested locally:  created new library and verified the Early reader lane shows up and the Easy Reader does not.
Manually reverted the to Easy Reader and ran the migration script.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
