### PR TITLE
Remove work_controller.report endpoint

### DIFF
--- a/api/opds.py
+++ b/api/opds.py
@@ -767,19 +767,6 @@ class LibraryAnnotator(CirculationManagerAnnotator):
     def annotate_work_entry(
         self, work, active_license_pool, edition, identifier, feed, entry
     ):
-        # Add a link for reporting problems.
-        feed.add_link_to_entry(
-            entry,
-            rel="issues",
-            href=self.url_for(
-                "report",
-                identifier_type=identifier.type,
-                identifier=identifier.identifier,
-                library_short_name=self.library.short_name,
-                _external=True,
-            ),
-        )
-
         super().annotate_work_entry(
             work, active_license_pool, edition, identifier, feed, entry
         )

--- a/api/routes.py
+++ b/api/routes.py
@@ -676,16 +676,6 @@ def related_books(identifier_type, identifier):
     return app.manager.work_controller.related(identifier_type, identifier)
 
 
-@library_route(
-    "/works/<identifier_type>/<path:identifier>/report", methods=["GET", "POST"]
-)
-@has_library
-@allows_patron_web
-@returns_problem_detail
-def report(identifier_type, identifier):
-    return app.manager.work_controller.report(identifier_type, identifier)
-
-
 @library_route("/analytics/<identifier_type>/<path:identifier>/<event_type>")
 @has_library
 @allows_auth

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -869,7 +869,7 @@ class TestLibraryAnnotator:
         with_auth, no_auth = linksets
 
         # Some links are present no matter what.
-        for expect in ["alternate", "issues", "related"]:
+        for expect in ["alternate", "related"]:
             assert expect in with_auth
             assert expect in no_auth
 
@@ -908,7 +908,6 @@ class TestLibraryAnnotator:
         # These links are still present.
         for expect in [
             "alternate",
-            "issues",
             "related",
             "http://www.w3.org/ns/oa#annotationservice",
         ]:
@@ -1044,15 +1043,6 @@ class TestLibraryAnnotator:
                 uri_partials = [uri_partials]
             for part in uri_partials:
                 assert part in link.href
-
-    def test_work_entry_includes_problem_reporting_link(
-        self, annotator_fixture: LibraryAnnotatorFixture
-    ):
-        work = annotator_fixture.db.work(with_open_access_download=True)
-        feed = self.get_parsed_feed(annotator_fixture, [work])
-        [entry] = feed.entries
-        expected_rel_and_partial = {"issues": "/report"}
-        self.assert_link_on_entry(entry, partials_by_rel=expected_rel_and_partial)
 
     def test_work_entry_includes_open_access_or_borrow_link(
         self, annotator_fixture: LibraryAnnotatorFixture


### PR DESCRIPTION
## Description

This PR removes endpoint for the `WorkController` `report` method. The code for the method was removed in [this PR](https://github.com/ThePalaceProject/circulation/pull/275), however, the actual endpoint (route) was never removed.

<!--- Describe your changes -->

## Motivation and Context

[Notion](https://www.notion.so/lyrasis/WorkController-object-has-no-attribute-report-4b2811328a304738b7f7858f55d6cd3a)

Since the code for the method was removed but the endpoint was still there we were getting errors because someone was trying to access that endpoint. Endpoint should have been removed in the original PR.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Updated tests and run them.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
