### PR TITLE
Collection based coverage records

### DIFF
--- a/alembic/versions/20230501_f9985f6b7767_remove_import_coverage_records_without_.py
+++ b/alembic/versions/20230501_f9985f6b7767_remove_import_coverage_records_without_.py
@@ -1,0 +1,24 @@
+"""Remove import coverage records without collections
+
+Revision ID: f9985f6b7767
+Revises: 3ee5b99f2ae7
+Create Date: 2023-05-01 10:07:45.737475+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f9985f6b7767"
+down_revision = "3ee5b99f2ae7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "DELETE FROM coveragerecords WHERE collection_id IS NULL AND operation='import'"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/alembic/versions/20230501_f9985f6b7767_remove_import_coverage_records_without_.py
+++ b/alembic/versions/20230501_f9985f6b7767_remove_import_coverage_records_without_.py
@@ -1,7 +1,7 @@
 """Remove import coverage records without collections
 
 Revision ID: f9985f6b7767
-Revises: 3ee5b99f2ae7
+Revises: 5dcbc92c20b2
 Create Date: 2023-05-01 10:07:45.737475+00:00
 
 """
@@ -9,7 +9,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "f9985f6b7767"
-down_revision = "3ee5b99f2ae7"
+down_revision = "5dcbc92c20b2"
 branch_labels = None
 depends_on = None
 

--- a/core/opds2_import.py
+++ b/core/opds2_import.py
@@ -880,6 +880,7 @@ class OPDS2Importer(
             error_message,
             data_source=self.data_source,
             transient=transient,
+            collection=self.collection,
         )
         failures[identifier.identifier].append(failure)
 

--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -517,6 +517,7 @@ class OPDSImporter:
                     traceback.format_exc(),
                     data_source=data_source,
                     transient=False,
+                    collection=self.collection,
                 )
                 failures[key] = failure
                 # clean up any edition might have created
@@ -539,6 +540,7 @@ class OPDSImporter:
                     traceback.format_exc(),
                     data_source=data_source,
                     transient=False,
+                    collection=self.collection,
                 )
                 failures[key] = failure
 
@@ -839,6 +841,7 @@ class OPDSImporter:
             # This really is a failure. Associate the internal
             # identifier with the CoverageFailure object.
             failure.obj = internal_identifier
+            failure.collection = self.collection
         return internal_identifier, failure
 
     @classmethod
@@ -893,6 +896,8 @@ class OPDSImporter:
             identifier, detail, failure = self.data_detail_for_feedparser_entry(
                 entry=entry, data_source=data_source
             )
+            if failure:
+                failure.collection = self.collection
 
             if identifier:
                 if failure:
@@ -1779,6 +1784,7 @@ class OPDSImportMonitor(CollectionMonitor, HasSelfTests, HasExternalIntegration)
             identifier,
             self.importer.data_source,
             operation=CoverageRecord.IMPORT_OPERATION,
+            collection=self.collection,
         )
 
         if not record:
@@ -1882,6 +1888,7 @@ class OPDSImportMonitor(CollectionMonitor, HasSelfTests, HasExternalIntegration)
                 self.importer.data_source,
                 CoverageRecord.IMPORT_OPERATION,
                 status=CoverageRecord.SUCCESS,
+                collection=self.collection,
             )
 
         # Create CoverageRecords for the failures.

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -48,7 +48,6 @@ from core.user_profile import ProfileController
 from core.util.authentication_for_opds import AuthenticationForOPDSDocument
 from core.util.datetime_helpers import utc_now
 from core.util.http import IntegrationException, RequestTimedOut
-from tests.core.mock import MockRequestsResponse
 
 from ..fixtures.api_controller import ControllerFixture
 from ..fixtures.database import DatabaseTransactionFixture

--- a/tests/api/test_sirsidynix_auth_provider.py
+++ b/tests/api/test_sirsidynix_auth_provider.py
@@ -14,7 +14,7 @@ from api.sirsidynix_authentication_provider import (
     SirsiDynixPatronData,
 )
 from core.model import ExternalIntegration, Patron
-from core.testing import MockRequestsResponse
+from tests.core.mock import MockRequestsResponse
 from tests.fixtures.database import DatabaseTransactionFixture
 
 

--- a/tests/core/models/test_collection.py
+++ b/tests/core/models/test_collection.py
@@ -1009,6 +1009,16 @@ class TestCollection:
         pool2 = db.licensepool(None, collection=collection2)
         work2.license_pools.append(pool2)
 
+        record, _ = CoverageRecord.add_for(
+            work.presentation_edition, collection.data_source, collection=collection
+        )
+        assert (
+            CoverageRecord.lookup(
+                work.presentation_edition, collection.data_source, collection=collection
+            )
+            != None
+        )
+
         # Finally, here's a mock ExternalSearchIndex so we can track when
         # Works are removed from the search index.
         class MockExternalSearchIndex:
@@ -1037,6 +1047,9 @@ class TestCollection:
 
         # The default library now has no collections.
         assert [] == db.default_library().collections
+
+        # The collection based coverage record got deleted
+        assert db.session.query(CoverageRecord).get(record.id) == None
 
         # The deletion of the Collection's sole LicensePool has
         # cascaded to Loan, Hold, License, and

--- a/tests/core/models/test_coverage.py
+++ b/tests/core/models/test_coverage.py
@@ -12,6 +12,7 @@ from core.model.coverage import (
     WorkCoverageRecord,
 )
 from core.model.datasource import DataSource
+from core.model.edition import Edition
 from core.model.identifier import Equivalency, Identifier
 from core.util.datetime_helpers import datetime_utc, utc_now
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -431,6 +432,30 @@ class TestCoverageRecord:
         assert source == new_record.data_source
         assert operation == new_record.operation
         assert "Oh no" == new_record.exception
+
+    def test_assert_coverage_operation(self, db: DatabaseTransactionFixture):
+        """Ensure all the methods that should raise errors, do raise the errors"""
+        edition: Edition = db.edition()
+        with pytest.raises(ValueError):
+            CoverageRecord.add_for(
+                edition,
+                edition.data_source,
+                CoverageRecord.IMPORT_OPERATION,
+            )
+
+        with pytest.raises(ValueError):
+            CoverageRecord.lookup(
+                edition,
+                edition.data_source,
+                CoverageRecord.IMPORT_OPERATION,
+            )
+
+        with pytest.raises(ValueError):
+            CoverageRecord.bulk_add(
+                [edition.primary_identifier],
+                edition.data_source,
+                CoverageRecord.IMPORT_OPERATION,
+            )
 
 
 class TestWorkCoverageRecord:

--- a/tests/core/test_opds_import.py
+++ b/tests/core/test_opds_import.py
@@ -365,7 +365,6 @@ class TestOPDSImporter:
         assert m(book_links) == "Book"
 
     def test_extract_link_rights_uri(self):
-
         # Most of the time, a link's rights URI is inherited from the entry.
         entry_rights = RightsStatus.PUBLIC_DOMAIN_USA
 
@@ -1912,7 +1911,6 @@ class TestCombine:
         assert "new value" == c(a_is_old, a_is_new)["a"]
 
     def test_combine_present_value_not_replaced_with_none(self):
-
         """When combining a dictionary where a key is set to None
         with a dictionary where that key is present, the value
         is left alone.
@@ -2524,12 +2522,18 @@ class TestOPDSImportMonitor:
         # If there are CoverageRecords that record work are after the updated
         # dates, there's nothing new.
         record, ignore = CoverageRecord.add_for(
-            editions[0], data_source, CoverageRecord.IMPORT_OPERATION
+            editions[0],
+            data_source,
+            CoverageRecord.IMPORT_OPERATION,
+            collection=transaction.default_collection(),
         )
         record.timestamp = datetime_utc(2016, 1, 1, 1, 1, 1)
 
         record2, ignore = CoverageRecord.add_for(
-            editions[1], data_source, CoverageRecord.IMPORT_OPERATION
+            editions[1],
+            data_source,
+            CoverageRecord.IMPORT_OPERATION,
+            collection=transaction.default_collection(),
         )
         record2.timestamp = datetime_utc(2016, 1, 1, 1, 1, 1)
 
@@ -2598,7 +2602,10 @@ class TestOPDSImportMonitor:
 
         for edition in editions:
             record, ignore = CoverageRecord.add_for(
-                edition, data_source, CoverageRecord.IMPORT_OPERATION
+                edition,
+                data_source,
+                CoverageRecord.IMPORT_OPERATION,
+                collection=transaction.default_collection(),
             )
             record.timestamp = datetime_utc(2016, 1, 1, 1, 1, 1)
 
@@ -2667,6 +2674,7 @@ class TestOPDSImportMonitor:
             editions[0].primary_identifier,
             data_source,
             operation=CoverageRecord.IMPORT_OPERATION,
+            collection=transaction.default_collection(),
         )
         assert CoverageRecord.SUCCESS == record.status
         assert None == record.exception
@@ -2699,7 +2707,10 @@ class TestOPDSImportMonitor:
             session, "urn:librarysimplified.org/terms/id/Gutenberg%20ID/10441"
         )
         failure = CoverageRecord.lookup(
-            identifier, data_source, operation=CoverageRecord.IMPORT_OPERATION
+            identifier,
+            data_source,
+            operation=CoverageRecord.IMPORT_OPERATION,
+            collection=transaction.default_collection(),
         )
         assert "Utter failure!" in failure.exception
 


### PR DESCRIPTION
## Description
Changed the OPDS and OPDS2 importers to maintain coverage records PER collection

Earlier they maintained one record per identifier, now it will be multiple records per identifier This will facilitate the re-import of a deleted collection

:warning: Merging this change causes all OPDS and OPDS2 feeds to re-import from scratch since there are currently no CoverageRecords with collections associated with them.

<!--- Describe your changes -->

## Motivation and Context
A collection will fail to re-import after being deleted and re-added. This appears to be a problem with the collection deletion cleanup logic; some record of the collection remains after being deleted, so the importer skips over all the entries because they appear to already be present in the CM.

[Notion](https://www.notion.so/lyrasis/Improve-collection-deletion-clean-up-logic-35e81b1ec14a4f3f82670311ae6da8ca)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Deleted and recreated both OPDS and OPDS2 type collections, both times the titles were re-imported.
Unit tests have been updated for collection based CoverageRecords.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
