### PR TITLE
Don't emit environment variable values during container startup.

### DIFF
--- a/docker/startup/01_set_simplified_environment.sh
+++ b/docker/startup/01_set_simplified_environment.sh
@@ -3,7 +3,7 @@
 # Local environment variables are not passed into cron, so variables set at
 # runtime need to be stored.
 
-set -ex
+set -e
 
 SIMPLIFIED_ENVIRONMENT=/var/www/circulation/environment.sh
 


### PR DESCRIPTION
## Description

Removes the `-x` setting from `01_set_simplified_environment.sh` docker container start-up script.

## Motivation and Context

Environment variable names and their associated values are being leaked into the logs. [[Notion](https://www.notion.so/lyrasis/CM-docker-container-startup-emits-environment-variable-values-c913aaf0d0f2411db1f0ee5dc6db3397?pvs=4)]

## How Has This Been Tested?

- Ran the sample `docker-compose.yml` environment without the change (i.e., with `set -x`) and observed the problem.
- Ran the sample `docker-compose.yml` environment with the fix (i.e., without `set -x`) and observed that the problem was no longer present.
- CI tests for this branch have already passed, but they are not meaningful for this fix.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.
