### PR TITLE
Refactor Authentication Providers

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -13,7 +13,6 @@ import jwt
 from flask import url_for
 from flask_babel import lazy_gettext as _
 from money import Money
-from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql.expression import or_
 from werkzeug.datastructures import Headers
@@ -1917,7 +1916,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
             #
             # Just make sure our local data is up-to-date with
             # whatever we just got from remote.
-            self.apply_patrondata(patrondata, patron)
+            patrondata.apply(patron)
             return patron
 
         # At this point there are two possibilities:
@@ -1966,15 +1965,8 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
         # but we needed to do a separate validation step. Either way,
         # we now need to update the Patron record with the account
         # information we just got from the source of truth.
-        self.apply_patrondata(patrondata, patron)
-        return patron
-
-    def apply_patrondata(self, patrondata: PatronData, patron: Patron) -> None:
-        """Apply a PatronData object to the given patron and make sure
-        any fields that need to be updated as a result of new data
-        are updated.
-        """
         patrondata.apply(patron)
+        return patron
 
     def get_credential_from_header(self, header: dict[str, str] | str) -> str | None:
         """Extract a password credential from a WWW-Authenticate header
@@ -2269,7 +2261,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
             remote_patron_info = self.remote_patron_lookup(patron)
 
         if isinstance(remote_patron_info, PatronData):
-            self.apply_patrondata(remote_patron_info, patron)
+            remote_patron_info.apply(patron)
 
         return patron
 

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1769,7 +1769,16 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
     def remote_patron_lookup(
         self, patron_or_patrondata: PatronData | Patron
     ) -> PatronData | ProblemDetail | None:
-        """Ask the remote for detailed information about this patron"""
+        """Ask the remote for detailed information about this patron
+
+        For some authentication providers, this is not necessary. If that is the case,
+        this method can just be implemented as `return patron_or_patrondata`.
+
+        If the patron is not found, or an error occurs communicating with the remote,
+        return None or a ProblemDetail.
+
+        Otherwise, return a PatronData object with the complete property set to True.
+        """
         ...
 
     @abstractmethod
@@ -1778,9 +1787,10 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
     ) -> PatronData | ProblemDetail | None:
         """Does the source of truth approve of these credentials?
 
-        If the credentials are valid, return a PatronData object. The PatronData object has a `complete` field. This
-        field on the returned PatronData object will be used to determine if we need to call `remote_patron_lookup`
-        later to get the complete information about the patron.
+        If the credentials are valid, return a PatronData object. The PatronData object
+        has a `complete` field. This field on the returned PatronData object will be used
+        to determine if we need to call `remote_patron_lookup` later to get the complete
+        information about the patron.
 
         If the credentials are invalid, return None.
 

--- a/api/firstbook2.py
+++ b/api/firstbook2.py
@@ -1,12 +1,13 @@
 import logging
 import time
 import urllib.parse
+from typing import Optional, Union
 
 import jwt
 import requests
 from flask_babel import lazy_gettext as _
 
-from core.model import ExternalIntegration
+from core.model import ExternalIntegration, Patron
 
 from .authenticator import BasicAuthenticationProvider, PatronData
 from .circulation_exceptions import RemoteInitiatedServerError
@@ -64,8 +65,13 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
     # Begin implementation of BasicAuthenticationProvider abstract
     # methods.
 
-    def remote_authenticate(self, username, password):
+    def remote_authenticate(
+        self, username: Optional[str], password: Optional[str]
+    ) -> Optional[PatronData]:
         # All FirstBook credentials are in upper-case.
+        if username is None or username == "":
+            return None
+
         username = username.upper()
 
         # If they fail a PIN test, there is no authenticated patron.
@@ -79,6 +85,14 @@ class FirstBookAuthenticationAPI(BasicAuthenticationProvider):
             permanent_id=username,
             authorization_identifier=username,
         )
+
+    def remote_patron_lookup(
+        self, patron_or_patrondata: Union[PatronData, Patron]
+    ) -> Optional[PatronData]:
+        if isinstance(patron_or_patrondata, PatronData):
+            return patron_or_patrondata
+
+        return None
 
     # End implementation of BasicAuthenticationProvider abstract methods.
 

--- a/api/saml/provider.py
+++ b/api/saml/provider.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Dict, Optional, Union
 
 from contextlib2 import contextmanager
 from flask import url_for
@@ -85,6 +86,12 @@ class SAMLWebSSOAuthenticationProvider(
             self._patron_id_regular_expression = (
                 configuration.patron_id_regular_expression
             )
+
+    def get_credential_from_header(
+        self, header: Union[Dict[str, str], str]
+    ) -> Optional[str]:
+        # We cannot extract the credential from the header, so we just return None
+        return None
 
     def _authentication_flow_document(self, db):
         """Creates a Authentication Flow object for use in an Authentication for OPDS document.

--- a/api/sirsidynix_authentication_provider.py
+++ b/api/sirsidynix_authentication_provider.py
@@ -33,9 +33,9 @@ class SirsiBlockReasons:
 class SirsiDynixHorizonAuthenticationProvider(BasicAuthenticationProvider):
     """SirsiDynix Authentication API implementation.
 
-    Currently is only used to authenticate patrons, there is no CRUD implemented for patron profiles.
-    It is recommended (but not mandatory) to have the environment variable `SIRSI_DYNIX_APP_ID` set, so that the API requests
-    have an identifiying App ID attached to them, which is the recommended approach as per the SirsiDynix docs.
+    Currently, is only used to authenticate patrons, there is no CRUD implemented for patron profiles.
+    It is recommended (but not mandatory) to have the environment variable `SIRSI_DYNIX_APP_ID` set, so that the API
+    requests have an identifying App ID attached to them, which is the recommended approach as per the SirsiDynix docs.
     """
 
     NAME = "SirsiDynix Horizon Authentication"
@@ -138,11 +138,16 @@ class SirsiDynixHorizonAuthenticationProvider(BasicAuthenticationProvider):
             ).value
         )
 
-    def remote_authenticate(self, username: str, password: str) -> PatronData | bool:
+    def remote_authenticate(
+        self, username: str | None, password: str | None
+    ) -> PatronData | None:
         """Authenticate this user with the remote server."""
+        if username is None or password is None:
+            return None
+
         data = self.api_patron_login(username, password)
         if not data:
-            return False
+            return None
 
         return SirsiDynixPatronData(
             username=username,
@@ -152,8 +157,8 @@ class SirsiDynixHorizonAuthenticationProvider(BasicAuthenticationProvider):
             complete=False,
         )
 
-    def _remote_patron_lookup(
-        self, patron_or_patrondata: Patron | SirsiDynixPatronData
+    def remote_patron_lookup(
+        self, patron_or_patrondata: Patron | PatronData
     ) -> None | SirsiDynixPatronData | ProblemDetail:
         """Do a remote patron lookup, this method can only lookup a patron with a patrondata object
         with a session_token already setup within it.

--- a/tests/api/admin/controller/test_patron_auth.py
+++ b/tests/api/admin/controller/test_patron_auth.py
@@ -6,20 +6,13 @@ from werkzeug.datastructures import MultiDict
 
 from api.admin.controller.patron_auth_services import PatronAuthServicesController
 from api.admin.exceptions import *
-from api.authenticator import AuthenticationProvider, BasicAuthenticationProvider
+from api.authenticator import BasicAuthenticationProvider
 from api.millenium_patron import MilleniumPatronAPI
 from api.problem_details import *
 from api.saml.provider import SAMLWebSSOAuthenticationProvider
 from api.simple_authentication import SimpleAuthenticationProvider
 from api.sip import SIP2AuthenticationProvider
-from core.model import (
-    AdminRole,
-    ConfigurationSetting,
-    ExternalIntegration,
-    Library,
-    create,
-    get_one,
-)
+from core.model import AdminRole, ExternalIntegration, Library, create, get_one
 
 
 class TestPatronAuth:
@@ -87,16 +80,7 @@ class TestPatronAuth:
                 settings_ctrl_fixture.ctrl.db.default_library().short_name
                 == library.get("short_name")
             )
-            assert None == library.get(
-                AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION
-            )
 
-        ConfigurationSetting.for_library_and_externalintegration(
-            settings_ctrl_fixture.ctrl.db.session,
-            AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION,
-            settings_ctrl_fixture.ctrl.db.default_library(),
-            auth_service,
-        ).value = "^(u)"
         with settings_ctrl_fixture.request_context_with_admin("/"):
             response = (
                 settings_ctrl_fixture.manager.admin_patron_auth_services_controller.process_patron_auth_services()
@@ -107,9 +91,6 @@ class TestPatronAuth:
             assert (
                 settings_ctrl_fixture.ctrl.db.default_library().short_name
                 == library.get("short_name")
-            )
-            assert "^(u)" == library.get(
-                AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION
             )
 
     def test_patron_auth_services_get_with_millenium_auth_service(
@@ -130,12 +111,6 @@ class TestPatronAuth:
             BasicAuthenticationProvider.PASSWORD_REGULAR_EXPRESSION
         ).value = "p*"
         auth_service.libraries += [settings_ctrl_fixture.ctrl.db.default_library()]
-        ConfigurationSetting.for_library_and_externalintegration(
-            settings_ctrl_fixture.ctrl.db.session,
-            AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION,
-            settings_ctrl_fixture.ctrl.db.default_library(),
-            auth_service,
-        ).value = "^(u)"
 
         with settings_ctrl_fixture.request_context_with_admin("/"):
             response = (
@@ -162,9 +137,6 @@ class TestPatronAuth:
                 settings_ctrl_fixture.ctrl.db.default_library().short_name
                 == library.get("short_name")
             )
-            assert "^(u)" == library.get(
-                AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION
-            )
 
     def test_patron_auth_services_get_with_sip2_auth_service(
         self, settings_ctrl_fixture
@@ -183,12 +155,6 @@ class TestPatronAuth:
         auth_service.setting(SIP2AuthenticationProvider.FIELD_SEPARATOR).value = ","
 
         auth_service.libraries += [settings_ctrl_fixture.ctrl.db.default_library()]
-        ConfigurationSetting.for_library_and_externalintegration(
-            settings_ctrl_fixture.ctrl.db.session,
-            AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION,
-            settings_ctrl_fixture.ctrl.db.default_library(),
-            auth_service,
-        ).value = "^(u)"
 
         with settings_ctrl_fixture.request_context_with_admin("/"):
             response = (
@@ -214,9 +180,6 @@ class TestPatronAuth:
             assert (
                 settings_ctrl_fixture.ctrl.db.default_library().short_name
                 == library.get("short_name")
-            )
-            assert "^(u)" == library.get(
-                AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION
             )
 
     def test_patron_auth_services_get_with_saml_auth_service(
@@ -397,8 +360,8 @@ class TestPatronAuth:
                             [
                                 {
                                     "short_name": library.short_name,
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_NONE,
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
+                                    BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_NONE,
+                                    BasicAuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
                                 }
                             ]
                         ),
@@ -412,30 +375,6 @@ class TestPatronAuth:
             assert response.uri == MULTIPLE_BASIC_AUTH_SERVICES.uri
 
         settings_ctrl_fixture.ctrl.db.session.delete(auth_service)
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            flask.request.form = MultiDict(
-                [
-                    ("protocol", SimpleAuthenticationProvider.__module__),
-                    (
-                        "libraries",
-                        json.dumps(
-                            [
-                                {
-                                    "short_name": library.short_name,
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_NONE,
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
-                                    AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION: "(invalid re",
-                                }
-                            ]
-                        ),
-                    ),
-                ]
-                + common_args
-            )
-            response = (
-                settings_ctrl_fixture.manager.admin_patron_auth_services_controller.process_patron_auth_services()
-            )
-            assert response == INVALID_EXTERNAL_TYPE_REGULAR_EXPRESSION
 
         with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
             flask.request.form = MultiDict(
@@ -447,9 +386,9 @@ class TestPatronAuth:
                             [
                                 {
                                     "short_name": library.short_name,
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION: "(invalid re",
+                                    BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+                                    BasicAuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
+                                    BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION: "(invalid re",
                                 }
                             ]
                         ),
@@ -509,10 +448,9 @@ class TestPatronAuth:
                             [
                                 {
                                     "short_name": library.short_name,
-                                    AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION: "^(.)",
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION: "^1234",
+                                    BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+                                    BasicAuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
+                                    BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION: "^1234",
                                 }
                             ]
                         ),
@@ -541,15 +479,6 @@ class TestPatronAuth:
             == auth_service.setting(BasicAuthenticationProvider.TEST_PASSWORD).value
         )
         assert [library] == auth_service.libraries
-        assert (
-            "^(.)"
-            == ConfigurationSetting.for_library_and_externalintegration(
-                settings_ctrl_fixture.ctrl.db.session,
-                AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION,
-                library,
-                auth_service,
-            ).value
-        )
         common_args: list = self._common_basic_auth_arguments()
 
         # test empty (BARCODE_FORMAT_NONE) values
@@ -655,9 +584,8 @@ class TestPatronAuth:
                             [
                                 {
                                     "short_name": l2.short_name,
-                                    AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION: "^(.)",
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_NONE,
-                                    AuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
+                                    BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE: BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_NONE,
+                                    BasicAuthenticationProvider.LIBRARY_IDENTIFIER_FIELD: BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE,
                                 }
                             ]
                         ),
@@ -682,15 +610,6 @@ class TestPatronAuth:
             == auth_service.setting(BasicAuthenticationProvider.TEST_PASSWORD).value
         )
         assert [l2] == auth_service.libraries
-        assert (
-            "^(.)"
-            == ConfigurationSetting.for_library_and_externalintegration(
-                settings_ctrl_fixture.ctrl.db.session,
-                AuthenticationProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION,
-                l2,
-                auth_service,
-            ).value
-        )
 
     def test_patron_auth_service_delete(self, settings_ctrl_fixture):
         l1, ignore = create(

--- a/tests/api/saml/test_provider.py
+++ b/tests/api/saml/test_provider.py
@@ -806,3 +806,12 @@ class TestSAMLWebSSOAuthenticationProvider:
             assert expected_patron_data.permanent_id == patron.external_identifier
             assert expected_patron_data == patron_data
             assert expected_expiration_time == credential.expires
+
+    def test_get_credential_from_header(self, saml_provider_fixture):
+        # This provider doesn't support getting the credential from the header.
+        # so this method should always return None.
+        provider = SAMLWebSSOAuthenticationProvider(
+            saml_provider_fixture.controller_fixture.db.default_library(),
+            saml_provider_fixture.integration,
+        )
+        assert provider.get_credential_from_header({}) is None

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -18,7 +18,6 @@ from money import Money
 from api.annotations import AnnotationWriter
 from api.announcements import Announcements
 from api.authenticator import (
-    AuthenticationProvider,
     Authenticator,
     BasicAuthenticationProvider,
     CirculationPatronProfileStorage,
@@ -62,28 +61,7 @@ from ..fixtures.database import DatabaseTransactionFixture
 from ..fixtures.vendor_id import VendorIDFixture
 
 
-class BasicConcreteAuthenticationProvider(BasicAuthenticationProvider):
-    def __init__(self, library, integration, analytics=None):
-        super().__init__(library, integration, analytics)
-
-
-class MockAuthenticationProvider:
-    """An AuthenticationProvider that always authenticates requests for
-    the given Patron and always returns the given PatronData when
-    asked to look up data.
-    """
-
-    def __init__(self, patron=None, patrondata=None):
-        self.patron = patron
-        self.patrondata = patrondata
-
-    def authenticate(self, _db, header):
-        return self.patron
-
-
-class MockBasicAuthenticationProvider(
-    BasicAuthenticationProvider, MockAuthenticationProvider
-):
+class MockBasicAuthenticationProvider(BasicAuthenticationProvider):
     """A mock basic authentication provider for use in testing the overall
     authentication process.
     """
@@ -95,10 +73,8 @@ class MockBasicAuthenticationProvider(
         analytics=None,
         patron=None,
         patrondata=None,
-        *args,
-        **kwargs,
     ):
-        super().__init__(library, integration, analytics, *args, **kwargs)
+        super().__init__(library, integration, analytics)
         self.patron = patron
         self.patrondata = patrondata
 
@@ -496,7 +472,7 @@ class MockAuthenticator(Authenticator):
 
     def __init__(self, current_library, authenticators, analytics=None):
         _db = Session.object_session(current_library)
-        super().__init__(_db, analytics)
+        super().__init__(_db, [current_library], analytics)
         self.current_library_name = current_library.short_name
         self.library_authenticators = authenticators
 
@@ -1462,16 +1438,6 @@ class TestAuthenticationProvider:
             == provider.external_integration(db.session)
         )
 
-    def test_private_remote_patron_lookup(
-        self, authenticator_fixture: AuthenticatorFixture
-    ):
-        provider = authenticator_fixture.mock_basic(patrondata=None)
-
-        # Passing a type other than Patron or PatronData to _remote_patron_lookup
-        # will raise a ValueError.
-        with pytest.raises(ValueError):
-            provider._remote_patron_lookup(MagicMock())
-
     def test_authenticated_patron_passes_on_none(
         self, authenticator_fixture: AuthenticatorFixture
     ):
@@ -1566,7 +1532,7 @@ class TestAuthenticationProvider:
         # patron has borrowing privileges.
         last_sync = patron.last_external_sync
         assert False == PatronUtility.needs_external_sync(patron)
-        patron = provider.authenticated_patron(db.session, dict(username=username))
+        patron = provider.authenticated_patron(db.session, self.credentials)
         assert last_sync == patron.last_external_sync
         assert barcode == patron.authorization_identifier
         assert username == patron.username
@@ -1586,7 +1552,7 @@ class TestAuthenticationProvider:
         )
         provider.patrondata = incomplete_data
         patron = provider.authenticated_patron(
-            db.session, dict(username="someotheridentifier")
+            db.session, dict(username="someotheridentifier", password="")
         )
         assert patron.last_external_sync > last_sync
 
@@ -1607,23 +1573,19 @@ class TestAuthenticationProvider:
         provider = authenticator_fixture.mock_basic(
             remote_patron_lookup_patrondata=patrondata
         )
-        provider.external_type_regular_expression = re.compile("^(.)")
         provider.update_patron_metadata(patron)
 
         # The patron's username has been changed.
         assert "user" == patron.username
 
         # last_external_sync has been updated.
-        assert patron.last_external_sync != None
-
-        # external_type was updated based on the regular expression
-        assert "2" == patron.external_type
+        assert patron.last_external_sync is not None
 
         # .neighborhood was not stored in .cached_neighborhood.  In
         # this case, it must be cheap to get .neighborhood every time,
         # and it's better not to store information we can get cheaply.
         assert "Little Homeworld" == patron.neighborhood
-        assert None == patron.cached_neighborhood
+        assert patron.cached_neighborhood is None
 
     def test_update_patron_metadata_noop_if_no_remote_metadata(
         self, authenticator_fixture: AuthenticatorFixture
@@ -1637,191 +1599,203 @@ class TestAuthenticationProvider:
         # patron.last_external_sync didn't change.
         assert None == patron.last_external_sync
 
-    def test_remote_patron_lookup(self, authenticator_fixture: AuthenticatorFixture):
-        """The default implementation of remote_patron_lookup returns whatever was passed in."""
-        db = authenticator_fixture.db
-        provider = BasicConcreteAuthenticationProvider(
-            db.default_library(), db.external_integration(db.fresh_str())
-        )
-        assert None == provider.remote_patron_lookup(None)
-        patron = db.patron()
-        assert patron == provider.remote_patron_lookup(patron)
-        patrondata = PatronData()
-        assert patrondata == provider.remote_patron_lookup(patrondata)
-
-    def test_update_patron_external_type(
+    def test_update_patron_metadata_returns_none_different_library(
         self, authenticator_fixture: AuthenticatorFixture
     ):
         db = authenticator_fixture.db
         patron = db.patron()
-        patron.authorization_identifier = "A123"
-        patron.external_type = "old value"
-        library = patron.library
-        integration = db.external_integration(db.fresh_str())
+        library1 = patron.library
+        library2 = db.library()
+        provider = MockBasic(library2, authenticator_fixture.mock_basic_integration)
+        patron_metadata = provider.update_patron_metadata(patron)
 
-        class MockProvider(AuthenticationProvider):
-            NAME = "Just a mock"
-
-        setting = ConfigurationSetting.for_library_and_externalintegration(
-            db.session,
-            MockProvider.EXTERNAL_TYPE_REGULAR_EXPRESSION,
-            library,
-            integration,
-        )
-        setting.value = None
-
-        # If there is no EXTERNAL_TYPE_REGULAR_EXPRESSION, calling
-        # update_patron_external_type does nothing.
-        MockProvider(library, integration).update_patron_external_type(patron)
-        assert "old value" == patron.external_type
-
-        setting.value = "([A-Z])"
-        MockProvider(library, integration).update_patron_external_type(patron)
-        assert "A" == patron.external_type
-
-        setting.value = "([0-9]$)"
-        MockProvider(library, integration).update_patron_external_type(patron)
-        assert "3" == patron.external_type
-
-        # These regexp has no groups, so it has no power to change
-        # external_type.
-        setting.value = "A"
-        MockProvider(library, integration).update_patron_external_type(patron)
-        assert "3" == patron.external_type
-
-        # This regexp is invalid, so it isn't used.
-        setting.value = "(not a valid regexp"
-        provider = MockProvider(library, integration)
-        assert None == provider.external_type_regular_expression
+        assert library1 != library2
+        assert patron_metadata is None
 
     def test_restriction_matches(self):
         """Test the behavior of the library identifier restriction algorithm."""
-        m = AuthenticationProvider._restriction_matches
+        m = BasicAuthenticationProvider._restriction_matches
 
         # If restriction is none, we always return True.
-        assert True == m(
-            "123",
-            None,
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_PREFIX,
+        assert (
+            m(
+                "123",
+                None,
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_PREFIX,
+            )
+            is True
         )
-        assert True == m(
-            "123",
-            None,
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING,
+        assert (
+            m(
+                "123",
+                None,
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING,
+            )
+            is True
         )
-        assert True == m(
-            "123",
-            None,
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+        assert (
+            m(
+                "123",
+                None,
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+            )
+            is True
         )
-        assert True == m(
-            "123", None, AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST
+        assert (
+            m(
+                "123",
+                None,
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST,
+            )
+            is True
         )
 
         # If field is None we always return False.
-        assert False == m(
-            None,
-            "1234",
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_PREFIX,
+        assert (
+            m(
+                None,
+                "1234",
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_PREFIX,
+            )
+            is False
         )
-        assert False == m(
-            None,
-            "1234",
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING,
+        assert (
+            m(
+                None,
+                "1234",
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING,
+            )
+            is False
         )
-        assert False == m(
-            None,
-            re.compile(".*"),
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+        assert (
+            m(
+                None,
+                re.compile(".*"),
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+            )
+            is False
         )
-        assert False == m(
-            None,
-            ["1", "2"],
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST,
+        assert (
+            m(
+                None,
+                ["1", "2"],
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST,
+            )
+            is False
         )
 
         # Test prefix
-        assert True == m(
-            "12345a",
-            "1234",
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_PREFIX,
+        assert (
+            m(
+                "12345a",
+                "1234",
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_PREFIX,
+            )
+            is True
         )
-        assert False == m(
-            "a1234",
-            "1234",
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_PREFIX,
+        assert (
+            m(
+                "a1234",
+                "1234",
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_PREFIX,
+            )
+            is False
         )
 
         # Test string
-        assert False == m(
-            "12345a",
-            "1234",
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING,
+        assert (
+            m(
+                "12345a",
+                "1234",
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING,
+            )
+            is False
         )
-        assert False == m(
-            "a1234",
-            "1234",
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING,
+        assert (
+            m(
+                "a1234",
+                "1234",
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING,
+            )
+            is False
         )
-        assert True == m(
-            "1234",
-            "1234",
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING,
+        assert (
+            m(
+                "1234",
+                "1234",
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING,
+            )
+            is True
         )
 
         # Test list
-        assert True == m(
-            "1234",
-            ["1234", "4321"],
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST,
+        assert (
+            True
+            == m(
+                "1234",
+                ["1234", "4321"],
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST,
+            )
+            is True
         )
-        assert True == m(
-            "4321",
-            ["1234", "4321"],
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST,
+        assert (
+            m(
+                "4321",
+                ["1234", "4321"],
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST,
+            )
+            is True
         )
-        assert False == m(
-            "12345",
-            ["1234", "4321"],
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST,
+        assert (
+            m(
+                "12345",
+                ["1234", "4321"],
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST,
+            )
+            is False
         )
-        assert False == m(
-            "54321",
-            ["1234", "4321"],
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST,
+        assert (
+            m(
+                "54321",
+                ["1234", "4321"],
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST,
+            )
+            is False
         )
 
         # Test Regex
-        assert True == m(
-            "123",
-            re.compile("^(12|34)"),
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+        assert (
+            m(
+                "123",
+                re.compile("^(12|34)"),
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+            )
+            is True
         )
-        assert True == m(
-            "345",
-            re.compile("^(12|34)"),
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+        assert (
+            m(
+                "345",
+                re.compile("^(12|34)"),
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+            )
+            is True
         )
-        assert False == m(
-            "abc",
-            re.compile("^bc"),
-            AuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+        assert (
+            m(
+                "abc",
+                re.compile("^bc"),
+                BasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX,
+            )
+            is False
         )
 
     def test_enforce_library_identifier_restriction(
         self, authenticator_fixture: AuthenticatorFixture
     ):
         """Test the enforce_library_identifier_restriction method."""
-        db = authenticator_fixture.db
         provider = authenticator_fixture.mock_basic()
         m = provider.enforce_library_identifier_restriction
-        patron = db.patron()
         patrondata = PatronData()
-
-        # Test with patron rather than patrondata as argument
-        assert patron == m(object(), patron)
-        patron.library_id = -1
-        assert False == m(object(), patron)
 
         # Test no restriction
         provider.library_identifier_restriction_type = (
@@ -1843,7 +1817,7 @@ class TestAuthenticationProvider:
         )
         assert patrondata == m("23456", patrondata)
         assert patrondata == m("2365", patrondata)
-        assert False == m("2375", provider.patrondata)
+        assert m("2375", provider.patrondata) is None
 
         # Test prefix against barcode
         provider.library_identifier_restriction_type = (
@@ -1854,7 +1828,7 @@ class TestAuthenticationProvider:
             MockBasic.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE
         )
         assert patrondata == m("23456", patrondata)
-        assert False == m("123456", patrondata)
+        assert m("123456", patrondata) is None
 
         # Test string against barcode
         provider.library_identifier_restriction_type = (
@@ -1864,7 +1838,7 @@ class TestAuthenticationProvider:
         provider.library_identifier_field = (
             MockBasic.LIBRARY_IDENTIFIER_RESTRICTION_BARCODE
         )
-        assert False == m("123456", patrondata)
+        assert m("123456", patrondata) is None
         assert patrondata == m("2345", patrondata)
 
         # Test match applied to field on patrondata not barcode
@@ -1876,7 +1850,26 @@ class TestAuthenticationProvider:
         patrondata.library_identifier = "2345"
         assert patrondata == m("123456", patrondata)
         patrondata.library_identifier = "12345"
-        assert False == m("2345", patrondata)
+        assert m("2345", patrondata) is None
+
+        # Calls out to remote if the patrondata is not complete
+        provider.library_identifier_restriction_type = (
+            MockBasic.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING
+        )
+        provider.library_identifier_restriction = "2345"
+        provider.library_identifier_field = "agent"
+        patrondata.library_identifier = "2345"
+        patrondata.complete = False
+        provider.remote_patron_lookup = MagicMock(return_value=patrondata)
+        assert patrondata == m("123456", patrondata)
+        provider.remote_patron_lookup.assert_called_once_with(patrondata)
+
+        # Test match field is blank
+        provider.library_identifier_restriction_type = (
+            MockBasic.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING
+        )
+        provider.library_identifier_field = None
+        assert patrondata == m("123456", patrondata)
 
     def test_patron_identifier_restriction(
         self, authenticator_fixture: AuthenticatorFixture
@@ -1885,72 +1878,80 @@ class TestAuthenticationProvider:
         library = db.default_library()
         integration = db.external_integration(db.fresh_str())
 
-        class MockProvider(AuthenticationProvider):
-            NAME = "Just a mock"
-
         string_setting = ConfigurationSetting.for_library_and_externalintegration(
             db.session,
-            MockProvider.LIBRARY_IDENTIFIER_RESTRICTION,
+            MockBasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION,
             library,
             integration,
         )
 
         type_setting = ConfigurationSetting.for_library_and_externalintegration(
             db.session,
-            MockProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE,
+            MockBasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE,
             library,
             integration,
         )
 
         # If the type is regex its converted into a regular expression.
-        type_setting.value = MockProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX
+        type_setting.value = (
+            MockBasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_REGEX
+        )
         string_setting.value = "^abcd"
-        provider = MockProvider(library, integration)
+        provider = MockBasicAuthenticationProvider(library, integration)
         assert "^abcd" == provider.library_identifier_restriction.pattern
 
         # If its type is list, make sure its converted into a list
-        type_setting.value = MockProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST
+        type_setting.value = (
+            MockBasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_LIST
+        )
         string_setting.value = "a,b,c"
-        provider = MockProvider(library, integration)
+        provider = MockBasicAuthenticationProvider(library, integration)
         assert ["a", "b", "c"] == provider.library_identifier_restriction
 
         # If its type is prefix make sure its a string
-        type_setting.value = MockProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_PREFIX
+        type_setting.value = (
+            MockBasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_PREFIX
+        )
         string_setting.value = "abc"
-        provider = MockProvider(library, integration)
+        provider = MockBasicAuthenticationProvider(library, integration)
         assert "abc" == provider.library_identifier_restriction
 
         # If its type is string make sure its a string
-        type_setting.value = MockProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING
+        type_setting.value = (
+            MockBasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_STRING
+        )
         string_setting.value = "abc"
-        provider = MockProvider(library, integration)
+        provider = MockBasicAuthenticationProvider(library, integration)
         assert "abc" == provider.library_identifier_restriction
 
         # If its type is none make sure its actually None
-        type_setting.value = MockProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_NONE
+        type_setting.value = (
+            MockBasicAuthenticationProvider.LIBRARY_IDENTIFIER_RESTRICTION_TYPE_NONE
+        )
         string_setting.value = "abc"
-        provider = MockProvider(library, integration)
-        assert None == provider.library_identifier_restriction
+        provider = MockBasicAuthenticationProvider(library, integration)
+        assert provider.library_identifier_restriction is None
 
 
 class TestBasicAuthenticationProvider:
     def test_constructor(self, authenticator_fixture: AuthenticatorFixture):
         db = authenticator_fixture.db
-        b = BasicAuthenticationProvider
-
-        class ConfigAuthenticationProvider(BasicAuthenticationProvider):
-            NAME = "Config loading test"
-
         integration = db.external_integration(
             db.fresh_str(), goal=ExternalIntegration.PATRON_AUTH_GOAL
         )
         db.default_library().integrations.append(integration)
-        integration.setting(b.IDENTIFIER_REGULAR_EXPRESSION).value = "idre"
-        integration.setting(b.PASSWORD_REGULAR_EXPRESSION).value = "pwre"
-        integration.setting(b.TEST_IDENTIFIER).value = "username"
-        integration.setting(b.TEST_PASSWORD).value = "pw"
+        integration.setting(
+            MockBasicAuthenticationProvider.IDENTIFIER_REGULAR_EXPRESSION
+        ).value = "idre"
+        integration.setting(
+            MockBasicAuthenticationProvider.PASSWORD_REGULAR_EXPRESSION
+        ).value = "pwre"
+        integration.setting(
+            MockBasicAuthenticationProvider.TEST_IDENTIFIER
+        ).value = "username"
+        integration.setting(MockBasicAuthenticationProvider.TEST_PASSWORD).value = "pw"
 
-        provider = ConfigAuthenticationProvider(db.default_library(), integration)
+        provider = MockBasicAuthenticationProvider(db.default_library(), integration)
         assert "idre" == provider.identifier_re.pattern
         assert "pwre" == provider.password_re.pattern
         assert "username" == provider.test_username
@@ -1961,9 +1962,11 @@ class TestBasicAuthenticationProvider:
             db.fresh_str(), goal=ExternalIntegration.PATRON_AUTH_GOAL
         )
 
-        provider = ConfigAuthenticationProvider(db.default_library(), integration)
+        provider = MockBasicAuthenticationProvider(db.default_library(), integration)
         assert (
-            re.compile(b.DEFAULT_IDENTIFIER_REGULAR_EXPRESSION)
+            re.compile(
+                MockBasicAuthenticationProvider.DEFAULT_IDENTIFIER_REGULAR_EXPRESSION
+            )
             == provider.identifier_re
         )
         assert None == provider.password_re
@@ -1983,7 +1986,7 @@ class TestBasicAuthenticationProvider:
 
         # You don't have to have a testing patron.
         integration = db.external_integration(db.fresh_str())
-        no_testing_patron = BasicConcreteAuthenticationProvider(
+        no_testing_patron = MockBasicAuthenticationProvider(
             db.default_library(), integration
         )
         assert (None, None) == no_testing_patron.testing_patron(db.session)
@@ -2074,9 +2077,9 @@ class TestBasicAuthenticationProvider:
         assert value == present_patron.testing_patron_or_bust(db.session)
 
     def test__run_self_tests(self, authenticator_fixture: AuthenticatorFixture):
-        _db = object()
+        _db = MagicMock()
 
-        class CantAuthenticateTestPatron(BasicAuthenticationProvider):
+        class CantAuthenticateTestPatron(MockBasicAuthenticationProvider):
             def __init__(self):
                 pass
 
@@ -2089,13 +2092,13 @@ class TestBasicAuthenticationProvider:
         provider = CantAuthenticateTestPatron()
         [result] = list(provider._run_self_tests(_db))
         assert _db == provider.called_with
-        assert False == result.success
+        assert result.success is False
         assert "Nope" == result.exception.args[0]
 
         # If we can authenticate a test patron, the patron and their
         # password are passed into the next test.
 
-        class Mock(BasicAuthenticationProvider):
+        class Mock(MockBasicAuthenticationProvider):
             def __init__(self, patron, password):
                 self.patron = patron
                 self.password = password
@@ -2110,7 +2113,7 @@ class TestBasicAuthenticationProvider:
                 return "some metadata"
 
         provider = Mock("patron", "password")
-        [get_patron, update_metadata] = provider._run_self_tests(object())
+        [get_patron, update_metadata] = provider._run_self_tests(_db)
         assert "Authenticating test patron" == get_patron.name
         assert True == get_patron.success
         assert (provider.patron, provider.password) == get_patron.result
@@ -2124,7 +2127,7 @@ class TestBasicAuthenticationProvider:
         ConfigurationSetting objects.
         """
         db = authenticator_fixture.db
-        b = BasicConcreteAuthenticationProvider
+        b = MockBasicAuthenticationProvider
         integration = db.external_integration(db.fresh_str())
         integration.setting(b.IDENTIFIER_KEYBOARD).value = b.EMAIL_ADDRESS_KEYBOARD
         integration.setting(b.PASSWORD_KEYBOARD).value = b.NUMBER_PAD
@@ -2142,27 +2145,27 @@ class TestBasicAuthenticationProvider:
 
     def test_server_side_validation(self, authenticator_fixture: AuthenticatorFixture):
         db = authenticator_fixture.db
-        b = BasicConcreteAuthenticationProvider
+        b = MockBasicAuthenticationProvider
         integration = db.external_integration(db.fresh_str())
         integration.setting(b.IDENTIFIER_REGULAR_EXPRESSION).value = "foo"
         integration.setting(b.PASSWORD_REGULAR_EXPRESSION).value = "bar"
 
         provider = b(db.default_library(), integration)
 
-        assert True == provider.server_side_validation("food", "barbecue")
-        assert False == provider.server_side_validation("food", "arbecue")
-        assert False == provider.server_side_validation("ood", "barbecue")
-        assert False == provider.server_side_validation(None, None)
+        assert provider.server_side_validation("food", "barbecue") is True
+        assert provider.server_side_validation("food", "arbecue") is False
+        assert provider.server_side_validation("ood", "barbecue") is False
+        assert provider.server_side_validation(None, None) is False
 
         # If this authenticator does not look at provided passwords,
         # then the only values that will pass validation are null
         # and the empty string.
         provider.password_keyboard = provider.NULL_KEYBOARD
-        assert False == provider.server_side_validation("food", "barbecue")
-        assert False == provider.server_side_validation("food", "is good")
-        assert False == provider.server_side_validation("food", " ")
-        assert True == provider.server_side_validation("food", None)
-        assert True == provider.server_side_validation("food", "")
+        assert provider.server_side_validation("food", "barbecue") is False
+        assert provider.server_side_validation("food", "is good") is False
+        assert provider.server_side_validation("food", " ") is False
+        assert provider.server_side_validation("food", None) is True
+        assert provider.server_side_validation("food", "") is True
         provider.password_keyboard = provider.DEFAULT_KEYBOARD
 
         # It's okay not to provide anything for server side validation.
@@ -2171,25 +2174,19 @@ class TestBasicAuthenticationProvider:
         integration.setting(b.PASSWORD_REGULAR_EXPRESSION).value = None
         provider = b(db.default_library(), integration)
         assert b.DEFAULT_IDENTIFIER_REGULAR_EXPRESSION == provider.identifier_re.pattern
-        assert None == provider.password_re
-        assert True == provider.server_side_validation("food", "barbecue")
-        assert True == provider.server_side_validation("a", None)
-        assert False == provider.server_side_validation("!@#$", None)
+        assert provider.password_re is None
+        assert provider.server_side_validation("food", "barbecue") is True
+        assert provider.server_side_validation("a", "abc") is True
+        assert provider.server_side_validation("!@#$", "def") is False
 
         # Test maximum length of identifier and password.
         integration.setting(b.IDENTIFIER_MAXIMUM_LENGTH).value = "5"
         integration.setting(b.PASSWORD_MAXIMUM_LENGTH).value = "10"
         provider = b(db.default_library(), integration)
 
-        assert True == provider.server_side_validation("a", "1234")
-        assert False == provider.server_side_validation("a", "123456789012345")
-        assert False == provider.server_side_validation("abcdefghijklmnop", "1234")
-
-        # You can disable the password check altogether by setting maximum
-        # length to zero.
-        integration.setting(b.PASSWORD_MAXIMUM_LENGTH).value = "0"
-        provider = b(db.default_library(), integration)
-        assert True == provider.server_side_validation("a", None)
+        assert provider.server_side_validation("a", "1234") is True
+        assert provider.server_side_validation("a", "123456789012345") is False
+        assert provider.server_side_validation("abcdefghijklmnop", "1234") is False
 
     def test_local_patron_lookup(self, authenticator_fixture: AuthenticatorFixture):
         db = authenticator_fixture.db
@@ -2296,36 +2293,6 @@ class TestBasicAuthenticationProvider:
                 == logo_link["href"]
             )
 
-    def test_remote_patron_lookup(self, authenticator_fixture: AuthenticatorFixture):
-        # remote_patron_lookup does the lookup by calling _remote_patron_lookup,
-        # then calls enforce_library_identifier_restriction to make sure that the patron
-        # is associated with the correct library
-        db = authenticator_fixture.db
-
-        class Mock(BasicAuthenticationProvider):
-            def _remote_patron_lookup(self, patron_or_patrondata):
-                self._remote_patron_lookup_called_with = patron_or_patrondata
-                return patron_or_patrondata
-
-            def enforce_library_identifier_restriction(self, identifier, patrondata):
-                self.enforce_library_identifier_restriction_called_with = (
-                    identifier,
-                    patrondata,
-                )
-                return "Result"
-
-        integration = db.external_integration(
-            db.fresh_str(), ExternalIntegration.PATRON_AUTH_GOAL
-        )
-        provider = Mock(db.default_library(), integration)
-        patron = db.patron()
-        assert "Result" == provider.remote_patron_lookup(patron)
-        assert provider._remote_patron_lookup_called_with == patron
-        assert provider.enforce_library_identifier_restriction_called_with == (
-            patron.authorization_identifier,
-            patron,
-        )
-
     def test_scrub_credential(self, authenticator_fixture: AuthenticatorFixture):
         # Verify that the scrub_credential helper method strips extra whitespace
         # and nothing else.
@@ -2334,9 +2301,7 @@ class TestBasicAuthenticationProvider:
         integration = db.external_integration(
             db.fresh_str(), ExternalIntegration.PATRON_AUTH_GOAL
         )
-        provider = BasicConcreteAuthenticationProvider(
-            db.default_library(), integration
-        )
+        provider = MockBasicAuthenticationProvider(db.default_library(), integration)
         m = provider.scrub_credential
 
         assert None == provider.scrub_credential(None)
@@ -2347,7 +2312,6 @@ class TestBasicAuthenticationProvider:
         assert "user" == provider.scrub_credential(" user")
         assert "user" == provider.scrub_credential(" user ")
         assert "user" == provider.scrub_credential("    \ruser\t     ")
-        assert b"user" == provider.scrub_credential(b" user ")
 
 
 class TestBasicAuthenticationProviderAuthenticate:
@@ -2583,7 +2547,6 @@ class TestBasicAuthenticationProviderAuthenticate:
         )
 
         provider = authenticator_fixture.mock_basic(patrondata=patrondata)
-        provider.external_type_regular_expression = re.compile("^(.)")
         patron2 = provider.authenticate(db.session, self.credentials)
 
         # We were able to match our local patron to the patron held by the
@@ -2594,7 +2557,6 @@ class TestBasicAuthenticationProviderAuthenticate:
         # new identifiers.
         assert new_identifier == patron.authorization_identifier
         assert new_username == patron.username
-        assert patron.authorization_identifier[0] == patron.external_type
 
     def test_authentication_updates_outdated_patron_on_username_match(
         self, authenticator_fixture: AuthenticatorFixture
@@ -2724,7 +2686,7 @@ class TestSirsiDynixAuthenticationProvider:
             assert response == response_dict
 
             mock_request.return_value = MockRequestsResponse(401, content=response_dict)
-            assert sirsi_fixture.api.api_patron_login("username", "pwd") == False
+            assert sirsi_fixture.api.api_patron_login("username", "pwd") is False
 
     def test_remote_authenticate(self, sirsi_fixture: SirsiDynixAuthenticatorFixture):
         with patch(
@@ -2740,7 +2702,16 @@ class TestSirsiDynixAuthenticationProvider:
             assert response.permanent_id == "test"
 
             mock_request.return_value = MockRequestsResponse(401, content=response_dict)
-            assert sirsi_fixture.api.remote_authenticate("username", "pwd") == False
+            assert sirsi_fixture.api.remote_authenticate("username", "pwd") is None
+
+    def test_remote_authenticate_username_password_none(
+        self, sirsi_fixture: SirsiDynixAuthenticatorFixture
+    ):
+        response = sirsi_fixture.api.remote_authenticate(None, "pwd")
+        assert response is None
+
+        response = sirsi_fixture.api.remote_authenticate("username", None)
+        assert response is None
 
     def test_remote_patron_lookup(self, sirsi_fixture: SirsiDynixAuthenticatorFixture):
         # Test the happy path, patron OK, some fines
@@ -2836,7 +2807,7 @@ class TestSirsiDynixAuthenticationProvider:
         patrondata = sirsi_fixture.api.remote_patron_lookup(
             SirsiDynixPatronData(permanent_id="xxxx", session_token="xxx")
         )
-        assert patrondata == None
+        assert patrondata is None
 
     def test__request(self, sirsi_fixture: SirsiDynixAuthenticatorFixture):
         # Leading slash on the path is not allowed, as it overwrites the urljoin prefix

--- a/tests/api/test_millenium_patron.py
+++ b/tests/api/test_millenium_patron.py
@@ -9,7 +9,7 @@ import pytest
 from api.authenticator import PatronData
 from api.config import CannotLoadConfiguration
 from api.millenium_patron import MilleniumPatronAPI
-from core.model import ConfigurationSetting
+from core.model import ConfigurationSetting, Patron
 from core.util.datetime_helpers import utc_now
 from tests.fixtures.api_millenium_files import MilleniumFilesFixture
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -133,24 +133,25 @@ class TestMilleniumPatronAPI:
             excinfo.value
         )
 
-    def test__remote_patron_lookup_no_such_patron(
+    def test_remote_patron_lookup_no_such_patron(
         self, millenium_fixture: MilleniumPatronFixture
     ):
         millenium_fixture.api.enqueue("dump.no such barcode.html")
         patrondata = PatronData(authorization_identifier="bad barcode")
-        assert None == millenium_fixture.api._remote_patron_lookup(patrondata)
+        assert millenium_fixture.api.remote_patron_lookup(patrondata) is None
 
-    def test__remote_patron_lookup_success(
+    def test_remote_patron_lookup_success(
         self, millenium_fixture: MilleniumPatronFixture
     ):
         millenium_fixture.api.enqueue("dump.success.html")
-        patrondata = PatronData(authorization_identifier="good barcode")
-        patrondata = millenium_fixture.api._remote_patron_lookup(patrondata)
+        data = PatronData(authorization_identifier="good barcode")
+        patrondata = millenium_fixture.api.remote_patron_lookup(data)
 
         # Although "good barcode" was successful in lookup this patron
         # up, it didn't show up in their patron dump as a barcode, so
         # the authorization_identifier from the patron dump took
         # precedence.
+        assert isinstance(patrondata, PatronData)
         assert "6666666" == patrondata.permanent_id
         assert "44444444444447" == patrondata.authorization_identifier
         assert "alice" == patrondata.username
@@ -160,16 +161,17 @@ class TestMilleniumPatronAPI:
         assert "alice@sheldon.com" == patrondata.email_address
         assert PatronData.NO_VALUE == patrondata.block_reason
 
-    def test__remote_patron_lookup_success_nonsensical_labels(
+    def test_remote_patron_lookup_success_nonsensical_labels(
         self, millenium_fixture: MilleniumPatronFixture
     ):
         millenium_fixture.api.enqueue("dump.success_nonsensical_labels.html")
-        patrondata = PatronData(authorization_identifier="good barcode")
-        patrondata = millenium_fixture.api._remote_patron_lookup(patrondata)
+        data = PatronData(authorization_identifier="good barcode")
+        patrondata = millenium_fixture.api.remote_patron_lookup(data)
 
         # The barcode is correctly captured from the "NONSENSE[pb]" element.
         # This checks that we care about the 'pb' code and don't care about
         # what comes before it.
+        assert isinstance(patrondata, PatronData)
         assert "6666666" == patrondata.permanent_id
         assert "44444444444447" == patrondata.authorization_identifier
         assert "alice" == patrondata.username
@@ -179,17 +181,18 @@ class TestMilleniumPatronAPI:
         assert "alice@sheldon.com" == patrondata.email_address
         assert PatronData.NO_VALUE == patrondata.block_reason
 
-    def test__remote_patron_lookup_success_alternative_identifier(
+    def test_remote_patron_lookup_success_alternative_identifier(
         self, millenium_fixture: MilleniumPatronFixture
     ):
         millenium_fixture.api = millenium_fixture.mock_api(
             field_used_as_patron_identifier="pu"
         )
         millenium_fixture.api.enqueue("dump.success_alternative_identifier.html")
-        patrondata = PatronData(authorization_identifier="good barcode")
-        patrondata = millenium_fixture.api._remote_patron_lookup(patrondata)
+        data = PatronData(authorization_identifier="good barcode")
+        patrondata = millenium_fixture.api.remote_patron_lookup(data)
 
         # The identifier is correctly captured from the "MENINX[pu]" element.
+        assert isinstance(patrondata, PatronData)
         assert "6666666" == patrondata.permanent_id
         assert "alice" == patrondata.authorization_identifier
         assert "alice" == patrondata.username
@@ -199,19 +202,20 @@ class TestMilleniumPatronAPI:
         assert "alice@sheldon.com" == patrondata.email_address
         assert PatronData.NO_VALUE == patrondata.block_reason
 
-    def test__remote_patron_lookup_barcode_spaces(
+    def test_remote_patron_lookup_barcode_spaces(
         self, millenium_fixture: MilleniumPatronFixture
     ):
         millenium_fixture.api.enqueue("dump.success_barcode_spaces.html")
-        patrondata = PatronData(authorization_identifier="44444444444447")
-        patrondata = millenium_fixture.api._remote_patron_lookup(patrondata)
+        data = PatronData(authorization_identifier="44444444444447")
+        patrondata = millenium_fixture.api.remote_patron_lookup(data)
+        assert isinstance(patrondata, PatronData)
         assert "44444444444447" == patrondata.authorization_identifier
         assert [
             "44444444444447",
             "4 444 4444 44444 7",
         ] == patrondata.authorization_identifiers
 
-    def test__remote_patron_lookup_block_rules(
+    def test_remote_patron_lookup_block_rules(
         self, millenium_fixture: MilleniumPatronFixture
     ):
         """This patron has a value of "m" in MBLOCK[56], which generally
@@ -219,33 +223,45 @@ class TestMilleniumPatronAPI:
         """
         # Default behavior -- anything other than '-' means blocked.
         millenium_fixture.api.enqueue("dump.blocked.html")
-        patrondata = PatronData(authorization_identifier="good barcode")
-        patrondata = millenium_fixture.api._remote_patron_lookup(patrondata)
+        data = PatronData(authorization_identifier="good barcode")
+        patrondata = millenium_fixture.api.remote_patron_lookup(data)
+        assert isinstance(patrondata, PatronData)
         assert PatronData.UNKNOWN_BLOCK == patrondata.block_reason
 
         # If we set custom block types that say 'm' doesn't really
         # mean the patron is blocked, they're not blocked.
         api = millenium_fixture.mock_api(block_types="abcde")
         api.enqueue("dump.blocked.html")
-        patrondata = PatronData(authorization_identifier="good barcode")
-        patrondata = api._remote_patron_lookup(patrondata)
+        data = PatronData(authorization_identifier="good barcode")
+        patrondata = api.remote_patron_lookup(data)
+        assert isinstance(patrondata, PatronData)
         assert PatronData.NO_VALUE == patrondata.block_reason
 
         # If we set custom block types that include 'm', the patron
         # is blocked.
         api = millenium_fixture.mock_api(block_types="lmn")
         api.enqueue("dump.blocked.html")
-        patrondata = PatronData(authorization_identifier="good barcode")
-        patrondata = api._remote_patron_lookup(patrondata)
+        data = PatronData(authorization_identifier="good barcode")
+        patrondata = api.remote_patron_lookup(data)
+        assert isinstance(patrondata, PatronData)
         assert PatronData.UNKNOWN_BLOCK == patrondata.block_reason
+
+    def test_remote_patron_lookup_patron_data_identifier_none(
+        self, millenium_fixture: MilleniumPatronFixture
+    ):
+        """If the patron data has no identifier, we can't look them up."""
+        data = PatronData(authorization_identifier=None)
+        patrondata = millenium_fixture.api.remote_patron_lookup(data)
+        assert patrondata is None
 
     def test_parse_poorly_behaved_dump(self, millenium_fixture: MilleniumPatronFixture):
         """The HTML parser is able to handle HTML embedded in
         field values.
         """
         millenium_fixture.api.enqueue("dump.embedded_html.html")
-        patrondata = PatronData(authorization_identifier="good barcode")
-        patrondata = millenium_fixture.api._remote_patron_lookup(patrondata)
+        data = PatronData(authorization_identifier="good barcode")
+        patrondata = millenium_fixture.api.remote_patron_lookup(data)
+        assert isinstance(patrondata, PatronData)
         assert "abcd" == patrondata.authorization_identifier
 
     def test_incoming_authorization_identifier_retained(
@@ -281,17 +297,13 @@ class TestMilleniumPatronAPI:
         self, millenium_fixture: MilleniumPatronFixture
     ):
         millenium_fixture.api.enqueue("pintest.no such barcode.html")
-        assert False == millenium_fixture.api.remote_authenticate(
-            "wrong barcode", "pin"
-        )
+        assert millenium_fixture.api.remote_authenticate("wrong barcode", "pin") is None
 
     def test_remote_authenticate_wrong_pin(
         self, millenium_fixture: MilleniumPatronFixture
     ):
         millenium_fixture.api.enqueue("pintest.bad.html")
-        assert False == millenium_fixture.api.remote_authenticate(
-            "barcode", "wrong pin"
-        )
+        assert millenium_fixture.api.remote_authenticate("barcode", "wrong pin") is None
 
     def test_remote_authenticate_correct_pin(
         self, millenium_fixture: MilleniumPatronFixture
@@ -300,6 +312,7 @@ class TestMilleniumPatronAPI:
         barcode = "barcode1234567!"
         pin = "!correct pin<>@/"
         patrondata = millenium_fixture.api.remote_authenticate(barcode, pin)
+        assert isinstance(patrondata, PatronData)
         # The return value includes everything we know about the
         # authenticated patron, which isn't much.
         assert "barcode1234567!" == patrondata.authorization_identifier
@@ -315,6 +328,12 @@ class TestMilleniumPatronAPI:
         # In particular, verify that the slash character in the PIN was encoded;
         # by default, parse.quote leaves it alone.
         assert "%2F" in url
+
+    def test_remote_authenticate_username_none(
+        self, millenium_fixture: MilleniumPatronFixture
+    ):
+        """If the username is none, we get none as a return value."""
+        assert millenium_fixture.api.remote_authenticate(None, "pin") is None
 
     def test_authentication_updates_patron_authorization_identifier(
         self, millenium_fixture: MilleniumPatronFixture
@@ -338,7 +357,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         p2 = millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session, dict(username="alice")
+            millenium_fixture.db.session, dict(username="alice", password="pin")
         )
         assert p2 == p
         assert "SECOND-barcode" == p.authorization_identifier
@@ -349,7 +368,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session, dict(username="FIRST-barcode")
+            millenium_fixture.db.session, dict(username="FIRST-barcode", password="pin")
         )
         assert "FIRST-barcode" == p.authorization_identifier
 
@@ -357,7 +376,8 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session, dict(username="SECOND-barcode")
+            millenium_fixture.db.session,
+            dict(username="SECOND-barcode", password="pin"),
         )
         assert "SECOND-barcode" == p.authorization_identifier
 
@@ -366,7 +386,7 @@ class TestMilleniumPatronAPI:
         p.authorization_identifier = "abcd"
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session, dict(username="alice")
+            millenium_fixture.db.session, dict(username="alice", password="pin")
         )
         assert "abcd" == p.authorization_identifier
         assert "alice" == p.username
@@ -380,7 +400,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session, dict(username="FIRST-barcode")
+            millenium_fixture.db.session, dict(username="FIRST-barcode", password="pin")
         )
         assert "FIRST-barcode" == p.authorization_identifier
 
@@ -390,7 +410,8 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session, dict(username="SECOND-barcode")
+            millenium_fixture.db.session,
+            dict(username="SECOND-barcode", password="pin"),
         )
         assert "SECOND-barcode" == p.authorization_identifier
 
@@ -400,7 +421,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session, dict(username="alice")
+            millenium_fixture.db.session, dict(username="alice", password="pin")
         )
         assert "FIRST-barcode" == p.authorization_identifier
 
@@ -418,7 +439,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session, dict(username="FIRST-barcode")
+            millenium_fixture.db.session, dict(username="FIRST-barcode", password="pin")
         )
         assert "SECOND-barcode" == p.authorization_identifier
 
@@ -434,6 +455,7 @@ class TestMilleniumPatronAPI:
         alice = millenium_fixture.api.authenticate(
             millenium_fixture.db.session, dict(username="alice", password="4444")
         )
+        assert isinstance(alice, Patron)
         assert "44444444444447" == alice.authorization_identifier
         assert "alice" == alice.username
 
@@ -451,6 +473,7 @@ class TestMilleniumPatronAPI:
             millenium_fixture.db.session,
             dict(username="44444444444447", password="4444"),
         )
+        assert isinstance(alice, Patron)
         assert "44444444444447" == alice.authorization_identifier
         assert "alice" == alice.username
 
@@ -459,6 +482,7 @@ class TestMilleniumPatronAPI:
         alice = millenium_fixture.api.authenticated_patron(
             millenium_fixture.db.session, dict(username="alice", password="4444")
         )
+        assert isinstance(alice, Patron)
         assert "44444444444447" == alice.authorization_identifier
         assert "alice" == alice.username
 
@@ -487,6 +511,7 @@ class TestMilleniumPatronAPI:
         p2 = millenium_fixture.api.authenticated_patron(
             millenium_fixture.db.session, auth
         )
+        assert isinstance(p2, Patron)
         assert p2 == p
         assert p2.last_external_sync == one_hour_ago
 
@@ -500,6 +525,7 @@ class TestMilleniumPatronAPI:
         p2 = millenium_fixture.api.authenticated_patron(
             millenium_fixture.db.session, auth
         )
+        assert isinstance(p2, Patron)
         assert p2 == p
 
         # Since the sync was performed, last_external_sync was updated.
@@ -521,7 +547,7 @@ class TestMilleniumPatronAPI:
             millenium_fixture.db.session, auth
         )
         assert p2 == p
-        assert None == p.authorization_expires
+        assert p.authorization_expires is None
 
     def test_authentication_patron_invalid_fine_amount(
         self, millenium_fixture: MilleniumPatronFixture
@@ -542,7 +568,7 @@ class TestMilleniumPatronAPI:
         patrondata = millenium_fixture.api.patron_dump_to_patrondata("alice", content)
         assert "44444444444447" == patrondata.authorization_identifier
         assert "alice" == patrondata.username
-        assert None == patrondata.library_identifier
+        assert patrondata.library_identifier is None
 
     def test_patron_dump_to_patrondata_restriction_field(
         self, millenium_fixture: MilleniumPatronFixture
@@ -612,10 +638,10 @@ class TestMilleniumPatronAPI:
         server's SSL certificate.
         """
         # By default, verify_certificate is True.
-        assert True == millenium_fixture.api.verify_certificate
+        assert millenium_fixture.api.verify_certificate is True
 
         api = millenium_fixture.mock_api(verify_certificate=False)
-        assert False == api.verify_certificate
+        assert api.verify_certificate is False
 
         # Test that the value of verify_certificate becomes the
         # 'verify' argument when _modify_request_kwargs() is called.
@@ -649,16 +675,16 @@ class TestMilleniumPatronAPI:
 
     def test_family_name_match(self):
         m = MilleniumPatronAPI.family_name_match
-        assert False == m(None, None)
-        assert False == m(None, "")
-        assert False == m("", None)
-        assert True == m("", "")
-        assert True == m("cher", "cher")
-        assert False == m("chert", "cher")
-        assert False == m("cher", "chert")
-        assert True == m("cherryh, c.j.", "cherryh")
-        assert True == m("c.j. cherryh", "cherryh")
-        assert True == m("caroline janice cherryh", "cherryh")
+        assert m(None, None) is False
+        assert m(None, "") is False
+        assert m("", None) is False
+        assert m("", "") is True
+        assert m("cher", "cher") is True
+        assert m("chert", "cher") is False
+        assert m("cher", "chert") is False
+        assert m("cherryh, c.j.", "cherryh") is True
+        assert m("c.j. cherryh", "cherryh") is True
+        assert m("caroline janice cherryh", "cherryh") is True
 
     def test_misconfigured_authentication_mode(
         self, millenium_fixture: MilleniumPatronFixture
@@ -679,17 +705,18 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api = millenium_fixture.mock_api(
             password_keyboard=MilleniumPatronAPI.NULL_KEYBOARD
         )
-        assert False == millenium_fixture.api.collects_password
+        assert millenium_fixture.api.collects_password is False
         # If the patron lookup succeeds, the user is authenticated
         # as that patron.
         millenium_fixture.api.enqueue("dump.success.html")
         patrondata = millenium_fixture.api.remote_authenticate("44444444444447", None)
+        assert isinstance(patrondata, PatronData)
         assert "44444444444447" == patrondata.authorization_identifier
 
         # If it fails, the user is not authenticated.
         millenium_fixture.api.enqueue("dump.no such barcode.html")
         patrondata = millenium_fixture.api.remote_authenticate("44444444444447", None)
-        assert False == patrondata
+        assert patrondata is None
 
     def test_authorization_family_name_success(
         self, millenium_fixture: MilleniumPatronFixture
@@ -702,11 +729,12 @@ class TestMilleniumPatronAPI:
         patrondata = millenium_fixture.api.remote_authenticate(
             "44444444444447", "Sheldon"
         )
+        assert isinstance(patrondata, PatronData)
         assert "44444444444447" == patrondata.authorization_identifier
 
         # Since we got a full patron dump, the PatronData we get back
         # is complete.
-        assert True == patrondata.complete
+        assert patrondata.complete is True
 
     def test_authorization_family_name_failure(
         self, millenium_fixture: MilleniumPatronFixture
@@ -716,8 +744,9 @@ class TestMilleniumPatronAPI:
         """
         millenium_fixture.api = millenium_fixture.mock_api(auth_mode="family_name")
         millenium_fixture.api.enqueue("dump.success.html")
-        assert False == millenium_fixture.api.remote_authenticate(
-            "44444444444447", "wrong name"
+        assert (
+            millenium_fixture.api.remote_authenticate("44444444444447", "wrong name")
+            is None
         )
 
     def test_authorization_family_name_no_such_patron(
@@ -728,8 +757,9 @@ class TestMilleniumPatronAPI:
         """
         millenium_fixture.api = millenium_fixture.mock_api(auth_mode="family_name")
         millenium_fixture.api.enqueue("dump.no such barcode.html")
-        assert False == millenium_fixture.api.remote_authenticate(
-            "44444444444447", "somebody"
+        assert (
+            millenium_fixture.api.remote_authenticate("44444444444447", "somebody")
+            is None
         )
 
     def test_extract_postal_code(self):
@@ -746,9 +776,9 @@ class TestMilleniumPatronAPI:
             "10145-6789 Main Street Apartment #12345$Arvin CA 93203 (old address)"
         )
 
-        assert None == m("10145 Main Street Apartment 123456$Arvin CA")
-        assert None == m("10145 Main Street$Arvin CA")
-        assert None == m("123 Main Street")
+        assert m("10145 Main Street Apartment 123456$Arvin CA") is None
+        assert m("10145 Main Street$Arvin CA") is None
+        assert m("123 Main Street") is None
 
         # Some cases where we incorrectly detect a ZIP code where there is none.
         assert "12345" == m("10145 Main Street, Apartment #12345$Arvin CA")


### PR DESCRIPTION
## Description

I've been working on updating how we are storing configuration settings in the database. As part of that work, I started replacing the configuration settings for our authentication providers and realized that these classes need a bit of refactoring. So I broke that out into this separate PR.

## Motivation and Context

This PR does some general refactoring of the various Authentication classes in the CM code. 

- Generally I tried to add type hinting to as much of this code as I could, to assist with refactoring. 
  - Once I had accurate type hints, it was pretty obvious that some of the methods could return way too many types. It was pretty common to see: `PatonData | Patron | ProblemDetail | None | bool` 😓
  - So some of the refactoring focused on reducing the number of types each method had to handle
- I also tried to update places where we were testing for none with `== None` to `is None`. 

### `Authenticator`

- Moved creating the logging into the constructor, so I could use the class dunder properties to name the logger.
https://github.com/ThePalaceProject/circulation/blob/9d39cc4e755b8823d7b3d4226f0c9463b266d4aa/api/authenticator.py#L540-L543
- Switched to using the logging context manager instead of the decorator, to use the new `self.log` instance property.

### `AuthenticationProvider`

- This base class is where the bulk of the changes happened. When I was working through the configuration settings, and trying to trace out which subclasses used which settings, it became evident that the class structure here did not align with how it was being used. 
- The `LIBRARY_SETTINGS` that are defined on this class, and all the associated constants were only being used by instances of `BasicAuthenticationProvider`, so it didn't make a lot of sense to have them defined on the base class.
- Most of the code in this class was being used to enforce the library identifier restriction, which is only used by `BasicAuthenticationProvider` as well.
- After these changes `AuthenticationProvider` becomes a very basic abstract base class that defines two abstract methods: `authenticated_patron` and `get_credential_from_header`. 
- Almost all of the code that was removed from `AuthenticationProvider` was directly moved into `BasicAuthenticationProvider`.

### `BasicAuthenticationProvider`

- There are two sets of changes for `BasicAuthenticationProvider`
  1. The code that was moved from `AuthenticationProvider`
  2. Refactoring to reduce the excessive number of types that each method had to handle.
- After the changes in this PR `BasicAuthenticationProvider` becomes an abstract base class with two abstract methods `remote_patron_lookup` and `remote_authenticate`.
- In order to simplify the logic here, the `_remote_patron_lookup` function was removed, and replaced with `remote_patron_lookup`. The public method used to just run `enforce_library_identifier_restriction`, and then call the private `_remote_patron_lookup` method. Digging through the logic, `enforce_library_identifier_restriction` was already being enforced elsewhere in the `authenticate` method, so this private method distinction was unnecessary.
- `remote_authenticate` was updated to that implementing classes return `None` instead of `False` or `None` on failure.
- Remove the `external_type_regular_expression` configuration setting entirely, since we are not using it in any of the 400 - 500 libraries we currently have configured.

### `api/firstbook2.py` & `api/kansas_patron.py`
Both these providers were just updated to implement the `remote_patron_lookup` abstract method, since the no-op implementation of this was removed from `BasicAuthenticationProvider` and made abstract.

### `api/millenium_patron.py`

- Switch from `False` to `None` as return type
- Additional `None` checks that were flagged as necessary by Mypy

### `api/saml/provider.py`

- Implement the abstract method `get_credential_from_header` since the no-op version was removed from the base class. This is the same as the code that used to be defined on the base class.

### `api/sip/__init__.py`

- Move the `INSTITUTION_ID` setting that was only used in this provider, from the base class into this provider.

### `api/sirsidynix_authentication_provider.py`

- Update `False` to `None` as per new conventions
- Some additional `None` checks, prompted by mypy.

## How Has This Been Tested?

- Ran unit tests locally and in CI
- Added unit tests for new code paths
- Done some basic, but not extensive testing locally in the admin UI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
