### PR TITLE
Add a mypy settings override that enforces --strict

### DIFF
--- a/api/admin/model/dashboard_statistics.py
+++ b/api/admin/model/dashboard_statistics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import List
+from typing import Any, Dict, List
 
 from pydantic import BaseModel, Extra, Field, NonNegativeInt
 
@@ -25,7 +25,9 @@ class CustomBaseModel(BaseModel):
         allow_population_by_field_name = True
         extra = Extra.forbid
 
-    def api_dict(self, *args, by_alias=True, **kwargs):
+    def api_dict(
+        self, *args: Any, by_alias: bool = True, **kwargs: Any
+    ) -> Dict[str, Any]:
         """Return the instance in a form suitable for a web response.
 
         By default, the properties use their lower camel case aliases,
@@ -35,7 +37,7 @@ class CustomBaseModel(BaseModel):
 
 
 class StatisticsBaseModel(CustomBaseModel):
-    def __getitem__(self, item):
+    def __getitem__(self, item: str) -> Any:
         return getattr(self, item)
 
     def __add__(self, other: Self) -> Self:

--- a/core/model/classification.py
+++ b/core/model/classification.py
@@ -20,7 +20,12 @@ from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.functions import func
 
 from .. import classifier
-from ..classifier import COMICS_AND_GRAPHIC_NOVELS, Classifier, Erotica, GenreData
+from ..classifier import (  # type: ignore[attr-defined]
+    COMICS_AND_GRAPHIC_NOVELS,
+    Classifier,
+    Erotica,
+    GenreData,
+)
 from . import (
     Base,
     get_one,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ disallow_untyped_decorators = true
 disallow_untyped_defs = true
 module = [
     "api.admin.model.dashboard_statistics",
+    "core.model.hassessioncache",
 ]
 no_implicit_reexport = true
 strict_concatenate = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,13 +106,45 @@ exclude = [
     'tests/core/test_scripts\.py',
 ]
 files = ["."]
-plugins = ["sqlmypy"]
+plugins = ["pydantic.mypy", "sqlmypy"]
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
+# This override is the equivalent of running mypy with the --strict flag.
+# This is a work in progress, but we should try to get as many of our files
+# into the module list here as possible.
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+module = [
+    "api.admin.model.dashboard_statistics",
+]
+no_implicit_reexport = true
+strict_concatenate = true
+strict_equality = true
+warn_return_any = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+# This override silences errors for modules in our own codebase that we import
+# from other covered modules. Ideally we will be able to remove this override
+# eventually, once we have type hints for all of our own code.
+follow_imports = "silent"
+module = [
+    "core.classifier.*",
+    "core.model.listeners",
+]
+
+[[tool.mypy.overrides]]
+# This override silences errors for modules we import that don't currently
+# have type hints, or type stubs that cover them. We should go through this
+# list periodically and remove modules that have since added type hints.
 ignore_missing_imports = true
 module = [
     "aws_xray_sdk.ext.*",
@@ -152,18 +184,6 @@ module = [
     "watchtower",
     "wcag_contrast_ratio",
     "webpub_manifest_parser.*",
-]
-
-[[tool.mypy.overrides]]
-follow_imports = "skip"
-module = [
-    "core.classifier.*",
-]
-
-[[tool.mypy.overrides]]
-follow_imports = "silent"
-module = [
-    "core.model.listeners",
 ]
 
 [tool.poetry]


### PR DESCRIPTION
## Description

- Adds some comments with rationalization of each section of our mypy config, so its easier to know what they are used for.
- Add a new mypy override that uses the mypy `--strict` mode flags, that we can add modules to as we refactor them.
- Adds the pydantic mypy plugin, since we are using pydantic in the codebase now.
- Moves our `core.classifier.*` imports into a mypy override that silences errors there. This required the addition of one type check ignore comment.

## Motivation and Context

Eventually it would be nice to have all of our code passing strict mypy type checking, but this will likely be an ongoing project as we refactor things. Once something is refactored, this override lets us make sure that it continues to pass in the future.

## How Has This Been Tested?

Running mypy locally.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
