### PR TITLE
Fixes broken palace cm logo.

### DIFF
--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -36,6 +36,14 @@ def setup_admin(_db=None):
     # already exist.
     local_analytics = LocalAnalyticsProvider.initialize(_db)
 
+    # Configure the default max age for the static file cache.
+    max_age = ConfigurationSetting.sitewide(
+        _db, Configuration.STATIC_FILE_CACHE_TIME
+    ).int_value
+
+    if max_age:
+        app.config["SEND_FILE_MAX_AGE_DEFAULT"] = max_age
+
 
 def allows_admin_auth_setup(f):
     @wraps(f)

--- a/api/controller.py
+++ b/api/controller.py
@@ -2698,10 +2698,7 @@ class SharedCollectionController(CirculationManagerController):
 
 class StaticFileController(CirculationManagerController):
     def static_file(self, directory, filename):
-        max_age = ConfigurationSetting.sitewide(
-            self._db, Configuration.STATIC_FILE_CACHE_TIME
-        ).int_value
-        return flask.send_from_directory(directory, filename, max_age=max_age)
+        return flask.send_from_directory(directory, filename)
 
     def image(self, filename):
         directory = os.path.join(


### PR DESCRIPTION
## Description
I appears that the Palace CM Logo link broke when we upgraded Flask.
The max_age argument is no longer supported in the send_from_directory method.
Instead the default max age is set elsewhere:  see https://flask.palletsprojects.com/en/2.2.x/api/ for details ( search for SEND_FILE_MAX_AGE_DEFAULT ).
 
## Motivation and Context

https://www.notion.so/lyrasis/Palace-CM-Logo-is-broken-78d753d9a5db491fa7ce3463d37c314c?pvs=4

## How Has This Been Tested?
Manually verified that it is fix by going to the sign in page.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
