### PR TITLE
Removed the specific sirsidynix FLOW TYPE

### DIFF
--- a/api/sirsidynix_authentication_provider.py
+++ b/api/sirsidynix_authentication_provider.py
@@ -40,7 +40,6 @@ class SirsiDynixHorizonAuthenticationProvider(BasicAuthenticationProvider):
 
     NAME = "SirsiDynix Horizon Authentication"
     DESCRIPTION = "SirsiDynix Horizon Webservice Authentication"
-    FLOW_TYPE = "http://librarysimplified.org/authtype/sirsidynix-horizon"
 
     DEFAULT_APP_ID = "PALACE"
 


### PR DESCRIPTION
## Description
This should revert back to the Basic Auth flow type In the hopes that the mobile Apps will react correctly
<!--- Describe your changes -->

## Motivation and Context
The Apps were not showing any barcode or password fields for the Patron identification.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
The authentication document has been tested to revert back to the basic auth flow type.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
