### PR TITLE
Attempt to require passwords (again)

### DIFF
--- a/tests/api/admin/controller/test_individual_admins.py
+++ b/tests/api/admin/controller/test_individual_admins.py
@@ -711,6 +711,26 @@ class TestIndividualAdmins(SettingsControllerTest):
             assert 400 == response.status_code
             assert response.uri == INCOMPLETE_CONFIGURATION.uri
 
+    def test_individual_admins_post_create_requires_non_empty_password(self):
+        """The password is required."""
+        for admin in self._db.query(Admin):
+            self._db.delete(admin)
+
+        with self.app.test_request_context("/", method="POST"):
+            flask.request.form = MultiDict(
+                [
+                    ("email", "first_admin@nypl.org"),
+                    ("password", ""),
+                    ("roles", json.dumps([{"role": AdminRole.SYSTEM_ADMIN}])),
+                ]
+            )
+            flask.request.files = {}
+            response = (
+                self.manager.admin_individual_admin_settings_controller.process_post()
+            )
+            assert 400 == response.status_code
+            assert response.uri == INCOMPLETE_CONFIGURATION.uri
+
     def test_individual_admins_post_create_on_setup(self):
         """Creating a system admin with a password works."""
         for admin in self._db.query(Admin):
@@ -773,6 +793,28 @@ class TestIndividualAdmins(SettingsControllerTest):
             flask.request.form = MultiDict(
                 [
                     ("email", "second_admin@nypl.org"),
+                    ("roles", []),
+                ]
+            )
+            flask.request.files = {}
+            response = (
+                self.manager.admin_individual_admin_settings_controller.process_post()
+            )
+            assert 400 == response.status_code
+
+    def test_individual_admins_post_create_second_admin_empty_password(self):
+        """Creating a second admin without a password fails."""
+        for admin in self._db.query(Admin):
+            self._db.delete(admin)
+
+        system_admin, ignore = create(self._db, Admin, email=self._str)
+        system_admin.add_role(AdminRole.SYSTEM_ADMIN)
+
+        with self.request_context_with_admin("/", method="POST", admin=system_admin):
+            flask.request.form = MultiDict(
+                [
+                    ("email", "second_admin@nypl.org"),
+                    ("password", ""),
                     ("roles", []),
                 ]
             )

--- a/tests/api/admin/controller/test_individual_admins.py
+++ b/tests/api/admin/controller/test_individual_admins.py
@@ -781,6 +781,24 @@ class TestIndividualAdmins(SettingsControllerTest):
             )
             assert 201 == response.status_code
 
+    def test_individual_admins_post_create_second_admin_no_roles(self):
+        """Creating a second admin with a password works."""
+        for admin in self._db.query(Admin):
+            self._db.delete(admin)
+
+        system_admin, ignore = create(self._db, Admin, email=self._str)
+        system_admin.add_role(AdminRole.SYSTEM_ADMIN)
+
+        with self.request_context_with_admin("/", method="POST", admin=system_admin):
+            flask.request.form = MultiDict(
+                [("email", "second_admin@nypl.org"), ("password", "pass")]
+            )
+            flask.request.files = {}
+            response = (
+                self.manager.admin_individual_admin_settings_controller.process_post()
+            )
+            assert 201 == response.status_code
+
     def test_individual_admins_post_create_second_admin_no_password(self):
         """Creating a second admin without a password fails."""
         for admin in self._db.query(Admin):
@@ -815,6 +833,28 @@ class TestIndividualAdmins(SettingsControllerTest):
                 [
                     ("email", "second_admin@nypl.org"),
                     ("password", ""),
+                    ("roles", []),
+                ]
+            )
+            flask.request.files = {}
+            response = (
+                self.manager.admin_individual_admin_settings_controller.process_post()
+            )
+            assert 400 == response.status_code
+
+    def test_individual_admins_post_create_second_admin_blank_password(self):
+        """Creating a second admin without a password fails."""
+        for admin in self._db.query(Admin):
+            self._db.delete(admin)
+
+        system_admin, ignore = create(self._db, Admin, email=self._str)
+        system_admin.add_role(AdminRole.SYSTEM_ADMIN)
+
+        with self.request_context_with_admin("/", method="POST", admin=system_admin):
+            flask.request.form = MultiDict(
+                [
+                    ("email", "second_admin@nypl.org"),
+                    ("password", "            "),
                     ("roles", []),
                 ]
             )


### PR DESCRIPTION
## Description

The original code to handle the creation or editing of admins had a serious bug in that, even if the endpoint returned an error, the code would still commit the admin that it might have created in the process of trying to check if the admin existed. This refactors the method into something much more explicit, where the three possible code paths are kept distinct, and an explicit rollback is made if anything other than success occurs.

There are still problems with this from a UI perspective, and I think it's something that needs design work. For example, the admin UI always says "Updated password successfully" even if you didn't specify a password (and therefore didn't ask the admin password to be updated). It always marks the password field as being required, when in fact it's only required if you want to update the password. The user interface doesn't give any way to express intent.

These changes at least mean that the server side always does the right thing, but the UI needs serious work.

## Motivation and Context

We're trying to make sure that admins can never have missing (or empty) passwords.

Affects: https://www.notion.so/lyrasis/Make-password-required-when-changing-already-existing-admin-account-information-in-the-CM-36df0e10860547d4a6a693eea452f37d

## How Has This Been Tested?

I tried creating new admins, and editing existing admins. I also ran the test suite, and added a new test.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
