### PR TITLE
Fix test_dashboard_stats test that is failing occasionally

### DIFF
--- a/tests/api/admin/test_dashboard_stats.py
+++ b/tests/api/admin/test_dashboard_stats.py
@@ -23,9 +23,6 @@ class AdminStatisticsSessionFixture:
         self.db = db
 
     def get_statistics(self):
-        # Avoid flaky tests by ensuring that the DB session is flushed
-        # before we generate statistics from the database.
-        self.db.session.flush()
         return generate_statistics(self.admin, self.db.session)
 
 
@@ -235,11 +232,14 @@ def test_stats_collections(admin_statistics_session: AdminStatisticsSessionFixtu
     for data in [library_data, total_data]:
         collections_data = data.get("collections")
         assert 1 == len(collections_data)
-        collection_data = collections_data.get(default_collection.name)
-        assert 0 == collection_data.get("licensed_titles")
-        assert 1 == collection_data.get("open_access_titles")
-        assert 0 == collection_data.get("licenses")
-        assert 0 == collection_data.get("available_licenses")
+        assert 0 == collections_data.get(default_collection.name).get("licensed_titles")
+        assert 1 == collections_data.get(default_collection.name).get(
+            "open_access_titles"
+        )
+        assert 0 == collections_data.get(default_collection.name).get("licenses")
+        assert 0 == collections_data.get(default_collection.name).get(
+            "available_licenses"
+        )
 
     c2 = db.collection()
     c3 = db.collection()
@@ -269,6 +269,7 @@ def test_stats_collections(admin_statistics_session: AdminStatisticsSessionFixtu
         with_license_pool=True,
         with_open_access_download=False,
         data_source_name=DataSource.BIBLIOTHECA,
+        collection=default_collection,
     )
     pool3.open_access = False
     pool3.licenses_owned = 3
@@ -292,17 +293,15 @@ def test_stats_collections(admin_statistics_session: AdminStatisticsSessionFixtu
     assert 2 == len(library_collections_data)
     assert 3 == len(total_collections_data)
     for data in [library_collections_data, total_collections_data]:
-        c1_data = data.get(default_collection.name)
-        assert 1 == c1_data.get("licensed_titles")
-        assert 1 == c1_data.get("open_access_titles")
-        assert 3 == c1_data.get("licenses")
-        assert 0 == c1_data.get("available_licenses")
+        assert 1 == data.get(default_collection.name).get("licensed_titles")
+        assert 1 == data.get(default_collection.name).get("open_access_titles")
+        assert 3 == data.get(default_collection.name).get("licenses")
+        assert 0 == data.get(default_collection.name).get("available_licenses")
 
-        c3_data = data.get(c3.name)
-        assert 0 == c3_data.get("licensed_titles")
-        assert 0 == c3_data.get("open_access_titles")
-        assert 0 == c3_data.get("licenses")
-        assert 0 == c3_data.get("available_licenses")
+        assert 0 == data.get(c3.name).get("licensed_titles")
+        assert 0 == data.get(c3.name).get("open_access_titles")
+        assert 0 == data.get(c3.name).get("licenses")
+        assert 0 == data.get(c3.name).get("available_licenses")
 
     assert None == library_collections_data.get(c2.name)
     c2_data = total_collections_data.get(c2.name)
@@ -322,19 +321,21 @@ def test_stats_collections(admin_statistics_session: AdminStatisticsSessionFixtu
     for data in [library_data, total_data]:
         collections_data = data.get("collections")
         assert 2 == len(collections_data)
-        assert None == collections_data.get(c2.name)
+        assert collections_data.get(c2.name) is None
 
-        c1_data = collections_data.get(default_collection.name)
-        assert 1 == c1_data.get("licensed_titles")
-        assert 1 == c1_data.get("open_access_titles")
-        assert 3 == c1_data.get("licenses")
-        assert 0 == c1_data.get("available_licenses")
+        assert 1 == collections_data.get(default_collection.name).get("licensed_titles")
+        assert 1 == collections_data.get(default_collection.name).get(
+            "open_access_titles"
+        )
+        assert 3 == collections_data.get(default_collection.name).get("licenses")
+        assert 0 == collections_data.get(default_collection.name).get(
+            "available_licenses"
+        )
 
-        c3_data = collections_data.get(c3.name)
-        assert 0 == c3_data.get("licensed_titles")
-        assert 0 == c3_data.get("open_access_titles")
-        assert 0 == c3_data.get("licenses")
-        assert 0 == c3_data.get("available_licenses")
+        assert 0 == collections_data.get(c3.name).get("licensed_titles")
+        assert 0 == collections_data.get(c3.name).get("open_access_titles")
+        assert 0 == collections_data.get(c3.name).get("licenses")
+        assert 0 == collections_data.get(c3.name).get("available_licenses")
 
 
 def test_stats_parent_collection_permissions(


### PR DESCRIPTION
## Description

After https://github.com/ThePalaceProject/circulation/pull/878 landed, we are still seeing test failures in the `test_dashboard_stats` tests. See: [here](https://github.com/ThePalaceProject/circulation/actions/runs/4319309510/jobs/7538338303#step:7:617).

I was unable to make this failure happen locally, but I *think* it must be caused by this edition not getting created in the correct collection: 
https://github.com/ThePalaceProject/circulation/blob/e8162db6c02e5eab76626f651f99de49ffafd9da/tests/api/admin/test_dashboard_stats.py#L268-L273

If that edition didn't end up in the default collection, then we would see the test results that we are seeing. Since we weren't specifying a collection for the edition before, we were relying on this function: 
https://github.com/ThePalaceProject/circulation/blob/c69fd8ce03f34f752f6fc2cfbf6c8ab9a8d23cc7/tests/fixtures/database.py#L225-L237

And I think that when a library has multiple collections, the ordering of `self.default_library().collections` would not be guaranteed, and would depend on the order which the database serializes the collections. 

This PR tests that theory by setting the collection explicitly on the edition. 

It also updates how we reference the problematic data
https://github.com/ThePalaceProject/circulation/blob/e8162db6c02e5eab76626f651f99de49ffafd9da/tests/api/admin/test_dashboard_stats.py#L296-L304

This will let us see the whole contents of the `data` dictionary, should the test fail again, so we are better able to troubleshoot what is going on here.

## Motivation and Context

Seeing occasional failures in CI like this:
```
          ...
          edition4, pool4 = db.edition(
              with_license_pool=True,
              with_open_access_download=False,
              data_source_name=DataSource.AXIS_360,
              collection=c2,
          )
          pool4.open_access = False
          pool4.licenses_owned = 5
          pool4.licenses_available = 5
      
          response = session.get_statistics()
          library_data = response.get(default_library.short_name)
          total_data = response.get("total")
          library_collections_data = library_data.get("collections")
          total_collections_data = total_data.get("collections")
          assert 2 == len(library_collections_data)
          assert 3 == len(total_collections_data)
          for data in [library_collections_data, total_collections_data]:
              c1_data = data.get(default_collection.name)
  >           assert 1 == c1_data.get("licensed_titles")
  E           AssertionError: assert 1 == 0
  E            +  where 0 = <built-in method get of dict object at 0x7f52f63cb240>('licensed_titles')
  E            +    where <built-in method get of dict object at 0x7f52f63cb240> = {'available_licenses': 0, 'licensed_titles': 0, 'licenses': 0, 'open_access_titles': 1}.get
  
  tests/api/admin/test_dashboard_stats.py:296: AssertionError
```

## How Has This Been Tested?

Running CI. But since it fails occasionally, no guarantees here.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
