### PR TITLE
Refactor strange authprovider inheritance pattern.

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -8,7 +8,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from abc import ABCMeta
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 import flask
 import jwt
@@ -1669,7 +1669,9 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
         """
         return None
 
-    def remote_patron_lookup(self, patron_or_patrondata):
+    def remote_patron_lookup(
+        self, patron_or_patrondata
+    ) -> Union[PatronData, Patron, None]:
         """Ask the remote for detailed information about a patron's account.
 
         This may be called in the course of authenticating a patron,
@@ -1687,23 +1689,7 @@ class AuthenticationProvider(OPDSAuthenticationFlow):
         :return: An updated PatronData object.
 
         """
-        if not patron_or_patrondata:
-            return None
-        if isinstance(patron_or_patrondata, PatronData) or isinstance(
-            patron_or_patrondata, Patron
-        ):
-
-            return patron_or_patrondata
-        raise ValueError(
-            "Unexpected object %r passed into remote_patron_lookup."
-            % patron_or_patrondata
-        )
-
-    # BasicAuthenticationProvider defines remote_patron_lookup to call this
-    # method and then do something additional; by default, we want the core
-    # lookup mechanism to work the same way as AuthenticationProvider.remote_patron_lookup.
-
-    _remote_patron_lookup = remote_patron_lookup
+        raise NotImplementedError()
 
     def _authentication_flow_document(self, _db):
         """Create a Authentication Flow object for use in an Authentication for
@@ -2006,9 +1992,26 @@ class BasicAuthenticationProvider(AuthenticationProvider, HasSelfTests):
             or self.DEFAULT_PASSWORD_LABEL
         )
 
-    def remote_patron_lookup(self, patron_or_patrondata):
+    def _remote_patron_lookup(
+        self, patron_or_patrondata
+    ) -> Union[PatronData, Patron, None]:
+        if not patron_or_patrondata:
+            return None
+        if isinstance(patron_or_patrondata, PatronData) or isinstance(
+            patron_or_patrondata, Patron
+        ):
+
+            return patron_or_patrondata
+        raise ValueError(
+            "Unexpected object %r passed into remote_patron_lookup."
+            % patron_or_patrondata
+        )
+
+    def remote_patron_lookup(
+        self, patron_or_patrondata
+    ) -> Union[PatronData, Patron, None]:
         """Ask the remote for information about this patron, and then make sure
-        the patron belongs to the library associated with thie BasicAuthenticationProvider."""
+        the patron belongs to the library associated with this BasicAuthenticationProvider."""
 
         patron_info = self._remote_patron_lookup(patron_or_patrondata)
         if patron_info:

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -1730,7 +1730,9 @@ class TestAuthenticationProvider:
             == provider.external_integration(db.session)
         )
 
-    def test_remote_patron_lookup(self, authenticator_fixture: AuthenticatorFixture):
+    def test_private_remote_patron_lookup(
+        self, authenticator_fixture: AuthenticatorFixture
+    ):
         provider = authenticator_fixture.mock_basic(patrondata=None)
 
         # Passing a type other than Patron or PatronData to _remote_patron_lookup

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -10,7 +10,7 @@ import urllib.parse
 import urllib.request
 from decimal import Decimal
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import flask
 import pytest
@@ -1729,6 +1729,14 @@ class TestAuthenticationProvider:
             authenticator_fixture.mock_basic_integration
             == provider.external_integration(db.session)
         )
+
+    def test_remote_patron_lookup(self, authenticator_fixture: AuthenticatorFixture):
+        provider = authenticator_fixture.mock_basic(patrondata=None)
+
+        # Passing a type other than Patron or PatronData to _remote_patron_lookup
+        # will raise a ValueError.
+        with pytest.raises(ValueError):
+            provider._remote_patron_lookup(MagicMock())
 
     def test_authenticated_patron_passes_on_none(
         self, authenticator_fixture: AuthenticatorFixture


### PR DESCRIPTION
## Description

Refactor the strange inheritance pattern being used in `AuthenticationProvider`. Where we defined `remote_patron_lookup` as `_remote_patron_lookup` on `AuthenticationProvider`, and then called that method from `BasicAuthenticationProvider` and override it in subclasses of `BasicAuthenticationProvider`.

## Motivation and Context

This inheritance pattern causes mypy some issues when trying to understand the types of the inherited methods, and makes this code a bit confusing to read.

We should be able to refactor in this way, because the two classes that inherit from `AuthenticationProvider` other then `BasicAuthenticationProvider` both override `remote_patron_lookup` and don't call `_remote_patron_lookup` at all. So it makes sense to move its definition up the class hierarchy.

## How Has This Been Tested?

Running CI tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
