### PR TITLE
Make sure remote_patron_lookup calls are necessary

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1905,67 +1905,41 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
 
         # First, try to look up the Patron object in our database.
         patron = self.local_patron_lookup(_db, username, patrondata)
-        if patron and (
-            patrondata.complete or not PatronUtility.needs_external_sync(patron)
-        ):
-            # We found them! And there is no need to do a separate
-            # lookup for purposes of external sync -- either because
-            # they don't need to be synced or because we got a
-            # complete PatronData as a side effect of the authentication
-            # check.
-            #
-            # Just make sure our local data is up-to-date with
-            # whatever we just got from remote.
+        if patron:
+            # We found the patron! Now we need to make sure the patron's
+            # information in the database is up-to-date.
+            if not patrondata.complete and PatronUtility.needs_external_sync(patron):
+                # We found the patron, but we need to sync their information with the
+                # remote source of truth.  We do this by calling remote_patron_lookup.
+                patrondata = self.remote_patron_lookup(patrondata)
+                if not isinstance(patrondata, PatronData):
+                    # Something went wrong, we can't get the patron's information.
+                    # so we fail the authentication process.
+                    return patrondata
+
+            # Apply the information we have to the patron and return it.
             patrondata.apply(patron)
             return patron
 
-        # At this point there are two possibilities:
-        #
-        # 1. We didn't find them. Now the question is: _why_ didn't
-        # the patron show up locally? Have we never seen them before
-        # or has their authorization identifier changed?
-        #
-        # 2. We found them, they need an external sync, and we found
-        # them in a way that didn't provide that information.
-        #
-        # In both cases, the next step is to look up the patron's
-        # account details remotely. In some providers this step may
-        # be a no-op. But we have to try it, because if the patron's
-        # account details are out of sync, the rest of the request (the
-        # thing they're actually trying to do) might fail.
-        patrondata = self.remote_patron_lookup(patrondata)
-        if patrondata is None or isinstance(patrondata, ProblemDetail):
-            # Either there was a problem looking up the patron data, or
-            # the patron does not exist on the remote. How we passed
-            # remote validation is a mystery, but ours not to reason
-            # why. There is no authenticated patron.
-            return patrondata
+        # At this point we didn't find the patron, so we want to look up the patron
+        # with the remote, in case this allows us to find an existing patron, based
+        # on the information returned by the remote_patron_lookup.
+        if not patrondata.complete:
+            patrondata = self.remote_patron_lookup(patrondata)
+            if not isinstance(patrondata, PatronData):
+                # Something went wrong, we can't get the patron's information.
+                # so we fail the authentication process.
+                return patrondata
+            patron = self.local_patron_lookup(_db, username, patrondata)
+            if patron:
+                # We found the patron, so we apply the information we have to the patron and return it.
+                patrondata.apply(patron)
+                return patron
 
-        if isinstance(patrondata, Patron):
-            # For whatever reason, the remote lookup implementation
-            # returned a Patron object instead of a PatronData. Just
-            # use that Patron object.
-            return patrondata
-
-        # At this point we have a _complete_ PatronData object which we
-        # know represents an existing patron on the remote side. Try
-        # the local lookup again.
-        patron = self.local_patron_lookup(_db, username, patrondata)
-
-        if patron is None:
-            # We have a PatronData from the ILS that does not
-            # correspond to any local Patron. Create the local Patron.
-            patron, is_new = patrondata.get_or_create_patron(
-                _db, self.library_id, analytics=self.analytics
-            )
-
-        # The lookup failed in the first place either because the
-        # Patron did not exist on the local side, or because one of
-        # the patron's identifiers changed; or, the lookup succeeded
-        # but we needed to do a separate validation step. Either way,
-        # we now need to update the Patron record with the account
-        # information we just got from the source of truth.
-        patrondata.apply(patron)
+        # We didn't find the patron, so we create a new patron with the information we have.
+        patron, _ = patrondata.get_or_create_patron(
+            _db, self.library_id, analytics=self.analytics
+        )
         return patron
 
     def get_credential_from_header(self, header: dict[str, str] | str) -> str | None:

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -1562,6 +1562,101 @@ class TestAuthenticationProvider:
         assert barcode == patron.authorization_identifier
         assert username == patron.username
 
+    @pytest.mark.parametrize(
+        "auth_return, enforce_return, lookup_return, calls_auth, calls_enforce, calls_lookup, expected",
+        [
+            # If we don't get a Patrondata from remote_authenticate, we don't call remote_patron_lookup
+            # or enforce_library_identifier_restriction
+            (None, None, None, 1, 0, 0, None),
+            # If we get a complete patrondata from remote_authenticate, we don't call remote_patron_lookup
+            (
+                PatronData(
+                    authorization_identifier="a", external_type="xyz", complete=True
+                ),
+                PatronData(
+                    authorization_identifier="a", external_type="xyz", complete=True
+                ),
+                None,
+                1,
+                1,
+                0,
+                True,
+            ),
+            # If we get an incomplete patrondata from remote_authenticate, but get a complete patrondata
+            # from enforce_library_identifier_restriction, we don't call remote_patron_lookup
+            (
+                PatronData(authorization_identifier="a", complete=False),
+                PatronData(
+                    authorization_identifier="a", external_type="xyz", complete=True
+                ),
+                None,
+                1,
+                1,
+                0,
+                True,
+            ),
+            # If we get an incomplete patrondata from remote_authenticate, and enforce_library_identifier_restriction
+            # returns None, we don't call remote_patron_lookup and get a ProblemDetail
+            (
+                PatronData(authorization_identifier="a", complete=False),
+                None,
+                None,
+                1,
+                1,
+                0,
+                PATRON_OF_ANOTHER_LIBRARY,
+            ),
+            # If we get an incomplete patrondata from remote_authenticate, and enforce_library_identifier_restriction
+            # returns an incomplete patrondata, we call remote_patron_lookup
+            (
+                PatronData(authorization_identifier="a", complete=False),
+                PatronData(authorization_identifier="a", complete=False),
+                PatronData(
+                    authorization_identifier="a", external_type="xyz", complete=True
+                ),
+                1,
+                1,
+                1,
+                True,
+            ),
+        ],
+    )
+    def test_authenticated_patron_only_calls_remote_patron_lookup_once(
+        self,
+        authenticator_fixture: AuthenticatorFixture,
+        auth_return,
+        enforce_return,
+        lookup_return,
+        calls_auth,
+        calls_enforce,
+        calls_lookup,
+        expected,
+    ):
+        # The call to remote_patron_lookup is potentially expensive, so we want to avoid calling it
+        # more than once. This test makes sure that if we have a complete patrondata from remote_authenticate,
+        # or from enforce_library_identifier_restriction, we don't call remote_patron_lookup.
+        db = authenticator_fixture.db
+        provider = authenticator_fixture.mock_basic()
+        provider.remote_authenticate = MagicMock(return_value=auth_return)
+        provider.enforce_library_identifier_restriction = MagicMock(
+            return_value=enforce_return
+        )
+        provider.remote_patron_lookup = MagicMock(return_value=lookup_return)
+
+        patron = provider.authenticated_patron(db.session, self.credentials)
+        assert provider.remote_patron_lookup.call_count == calls_lookup
+        assert (
+            provider.enforce_library_identifier_restriction.call_count == calls_enforce
+        )
+        assert provider.remote_authenticate.call_count == calls_auth
+        if expected is True:
+            # Make sure we get a Patron object back and that the patrondata has been
+            # properly applied to it
+            assert isinstance(patron, Patron)
+            assert patron.external_type == "xyz"
+        else:
+            assert patron is expected
+
     def test_update_patron_metadata(self, authenticator_fixture: AuthenticatorFixture):
         db = authenticator_fixture.db
         patron = db.patron()
@@ -2527,14 +2622,14 @@ class TestBasicAuthenticationProviderAuthenticate:
         authentication provider. But we handle it.
         """
         db = authenticator_fixture.db
-        patrondata = PatronData(permanent_id=db.fresh_str())
+        patrondata = PatronData(permanent_id=db.fresh_str(), complete=False)
         provider = authenticator_fixture.mock_basic(patrondata=patrondata)
 
         # When we call remote_authenticate(), we get patrondata, but
         # there is no corresponding local patron, so we call
         # remote_patron_lookup() for details, and we get nothing.  At
         # this point we give up -- there is no authenticated patron.
-        assert None == provider.authenticate(db.session, self.credentials)
+        assert provider.authenticate(db.session, self.credentials) is None
 
     def test_authentication_creates_missing_patron(
         self, authenticator_fixture: AuthenticatorFixture


### PR DESCRIPTION
## Description

While writing the tests for #1032, I realized that in the case of a new patron, we were calling `remote_patron_lookup` twice. This is a potentially expensive call, so it would be nice to avoid making it twice. 

This PR is based on #1027, but I wanted to keep it as a separate PR, since it changes the logic in the `authenticate` function, so it should get a good code review before going in.

## Motivation and Context

This reworks the logic in the `authenticate` function, to avoid calling out to `remote_patron_lookup` in the case where we already have a complete `patrondata` and adds a new test, to make sure that we are calling `remote_patron_lookup` the expected number of times.

## How Has This Been Tested?

Running unit tests locally.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
