### PR TITLE
Use minio image that supports arm64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,13 +28,14 @@ services:
       POSTGRES_DB: circ
 
   minio:
-    image: "bitnami/minio:2022.3.3"
+    image: "bitnami/minio:2023.2.27"
     ports:
       - "9000:9000"
       - "9001:9001"
     environment:
       MINIO_ROOT_USER: "palace"
       MINIO_ROOT_PASSWORD: "test123456789"
+      MINIO_SCHEME: "http"
 
   os:
     image: opensearchproject/opensearch:1


### PR DESCRIPTION
## Description

The older minio image we had in our docker compose file doesn't have an arm64 build for m1 macs. This bumps up a version to one that is built with arm64 support.

## Motivation and Context

```
requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```
Was getting this when running `docker-compose up -d` for CM.

## How Has This Been Tested?

Tested with docker-compose locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
