### PR TITLE
Closed the leaking connection pool sessions

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1634,6 +1634,14 @@ class CirculationAPI:
                     "Synced %s in %.2f sec", self.api.__class__.__name__, after - before
                 )
 
+                # While testing we are in a Session scope
+                # we need to only close this if api._db is a flask_scoped_session.
+                if type(api._db) != Session:
+                    # Since we are in a Thread using a flask_scoped_session
+                    # we can assume a new Session was opened due to the thread activity.
+                    # We must close this session to avoid connection pool leaks
+                    api._db.close()
+
         threads = []
         before = time.time()
         for api in list(self.api_for_collection.values()):

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -1636,11 +1636,11 @@ class CirculationAPI:
 
                 # While testing we are in a Session scope
                 # we need to only close this if api._db is a flask_scoped_session.
-                if type(api._db) != Session:
+                if getattr(self.api, "_db", None) and type(self.api._db) != Session:
                     # Since we are in a Thread using a flask_scoped_session
                     # we can assume a new Session was opened due to the thread activity.
                     # We must close this session to avoid connection pool leaks
-                    api._db.close()
+                    self.api._db.close()
 
         threads = []
         before = time.time()


### PR DESCRIPTION
## Description
In the PatronActivityThreads the api objects would access the db using the flask_scoped_session which creates a new Session per python thread 
Since the PatronActivityThread is spawned for every bookshelf_sync and the newly created Session is never torn down, we end up with orphaned Sessions using up the connection pool and never being closed 
The leak occurs slowly because python reuses completed threads which are identified via get_ident()

The fix __isn't__ a catchall thread safety change to the entire CirculationAPI architecture, but a fix specifically for the PatronActivityThread. 
Any new threads introduced into the CM will have to be handled again.
<!--- Describe your changes -->

## Motivation and Context
We are seeing a number of errors coming back from our production webservers:
> `Exception in web app: QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30 (Background on this error at: http://sqlalche.me/e/13/3o7r)`
>

[Notion](https://www.notion.so/lyrasis/QueuePool-limit-reached-fd9d8a7f6f1e4e7785c2040cbc1d00ef)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- Ran the CM under uwsgi locally (3 processes, 2 threads)
- Changed the bookshelf_sync code to ignore caching
- Hit the `/patron/loans` endpoint continuously using `siege`
- Observed the lack of leaking connections with `engine.pool.status()` [[source](https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_3/lib/sqlalchemy/pool/impl.py#L192)]
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
