### PR TITLE
Mypy linting mistakes fixed

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1297,7 +1297,7 @@ class AuthenticationProvider(OPDSAuthenticationFlow, HasSelfTests, ABC):
 
     @abstractmethod
     def authenticated_patron(
-        self, _db: Session, header: Authorization
+        self, _db: Session, header: dict | str
     ) -> Patron | ProblemDetail | None:
         """Go from a WWW-Authenticate header (or equivalent) to a Patron object.
 
@@ -1854,7 +1854,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
         return value.strip()
 
     def authenticate(
-        self, _db: Session, credentials: Authorization
+        self, _db: Session, credentials: dict
     ) -> Patron | ProblemDetail | None:
         """Turn a set of credentials into a Patron object.
 
@@ -2173,7 +2173,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
             return None
 
     def authenticated_patron(
-        self, _db: Session, authorization: Authorization
+        self, _db: Session, authorization: dict | str
     ) -> Patron | ProblemDetail | None:
         """Go from a werkzeug.Authorization object to a Patron object.
 
@@ -2183,6 +2183,9 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
         :return: A Patron if one can be authenticated; a ProblemDetail
             if an error occurs; None if the credentials are missing or wrong.
         """
+        if type(authorization) != dict:
+            return None
+
         with elapsed_time_logging(
             log_method=self.logger().info,
             message_prefix="authenticated_patron - authenticate",

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -1790,10 +1790,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
         """
         if self.test_username is None:
             return self.test_username, self.test_password
-        header = Authorization(
-            auth_type="basic",
-            data=dict(username=self.test_username, password=self.test_password),
-        )
+        header = dict(username=self.test_username, password=self.test_password)
         return self.authenticated_patron(_db, header), self.test_password
 
     def testing_patron_or_bust(self, _db: Session) -> tuple[Patron, str]:
@@ -2184,7 +2181,7 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
             if an error occurs; None if the credentials are missing or wrong.
         """
         if type(authorization) != dict:
-            return None
+            return UNSUPPORTED_AUTHENTICATION_MECHANISM
 
         with elapsed_time_logging(
             log_method=self.logger().info,

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -1458,9 +1458,7 @@ class TestLibraryAuthenticator:
 
 class TestAuthenticationProvider:
 
-    credentials = Authorization(
-        auth_type="basic", data=dict(username="user", password="")
-    )
+    credentials = dict(username="user", password="")
 
     def test_external_integration(self, authenticator_fixture: AuthenticatorFixture):
         db = authenticator_fixture.db
@@ -1585,10 +1583,7 @@ class TestAuthenticationProvider:
         provider.patrondata = incomplete_data
         patron = provider.authenticated_patron(
             db.session,
-            Authorization(
-                auth_type="basic",
-                data=dict(username="someotheridentifier", password=""),
-            ),
+            dict(username="someotheridentifier", password=""),
         )
         assert patron.last_external_sync > last_sync
 
@@ -2549,9 +2544,7 @@ class TestBasicAuthenticationProviderAuthenticate:
 
     # A dummy set of credentials, for use when the exact details of
     # the credentials passed in are not important.
-    credentials = Authorization(
-        auth_type="basic", data=dict(username="user", password="pass")
-    )
+    credentials = dict(username="user", password="pass")
 
     def test_success(self, authenticator_fixture: AuthenticatorFixture):
         db = authenticator_fixture.db
@@ -2565,9 +2558,7 @@ class TestBasicAuthenticationProviderAuthenticate:
 
         # BasicAuthenticationProvider scrubs leading and trailing spaces from
         # the credentials.
-        credentials_with_spaces = Authorization(
-            auth_type="basic", data=dict(username="  user ", password=" pass \t ")
-        )
+        credentials_with_spaces = dict(username="  user ", password=" pass \t ")
         for creds in (self.credentials, credentials_with_spaces):
             assert patron == provider.authenticate(db.session, self.credentials)
 
@@ -2702,10 +2693,7 @@ class TestBasicAuthenticationProviderAuthenticate:
 
         # This succeeds because we pass the regex test.
         assert patron == provider.authenticate(
-            db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="food", password="barbecue")
-            ),
+            db.session, dict(username="food", password="barbecue")
         )
 
     def test_authentication_succeeds_but_patronlookup_fails(

--- a/tests/api/test_millenium_patron.py
+++ b/tests/api/test_millenium_patron.py
@@ -5,7 +5,6 @@ from typing import Any, List
 from urllib import parse
 
 import pytest
-from werkzeug.datastructures import Authorization
 
 from api.authenticator import PatronData
 from api.config import CannotLoadConfiguration
@@ -358,10 +357,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         p2 = millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="alice", password="pin")
-            ),
+            millenium_fixture.db.session, dict(username="alice", password="pin")
         )
         assert p2 == p
         assert "SECOND-barcode" == p.authorization_identifier
@@ -372,10 +368,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="FIRST-barcode", password="pin")
-            ),
+            millenium_fixture.db.session, dict(username="FIRST-barcode", password="pin")
         )
         assert "FIRST-barcode" == p.authorization_identifier
 
@@ -384,9 +377,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
             millenium_fixture.db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="SECOND-barcode", password="pin")
-            ),
+            dict(username="SECOND-barcode", password="pin"),
         )
         assert "SECOND-barcode" == p.authorization_identifier
 
@@ -395,10 +386,7 @@ class TestMilleniumPatronAPI:
         p.authorization_identifier = "abcd"
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="alice", password="pin")
-            ),
+            millenium_fixture.db.session, dict(username="alice", password="pin")
         )
         assert "abcd" == p.authorization_identifier
         assert "alice" == p.username
@@ -412,10 +400,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="FIRST-barcode", password="pin")
-            ),
+            millenium_fixture.db.session, dict(username="FIRST-barcode", password="pin")
         )
         assert "FIRST-barcode" == p.authorization_identifier
 
@@ -426,9 +411,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
             millenium_fixture.db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="SECOND-barcode", password="pin")
-            ),
+            dict(username="SECOND-barcode", password="pin"),
         )
         assert "SECOND-barcode" == p.authorization_identifier
 
@@ -438,10 +421,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="alice", password="pin")
-            ),
+            millenium_fixture.db.session, dict(username="alice", password="pin")
         )
         assert "FIRST-barcode" == p.authorization_identifier
 
@@ -459,10 +439,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.two_barcodes.html")
         millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="FIRST-barcode", password="pin")
-            ),
+            millenium_fixture.db.session, dict(username="FIRST-barcode", password="pin")
         )
         assert "SECOND-barcode" == p.authorization_identifier
 
@@ -476,10 +453,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.success.html")
         alice = millenium_fixture.api.authenticate(
-            millenium_fixture.db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="alice", password="4444")
-            ),
+            millenium_fixture.db.session, dict(username="alice", password="4444")
         )
         assert isinstance(alice, Patron)
         assert "44444444444447" == alice.authorization_identifier
@@ -497,9 +471,7 @@ class TestMilleniumPatronAPI:
         millenium_fixture.api.enqueue("pintest.good.html")
         alice = millenium_fixture.api.authenticated_patron(
             millenium_fixture.db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="44444444444447", password="4444")
-            ),
+            dict(username="44444444444447", password="4444"),
         )
         assert isinstance(alice, Patron)
         assert "44444444444447" == alice.authorization_identifier
@@ -508,10 +480,7 @@ class TestMilleniumPatronAPI:
         # Authenticate with username again
         millenium_fixture.api.enqueue("pintest.good.html")
         alice = millenium_fixture.api.authenticated_patron(
-            millenium_fixture.db.session,
-            Authorization(
-                auth_type="basic", data=dict(username="alice", password="4444")
-            ),
+            millenium_fixture.db.session, dict(username="alice", password="4444")
         )
         assert isinstance(alice, Patron)
         assert "44444444444447" == alice.authorization_identifier
@@ -538,9 +507,8 @@ class TestMilleniumPatronAPI:
         # and updates last_external_sync if the last sync was twelve
         # hours ago.
         millenium_fixture.api.enqueue("pintest.good.html")
-        auth = Authorization(
-            auth_type="basic", data=dict(username="44444444444447", password="4444")
-        )
+        auth = dict(username="44444444444447", password="4444")
+
         p2 = millenium_fixture.api.authenticated_patron(
             millenium_fixture.db.session, auth
         )
@@ -575,9 +543,8 @@ class TestMilleniumPatronAPI:
         p.authorization_identifier = "44444444444447"
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.invalid_expiration.html")
-        auth = Authorization(
-            auth_type="basic", data=dict(username="44444444444447", password="4444")
-        )
+        auth = dict(username="44444444444447", password="4444")
+
         p2 = millenium_fixture.api.authenticated_patron(
             millenium_fixture.db.session, auth
         )
@@ -591,9 +558,8 @@ class TestMilleniumPatronAPI:
         p.authorization_identifier = "44444444444447"
         millenium_fixture.api.enqueue("pintest.good.html")
         millenium_fixture.api.enqueue("dump.invalid_fines.html")
-        auth = Authorization(
-            auth_type="basic", data=dict(username="44444444444447", password="4444")
-        )
+        auth = dict(username="44444444444447", password="4444")
+
         p2 = millenium_fixture.api.authenticated_patron(
             millenium_fixture.db.session, auth
         )


### PR DESCRIPTION
## Description
Not sure how [this github action](https://github.com/ThePalaceProject/circulation/actions/runs/4850946216) ran successfully but the mypy typing was incorrect after the change from using dict/str's to werkzeug.Authorization objects.
The inner function still need to use dict/str types.
<!--- Describe your changes -->

## Motivation and Context
Main broke due to these incorrectly typed methods.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Mypy ran successfully.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
