### PR TITLE
Prevent duplicate lanes from being autogenerated

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -93,13 +93,12 @@ def _lane_configuration_from_collection_sizes(estimates):
 def create_default_lanes(_db, library):
     """Reset the lanes for the given library to the default.
 
-    The database will have the following top-level lanes for
-    each large-collection:
-    'Adult Fiction', 'Adult Nonfiction', 'Young Adult Fiction',
-    'Young Adult Nonfiction', and 'Children'.
-    Each lane contains additional sublanes.
-    If an NYT integration is configured, there will also be a
-    'Best Sellers' top-level lane.
+    This method will create a set of default lanes  for the first
+    major language specified in the UI or if no language is specified
+    then the most represented language in the catalogue.  If more than
+    one major language is specified, all but the first will be ignored
+    in terms of default lane creation. In other words, don't specify
+    multiple top level languages.
 
     If there are any small- or tiny-collection languages, the database
     will also have a top-level lane called 'World Languages'. The
@@ -133,7 +132,7 @@ def create_default_lanes(_db, library):
         large, small, tiny = _lane_configuration_from_collection_sizes(estimates)
     priority = 0
 
-    if large:
+    if large and len(large) > 0:
         language = large[0]
         priority = create_lanes_for_large_collection(
             _db, library, language, priority=priority

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -132,7 +132,9 @@ def create_default_lanes(_db, library):
         estimates = library.estimated_holdings_by_language()
         large, small, tiny = _lane_configuration_from_collection_sizes(estimates)
     priority = 0
-    for language in large:
+
+    if large:
+        language = large[0]
         priority = create_lanes_for_large_collection(
             _db, library, language, priority=priority
         )

--- a/core/model/library.py
+++ b/core/model/library.py
@@ -393,6 +393,7 @@ class Library(Base, HasSessionCache):
             .join(Work.presentation_edition)
             .filter(Edition.language != None)
             .group_by(Edition.language)
+            .order_by("work_count desc")
         )
         qu = self.restrict_to_ready_deliverable_works(qu)
         if not include_open_access:

--- a/core/model/library.py
+++ b/core/model/library.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Table,
     Unicode,
     UniqueConstraint,
+    desc,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
@@ -393,7 +394,7 @@ class Library(Base, HasSessionCache):
             .join(Work.presentation_edition)
             .filter(Edition.language != None)
             .group_by(Edition.language)
-            .order_by("work_count desc")
+            .order_by(desc(func.count(Work.id).label("work_count")))
         )
         qu = self.restrict_to_ready_deliverable_works(qu)
         if not include_open_access:

--- a/core/model/library.py
+++ b/core/model/library.py
@@ -12,7 +12,6 @@ from sqlalchemy import (
     Table,
     Unicode,
     UniqueConstraint,
-    desc,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
@@ -394,7 +393,6 @@ class Library(Base, HasSessionCache):
             .join(Work.presentation_edition)
             .filter(Edition.language != None)
             .group_by(Edition.language)
-            .order_by(desc(func.count(Work.id).label("work_count")))
         )
         qu = self.restrict_to_ready_deliverable_works(qu)
         if not include_open_access:


### PR DESCRIPTION
## Description

Prevents duplicate sets of top level lanes from being generated by ensuring that top level lanes for the most represented language is generated.

## Motivation and Context
There are multiple tickets involving duplicate top level lanes.  For details on how this occurs see https://www.notion.so/lyrasis/Columbia-and-Vermont-Two-top-level-lanes-are-named-Nonfiction-b33f15333d134b40b8bb3102acfa9cdf#da1ff9ed40e74d57bcc76da9bbc3aa77

## How Has This Been Tested?
I have manually tested that only one top level set of lanes are created regardless of the number of major languages are set.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
