### PR TITLE
Removed the Hold object creation from within the ODLAPI implementation

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -396,12 +396,14 @@ class HoldInfo(CirculationInfo):
         end_date,
         hold_position,
         external_identifier=None,
+        integration_client=None,
     ):
         super().__init__(collection, data_source_name, identifier_type, identifier)
         self.start_date = start_date
         self.end_date = end_date
         self.hold_position = hold_position
         self.external_identifier = external_identifier
+        self.integration_client = integration_client
 
     def __repr__(self):
         return "<HoldInfo for {}/{}, start={} end={}, position={}>".format(
@@ -1229,7 +1231,7 @@ class CirculationAPI:
         # to needing to put it on hold, but we do check for that case.
         __transaction = self._db.begin_nested()
         hold, is_new = licensepool.on_hold_to(
-            patron,
+            hold_info.integration_client or patron,
             hold_info.start_date or now,
             hold_info.end_date,
             hold_info.hold_position,

--- a/api/odl.py
+++ b/api/odl.py
@@ -54,6 +54,7 @@ from core.model.configuration import (
     HasExternalIntegration,
 )
 from core.model.licensing import LicenseStatus
+from core.model.patron import Patron
 from core.monitor import CollectionMonitor
 from core.opds_import import OPDSImporter, OPDSImportMonitor, OPDSXMLParser
 from core.testing import DatabaseTest, MockRequestsResponse
@@ -469,7 +470,7 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
         self.update_licensepool(licensepool)
 
         if hold:
-            self._update_hold_end_date(hold)
+            self._update_hold_data(hold)
 
         # If there's a holds queue, the patron or client must have a non-expired hold
         # with position 0 to check out the book.
@@ -620,14 +621,14 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
             expires,
         )
 
-    def _count_holds_before(self, hold):
+    def _count_holds_before(self, holdinfo: HoldInfo, pool: LicensePool) -> int:
         # Count holds on the license pool that started before this hold and
         # aren't expired.
-        _db = Session.object_session(hold)
+        _db = Session.object_session(pool)
         return (
             _db.query(Hold)
-            .filter(Hold.license_pool_id == hold.license_pool_id)
-            .filter(Hold.start < hold.start)
+            .filter(Hold.license_pool_id == pool.id)
+            .filter(Hold.start < holdinfo.start_date)
             .filter(
                 or_(
                     Hold.end == None,
@@ -638,30 +639,48 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
             .count()
         )
 
-    def _update_hold_end_date(self, hold):
-        _db = Session.object_session(hold)
-        pool = hold.license_pool
+    def _update_hold_data(self, hold: Hold):
+        pool: LicensePool = hold.license_pool
+        holdinfo = HoldInfo(
+            pool.collection,
+            pool.data_source.name,
+            pool.identifier.type,
+            pool.identifier.identifier,
+            hold.start,
+            hold.end,
+            hold.position,
+        )
+        library = hold.patron.library if hold.patron_id else None
+        client = hold.integration_client if hold.integration_client_id else None
+        self._update_hold_end_date(holdinfo, pool, library=library, client=client)
+        hold.end = holdinfo.end_date
+        hold.position = holdinfo.hold_position
+
+    def _update_hold_end_date(
+        self, holdinfo: HoldInfo, pool: LicensePool, client=None, library=None
+    ):
+        _db = Session.object_session(pool)
 
         # First make sure the hold position is up-to-date, since we'll
         # need it to calculate the end date.
-        original_position = hold.position
-        self._update_hold_position(hold)
+        original_position = holdinfo.hold_position
+        self._update_hold_position(holdinfo, pool)
 
         default_loan_period = self.collection(_db).default_loan_period(
-            hold.library or hold.integration_client
+            library or client
         )
         default_reservation_period = self.collection(_db).default_reservation_period
 
         # If the hold was already to check out and already has an end date,
         # it doesn't need an update.
-        if hold.position == 0 and original_position == 0 and hold.end:
+        if holdinfo.hold_position == 0 and original_position == 0 and holdinfo.end_date:
             return
 
         # If the patron is in the queue, we need to estimate when the book
         # will be available for check out. We can do slightly better than the
         # default calculation since we know when all current loans will expire,
         # but we're still calculating the worst case.
-        elif hold.position > 0:
+        elif holdinfo.hold_position > 0:
             # Find the current loans and reserved holds for the licenses.
             current_loans = (
                 _db.query(Loan)
@@ -691,12 +710,16 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
             # The licenses will have to go through some number of cycles
             # before one of them gets to this hold. This leavs out the first cycle -
             # it's already started so we'll handle it separately.
-            cycles = (hold.position - licenses_reserved - 1) // pool.licenses_owned
+            cycles = (
+                holdinfo.hold_position - licenses_reserved - 1
+            ) // pool.licenses_owned
 
             # Each of the owned licenses is currently either on loan or reserved.
             # Figure out which license this hold will eventually get if every
             # patron keeps their loans and holds for the maximum time.
-            copy_index = (hold.position - licenses_reserved - 1) % pool.licenses_owned
+            copy_index = (
+                holdinfo.hold_position - licenses_reserved - 1
+            ) % pool.licenses_owned
 
             # In the worse case, the first cycle ends when a current loan expires, or
             # after a current reservation is checked out and then expires.
@@ -710,18 +733,19 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
 
             # Assume all cycles after the first cycle take the maximum time.
             cycle_period = default_loan_period + default_reservation_period
-            hold.end = next_cycle_start + datetime.timedelta(
+            holdinfo.end_date = next_cycle_start + datetime.timedelta(
                 days=(cycle_period * cycles)
             )
 
         # If the end date isn't set yet or the position just became 0, the
         # hold just became available. The patron's reservation period starts now.
         else:
-            hold.end = utc_now() + datetime.timedelta(days=default_reservation_period)
+            holdinfo.end_date = utc_now() + datetime.timedelta(
+                days=default_reservation_period
+            )
 
-    def _update_hold_position(self, hold):
-        _db = Session.object_session(hold)
-        pool = hold.license_pool
+    def _update_hold_position(self, holdinfo: HoldInfo, pool: LicensePool):
+        _db = Session.object_session(pool)
         loans_count = (
             _db.query(Loan)
             .filter(
@@ -730,17 +754,17 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
             .filter(or_(Loan.end == None, Loan.end > utc_now()))
             .count()
         )
-        holds_count = self._count_holds_before(hold)
+        holds_count = self._count_holds_before(holdinfo, pool)
 
         remaining_licenses = pool.licenses_owned - loans_count
 
         if remaining_licenses > holds_count:
             # The hold is ready to check out.
-            hold.position = 0
+            holdinfo.hold_position = 0
 
         else:
             # Add 1 since position 0 indicates the hold is ready.
-            hold.position = holds_count + 1
+            holdinfo.hold_position = holds_count + 1
 
     def update_licensepool(self, licensepool: LicensePool):
         # Update the pool and the next holds in the queue when a license is reserved.
@@ -752,20 +776,11 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
         for hold in holds[: licensepool.licenses_reserved]:
             if hold.position != 0:
                 # This hold just got a reserved license.
-                self._update_hold_end_date(hold)
+                self._update_hold_data(hold)
 
     def place_hold(self, patron, pin, licensepool, notification_email_address):
         """Create a new hold."""
-        hold = self._place_hold(patron, licensepool)
-        return HoldInfo(
-            licensepool.collection,
-            licensepool.data_source.name,
-            licensepool.identifier.type,
-            licensepool.identifier.identifier,
-            start_date=hold.start,
-            end_date=hold.end,
-            hold_position=hold.position,
-        )
+        return self._place_hold(patron, licensepool)
 
     def _place_hold(self, patron_or_client, licensepool):
         _db = Session.object_session(patron_or_client)
@@ -776,15 +791,44 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
         if licensepool.licenses_available > 0:
             raise CurrentlyAvailable()
 
-        # Create local hold.
-        hold, is_new = licensepool.on_hold_to(patron_or_client)
+        patron_id, client_id = None, None
+        if isinstance(patron_or_client, Patron):
+            patron_id = patron_or_client.id
+        else:
+            client_id = patron_or_client.id
 
-        if not is_new:
+        # Check for local hold
+        hold = get_one(
+            _db,
+            Hold,
+            patron_id=patron_id,
+            integration_client_id=client_id,
+            license_pool_id=licensepool.id,
+        )
+
+        if hold is not None:
             raise AlreadyOnHold()
 
         licensepool.patrons_in_hold_queue += 1
-        self._update_hold_end_date(hold)
-        return hold
+        holdinfo = HoldInfo(
+            licensepool.collection,
+            licensepool.data_source.name,
+            licensepool.identifier.type,
+            licensepool.identifier.identifier,
+            utc_now(),
+            0,
+            0,
+        )
+        client = patron_or_client if client_id else None
+        library = patron_or_client.library if patron_id else None
+        self._update_hold_end_date(
+            holdinfo, licensepool, library=library, client=client
+        )
+
+        if client is not None:
+            holdinfo.integration_client = client
+
+        return holdinfo
 
     def release_hold(self, patron, pin, licensepool):
         """Cancel a hold."""
@@ -838,7 +882,7 @@ class ODLAPI(BaseCirculationAPI, BaseSharedCollectionAPI, HasExternalIntegration
                 _db.delete(hold)
                 self.update_licensepool(hold.license_pool)
             else:
-                self._update_hold_end_date(hold)
+                self._update_hold_data(hold)
                 remaining_holds.append(hold)
 
         return [

--- a/core/model/integrationclient.py
+++ b/core/model/integrationclient.py
@@ -39,7 +39,7 @@ class IntegrationClient(Base):
     last_accessed = Column(DateTime(timezone=True))
 
     loans = relationship("Loan", backref="integration_client")
-    holds = relationship("Hold", backref="integration_client")
+    holds = relationship("Hold", back_populates="integration_client")
 
     def __repr__(self):
         return f"<IntegrationClient: URL={self.url} ID={self.id}>"

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -30,6 +30,7 @@ from . import Base, get_one_or_create, numericrange_to_tuple
 from .credential import Credential
 
 if TYPE_CHECKING:
+    from core.model import IntegrationClient  # noqa: autoflake
     from core.model.library import Library  # noqa: autoflake
     from core.model.licensing import LicensePool  # noqa: autoflake
 
@@ -568,6 +569,11 @@ class Hold(Base, LoanAndHoldMixin):
     end = Column(DateTime(timezone=True), index=True)
     position = Column(Integer, index=True)
     external_identifier = Column(Unicode, unique=True, nullable=True)
+
+    patron = relationship("Patron", back_populates="holds", lazy="joined")
+    integration_client = relationship(
+        "IntegrationClient", back_populates="holds", lazy="joined"
+    )
 
     def __lt__(self, other):
         return self.id < other.id

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -155,7 +155,11 @@ class Patron(Base):
 
     loans = relationship("Loan", backref="patron", cascade="delete", uselist=True)
     holds = relationship(
-        "Hold", back_populates="patron", cascade="delete", uselist=True
+        "Hold",
+        back_populates="patron",
+        cascade="delete",
+        uselist=True,
+        order_by="Hold.id",
     )
 
     annotations = relationship(

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -154,7 +154,9 @@ class Patron(Base):
     cached_neighborhood = Column(Unicode, default=None, index=True)
 
     loans = relationship("Loan", backref="patron", cascade="delete", uselist=True)
-    holds = relationship("Hold", backref="patron", cascade="delete", uselist=True)
+    holds = relationship(
+        "Hold", back_populates="patron", cascade="delete", uselist=True
+    )
 
     annotations = relationship(
         "Annotation",

--- a/tests/api/test_odl2.py
+++ b/tests/api/test_odl2.py
@@ -22,9 +22,11 @@ from core.model import (
     LicensePool,
     MediaTypes,
     Work,
+    create,
 )
 from core.model.configuration import ConfigurationFactory, ConfigurationStorage
 from core.model.constants import IdentifierConstants
+from core.model.patron import Hold
 from core.model.resource import Hyperlink
 from tests.api.test_odl import LicenseHelper, LicenseInfoHelper, TestODLImporter
 from tests.fixtures.api_odl2_files import ODL2APIFilesFixture
@@ -423,6 +425,7 @@ class TestODL2API:
         response = odl2api.api.place_hold(odl2api.patron, "pin", pool, "")
         # Hold was successful
         assert response.hold_position == 1
+        create(db.session, Hold, patron_id=odl2api.patron.id, license_pool=pool)
 
         # Second work should fail for the test patron due to the hold limit
         work2: Work = odl2api.fixture.work(odl2api.collection)

--- a/tests/fixtures/odl.py
+++ b/tests/fixtures/odl.py
@@ -226,7 +226,7 @@ class ODLAPITestFixture:
         self.collection = collection
         self.work = work
         self.license = license
-        self.api = api
+        self.api: ODLAPI = api
         self.patron = patron
         self.pool = license.license_pool  # type: ignore
         self.client = client


### PR DESCRIPTION
## Description
All other integrations depend on the CirculationAPI to create the Hold object 
They create a HoldInfo object with the required information, which is what the ODLAPI also does now 
The CirculationAPI is also aware of integration_client based Holds now
There should be no behavioural changes while booking a Hold for ODL type collections, except for the bugfix which allows the analytics event to be captured. 
<!--- Describe your changes -->

## Motivation and Context
During a recent test, we noticed that the circulation_manager_hold_place event was not being captured in either Redshift or the CM CSV export for Palace Marketplace content. The event is being captured for all other distributors.

[Notion](https://www.notion.so/lyrasis/Hold-placed-events-are-not-captured-for-Palace-Marketplace-content-03b00ca9543b4b76b0fc56474aa42373)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually Tested the borrow/hold workflow for the ODLAPI
All unit tests were run
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
