### PR TITLE
Remove default Sirsidynix URL

### DIFF
--- a/api/sirsidynix_authentication_provider.py
+++ b/api/sirsidynix_authentication_provider.py
@@ -57,7 +57,6 @@ class SirsiDynixHorizonAuthenticationProvider(BasicAuthenticationProvider):
             "label": _("Server URL"),
             "description": _("The external server url."),
             "required": True,
-            "default": "",
         },
         {
             "key": Keys.CLIENT_ID,

--- a/api/sirsidynix_authentication_provider.py
+++ b/api/sirsidynix_authentication_provider.py
@@ -57,7 +57,7 @@ class SirsiDynixHorizonAuthenticationProvider(BasicAuthenticationProvider):
             "label": _("Server URL"),
             "description": _("The external server url."),
             "required": True,
-            "default": "https://vendor1-sym.sirsidynix.net/ilsws_current/",
+            "default": "",
         },
         {
             "key": Keys.CLIENT_ID,


### PR DESCRIPTION
Resolves: https://www.notion.so/lyrasis/Do-not-auto-populate-URL-when-SirsiDynix-Horizon-Authentication-is-selected-in-the-CM-b0f6cb86719f48d49929fb813badf820?pvs=4

## Description

This PR simply changes the default SirsiDynix url from a mock value to "". 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://www.notion.so/lyrasis/Do-not-auto-populate-URL-when-SirsiDynix-Horizon-Authentication-is-selected-in-the-CM-b0f6cb86719f48d49929fb813badf820?pvs=4
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested it manually by firing up a fresh cm, created a sirsidynix patron auth and validated that the default value is no longer set.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] All new and existing tests passed.
