### PR TITLE
ContextManager based advisory locks

### DIFF
--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import warnings
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Dict, Generator, List
 
 from contextlib2 import contextmanager
 from psycopg2.extensions import adapt as sqlescape
@@ -294,7 +294,9 @@ DEBUG = False
 
 
 @contextmanager
-def pg_advisory_lock(connection: Session, lock_id: int | None) -> None:
+def pg_advisory_lock(
+    connection: Session, lock_id: int | None
+) -> Generator[None, None, None]:
     """Application wide locking based on Lock IDs
     :param connection: The database connection
     :param lock_id: The numeric lock ID to create, if None do not create a lock at all

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import warnings

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -3,6 +3,7 @@ import os
 import warnings
 from typing import TYPE_CHECKING, Dict, List
 
+from contextlib2 import contextmanager
 from psycopg2.extensions import adapt as sqlescape
 from psycopg2.extras import NumericRange
 from sqlalchemy import create_engine
@@ -290,12 +291,25 @@ def dump_query(query):
 DEBUG = False
 
 
-def acquire_advisory_lock(connection, lock_id):
-    connection.execute(f"SELECT pg_advisory_lock({lock_id});")
+@contextmanager
+def pg_advisory_lock(connection: Session, lock_id: int | None):
+    """Application wide locking based on Lock IDs
+    :param connection: The database connection
+    :param lock_id: The numeric lock ID to create, if None do not create a lock at all
+    """
+    if lock_id is not None:
+        # Create the lock
+        connection.execute(f"SELECT pg_advisory_lock({lock_id});")
+        try:
+            yield
+        finally:
+            # Close the lock
+            connection.execute(f"SELECT pg_advisory_unlock({lock_id});")
+    else:
+        yield
 
 
 class SessionManager:
-
     # A function that calculates recursively equivalent identifiers
     # is also defined in SQL.
     RECURSIVE_EQUIVALENTS_FUNCTION = "recursive_equivalents.sql"
@@ -342,39 +356,45 @@ class SessionManager:
         engine = cls.engine(url)
         with engine.connect() as connection:
             tx = connection.begin()
-            if initialize_schema or initialize_data:
-                acquire_advisory_lock(connection, CIRCULATION_ADVISORY_LOCK_ID)
 
-            if initialize_schema:
-                cls.initialize_schema(connection)
-
-            # Check if the recursive equivalents function exists already.
-            query = (
-                select([literal_column("proname")])
-                .select_from(table("pg_proc"))
-                .where(literal_column("proname") == "fn_recursive_equivalents")
+            # Only lock the application under certain conditions
+            lock_id = (
+                CIRCULATION_ADVISORY_LOCK_ID
+                if initialize_schema or initialize_data
+                else None
             )
-            result = connection.execute(query)
-            result = list(result)
 
-            # If it doesn't, create it.
-            if not result and initialize_data:
-                resource_file = os.path.join(
-                    cls.resource_directory(), cls.RECURSIVE_EQUIVALENTS_FUNCTION
+            with pg_advisory_lock(connection, lock_id):
+                if initialize_schema:
+                    cls.initialize_schema(connection)
+
+                # Check if the recursive equivalents function exists already.
+                query = (
+                    select([literal_column("proname")])
+                    .select_from(table("pg_proc"))
+                    .where(literal_column("proname") == "fn_recursive_equivalents")
                 )
-                if not os.path.exists(resource_file):
-                    raise OSError(
-                        "Could not load recursive equivalents function from %s: file does not exist."
-                        % resource_file
+                result = connection.execute(query)
+                result = list(result)
+
+                # If it doesn't, create it.
+                if not result and initialize_data:
+                    resource_file = os.path.join(
+                        cls.resource_directory(), cls.RECURSIVE_EQUIVALENTS_FUNCTION
                     )
-                sql = open(resource_file).read()
-                connection.execute(sql)
+                    if not os.path.exists(resource_file):
+                        raise OSError(
+                            "Could not load recursive equivalents function from %s: file does not exist."
+                            % resource_file
+                        )
+                    sql = open(resource_file).read()
+                    connection.execute(sql)
 
-            if initialize_data:
-                session = Session(connection)
-                cls.initialize_data(session)
+                if initialize_data:
+                    session = Session(connection)
+                    cls.initialize_data(session)
 
-            tx.commit()
+                tx.commit()
 
         if initialize_schema and initialize_data:
             # Only cache the engine if all initialization has been performed.

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -294,7 +294,7 @@ DEBUG = False
 
 
 @contextmanager
-def pg_advisory_lock(connection: Session, lock_id: int | None):
+def pg_advisory_lock(connection: Session, lock_id: int | None) -> None:
     """Application wide locking based on Lock IDs
     :param connection: The database connection
     :param lock_id: The numeric lock ID to create, if None do not create a lock at all


### PR DESCRIPTION
## Description
So that we never have a state where an application has accidentally held onto an application wide lock forever
<!--- Describe your changes -->

## Motivation and Context
Currently we acquire the advisory lock in the initialize database method but never do an "advisory_unlock"
Which means one instance of the CM always holds the database lock, which will prevent
a) In production any load balanced CMs from starting up
b) In development any auto-reload functionality from working

Running the current main branch (merged #898 ) we get the following output with uwsgi (3 processes)
<details>
<summary>Output</summary>

  ```
*** uWSGI is running in multiple interpreter mode ***
spawned uWSGI master process (pid: 36634)
spawned uWSGI worker 1 (pid: 36678, cores: 2)
spawned uWSGI worker 2 (pid: 36679, cores: 2)
spawned uWSGI worker 3 (pid: 36680, cores: 2)
spawned uWSGI http 1 (pid: 36681)
unable to stat() ./uwsgi.ini, events will be triggered as soon as the file is created
LOCKING DB
LOCKING DB SUCCESSFUL...
LOCKING DB
LOCKING DB
{"host": "Q", "app": "simplified", "name": "root", "level": "INFO", "filename": "app.py", "message": "Application debug mode==False", "timestamp": "2023-05-16T09:42:30.950243+00:00"}
{"host": "Q", "app": "simplified", "name": "api.controller.CirculationManager", "level": "INFO", "filename": "log.py", "message": "load_settings: Starting...", "timestamp": "2023-05-16T09:42:30.952440+00:00"}
{"host": "Q", "app": "simplified", "name": "core.analytics.Analytics", "level": "INFO", "filename": "analytics.py", "message": "Provider 'LocalAnalyticsProvider' for protocol 'core.local_analytics_provider' has per-library (1) scope.", "timestamp": "2023-05-16T09:42:30.968904+00:00"}
{"host": "Q", "app": "simplified", "name": "External search index", "level": "INFO", "filename": "external_search.py", "message": "Connecting to index vt-vermont-v5 in the search cluster at http://localhost:9201", "timestamp": "2023-05-16T09:42:31.443085+00:00"}
{"host": "Q", "app": "simplified", "name": "api.controller.CirculationManager", "level": "INFO", "filename": "log.py", "message": "load_settings: Completed. (elapsed time: 0.7789 seconds)", "timestamp": "2023-05-16T09:42:31.731459+00:00"}
WSGI app 0 (mountpoint='') ready in 3 seconds on interpreter 0x56027fb22de0 pid: 36679 (default app)
```
</details>

Notice the successive DB locks in a deadlock after the first succeeds.
With the context manager this is avoided.

On force-quitting uwsgi we get the following logs in the PG docker
```
pg_1          | 2023-05-16 09:49:38.398 UTC [2310] LOG:  duration: 427716.578 ms  statement: SELECT pg_advisory_lock(1000000001);
pg_1          | 2023-05-16 09:49:38.399 UTC [2311] LOG:  duration: 427713.922 ms  statement: SELECT pg_advisory_lock(1000000001);
```
Indicating 2 of the 3 processes were waiting for the advisory_lock for 427 seconds.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated
2 CMs have been run simultaneously 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
