### PR TITLE
Fix pytest warning

### DIFF
--- a/tests/core/test_app_server.py
+++ b/tests/core/test_app_server.py
@@ -47,8 +47,12 @@ class TestApplicationVersionController:
         monkeypatch.setattr(core, "__branch__", branch)
 
         # Mock the admin ui version strings
-        monkeypatch.setenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_NAME, ui_package)
-        monkeypatch.setenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_VERSION, ui_version)
+        monkeypatch.setenv(
+            AdminUiConfig.ENV_ADMIN_UI_PACKAGE_NAME, ui_package if ui_package else ""
+        )
+        monkeypatch.setenv(
+            AdminUiConfig.ENV_ADMIN_UI_PACKAGE_VERSION, ui_version if ui_version else ""
+        )
 
         controller = ApplicationVersionController()
         with app.test_request_context("/"):

--- a/tests/core/test_app_server.py
+++ b/tests/core/test_app_server.py
@@ -47,12 +47,15 @@ class TestApplicationVersionController:
         monkeypatch.setattr(core, "__branch__", branch)
 
         # Mock the admin ui version strings
-        monkeypatch.setenv(
-            AdminUiConfig.ENV_ADMIN_UI_PACKAGE_NAME, ui_package if ui_package else ""
-        )
-        monkeypatch.setenv(
-            AdminUiConfig.ENV_ADMIN_UI_PACKAGE_VERSION, ui_version if ui_version else ""
-        )
+        if ui_package is not None:
+            monkeypatch.setenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_NAME, ui_package)
+        else:
+            monkeypatch.delenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_NAME)
+
+        if ui_version is not None:
+            monkeypatch.setenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_VERSION, ui_version)
+        else:
+            monkeypatch.delenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_VERSION)
 
         controller = ApplicationVersionController()
         with app.test_request_context("/"):

--- a/tests/core/test_app_server.py
+++ b/tests/core/test_app_server.py
@@ -50,12 +50,14 @@ class TestApplicationVersionController:
         if ui_package is not None:
             monkeypatch.setenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_NAME, ui_package)
         else:
-            monkeypatch.delenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_NAME)
+            monkeypatch.delenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_NAME, raising=False)
 
         if ui_version is not None:
             monkeypatch.setenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_VERSION, ui_version)
         else:
-            monkeypatch.delenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_VERSION)
+            monkeypatch.delenv(
+                AdminUiConfig.ENV_ADMIN_UI_PACKAGE_VERSION, raising=False
+            )
 
         controller = ApplicationVersionController()
         with app.test_request_context("/"):


### PR DESCRIPTION
## Description

Fix pytest warning that I introduced in https://github.com/ThePalaceProject/circulation/pull/765

```
tests/core/test_app_server.py::TestApplicationVersionController::test_version[None-None-None-None-None]
test_app_server.py:50: PytestWarning: Value of environment variable TPP_CIRCULATION_ADMIN_PACKAGE_NAME type should be str, but got None (type: NoneType); converted to str implicitly
    monkeypatch.setenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_NAME, ui_package)

tests/core/test_app_server.py::TestApplicationVersionController::test_version[None-None-None-None-None]
test_app_server.py:51: PytestWarning: Value of environment variable TPP_CIRCULATION_ADMIN_PACKAGE_VERSION type should be str, but got None (type: NoneType); converted to str implicitly
    monkeypatch.setenv(AdminUiConfig.ENV_ADMIN_UI_PACKAGE_VERSION, ui_version)
```

## Motivation and Context

Warning is fairly benign, but its good to reduce the number of warnings that we have in our tests.

## How Has This Been Tested?

Ran tests on the branch.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
