### PR TITLE
Switch to using Self when type checking

### DIFF
--- a/api/admin/model/dashboard_statistics.py
+++ b/api/admin/model/dashboard_statistics.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
-from typing import List, TypeVar
+import sys
+from typing import List
 
 from pydantic import BaseModel, Extra, Field, NonNegativeInt
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 def _snake_to_camel_case(name: str) -> str:
@@ -32,19 +38,16 @@ class StatisticsBaseModel(CustomBaseModel):
     def __getitem__(self, item):
         return getattr(self, item)
 
-    def __add__(self: S, other: S) -> S:
+    def __add__(self, other: Self) -> Self:
         """Sum each property and return new instance."""
         return self.__class__(
             **{field: self[field] + other[field] for field in self.__fields__.keys()}
         )
 
     @classmethod
-    def zeroed(cls: type[S]) -> S:
+    def zeroed(cls) -> Self:
         """An instance of this class with all values set to zero."""
         return cls(**{field: 0 for field in cls.__fields__.keys()})
-
-
-S = TypeVar("S", bound=StatisticsBaseModel)
 
 
 class PatronStatistics(StatisticsBaseModel):

--- a/core/model/devicetokens.py
+++ b/core/model/devicetokens.py
@@ -1,4 +1,5 @@
-from typing import Type, TypeVar, Union
+import sys
+from typing import Union
 
 from sqlalchemy import Column, Enum, ForeignKey, Index, Integer, Unicode
 from sqlalchemy.exc import IntegrityError
@@ -8,13 +9,15 @@ from core.model.patron import Patron
 
 from . import Base
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 
 class DeviceTokenTypes:
     FCM_ANDROID = "FCMAndroid"
     FCM_IOS = "FCMiOS"
-
-
-T = TypeVar("T", bound="DeviceToken")
 
 
 class DeviceToken(Base):
@@ -49,12 +52,12 @@ class DeviceToken(Base):
 
     @classmethod
     def create(
-        cls: Type[T],
+        cls,
         db,
         token_type: str,
         device_token: str,
         patron: Union[Patron, int],
-    ) -> T:
+    ) -> Self:
         """Create a DeviceToken while ensuring sql issues are managed.
         Raises InvalidTokenTypeError, DuplicateDeviceTokenError"""
 

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import logging
+import sys
 from collections import Counter
 from datetime import date, datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytz
 from sqlalchemy import (
@@ -51,6 +52,11 @@ from .edition import Edition
 from .identifier import Identifier, RecursiveEquivalencyCache
 from .measurement import Measurement
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 # Import related models when doing type checking
 if TYPE_CHECKING:
     from core.model import (  # noqa: autoflake
@@ -78,9 +84,6 @@ class WorkGenre(Base):
 
     def __repr__(self):
         return "%s (%d%%)" % (self.genre.name, self.affinity * 100)
-
-
-WorkTypevar = TypeVar("WorkTypevar", bound="Work")
 
 
 class Work(Base):
@@ -1439,9 +1442,7 @@ class Work(Base):
     OPENSEARCH_TIME_FORMAT = 'YYYY-MM-DD"T"HH24:MI:SS"."MS'
 
     @classmethod
-    def to_search_documents(
-        cls: type[WorkTypevar], works: list[WorkTypevar]
-    ) -> list[dict]:
+    def to_search_documents(cls, works: list[Self]) -> list[dict]:
         """In app to search documents needed to ease off the burden
         of complex queries from the DB cluster
         No recursive identifier policy is taken here as using the
@@ -1563,7 +1564,7 @@ class Work(Base):
             )
 
             try:
-                search_doc = cls.search_doc_as_dict(cast(WorkTypevar, item))
+                search_doc = cls.search_doc_as_dict(cast(Self, item))
                 results.append(search_doc)
             except:
                 logging.exception(f"Could not create search document for {item}")
@@ -1571,7 +1572,7 @@ class Work(Base):
         return results
 
     @classmethod
-    def search_doc_as_dict(cls: type[WorkTypevar], doc: WorkTypevar):
+    def search_doc_as_dict(cls, doc: Self):
         columns = {
             "work": [
                 "fiction",

--- a/poetry.lock
+++ b/poetry.lock
@@ -3493,14 +3493,14 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.2.0"
+version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
-    {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
+    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
+    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
 ]
 
 [[package]]
@@ -3778,4 +3778,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "9add6b03b1ae3b367a3bca388902438a7c8fe4ccb60a6254c99995855ab83f80"
+content-hash = "e41fa7460e259bc6eebcd44cc2fb6d8d3725dc7771f8057da45dfbe22add6add"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,9 +221,7 @@ redmail = "^0.6.0"
 requests = "^2.29"
 SQLAlchemy = "~1.3.19"
 textblob = "0.17.1"
-# We import typing extensions, to be able to use ParamSpec and Self
-# in our type annotations.
-# - ParamSpec is included in Python 3.10
+# We import typing_extensions, so we can use Self in our type annotations.
 # - Self is included in Python 3.11
 # Once we upgrade to Python 3.11, we can remove this dependency.
 typing_extensions = {version = "^4.5.0", python = "<3.11"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,12 @@ redmail = "^0.6.0"
 requests = "^2.29"
 SQLAlchemy = "~1.3.19"
 textblob = "0.17.1"
+# We import typing extensions, to be able to use ParamSpec and Self
+# in our type annotations.
+# - ParamSpec is included in Python 3.10
+# - Self is included in Python 3.11
+# Once we upgrade to Python 3.11, we can remove this dependency.
+typing_extensions = {version = "^4.5.0", python = "<3.11"}
 unicodecsv = "0.14.1"  # this is used, but can probably be removed on py3
 uritemplate = "4.1.1"
 urllib3 = "~1.26.14"


### PR DESCRIPTION
## Description

This just updates our code to use the new [PEP 673](https://peps.python.org/pep-0673/) `typing.Self` style `Self` annotations, instead of the old style ones. It doesn't functionally change the code at all.

## Motivation and Context

We can use the new [`typing.Self`](https://mypy.readthedocs.io/en/stable/generics.html?#automatic-self-types-using-typing-self) in Python versions before 3.11 by importing `typing_extensions`. See the [mypy docs](https://mypy.readthedocs.io/en/stable/runtime_troubles.html#using-new-additions-to-the-typing-module).

The new `Self` notation is a bit easier at the expense of a slightly more ugly import. It also gives us the ability to use other new type extensions like `ParamSpec`.

## How Has This Been Tested?

Running Mypy.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
