### PR TITLE
Speed up controller tests

### DIFF
--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -85,7 +85,11 @@ class AdminControllerTest(CirculationControllerTest):
             Admin,
             email="example@nypl.org",
         )
-        self.admin.password = "password"
+        # This is a hash for 'password', we use the hash directly to avoid the cost
+        # of doing the password hashing during test setup.
+        self.admin.password_hashed = (
+            "$2a$12$Dw74btoAgh49.vtOB56xPuumtcOY9HCZKS3RYImR42lR5IiT7PIOW"
+        )
 
     @contextmanager
     def request_context_with_admin(self, route, *args, **kwargs):


### PR DESCRIPTION
## Description

Doing a bit more profiling of our code, it seems that the single most expensive function we call when running the tests is now the call to set `password` in `AdminControllerTest`. This removes the need to hash this password on each test setup, by directly setting the the hashed password.

This doesn't speed up the tests dramatically, but does shave about a minute off the test run on my machine.

## Motivation and Context

This came up when doing other profiling, and it seemed worth it to address. Save a bit of time every time we run the tests.

## How Has This Been Tested?

Running CI against it.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
