### PR TITLE
Language expansion and contraction for the JSON search endpoint

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -6,7 +6,17 @@ import os
 import sys
 import urllib.parse
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import flask
 from flask import Request, Response, redirect, url_for

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -89,6 +89,7 @@ from core.s3 import S3UploaderConfiguration
 from core.selftest import HasSelfTests
 from core.util.cache import memoize
 from core.util.flask_util import OPDSFeedResponse
+from core.util.languages import LanguageCodes, LanguageNames
 from core.util.problem_detail import ProblemDetail
 
 if TYPE_CHECKING:
@@ -2470,7 +2471,14 @@ class AdminSearchController(AdminController):
                 func.distinct(Edition.language), func.count(Edition.language)
             )
         )
-        languages = _unzip(languages_list)
+        converted_languages_list = []
+        # We want full english names, not codes
+        for name, num in languages_list:
+            full_name = LanguageCodes.english_names.get(name, [name])
+            # Language codes are an array of multiple choices, we only want one
+            full_name = full_name[0] if len(full_name) > 0 else name
+            converted_languages_list.append((full_name, num))
+        languages = _unzip(converted_languages_list)
 
         publishers_list = list(
             editions_query.group_by(Edition.publisher).values(

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -2416,7 +2416,7 @@ class AdminSearchController(AdminController):
     # 1 hour in-memory cache
     @memoize(ttls=3600)
     def _search_field_values_cached(self, collection_ids: List[int]) -> dict:
-        def _unzip(values: List[tuple[str, int]]) -> dict:
+        def _unzip(values: List[Tuple[str, int]]) -> dict:
             """Covert a list of tuples to a {value0: value1} dictionary"""
             return {a[0]: a[1] for a in values if type(a[0]) is str}
 

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -7,7 +7,6 @@ import sys
 import urllib.parse
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypeVar, Union
-from urllib.parse import quote, urlparse, urlunparse
 
 import flask
 from flask import Request, Response, redirect, url_for
@@ -2417,7 +2416,7 @@ class AdminSearchController(AdminController):
     # 1 hour in-memory cache
     @memoize(ttls=3600)
     def _search_field_values_cached(self, collection_ids: List[int]) -> dict:
-        def _unzip(values: List[tuple]) -> dict:
+        def _unzip(values: List[tuple[str, int]]) -> dict:
             """Covert a list of tuples to a {value0: value1} dictionary"""
             return {a[0]: a[1] for a in values if type(a[0]) is str}
 
@@ -2474,9 +2473,9 @@ class AdminSearchController(AdminController):
         converted_languages_list = []
         # We want full english names, not codes
         for name, num in languages_list:
-            full_name = LanguageCodes.english_names.get(name, [name])
+            full_name_set = LanguageCodes.english_names.get(name, [name])
             # Language codes are an array of multiple choices, we only want one
-            full_name = full_name[0] if len(full_name) > 0 else name
+            full_name = full_name_set[0] if len(full_name_set) > 0 else name
             converted_languages_list.append((full_name, num))
         languages = _unzip(converted_languages_list)
 

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -2129,8 +2129,8 @@ class JSONQuery(Query):
         def language(value: str) -> str:
             """Transform a possibly english language name to an alpha3 code"""
             transformed = LanguageNames.name_to_codes.get(value.lower(), {value})
-            transformed = list(transformed)[0] if len(transformed) > 0 else value
-            return transformed
+            value = list(transformed)[0] if len(transformed) > 0 else value
+            return value
 
     VALUE_TRANSORMS = {
         "data_source": ValueTransforms.data_source,

--- a/tests/api/admin/controller/test_admin_search_controller.py
+++ b/tests/api/admin/controller/test_admin_search_controller.py
@@ -83,6 +83,6 @@ class TestAdminSearchController(AdminControllerTest):
         }
         assert response["audiences"] == {"Adult": 3, "Young Adult": 10}
         assert response["genres"] == {"Education": 2, "Horror": 1, "Drama": 10}
-        assert response["languages"] == {"eng": 2, "spa": 1, "man": 10}
+        assert response["languages"] == {"English": 2, "Spanish": 1, "Mandingo": 10}
         assert response["publishers"] == {"Publisher 1": 3, "Publisher 10": 10}
         assert response["distributors"] == {"Gutenberg": 13}


### PR DESCRIPTION
## Description
In the search field value API expand the language codes into full english names.
In the json search API contract the english language names into language codes again.
This does not mean language codes cannot be used in the API at all, they will still work in the search.

Incidental changes: In #702 a change was made to search with some fuzziness on text fields. This also added fuzziness to the language field. This is not required for languages, so this PR also fixes that inadvertent change.

<!--- Describe your changes -->

## Motivation and Context
When creating a list and searching using the language filter, the language field executes the search based on language code instead of the full name of a language. For example, the user must search for “Eng” instead of “English” to return the expected result of materials written in English. If the user searches for materials in English, no results are returned.

[Notion](https://www.notion.so/lyrasis/Add-support-to-list-creation-search-for-full-name-of-language-88cbaa729ee8429789ace553bc382f85)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have run.
Manually tested the JSON search endpoint.
Example: http://localhost:6500/localtest/search?q={%22query%22:{%22value%22:%22english%22,%22key%22:%22language%22}}&search_type=json
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
