### PR TITLE
Bump the uwsgi limit to 4096

### DIFF
--- a/docker/services/uwsgi.ini
+++ b/docker/services/uwsgi.ini
@@ -13,6 +13,9 @@ harakiri = 300
 lazy-apps = true
 buffer-size = 131072
 
+# Make the socket backlog equal to SOMAXCONN on modern kernels
+listen = 4096
+
 # load any additional config
 for-glob = /etc/uwsgi.d/*
 include = %(_)


### PR DESCRIPTION
## Description

This bumps the internal `uwsgi` socket backlog to the maximum supported on Linux these days.

## Motivation and Context

The default uwsgi socket backlog limit is 100. This is an extremely conservative default apparently intended to work on old Linux kernels. Modern Linux kernels have a socket backlog limit of 4096, so there's no real reason to use less than that.

This allows us to serve over a thousand concurrent clients rather than failing at ~200.

Affects: https://www.notion.so/lyrasis/Load-Testing-2023-05-02-48e794ac2a0c4f2b836c299b79618e55

## How Has This Been Tested?

This was load tested heavily in the above ticket. We should do more testing in the dev/QA environment though.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
