### PR TITLE
Revert "Roll back buildkit version (#758)"

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -67,17 +67,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
-      # TODO: We can remove the `with` statement here once these open upstream issues are resolved
-      # https://github.com/docker/build-push-action/issues/761
-      # https://github.com/moby/buildkit/issues/3347
-      # It was added to stop an issue we saw in buildkit v0.11 where builds were failing to
-      # push with the error:
-      # failed to copy: io: read/write on closed pipe
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: image=moby/buildkit:v0.10.6
-          buildkitd-flags: --debug
 
       - name: Create version file
         run: git rev-parse --short HEAD > .version
@@ -127,12 +118,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
-      # TODO: See comment in the docker-image-build section for setup-buildx-action
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: image=moby/buildkit:v0.10.6
-          buildkitd-flags: --debug
 
       - name: Create version file
         run: git rev-parse --short HEAD > .version
@@ -183,12 +170,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
-      # TODO: See comment in the docker-image-build section for setup-buildx-action
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          driver-opts: image=moby/buildkit:v0.10.6
-          buildkitd-flags: --debug
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Description

This PR reverts the changes made in #758 (commit 0af51f44c47a3147d0342785470f74e47cc0696b).

## Motivation and Context

In an update on the upstream issue https://github.com/docker/build-push-action/issues/761#issuecomment-1406261692, this has been resolved with the release of a new version of buildkit (v0.11.2), so we can roll back the mitigation we put in place to keep our docker images building.

## How Has This Been Tested?

Should be good to go if CI passes and docker containers build. Would be good to check the build logs to make sure that buildkit v0.11.2 is what gets installed by CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
