### PR TITLE
Fix failing tests due to werkzeug escaping changes

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import and_, desc, distinct, join, nullslast, select
-from werkzeug.urls import url_fix, url_parse, url_quote, url_unparse
+from werkzeug.urls import url_fix, url_parse, url_quote, url_quote_plus, url_unparse
 from werkzeug.wrappers import Response as werkzeug_response
 
 from api.admin.config import Configuration as AdminClientConfig
@@ -367,26 +367,13 @@ class ViewController(AdminController):
         if not setting_up:
             admin = self.authenticated_admin_from_request()
             if isinstance(admin, ProblemDetail):
-                url = urlparse(flask.request.url)
-                redirect_url = url_unparse(
-                    (
-                        url.scheme,
-                        url.netloc,
-                        quote(url.path),
-                        quote(url.query),
-                        quote(url.fragment),
-                    )
-                )
+                redirect_url = flask.request.url
                 if collection:
-                    quoted_collection = urllib.parse.quote(collection)
                     redirect_url = redirect_url.replace(
-                        quoted_collection, quoted_collection.replace("/", "%2F")
+                        collection, url_quote_plus(collection)
                     )
                 if book:
-                    quoted_book = urllib.parse.quote(book)
-                    redirect_url = redirect_url.replace(
-                        quoted_book, quoted_book.replace("/", "%2F")
-                    )
+                    redirect_url = redirect_url.replace(book, url_quote_plus(book))
                 return redirect(
                     url_for("admin_sign_in", redirect=redirect_url, _external=True)
                 )

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -143,8 +143,8 @@ class TestViewController(AdminControllerTest):
             location = response.headers.get("Location")
             assert "sign_in" in location
             assert "admin%2Fweb" in location
-            assert "collection%2Fa%252F%2528b%2529" in location
-            assert "book%2Fc%252F%2528d%2529" in location
+            assert "collection%2Fa%252F(b)" in location
+            assert "book%2Fc%252F(d)" in location
 
     def test_redirect_to_library(self):
         # If the admin doesn't have access to any libraries, they get a message

--- a/tests/api/test_controller_opdsfeed.py
+++ b/tests/api/test_controller_opdsfeed.py
@@ -1,11 +1,11 @@
 import datetime
 import json
-import urllib.parse
 from typing import Any, Dict
 from unittest.mock import MagicMock
 
 import feedparser
 from flask import url_for
+from werkzeug.urls import url_quote_plus
 
 from api.controller import CirculationManager
 from api.lanes import HasSeriesFacets, JackpotFacets, JackpotWorkList
@@ -148,9 +148,7 @@ class TestOPDSFeedController:
                 last_item.sort_author,
                 last_item.id,
             ]
-            expect = "key=%s" % urllib.parse.quote_plus(
-                json.dumps(expected_pagination_key)
-            )
+            expect = "key=%s" % url_quote_plus(json.dumps(expected_pagination_key))
             assert expect in next_link
 
             search_link = by_rel["search"]


### PR DESCRIPTION
## Description

Currently our tests are failing on the `main` branch, due to a conflict between that tests that started running in #835 and #855. This is caused by Werkzeug not escaping as many characters in URLS see issue here https://github.com/pallets/werkzeug/issues/262. These URLs are still valid, but have less characters in them escaped.

## Motivation and Context

https://github.com/ThePalaceProject/circulation/commit/cf09bf08e22055b5ee1136aaeeafdb37326e0ea0 gets our tests running again. 

Working through this issue, and looking at the linked Werkzeug issue, made me reconsider the fix I made in #855 to fix the `admin/controller` URL escaping tests. 

https://github.com/ThePalaceProject/circulation/commit/d1d663a63f1f0310409301bd2df0cb8ed0c28936 mostly reverts the changes from https://github.com/ThePalaceProject/circulation/pull/855/commits/f0cca3232e51f4e379a6816e169189628e905763 what went in with #855 and takes a different approach to solving that test failure.

In these tests `(` was previously escaped, but it isn't escaped anymore. This is also due to Werkzeug changes from the linked issue. Based on that I'm imported the workzeug `url_quote_plus` function, and used that to do the escaping instead of the python stdlib function we were using before.

## How Has This Been Tested?

Ran tests locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
