### PR TITLE
Make passwords required (in most cases)

### DIFF
--- a/core/model/admin.py
+++ b/core/model/admin.py
@@ -150,7 +150,7 @@ class Admin(Base, HasSessionCache):
         # First check if the admin is a manager of _all_ libraries.
         if self.is_sitewide_library_manager():
             return True
-        # If not, they could stil be a manager of _this_ library.
+        # If not, they could still be a manager of _this_ library.
         def lookup_hook():
             return (
                 get_one(


### PR DESCRIPTION
## Description

This updates the code in the Admin API controller that handles password changes. Now, passwords are always required for new admins.

There are numerous issues with the original password checking code that will require a lot of refactoring, but these are all outside of the scope of the ticket associated with this work.

## Motivation and Context

Passwords have been practically required for a while, but the code doesn't enforce the fact that they are.

Affects: https://www.notion.so/lyrasis/Make-password-a-required-field-when-creating-an-account-on-the-CM-ab4313f97fc4465687dfbafc9f64dc1e

## How Has This Been Tested?

I created a new admin locally, and ensured all of the existing tests pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
