### PR TITLE
Tightening up manager password permissions

### DIFF
--- a/api/admin/exceptions.py
+++ b/api/admin/exceptions.py
@@ -4,5 +4,15 @@ from .problem_details import *
 class AdminNotAuthorized(Exception):
     status_code = 403
 
+    def __init__(self, *args: object) -> None:
+        self.message = None
+        if len(args) > 0:
+            self.message = args[0]
+        super().__init__(*args)
+
     def as_problem_detail_document(self, debug=False):
-        return ADMIN_NOT_AUTHORIZED
+        return (
+            ADMIN_NOT_AUTHORIZED.detailed(self.message)
+            if self.message
+            else ADMIN_NOT_AUTHORIZED
+        )

--- a/tests/api/admin/controller/test_individual_admins.py
+++ b/tests/api/admin/controller/test_individual_admins.py
@@ -461,8 +461,8 @@ class TestIndividualAdmins:
         # Various types of user trying to change a sitewide librarian's password
         test_changing_password(system, sitewide_librarian, allowed=True)
         test_changing_password(sitewide_manager, sitewide_librarian, allowed=True)
-        test_changing_password(manager1, sitewide_librarian, allowed=True)
-        test_changing_password(manager2, sitewide_librarian, allowed=True)
+        test_changing_password(manager1, sitewide_librarian)
+        test_changing_password(manager2, sitewide_librarian)
         test_changing_password(sitewide_librarian, sitewide_librarian)
         test_changing_password(librarian1, sitewide_librarian)
         test_changing_password(librarian2, sitewide_librarian)
@@ -498,6 +498,29 @@ class TestIndividualAdmins:
         test_changing_password(sitewide_librarian, librarian2)
         test_changing_password(manager1, librarian2)
         test_changing_password(librarian1, librarian2)
+
+        # Library crossover tests
+        manager1_2, ignore = create(
+            db.session, Admin, email="library_manager_l1_l2@example.com"
+        )
+        manager1_2.add_role(AdminRole.LIBRARY_MANAGER, l1)
+        manager1_2.add_role(AdminRole.LIBRARY_MANAGER, l2)
+        # A manager of library1 should not be allowed for a manager of library1 and library2
+        test_changing_password(system, manager1_2, allowed=True)
+        test_changing_password(sitewide_manager, manager1_2, allowed=True)
+        test_changing_password(manager1_2, manager1_2, allowed=True)
+        test_changing_password(sitewide_librarian, manager1_2)
+        test_changing_password(manager1, manager1_2)
+        test_changing_password(manager2, manager1_2)
+        test_changing_password(librarian1, manager1_2)
+        # A manager of both libraries should be able to change the passwords of both
+        test_changing_password(manager1_2, manager1, allowed=True)
+        test_changing_password(manager1_2, manager2, allowed=True)
+        test_changing_password(manager1_2, librarian1, allowed=True)
+        test_changing_password(manager1_2, librarian2, allowed=True)
+        test_changing_password(manager1_2, system)
+        test_changing_password(manager1_2, sitewide_manager)
+        test_changing_password(manager1_2, sitewide_librarian)
 
     def test_individual_admins_post_create(self, settings_ctrl_fixture):
         db = settings_ctrl_fixture.ctrl.db


### PR DESCRIPTION
## Description
Only a library manager which has permissions for all libraries on a target manager profile may change the password of the target manager

Following this philososphy, a library manager cannot change the password of a sitewide librarian anymore.
<!--- Describe your changes -->

## Motivation and Context
Consider two admins `A` and `B`.
Admin `A` is a manager of libraries `L` and `M` .
Admin `B` is a manager of libraries `M` and `N` .
Because `A` is a manager of `M`, and `B` is also a manager of `M`, `A` can change `B`'s password. This means that `A` can effectively take over `B`'s account and can act as a manager of `N`.

[Notion](https://www.notion.so/lyrasis/Role-system-privilege-escalation-6021016bc340481e92996e553666bbb2)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested the error message on the Admin UI.
Unit tests have been updated.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
