### PR TITLE
Ensure that works with a language of both Persian and Farsi are assig…

### DIFF
--- a/core/util/languages.py
+++ b/core/util/languages.py
@@ -376,7 +376,7 @@ pan||pa|Panjabi; Punjabi|pendjabi
 pap|||Papiamento|papiamento
 pau|||Palauan|palau
 peo|||Persian, Old (ca.600-400 B.C.)|perse, vieux (ca. 600-400 av. J.-C.)
-per|fas|fa|Persian|persan
+per|fas|fa|Persian; Farsi|persan
 phi|||Philippine languages|philippines, langues
 phn|||Phoenician|phénicien
 pli||pi|Pali|pali

--- a/tests/core/util/test_languages.py
+++ b/tests/core/util/test_languages.py
@@ -105,6 +105,9 @@ class TestLanguageCodes:
         assert "tib" == m("bod")
         # test reserved codes
         assert "qab" == m("qab")
+        assert "per" == m("Persian")
+        assert "per" == m("Farsi")
+        assert "per" == m("per")
         # test bad data
         assert None == m(self.NONEXISTENT_LABEL)
 


### PR DESCRIPTION
…ned the "per" langugage code

## Description
This update simply adds "Farsi" as a possible English name for the "per" (Persian) language code.  ONIX apparently supports both Persian and Farsi whereas the ISO standard we use only supports "Persian".
## Motivation and Context

This issue was discovered in the process of investigating this: https://www.notion.so/lyrasis/Investigate-Foreign-Language-titles-not-being-sorted-into-individual-language-lanes-on-CM-73c4a57adf5142178b0c05e37794d560#d25770ed5f9b40a49f877fb9e969f8be

This  PR won't solve the problem identified by the ticket: the issue is a data issue on the distributor side. However if the distributor updates their metadata data and they use "Farsi" rather than "Persian" the problem will persist.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

It's covered by unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
