### PR TITLE
Adds "Persian Farsi" as an English to iso language code mapping

### DIFF
--- a/core/util/languages.py
+++ b/core/util/languages.py
@@ -376,7 +376,7 @@ pan||pa|Panjabi; Punjabi|pendjabi
 pap|||Papiamento|papiamento
 pau|||Palauan|palau
 peo|||Persian, Old (ca.600-400 B.C.)|perse, vieux (ca. 600-400 av. J.-C.)
-per|fas|fa|Persian; Farsi|persan
+per|fas|fa|Persian; Farsi; Persian Farsi|persan
 phi|||Philippine languages|philippines, langues
 phn|||Phoenician|phénicien
 pli||pi|Pali|pali

--- a/tests/core/util/test_languages.py
+++ b/tests/core/util/test_languages.py
@@ -107,6 +107,8 @@ class TestLanguageCodes:
         assert "qab" == m("qab")
         assert "per" == m("Persian")
         assert "per" == m("Farsi")
+        # Baker and Taylor sends "Persian Farsi" rather than "Persian" or "Farsi"
+        assert "per" == m("Persian Farsi")
         assert "per" == m("per")
         # test bad data
         assert None == m(self.NONEXISTENT_LABEL)
@@ -153,6 +155,11 @@ class TestLanguageNames:
         coded("irish", "gle")
         coded("tokelau", "tkl")
         coded("persian", "per")
+        coded("farsi", "per")
+
+        # for baker and taylor (they are not sending the correct
+        # english name and are unwilling to fix their metadata FWIW
+        coded("persian farsi", "per")
 
         # (Some) native-language names work
         coded("francais", "fre")

--- a/tests/core/util/test_languages.py
+++ b/tests/core/util/test_languages.py
@@ -157,8 +157,8 @@ class TestLanguageNames:
         coded("persian", "per")
         coded("farsi", "per")
 
-        # for baker and taylor (they are not sending the correct
-        # english name and are unwilling to fix their metadata FWIW
+        # This non-standard English name has been added to accommodate Baker and Taylor
+        # as they are not sending the correct English name and are unwilling to fix their metadata.
         coded("persian farsi", "per")
 
         # (Some) native-language names work


### PR DESCRIPTION
because Baker and Taylor is unable or unwilling to fix their feed.

## Description

## Motivation and Context
https://www.notion.so/lyrasis/Investigate-Foreign-Language-titles-not-being-sorted-into-individual-language-lanes-on-CM-73c4a57adf5142178b0c05e37794d560?pvs=4#a08aab6bec4543fcb5108648257cb01c
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I've updated the unit tests to reflect this change.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
