### PR TITLE
Fall back to the patron external_identifier if no username has been s…

### DIFF
--- a/api/opds2.py
+++ b/api/opds2.py
@@ -118,17 +118,20 @@ class TokenAuthenticationFulfillmentProcessor(CirculationFulfillmentPostProcesso
     ) -> ProblemDetail | str:
         """Get the authentication token for a patron"""
         log = logging.getLogger("OPDS2API")
-        if patron.username is None:
+
+        patron_id = patron.username if patron.username else patron.external_identifier
+        if patron_id is None:
             log.error(
-                f"Could not authenticate the patron({patron.authorization_identifier}), username is None."
+                f"Could not authenticate the patron({patron.authorization_identifier}): "
+                f"both username and external_identifier are None."
             )
             return INVALID_CREDENTIALS
 
-        url = URITemplate(token_auth_url).expand(patron_id=patron.username)
+        url = URITemplate(token_auth_url).expand(patron_id=patron_id)
         response = HTTP.get_with_timeout(url)
         if response.status_code != 200:
             log.error(
-                f"Could not authenticate the patron({patron.username}): {str(response.content)}"
+                f"Could not authenticate the patron({patron_id}): {str(response.content)}"
             )
             return INVALID_CREDENTIALS
 
@@ -136,7 +139,7 @@ class TokenAuthenticationFulfillmentProcessor(CirculationFulfillmentPostProcesso
         token = response.text
         if not token:
             log.error(
-                f"Could not authenticate the patron({patron.username}): {str(response.content)}"
+                f"Could not authenticate the patron({patron_id}): {str(response.content)}"
             )
             return INVALID_CREDENTIALS
 


### PR DESCRIPTION
…et for the patron.


## Description

This update very simply allows the patron external_identifier to be used in case there is no username as is the case when a patron record is created by the SAML authentication process.

## Motivation and Context
https://www.notion.so/lyrasis/For-PQ-content-a-500-error-is-generated-during-acquisition-process-resulting-into-the-app-restartin-531f60890b564e54bd0140ece63a96b6


## How Has This Been Tested?

Once I get a preliminary approval I will test this on the columbia test instance before merging it.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
