### PR TITLE
Add codecov token

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -49,6 +49,9 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   docker-image-build:
     name: Docker build base

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -51,7 +51,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          files: ./coverage.xml
 
   docker-image-build:
     name: Docker build base


### PR DESCRIPTION
## Description

It seems like our uploads to codecov are failing sometimes. 

For example here: 
https://github.com/ThePalaceProject/circulation/actions/runs/4197047024/jobs/7278857061#step:8:37

## Motivation and Context

> Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.
 
The [codecov docs](https://docs.codecov.com/docs) say the token isn't required for public github repos, but it seems like the action fails occasionally without it, so its probably worth including it anyway. 

## How Has This Been Tested?

CI Running on the request now. PR should be good to go if CI passes and coverage uploads.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
