### PR TITLE
Palace Marketplace (ODL 2.0) collections with loan and hold limits

### DIFF
--- a/api/circulation_exceptions.py
+++ b/api/circulation_exceptions.py
@@ -148,10 +148,12 @@ class LimitReached(CirculationException):
     SETTING_NAME = None
     MESSAGE_WITH_LIMIT = None
 
-    def __init__(self, message=None, debug_info=None, library=None):
+    def __init__(self, message=None, debug_info=None, library=None, limit=None):
         super().__init__(message=message, debug_info=debug_info)
         if library:
             self.limit = library.setting(self.SETTING_NAME).int_value
+        elif limit:
+            self.limit = limit
         else:
             self.limit = None
 

--- a/api/odl2.py
+++ b/api/odl2.py
@@ -45,7 +45,7 @@ class ODL2APIConfiguration(OPDSImporterConfiguration):
         key="odl2_loan_limit",
         label=_("Loan limit per patron"),
         description=_(
-            "The number of assets a patron can have loaned out at any given time."
+            "The maximum number of books a patron can have loaned out at any given time."
         ),
         type=ConfigurationAttributeType.NUMBER,
         required=False,
@@ -56,7 +56,7 @@ class ODL2APIConfiguration(OPDSImporterConfiguration):
         key="odl2_hold_limit",
         label=_("Hold limit per patron"),
         description=_(
-            "The number of assets a patron can have on hold at any given time."
+            "The maximum number of books a patron can have on hold at any given time."
         ),
         type=ConfigurationAttributeType.NUMBER,
         required=False,


### PR DESCRIPTION
## Description
Both are implemented as collection settings for ODL2 type collections
Initially, ODL 2 only differed from the ODL 1 implementation with respect to the import format.
This adds a deviation to the loan and hold functions, only ODL 2 supports the loan and hold limits.
<!--- Describe your changes -->

## Motivation and Context
Suffolk County Library System requested the ability to configure in the CM the amount of loans and   holds that are allowed for Palace Marketplace content.

[Notion](https://www.notion.so/lyrasis/In-the-Collection-Manager-Add-ability-to-define-the-number-of-loans-and-holds-available-for-Palace--c4efa7e8ccb04e28aa677eee5055ec92)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
