### PR TITLE
Fix UpdateLaneSizeScript causing performance issue

### DIFF
--- a/core/lane.py
+++ b/core/lane.py
@@ -3247,9 +3247,7 @@ def configuration_relevant_lifecycle_event(mapper, connection, target):
 @event.listens_for(Lane, "after_update")
 @event.listens_for(LaneGenre, "after_update")
 def configuration_relevant_update(mapper, connection, target):
-    suppressed = (
-        target._suppress_configuration_changes if isinstance(target, Lane) else False
-    )
+    suppressed = getattr(target, "_suppress_configuration_changes", False)
     if directly_modified(target) and not suppressed:
         site_configuration_has_changed(target)
 

--- a/core/lane.py
+++ b/core/lane.py
@@ -2696,15 +2696,18 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
         cascade="all, delete-orphan",
     )
 
-    # We add this property to the class, so that we can disable the sqlalchemy
-    # listener that calls site_configuration_has_changed. Calling this repeatedly
-    # when updating lanes can cause performance issues. The plan is for this to
-    # be a temporary fix while we replace the need for the site_configuration_has_changed
-    # and listeners at all.
-    # TODO: we should remove this, once we remove the site_configuration_has_changed listeners
-    _suppress_configuration_changes = False
-
     __table_args__ = (UniqueConstraint("parent_id", "display_name"),)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # We add this property to the class, so that we can disable the sqlalchemy
+        # listener that calls site_configuration_has_changed. Calling this repeatedly
+        # when updating lanes can cause performance issues. The plan is for this to
+        # be a temporary fix while we replace the need for the site_configuration_has_changed
+        # and listeners at all.
+        # TODO: we should remove this, once we remove the site_configuration_has_changed listeners
+        self._suppress_configuration_changes = False
 
     def get_library(self, _db):
         """For compatibility with WorkList.get_library()."""

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -3420,8 +3420,20 @@ class UpdateLaneSizeScript(LaneSweeperScript):
 
     def process_lane(self, lane):
         """Update the estimated size of a Lane."""
+
+        # We supress the configuration changes updates, as each lane is updated
+        # and call the site_configuration_has_changed function once after this
+        # script has finished running.
+        #
+        # This is done because calling site_configuration_has_changed repeatedly
+        # was causing performance problems, when we have lots of lanes to update.
+        lane._suppress_configuration_changes = True
         lane.update_size(self._db)
         self.log.info("%s: %d", lane.full_identifier, lane.size)
+
+    def do_run(self, *args, **kwargs):
+        super().do_run(*args, **kwargs)
+        site_configuration_has_changed(self._db)
 
 
 class UpdateCustomListSizeScript(CustomListSweeperScript):

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -4032,6 +4032,15 @@ class TestLane:
         assert facets == lane.called_with
         Lane._groups_for_lanes = old_value
 
+    def test_suppress(self, db: DatabaseTransactionFixture):
+        lane1 = db.lane()
+        lane2 = db.lane()
+
+        # Updating the flag on one lane does not impact others
+        lane1._suppress_configuration_changes = True
+        assert lane1._suppress_configuration_changes is True
+        assert lane2._suppress_configuration_changes is False
+
 
 class TestWorkListGroupsEndToEndData:
     best_seller_list: CustomList


### PR DESCRIPTION
## Description

Add a new local flag to lanes, that allows a lane update to suppress the listener that triggers an update to the configuration time stamp. This lets the `UpdateLaneSizeScript` update all the lanes before changing the timestamp.

This should resolve a performance problem we are seeing on our production servers, especially the ones with lots of lane.

[Notion](https://www.notion.so/lyrasis/Investigate-and-fix-update_lane_size-script-causes-response-time-issues-in-web-servers-0fc89b26cf164c6ebc5422e2f59fa0ba)

## Motivation and Context

When update_lane_size is running, responses from CM servers are delayed to the point that neither the OPDS feeds nor the Admin UI is served from the web servers.

This is a quick fix, while we work through the more complicated solution to the problem of removing the need for the configuration reload mechanism at all.

## How Has This Been Tested?

I have a local environment setup, that is showing the same symptoms as the production environment. The test setup is similar to what [Rishi describes in notion](https://www.notion.so/lyrasis/Investigate-and-fix-update_lane_size-script-causes-response-time-issues-in-web-servers-0fc89b26cf164c6ebc5422e2f59fa0ba#8e482ae95a814ecdbd5f43f8fd4d3ce3). 

Before this update, when running `UpdateLaneSizeScript` I am seeing very slow response times, about 8 seconds per request on average. After making this change, I see an average response time of 0.13 seconds, which is the same as I saw without the script running.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
