### PR TITLE
Changed socket timeouts for SIP2 connections to 3 seconds

### DIFF
--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -222,6 +222,8 @@ class SIPClient(Constants):
 
     # Maximum retries of a SIP message before failing.
     MAXIMUM_RETRIES = 5
+    # Timeout in seconds
+    TIMEOUT = 3
 
     # These are the subfield names associated with the 'patron status'
     # field as specified in the SIP2 spec.
@@ -386,7 +388,7 @@ class SIPClient(Constants):
             else:
                 self.connection = self.make_insecure_connection()
 
-            self.connection.settimeout(2)
+            self.connection.settimeout(self.TIMEOUT)
             self.connection.connect((self.target_server, self.target_port))
         except OSError as message:
             raise OSError(

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -386,7 +386,7 @@ class SIPClient(Constants):
             else:
                 self.connection = self.make_insecure_connection()
 
-            self.connection.settimeout(12)
+            self.connection.settimeout(2)
             self.connection.connect((self.target_server, self.target_port))
         except OSError as message:
             raise OSError(

--- a/tests/api/sip/test_client.py
+++ b/tests/api/sip/test_client.py
@@ -149,7 +149,7 @@ class TestSIPClient:
         # Call connect() and make sure timeout is set properly.
         try:
             sip.connect()
-            assert 12 == sip.connection.timeout
+            assert 2 == sip.connection.timeout
         finally:
             # Un-mock the socket.socket function
             socket.socket = old_socket

--- a/tests/api/sip/test_client.py
+++ b/tests/api/sip/test_client.py
@@ -149,7 +149,7 @@ class TestSIPClient:
         # Call connect() and make sure timeout is set properly.
         try:
             sip.connect()
-            assert 2 == sip.connection.timeout
+            assert 3 == sip.connection.timeout
         finally:
             # Un-mock the socket.socket function
             socket.socket = old_socket


### PR DESCRIPTION
## Description
To ensure speedy failures for faulty SIP2 providers
During a timeout the API will respond with a 
`{"type": "http://librarysimplified.org/terms/problem/remote-integration-failed", "title": "Failure contacting external service", "status": 502, "detail": "The server tried to access 127.0.0.1 but the third-party service experienced an error."}`
<!--- Describe your changes -->

## Motivation and Context
We have seen an incident twice in the past two weeks, where a SIP integration has gone offline, and this has caused one of our CM to become unresponsive for all the libraries in the CM. In order to reduce this happening, we should reduce the timeout that we wait for a SIP connection to respond.

Rationale explained in [Notion](https://www.notion.so/lyrasis/Reduce-the-length-of-timeouts-for-SIP-connections-d841aa38edfe4d54a2bc3bc62129e866) 

3 seconds is based on some statistics collected from our production CM instances. See [comment](https://github.com/ThePalaceProject/circulation/pull/919#issuecomment-1496009603) below.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
