### PR TITLE
Escaping reserved characters in the JSON search type

### DIFF
--- a/core/external_search.py
+++ b/core/external_search.py
@@ -2015,6 +2015,10 @@ class JSONQuery(Query):
         REGEX = "regex"
         CONTAINS = "contains"
 
+    # Reserved characters and their mapping to escaped characters
+    RESERVED_CHARS = '.?+*|{}[]()"\\#@&<>~'
+    RESERVED_CHARS_MAP = dict(map(lambda ch: (ord(ch), f"\\{ch}"), RESERVED_CHARS))
+
     _KEYWORD_ONLY = {"keyword": True}
     _LONG_TYPE = {"type": "long"}
     _BOOL_TYPE = {"type": "bool"}
@@ -2187,6 +2191,11 @@ class JSONQuery(Query):
         # In case values need to be transformed
         if old_key in self.VALUE_TRANSORMS:
             value = self.VALUE_TRANSORMS[old_key](value)
+
+        # The contains/regex operators are a regex match
+        # So we must replace special operators where encountered
+        if op in {self.Operators.CONTAINS, self.Operators.REGEX}:
+            value = value.translate(self.RESERVED_CHARS_MAP)
 
         key = self.FIELD_TRANSFORMS.get(
             old_key, old_key


### PR DESCRIPTION

## Description
In case a JSON query is made for a regex/contains match we must escape the regex special characters as documented here
https://www.elastic.co/guide/en/elasticsearch/reference/current/regexp-syntax.html#regexp-reserved-characters

<!--- Describe your changes -->

## Motivation and Context
No results are returned when searching for titles that include a plus sign (+) or an ampersand (&) when searching for titles on the list search screen using the contains operator.
[Notion](https://www.notion.so/lyrasis/Investigate-and-Fix-Cannot-search-for-titles-with-ampersand-or-plus-sign-in-list-title-search-using-5942cc480346485988e1c966fb0ccf21)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested the search endpoint with queries like
http://localhost:6500/localtest/search/?q={%22query%22:{%22value%22:%22Essays%20%26%20Term%22,%22key%22:%22title%22,%22op%22:%22contains%22}}&size=100&search_type=json
Updated unit tests for special characters
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
