### PR TITLE
Automate overdrive advantage account setup

### DIFF
--- a/bin/import_new_overdrive_advantage_accounts
+++ b/bin/import_new_overdrive_advantage_accounts
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+"""Import new overdrive advantage collections associated with a main overdrive account"""
+import os
+import sys
+
+from core.scripts import ImportNewOverdriveAdvantageAccounts
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+
+
+ImportNewOverdriveAdvantageAccounts().run()

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -3593,35 +3593,35 @@ class TestImportNewOverdriveAdvantageAccounts:
         smtp_client.sendmail = MagicMock()
         smtp_client.quit = MagicMock()
 
-        with (
-            patch(
-                "core.scripts.ImportNewOverdriveAdvantageAccounts._configure_smtp_client"
-            ) as configure_smtp_client,
-            patch(
+        with patch(
+            "core.scripts.ImportNewOverdriveAdvantageAccounts._configure_smtp_client"
+        ) as configure_smtp_client:
+            with patch(
                 "core.scripts.ImportNewOverdriveAdvantageAccounts._create_overdrive_api"
-            ) as create_overdrive_api,
-        ):
-            configure_smtp_client.return_value = smtp_client
-            create_overdrive_api.return_value = overdrive_api
-            ImportNewOverdriveAdvantageAccounts(_db=db.session).run()
-            assert overdrive_api.get_advantage_accounts.call_count == 1
-            parent_coll, is_new = Collection.by_name_and_protocol(
-                _db=db.session,
-                name=parent_library_name,
-                protocol=ExternalIntegration.OVERDRIVE,
-            )
-            assert not is_new
-            assert parent_coll.id == parent.id
-            assert parent_coll.external_account_id == parent_id
-            advantage_collection_name = advantage_library_name + " Overdrive Advantage"
-            advantage_collection, is_new = Collection.by_name_and_protocol(
-                _db=db.session,
-                name=advantage_collection_name,
-                protocol=ExternalIntegration.OVERDRIVE,
-            )
-            assert not is_new
-            assert advantage_collection.external_account_id == advantage_library_id
-            smtp_client.quit.assert_called()
-            # run again to ensure email is only sent when the new accounts are created.
-            ImportNewOverdriveAdvantageAccounts(_db=db.session).run()
-            smtp_client.sendmail.assert_called_once()
+            ) as create_od_api:
+                configure_smtp_client.return_value = smtp_client
+                create_od_api.return_value = overdrive_api
+                ImportNewOverdriveAdvantageAccounts(_db=db.session).run()
+                assert overdrive_api.get_advantage_accounts.call_count == 1
+                parent_coll, is_new = Collection.by_name_and_protocol(
+                    _db=db.session,
+                    name=parent_library_name,
+                    protocol=ExternalIntegration.OVERDRIVE,
+                )
+                assert not is_new
+                assert parent_coll.id == parent.id
+                assert parent_coll.external_account_id == parent_id
+                advantage_collection_name = (
+                    advantage_library_name + " Overdrive Advantage"
+                )
+                advantage_collection, is_new = Collection.by_name_and_protocol(
+                    _db=db.session,
+                    name=advantage_collection_name,
+                    protocol=ExternalIntegration.OVERDRIVE,
+                )
+                assert not is_new
+                assert advantage_collection.external_account_id == advantage_library_id
+                smtp_client.quit.assert_called()
+                # run again to ensure email is only sent when the new accounts are created.
+                ImportNewOverdriveAdvantageAccounts(_db=db.session).run()
+                smtp_client.sendmail.assert_called_once()

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -3585,7 +3585,6 @@ class TestImportNewOverdriveAdvantageAccounts:
                 parent_id,
                 advantage_library_id,
                 advantage_library_name,
-                "token value",
             )
         ]
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -19,6 +19,8 @@ from core.classifier import Classifier
 from core.config import Configuration
 from core.log import LogConfiguration
 from core.model import (
+    Admin,
+    AdminRole,
     Base,
     Classification,
     Collection,
@@ -899,6 +901,16 @@ class DatabaseTransactionFixture:
             self.session, data_source, type, patron
         )
         return credential
+
+    def admin(self):
+        admin = Admin()
+        admin.email = "circmanager_tests@lyrasis.org"
+        admin.credential = "test"
+        admin.password = "x"
+        admin.password_hashed = "x"
+        self.session.add(admin)
+        admin.add_role(role=AdminRole.SYSTEM_ADMIN)
+        return admin
 
 
 class TemporaryDirectoryConfigurationFixture:

--- a/tests/fixtures/smtp.py
+++ b/tests/fixtures/smtp.py
@@ -1,0 +1,13 @@
+from smtplib import SMTP
+
+import pytest
+
+
+class MockSMTP(SMTP):
+    def __init__(self):
+        pass
+
+
+@pytest.fixture(scope="function")
+def smtp_fixture() -> SMTP:
+    return MockSMTP


### PR DESCRIPTION
## Description
This PR contains a new script and a test for importing new advantage accounts associated with a main account. 
It should not yet be merged because it currently is importing all accounts associated with a main account.   Some Overdrive advantage libraries are not signed up with Palace and so should not be imported into the system.  Until we can figure out how to prevent this from happening,  we should hold off on merging this PR.
## Motivation and Context
https://www.notion.so/lyrasis/Automatically-import-OD-Advantage-Accounts-7f604219d69a421a881c3711c91cdfb7

## How Has This Been Tested?

It has been tested manually and the unit test passes.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
