### PR TITLE
Adds script bin/repair/delete_invisible_lanes_and_their_descendants

### DIFF
--- a/bin/repair/delete_invisible_lanes_and_their_descendants
+++ b/bin/repair/delete_invisible_lanes_and_their_descendants
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""Regenerate the lanes for a library."""
+import os
+import sys
+
+from core.scripts import DeleteInvisibleLanesScript
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+
+DeleteInvisibleLanesScript().run()

--- a/bin/repair/delete_invisible_lanes_and_their_descendants
+++ b/bin/repair/delete_invisible_lanes_and_their_descendants
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Regenerate the lanes for a library."""
+"""Delete invisible lanes associated with one or more libraries."""
 import os
 import sys
 

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -3576,50 +3576,15 @@ class CustomListUpdateEntriesScript(CustomListSweeperScript):
 
 
 class DeleteInvisibleLanesScript(LibraryInputScript):
-    """Delete lanes that are flagged as invisible including any visible sub-lanes."""
+    """Delete lanes that are flagged as invisible"""
 
     def process_library(self, library):
 
         try:
-            continue_update = True
-            while continue_update:
-                rows = self._db.execute(
-                    "select count(l.id) from  lanes l, \
-                 (select id from lanes where visible = false and library_id = :library_id) invisible_lanes  \
-                 where l.visible = true and l.library_id = :library_id and  \
-                 l.parent_id = invisible_lanes.id",
-                    {"library_id": library.id},
-                )
-                if rows.first()[0] == 0:
-                    continue_update = False
-                else:
-                    self._db.execute(
-                        "update lanes set visible = false where id in ( select l.id from  lanes l, "
-                        "(select id from lanes where visible = false and  library_id = :library_id) "
-                        "invisible_lanes where l.visible = true and l.library_id = :library_id and  "
-                        "l.parent_id = invisible_lanes.id)",
-                        {"library_id": library.id},
-                    )
-
-            self._db.execute(
-                "delete from lanes_genres where lane_id in "
-                "(select id from lanes where library_id = :library_id and visible = false)",
-                {"library_id": library.id},
-            )
-
-            self._db.execute(
-                "delete from cachedfeeds where lane_id in ( "
-                "select id from lanes where library_id = :library_id and visible = false)",
-                {"library_id": library.id},
-            )
-
-            self._db.execute(
-                "delete from lanes where library_id = :library_id and visible = false",
-                {"library_id": library.id},
-            )
-
+            for lane in self._db.query(Lane).filter(Lane.library_id == library.id):
+                if not lane.visible:
+                    self._db.delete(lane)
             self._db.commit()
-
             logging.info(f"Completed hidden lane deletion for {library.short_name}")
         except Exception as e:
             try:


### PR DESCRIPTION
to delete invisible lanes and their descendants for a given list of libraries.

## Description

Some libraries have multiple sets of top level default lanes due to bugs in the code.  This PR is an attempt to correct it.  Admins can hide the top level lanes default lanes they want removed. Then this script can be run using the library's short name as an input parameter in order to remove the invisible lanes and their descendants.

## Motivation and Context

cf https://www.notion.so/lyrasis/Columbia-and-Vermont-Two-top-level-lanes-are-named-Nonfiction-b33f15333d134b40b8bb3102acfa9cdf

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

It's been tested and there is an integration test included with this PR.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
