### PR TITLE
Add docker-compose file to setup testing environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ absolutely necessary.
 
 ## Set Up
 
+### Docker Compose
+
+In order to help quickly set up a development environment, we include a [docker-compose.yml](./docker-compose.yml)
+file. This docker-compose file, will build the webapp and scripts containers from your local repository, and start
+those containers as well as all the necessary service containers.
+
+You can give this a try by running the following command:
+
+```shell
+docker-compose up --build
+```
+
 ### Python Set Up
 
 #### Homebrew (OSX)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.9"
+services:
+  # example docker compose configuration for testing and development
+
+  webapp:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      target: webapp
+    ports:
+      - "6500:80"
+    environment:
+      SIMPLIFIED_PRODUCTION_DATABASE: "postgres://palace:test@pg:5432/circ"
+
+  scripts:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      target: scripts
+    environment:
+      SIMPLIFIED_PRODUCTION_DATABASE: "postgres://palace:test@pg:5432/circ"
+
+  pg:
+    image: "postgres:12"
+    environment:
+      POSTGRES_USER: palace
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: circ
+
+  minio:
+    image: "bitnami/minio:2022.3.3"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ACCESS_KEY: "palace"
+      MINIO_SECRET_KEY: "test123456789"
+
+  os:
+    image: opensearchproject/opensearch:1
+    environment:
+      discovery.type: single-node
+      DISABLE_SECURITY_PLUGIN: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,8 @@ services:
       - "9000:9000"
       - "9001:9001"
     environment:
-      MINIO_ACCESS_KEY: "palace"
-      MINIO_SECRET_KEY: "test123456789"
+      MINIO_ROOT_USER: "palace"
+      MINIO_ROOT_PASSWORD: "test123456789"
 
   os:
     image: opensearchproject/opensearch:1

--- a/tox.ini
+++ b/tox.ini
@@ -71,8 +71,8 @@ ports =
 [docker:minio-circ]
 image = bitnami/minio:2022.3.3
 environment =
-    MINIO_ACCESS_KEY=simplified
-    MINIO_SECRET_KEY=12345678901234567890
+    MINIO_ROOT_USER=simplified
+    MINIO_ROOT_PASSWORD=12345678901234567890
 ports =
     9004:9000/tcp
 


### PR DESCRIPTION
## Description

Add a small docker-compose file that builds and runs containers to quickly get setup with a working circulation manager from the code in the local repository.

## Motivation and Context

Similar to this PR:
https://github.com/ThePalaceProject/virtual-library-card/pull/130

And the `docker-compose` file included with the library registry code.

Since we discussed in the sprint retrospective, the need to more easily setup an environment for things like code review, this PR attempts to make that process a little easier. I needed to setup a dockerized environment for testing https://github.com/ThePalaceProject/circulation/pull/576. So I took the opportunity to write a basic docker-compose file.

## How Has This Been Tested?

I've been using it to test https://github.com/ThePalaceProject/circulation/pull/576

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
