### PR TITLE
Bump CM admin interface version to v0.5.0

### DIFF
--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -13,7 +13,7 @@ class Configuration:
 
     APP_NAME = "Palace Collection Manager"
     PACKAGE_NAME = "@thepalaceproject/circulation-admin"
-    PACKAGE_VERSION = "0.4.2"
+    PACKAGE_VERSION = "0.5.0"
 
     STATIC_ASSETS = {
         "admin_js": "circulation-admin.js",


### PR DESCRIPTION
## Description

Bump the version of the CM admin interface we are using to v.0.5.0
https://github.com/ThePalaceProject/circulation-admin/releases/tag/v0.5.0

## Motivation and Context

Working on a release cycle for the circulation manager code, and some new CM features in https://github.com/ThePalaceProject/circulation/pull/801 and https://github.com/ThePalaceProject/circulation/pull/785 require the new CM admin interface version.

## How Has This Been Tested?

Ran CM locally to test that new interface comes in correctly.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
