### PR TITLE
Add --keep-runtime-typing option for Pydantic.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
       - id: pyupgrade
         args:
           - --py38-plus
+          - --keep-runtime-typing
 
   - repo: https://github.com/myint/autoflake
     rev: v2.0.0


### PR DESCRIPTION
## Description

Add the `--keep-runtime-typing` option to our pre-commit config for [pyupgrade](https://github.com/asottile/pyupgrade).

Here is an upstream issue describing the situation: https://github.com/asottile/pyupgrade/issues/415

## Motivation and Context

By default, if `from __future__ import annotations` is included in a file, pyupgrade enables [pep 585 typing rewrites](https://github.com/asottile/pyupgrade#pep-585-typing-rewrites) and [pep 604 typing rewrites](https://github.com/asottile/pyupgrade#pep-604-typing-rewrites). This works for mypy, but causes issues with pydantic, as it evals types at runtime. 

Since we've been using Pydantic more in the code base, (for example in https://github.com/ThePalaceProject/circulation/pull/993) we should enable this flag, so our use of future imports doesn't cause issues with Pydantic.

## How Has This Been Tested?

I've tested this locally with some Pydantic code I've been working on, and it should be okay, as long as CI runs on it. 

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
