### PR TITLE
Allow circulation tests to run locally on a Mac M1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,6 @@ skipsdist = true
 
 [testenv]
 commands_pre =
-    docker: docker exec es-circ elasticsearch-plugin -s install analysis-icu
-    docker: docker restart es-circ
     docker: docker exec os-circ /usr/share/opensearch/bin/opensearch-plugin -s install analysis-icu
     docker: docker restart os-circ
     poetry install --without ci -v
@@ -54,9 +52,10 @@ healthcheck_interval = 5
 healthcheck_retries = 10
 
 [docker:es-circ]
-image = elasticsearch:6.8.23
+image = webhippie/elasticsearch:6.8
 environment =
-    discovery.type=single-node
+    ELASTICSEARCH_XPACK_SECURITY_ENABLED=false
+    ELASTICSEARCH_PLUGINS_INSTALL=analysis-icu
 ports =
     9006:9200/tcp
 


### PR DESCRIPTION
## Description

Right now, we can't run our circulation tests locally on a mac m1 machine, because the official elasticsearch docker image, does not build an arm64 version for ES 6.x. This PR changes our `tox.ini` to use an alternate docker image, that builds arm images for ES 6.x.

## Motivation and Context

We are moving away from ES 6.x soon, we've already mentioned it as deprecated in our README. So our need for this container should go away soon, but it would be nice to be able to run tests locally until we remove the need for an ES 6.8 container.

## How Has This Been Tested?

Ran tests locally a M1 machine. Tox wouldn't start the tests before, because it couldn't find an arm64 docker image for ES, after this change the tests pass successfully.

Once CI runs on this PR it should let us know if the images work for amd64 images as well.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
