### PR TITLE
Limit build concurrency

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,6 +1,10 @@
 name: Test & Build
 on: [push, pull_request]
 
+concurrency:
+  group: test-build-${{ github.ref_name }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: ${{ matrix.module }} Tests (Py ${{ matrix.python-version }})


### PR DESCRIPTION
## Description

Similar to https://github.com/ThePalaceProject/virtual-library-card/pull/317, this aims to limit our build concurrency, by cancelling existing CI jobs, if a new job is submitted for the same branch. 

This has two benefits:
- This should let us use fewer build minutes, so the jobs we do need will complete faster.
- Make sure that images don't get pushed out of order. 

The concurrency group is composed of:
- test-build: The name of the action
  - In case we want to add concurrency controls for other actions in the future
- github.ref_name: The branch / tag
  - We don't want to cancel actions from other tags / branches, only on updates to a single tag / branch
- github.event_name: The name of the event
  - Since our events fire on both PR and Push events, we don't want one event to cancel the other, so we use a different concurrency group for each event type. 

## Motivation and Context

We saw an issue with our nightly deploy on VLC where two PR were merged quickly one after another. The docker builds completed out of order, so the development environment never got updated to the most recent commit 😅.

## How Has This Been Tested?

Letting CI run on it

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
