### PR TITLE
Update dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: increase-if-necessary
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Description

Update the dependabot versioning strategy to `increase-if-necessary`.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy

## Motivation and Context

When the pyproject file gets updated, it changes the hash in the lock file, so further changes require a rebase. Lots of the time we don't actually need to update the versions in pyproject.toml. So hopefully changing the strategy will reduce the number of merge conflicts we have with dependabot PRs.

## How Has This Been Tested?

Read dependabot manual.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
