### PR TITLE
Fix attribute error in the single item feed

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1843,6 +1843,10 @@ class LoanController(CirculationManagerController):
             feed = LibraryLoanAndHoldAnnotator.single_item_feed(
                 self.circulation, loan, fulfillment=fulfillment
             )
+            if isinstance(feed, ProblemDetail):
+                # This should typically never happen, since we've gone through the entire fulfill workflow
+                # But for the sake of return-type completeness we are adding this here
+                return feed
             if isinstance(feed, Response):
                 return feed
             if isinstance(feed, OPDSFeed):

--- a/api/controller.py
+++ b/api/controller.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import email
 import json
 import logging
@@ -5,7 +7,7 @@ import os
 import urllib.parse
 from collections import defaultdict
 from time import mktime
-from typing import List, Optional
+from typing import TYPE_CHECKING, Any
 from wsgiref.handlers import format_date_time
 
 import flask
@@ -125,6 +127,9 @@ from .opds import (
 from .problem_details import *
 from .shared_collection import SharedCollectionAPI
 from .testing import MockCirculationAPI, MockSharedCollectionAPI
+
+if TYPE_CHECKING:
+    from werkzeug import Response as wkResponse
 
 
 class CirculationManager:
@@ -312,8 +317,8 @@ class CirculationManager:
         )
 
     def _dev_mgmt_from_libraries(
-        self, libraries: List[Library]
-    ) -> Optional[DeviceManagementProtocolController]:
+        self, libraries: list[Library]
+    ) -> DeviceManagementProtocolController | None:
         """Return a DeviceManagementProtocolController in any library uses Adobe Vendor IDs."""
 
         for library in libraries:
@@ -1322,10 +1327,10 @@ class OPDSFeedController(CirculationManagerController):
 class FeedRequestParameters:
     """Frequently used request parameters for feed requests"""
 
-    library: Optional[Library] = None
-    pagination: Optional[Pagination] = None
-    facets: Optional[Facets] = None
-    problem: Optional[ProblemDetail] = None
+    library: Library | None = None
+    pagination: Pagination | None = None
+    facets: Facets | None = None
+    problem: ProblemDetail | None = None
 
 
 class OPDS2FeedController(CirculationManagerController):
@@ -1701,7 +1706,13 @@ class LoanController(CirculationManagerController):
             return problem_doc
         return best, mechanism
 
-    def fulfill(self, license_pool_id, mechanism_id=None, part=None, do_get=None):
+    def fulfill(
+        self,
+        license_pool_id: int,
+        mechanism_id: int | None = None,
+        part: str | None = None,
+        do_get: Any | None = None,
+    ) -> wkResponse | ProblemDetail:
         """Fulfill a book that has already been checked out,
         or which can be fulfilled with no active loan.
 
@@ -1737,7 +1748,7 @@ class LoanController(CirculationManagerController):
             # There's still a chance this request can succeed, but if not,
             # we'll be sending out authentication_response.
             patron = None
-        library = flask.request.library
+        library = flask.request.library  # type: ignore
         header = self.authorization_header()
         credential = self.manager.auth.get_credential_from_header(header)
 
@@ -1849,7 +1860,7 @@ class LoanController(CirculationManagerController):
                 return feed
             if isinstance(feed, Response):
                 return feed
-            if isinstance(feed, OPDSFeed):
+            if isinstance(feed, OPDSFeed):  # type: ignore
                 content = str(feed)
             else:
                 content = etree.tostring(feed)

--- a/api/opds.py
+++ b/api/opds.py
@@ -1726,11 +1726,17 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
                 )
             )
 
+        log = logging.getLogger(cls.__name__)
+
         # Sometimes the pool or work may be None
         # In those cases we have to protect against the exceptions
         try:
             work = license_pool.work or license_pool.presentation_edition.work
-        except AttributeError:
+        except AttributeError as ex:
+            log.error(f"Error retrieving a Work Object {ex}")
+            log.error(
+                f"Error Data: {license_pool} | {license_pool and license_pool.presentation_edition}"
+            )
             return NOT_FOUND_ON_REMOTE
 
         if not work:

--- a/api/opds.py
+++ b/api/opds.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Tuple
 from flask import url_for
 
 from api.lanes import DynamicLane
+from api.problem_details import NOT_FOUND_ON_REMOTE
 from core.analytics import Analytics
 from core.classifier import Classifier
 from core.entrypoint import EverythingEntryPoint
@@ -1722,7 +1723,17 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
             )
 
         _db = Session.object_session(item)
-        work = license_pool.work or license_pool.presentation_edition.work
+
+        # Sometimes the pool or work may be None
+        # In those cases we have to protect against the exceptions
+        try:
+            work = license_pool.work or license_pool.presentation_edition.work
+        except AttributeError:
+            return NOT_FOUND_ON_REMOTE
+
+        if not work:
+            return NOT_FOUND_ON_REMOTE
+
         active_loans_by_work = {}
         active_holds_by_work = {}
         active_fulfillments_by_work = {}

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -3,7 +3,7 @@ import json
 import re
 from collections import defaultdict
 from typing import Any, Dict, List
-from unittest.mock import create_autospec
+from unittest.mock import MagicMock, create_autospec
 
 import dateutil
 import feedparser
@@ -23,6 +23,7 @@ from api.opds import (
     SharedCollectionAnnotator,
     SharedCollectionLoanAndHoldAnnotator,
 )
+from api.problem_details import NOT_FOUND_ON_REMOTE
 from core.analytics import Analytics
 from core.classifier import Classifier, Fantasy, Urban_Fantasy
 from core.entrypoint import AudiobooksEntryPoint, EverythingEntryPoint
@@ -42,9 +43,11 @@ from core.model import (
     Representation,
     RightsStatus,
     Work,
+    get_one,
 )
 from core.model.formats import FormatPriorities
 from core.model.licensing import LicensePool
+from core.model.patron import Loan
 from core.opds import AcquisitionFeed, MockAnnotator, UnfulfillableWork
 from core.opds_import import OPDSXMLParser
 from core.util.datetime_helpers import datetime_utc, utc_now
@@ -2210,6 +2213,35 @@ class TestLibraryLoanAndHoldAnnotator:
         assert {work: hold} == annotator.active_holds_by_work
         assert {} == annotator.active_loans_by_work
         assert {} == annotator.active_fulfillments_by_work
+
+    def test_single_item_feed_without_work(self, db: DatabaseTransactionFixture):
+        """If a licensepool has no work or edition the single_item_feed mustn't raise an exception"""
+        mock = MagicMock()
+        # A loan without a pool
+        loan = Loan(patron=db.patron())
+        assert (
+            LibraryLoanAndHoldAnnotator.single_item_feed(mock, loan)
+            == NOT_FOUND_ON_REMOTE
+        )
+
+        work = db.work(with_license_pool=True)
+        pool: LicensePool = get_one(db.session, LicensePool, work_id=work.id)
+        # Pool with no work, and the presentation edition has no work either
+        pool.work_id = None
+        work.presentation_edition_id = None
+        db.session.commit()
+        assert (
+            LibraryLoanAndHoldAnnotator.single_item_feed(mock, pool)
+            == NOT_FOUND_ON_REMOTE
+        )
+
+        # pool with no work and no presentation edition
+        pool.presentation_edition_id = None
+        db.session.commit()
+        assert (
+            LibraryLoanAndHoldAnnotator.single_item_feed(mock, pool)
+            == NOT_FOUND_ON_REMOTE
+        )
 
 
 class SharedCollectionAnnotatorFixture:


### PR DESCRIPTION
## Description
Protect against the rare case where we may not have a licensepool or the licensepool does not have the right relationships
<!--- Describe your changes -->

## Motivation and Context
We are seeing the following exception happening on our production CMs:
`AttributeError: 'NoneType' object has no attribute 'work'`
in the file `  File "/var/www/circulation/api/opds.py", line 1725, in single_item_feed`

[Notion](https://www.notion.so/lyrasis/Exception-in-web-app-NoneType-object-has-no-attribute-work-8a2e407b710d42e69c1f05638982dcd1)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
A unit test has been written to mock the situation.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
