### PR TITLE
Fix a regex typo

### DIFF
--- a/core/model/contributor.py
+++ b/core/model/contributor.py
@@ -365,7 +365,7 @@ class Contributor(Base):
 
     # Regular expressions used by default_names().
     PARENTHETICAL = re.compile(r"\([^)]*\)")
-    ALPHABETIC = re.compile("[a-zA-z]")
+    ALPHABETIC = re.compile("[a-zA-Z]")
     NUMBERS = re.compile("[0-9]")
 
     DATE_RES = [


### PR DESCRIPTION
## Description

This regex appears to have been introduced years ago, and matches a few more characters than it should due to a lowercase/uppercase typo. The code scanning tool flags this as a vulnerability, but it probably isn't. It's still a bug worth correcting though.

## Motivation and Context

We're trying to clean up security-related code scanning issues. This was one of them.

Affects: https://github.com/ThePalaceProject/circulation/security/code-scanning/33
Affects: https://www.notion.so/lyrasis/Address-codeql-code-scanning-security-alerts-94b682553e9f43fb98496582278a41b1

## How Has This Been Tested?

I ran the test suite.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
