### PR TITLE
Add chmod to uwsgi log configuration

### DIFF
--- a/docker/services/uwsgi.d/40_log.ini
+++ b/docker/services/uwsgi.d/40_log.ini
@@ -2,3 +2,4 @@
 # location of log files
 logto = /var/log/uwsgi/uwsgi.log
 log-format = %(var.HTTP_X_FORWARDED_FOR) (%(addr)) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
+logfile-chmod = 644


### PR DESCRIPTION
## Description

In order for the AWS cloudwatch logs deamon to be able to send the uwsgi logs to cloudwatch, the logs need to be readable by the cwagent user.

This config allows the logs to be read by everybody, so that the cwagent user can send them to cloudwatch.

## Motivation and Context

We added an override to the uwsgi.ini we deploy to our hosting environment CMs in https://github.com/ThePalaceProject/hosting-playbook/pull/318 to add this flag, so that the cloudwatch agent could send these logs into cloudwatch logs.

This seems like something that should be part of the base image. Once this is merged in and rolled out everywhere, we can remove the override from our hosting deployments.

## How Has This Been Tested?

- Ran container, checked permissions on `/var/log/uwsgi/uwsgi.log` 

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
