### PR TITLE
Fix Axis360API inheriting from Authenticator

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -49,7 +49,6 @@ from core.util.problem_detail import ProblemDetail
 from core.util.string_helpers import base64
 from core.util.xmlparser import XMLParser
 
-from .authenticator import Authenticator
 from .circulation import (
     APIAwareFulfillmentInfo,
     BaseCirculationAPI,
@@ -66,9 +65,7 @@ class Axis360APIConstants:
     VERIFY_SSL = "verify_certificate"
 
 
-class Axis360API(
-    Authenticator, BaseCirculationAPI, HasCollectionSelfTests, Axis360APIConstants
-):
+class Axis360API(BaseCirculationAPI, HasCollectionSelfTests, Axis360APIConstants):
 
     NAME = ExternalIntegration.AXIS_360
 


### PR DESCRIPTION
## Description

`Axis360API` inherits from `Authenticator` which doesn't make a lot of sense. Looking back at git blame, this was done a long time ago, I think it was added by accident in testing. 

Nothing in `Axis360API` calls any methods from `Authenticator` and all the tests pass without it.

## Motivation and Context

I'm following through the class structure of `BaseCirculationAPI` to understand how we can update the storage of settings there, and this stuck out to me as obviously incorrect.

## How Has This Been Tested?

Running tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
