### PR TITLE
Fix an issue with loading ssl_verify setting for SIP2 integration.

### DIFF
--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -202,7 +202,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         self.use_ssl = integration.setting(self.USE_SSL).json_value
         self.ssl_cert = integration.setting(self.SSL_CERTIFICATE).value
         self.ssl_key = integration.setting(self.SSL_KEY).value
-        self.ssl_verification = integration.setting(self.SSL_VERIFICATION).json_value
+        self.ssl_verification = integration.setting(self.SSL_VERIFICATION).bool_value
         self.dialect = Sip2Dialect.load_dialect(integration.setting(self.ILS).value)
         self.client = client
 

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -202,7 +202,7 @@ class SIP2AuthenticationProvider(BasicAuthenticationProvider):
         self.use_ssl = integration.setting(self.USE_SSL).json_value
         self.ssl_cert = integration.setting(self.SSL_CERTIFICATE).value
         self.ssl_key = integration.setting(self.SSL_KEY).value
-        self.ssl_verification = integration.setting(self.SSL_VERIFICATION).value
+        self.ssl_verification = integration.setting(self.SSL_VERIFICATION).json_value
         self.dialect = Sip2Dialect.load_dialect(integration.setting(self.ILS).value)
         self.client = client
 


### PR DESCRIPTION
## Description

The existing code had an idiotic problem that the type checker was unable to catch. Essentially, calling `.value` on a configuration setting that contains a value `true` or `false` (or really any string), will result in that value being returned as a string. If the code was expecting a `bool`... Tough luck, it's getting a `str`.

Using `.json_value` on the configuration setting instead forces the code to actually interpret the setting's value, and will correctly result in a `bool` being returned.

## Motivation and Context

TLS verification was still being performed, even though the configuration setting stated that it shouldn't be.

## How Has This Been Tested?

I ran the existing test suite, and I tested this locally in a debugger. I was not impressed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
