### PR TITLE
Enable the authentication document cache by default

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -31,10 +31,6 @@ class Configuration(CoreConfiguration):
     # documents are cached.
     AUTHENTICATION_DOCUMENT_CACHE_TIME = "authentication_document_cache_time"
 
-    # The name of a setting that turns UWSGI debugging information on
-    # or off.
-    WSGI_DEBUG_KEY = "wsgi_debug"
-
     # A custom link to a Terms of Service document to be understood by
     # users of the administrative interface.
     #

--- a/api/controller.py
+++ b/api/controller.py
@@ -304,16 +304,10 @@ class CirculationManager:
         authentication_document_cache_time = int(
             ConfigurationSetting.sitewide(
                 self._db, Configuration.AUTHENTICATION_DOCUMENT_CACHE_TIME
-            ).value_or_default(0)
+            ).value_or_default(3600)
         )
         self.authentication_for_opds_documents = ExpiringDict(
             max_len=1000, max_age_seconds=authentication_document_cache_time
-        )
-        self.wsgi_debug = (
-            ConfigurationSetting.sitewide(
-                self._db, Configuration.WSGI_DEBUG_KEY
-            ).bool_value
-            or False
         )
 
     def _dev_mgmt_from_libraries(
@@ -567,20 +561,6 @@ class CirculationManager:
             # time.
             value = self.auth.create_authentication_document()
             self.authentication_for_opds_documents[name] = value
-
-        if self.wsgi_debug and "debug" in flask.request.args:
-            # Annotate with debugging information about the WSGI
-            # environment and the authentication document cache
-            # itself.
-            value = json.loads(value)
-            value["_debug"] = dict(
-                url=url_for(
-                    "authentication_document", library_short_name=name, _external=True
-                ),
-                environ=str(dict(flask.request.environ)),
-                cache=str(self.authentication_for_opds_documents),
-            )
-            value = json.dumps(value)
         return value
 
 

--- a/tests/api/test_controller_cm.py
+++ b/tests/api/test_controller_cm.py
@@ -47,10 +47,7 @@ class TestCirculationManager:
 
         # The authentication document cache has a default value for
         # max_age.
-        assert 0 == manager.authentication_for_opds_documents.max_age
-
-        # WSGI debug is off by default.
-        assert False == manager.wsgi_debug
+        assert 3600 == manager.authentication_for_opds_documents.max_age
 
         # Now let's create a brand new library, never before seen.
         library = circulation_fixture.db.library()
@@ -91,10 +88,6 @@ class TestCirculationManager:
             circulation_fixture.db.session,
             Configuration.AUTHENTICATION_DOCUMENT_CACHE_TIME,
         ).value = "60"
-
-        ConfigurationSetting.sitewide(
-            circulation_fixture.db.session, Configuration.WSGI_DEBUG_KEY
-        ).value = "true"
 
         # Then reload the CirculationManager...
         circulation_fixture.manager.load_settings()
@@ -137,9 +130,6 @@ class TestCirculationManager:
         # The authentication document cache has been rebuilt with a
         # new max_age.
         assert 60 == manager.authentication_for_opds_documents.max_age
-
-        # The WSGI debug setting has been changed.
-        assert True == manager.wsgi_debug
 
         # Controllers that don't depend on site configuration
         # have not been reloaded.


### PR DESCRIPTION
## Description

This reverts commit a8f65748f2e9a995042205ce690b31a3a80ba84b.

See [notion](https://www.notion.so/lyrasis/Investigate-CM-authentication-document-caching-289f93f5675c4bf6bd529efc24ba150a?pvs=4). 

## Motivation and Context

This re-enables authentication document caching reverting an older commit that disabled it. Authentication documents are expensive to build, so it would be nice to be able to cache them. There is some risk that this will trigger a bug, outlined here https://jira.nypl.org/browse/SIMPLY-3346, which is the reason it was disabled. However a lot has changed since that bug was a problem, so we don't think it will cause any issue here. 

If it does end up causing an issue, the plan is to just revert this PR.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
