### PR TITLE
Provides a configuration script to add SAML federations to the CM.

### DIFF
--- a/bin/configuration/add_saml_federations.py
+++ b/bin/configuration/add_saml_federations.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""Adds SAML federation metadata to `samlfederations` table."""
+
+import os
+import sys
+from contextlib import closing
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from api.saml.metadata.federations import incommon
+from api.saml.metadata.federations.model import SAMLFederation
+from core.model import production_session
+
+with closing(production_session()) as db:
+    incommon_federation = (
+        db.query(SAMLFederation)
+        .filter(SAMLFederation.type == incommon.FEDERATION_TYPE)
+        .one_or_none()
+    )
+
+    if not incommon_federation:
+        incommon_federation = SAMLFederation(
+            incommon.FEDERATION_TYPE,
+            incommon.IDP_METADATA_SERVICE_URL,
+            incommon.CERTIFICATE,
+        )
+
+        db.add(incommon_federation)
+        db.commit()


### PR DESCRIPTION
## Description

Provides a configuration script to add SAML federations to the CM.

## Motivation and Context

The method for adding this configuration had been previously captured -- incorrectly -- in a database migration. That migration has since been removed from current versions of the project.

## How Has This Been Tested?

- Tested locally in my development environment.
- No new tests have been added for this script.
