### PR TITLE
Add release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - ignore for notes
+  categories:
+    - title: Incompatible Changes
+      labels:
+        - incompatible changes
+    - title: Features
+      labels:
+        - feature
+    - title: Bugfixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+    - title: Dependency Updates
+      labels:
+        - dependencies


### PR DESCRIPTION
## Description

In an effort to make our releases easier, I added a [release note configuration](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) file to the repo.

## Motivation and Context

It makes use of [labels](https://github.com/ThePalaceProject/circulation/labels) on each PR to put them into categories in the release.

## How Has This Been Tested?

So far it hasn't been tested, I'm going to do a bit of testing in my fork before merging.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
