### PR TITLE
Ensure uwsgi logs go to stdout

### DIFF
--- a/docker/services/uwsgi.d/40_log.ini
+++ b/docker/services/uwsgi.d/40_log.ini
@@ -1,5 +1,2 @@
 [uwsgi]
-# location of log files
-logto = /var/log/uwsgi/uwsgi.log
 log-format = %(var.HTTP_X_FORWARDED_FOR) (%(addr)) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
-logfile-chmod = 644

--- a/docker/services/uwsgi.d/40_log.ini
+++ b/docker/services/uwsgi.d/40_log.ini
@@ -1,2 +1,5 @@
 [uwsgi]
 log-format = %(var.HTTP_X_FORWARDED_FOR) (%(addr)) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
+logfile-chmod = 644
+logger = stdio:
+logger = file:/var/log/uwsgi/uwsgi.log


### PR DESCRIPTION
## Description

This adjusts the `uwsgi` configuration so that access logs go to stdout.

## Motivation and Context

We want all logs to go to stdout so that we can collect logs in a central location when running on Fargate.

Affects: https://www.notion.so/lyrasis/Update-our-docker-webapp-build-so-uwsgi-access-logs-are-on-stdout-15dd47b802e145358ff20aff0301fded

## How Has This Been Tested?

I built Docker images locally, ran them, and made requests. I saw logs such as this on stdout:

```
- (172.17.0.1) - - [15/Mar/2023:12:24:07 +0000] "GET / HTTP/1.1" 302 399 "-" "curl/7.88.1" host_hdr=localhost:32770 req_time_elapsed=11745
```

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
