### PR TITLE
Bump up the log level for load_settings.

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -210,7 +210,7 @@ class CirculationManager:
             self.load_settings()
             self.site_configuration_last_update = last_update
 
-    @log_elapsed_time(log_method=log.debug, message_prefix="load_settings")
+    @log_elapsed_time(log_method=log.info, message_prefix="load_settings")
     def load_settings(self):
         """Load all necessary configuration settings and external
         integrations from the database.


### PR DESCRIPTION
## Description

As part of https://github.com/ThePalaceProject/circulation/pull/778, it would be nice to have some clear logging around when settings are loaded. So we can review our logs and see clearly when we are triggering settings reloads.

## Motivation and Context

This would have made it much clearer what was happening with the `update_lane_size` script.

## How Has This Been Tested?

Unit tests run

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
