### PR TITLE
Fix export of MARC records with summaries.

### DIFF
--- a/core/marc.py
+++ b/core/marc.py
@@ -455,10 +455,7 @@ class Annotator:
                 Field(
                     tag="520",
                     indicators=[" ", " "],
-                    subfields=[
-                        "a",
-                        stripped.encode("ascii", "ignore"),
-                    ],
+                    subfields=["a", stripped],
                 )
             )
 

--- a/tests/core/test_marc.py
+++ b/tests/core/test_marc.py
@@ -432,6 +432,7 @@ class TestAnnotator:
         record = Record()
         Annotator.add_summary(record, work)
         self._check_field(record, "520", {"a": b" Summary "})
+        record.as_marc()
 
     def test_add_simplified_genres(self, db: DatabaseTransactionFixture):
         work = db.work(with_license_pool=True)

--- a/tests/core/test_marc.py
+++ b/tests/core/test_marc.py
@@ -429,10 +429,16 @@ class TestAnnotator:
         work = db.work(with_license_pool=True)
         work.summary_text = "<p>Summary</p>"
 
+        # Build and validate a record with a `520|a` summary.
         record = Record()
         Annotator.add_summary(record, work)
-        self._check_field(record, "520", {"a": b" Summary "})
-        record.as_marc()
+        self._check_field(record, "520", {"a": " Summary "})
+        exported_record = record.as_marc()
+
+        # Round trip the exported record to validate it.
+        marc_reader = MARCReader(exported_record)
+        round_tripped_record = next(marc_reader)
+        self._check_field(round_tripped_record, "520", {"a": " Summary "})
 
     def test_add_simplified_genres(self, db: DatabaseTransactionFixture):
         work = db.work(with_license_pool=True)


### PR DESCRIPTION
## Description

- Fixes export of MARC records with summaries.
- Improves an existing test by: 
  - actually creating the MARC record for export, which would have detected the bug addressed here; and
  - re-importing the exported record to verify that the expected values are present there.

## Motivation and Context

MARC record export (`./bin/cache_marc_files`) failed when a `work.summary_text` was present and summaries were requested in the export configuration.

The `core.marc.Annotator.add_summary` method was performing an unnecessary string encode. `work.text_summary` is `utf-8`, which is a supported encoding for MARC 21. And `pymarc.Record.as_marc` already takes care of converting the overall record to bytes.

[[Notion](https://www.notion.so/lyrasis/Error-concatenating-bytes-to-string-in-MARC-record-generator-9b1ae08874794b9fa559299d2b878446?pvs=4)]

## How Has This Been Tested?

- Ran specific tests locally.
- Manually verified that MARC exporter now works in local development environment and that it did not work on the current `main` branch.
- CI passes for this bugfix branch. [[test & build](https://github.com/ThePalaceProject/circulation/actions/runs/4461875614)]

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
