### PR TITLE
License counts are considered in the search field values API

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -24,7 +24,7 @@ from flask_pydantic_spec.flask_backend import Context
 from pydantic import BaseModel
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
-from sqlalchemy.sql import and_, func
+from sqlalchemy.sql import func
 from sqlalchemy.sql.expression import desc, nullslast
 from werkzeug.urls import BaseURL, url_parse, url_quote_plus
 from werkzeug.wrappers import Response as werkzeug_response

--- a/tests/api/admin/controller/test_admin_search_controller.py
+++ b/tests/api/admin/controller/test_admin_search_controller.py
@@ -103,7 +103,7 @@ class TestAdminSearchController:
         assert response["publishers"] == {"Publisher 1": 3, "Publisher 10": 10}
         assert response["distributors"] == {"Gutenberg": 13}
 
-    def test_no_license_counts(self, admin_search_fixture: AdminSearchFixture):
+    def test_different_license_types(self, admin_search_fixture: AdminSearchFixture):
         # Remove the cache
         admin_search_fixture.manager.admin_search_controller.__class__._search_field_values_cached.ttls = (
             0


### PR DESCRIPTION
## Description
Open access and self hosted licenses are added unconditionally.
Otherwise the license pool must have more than owned licenses.
<!--- Describe your changes -->

## Motivation and Context
The search API only displays items that have owned licenses of the work.
Due to this the count of works in the search field would be different than the actual results returned.
More details in [notion](https://www.notion.so/lyrasis/Search-Field-Values-API-does-not-account-for-unavailable-license-counts-9eab8a7e46ea4dbd90b14e6aff9cb287).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
