### PR TITLE
Fix bug in millenium alembic migration

### DIFF
--- a/alembic/versions/20230512_5a425ebe026c_migrate_millenium_apis_to_post.py
+++ b/alembic/versions/20230512_5a425ebe026c_migrate_millenium_apis_to_post.py
@@ -81,7 +81,7 @@ def upgrade() -> None:
         if config_results and len(post_results) > 0:
             use_post = post_results[0][0]
             if use_post is None:
-                use_post == "false"
+                use_post = "false"
         else:
             use_post = None
 

--- a/tests/migration/conftest.py
+++ b/tests/migration/conftest.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import random
+import string
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Generator, Union
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional, Protocol, Union
 
 import pytest
 import pytest_alembic
@@ -12,7 +14,7 @@ from tests.fixtures.database import ApplicationFixture, DatabaseFixture
 
 if TYPE_CHECKING:
     from pytest_alembic import MigrationContext
-    from sqlalchemy.engine import Engine
+    from sqlalchemy.engine import Connection, Engine
 
     import alembic.config
 
@@ -65,3 +67,113 @@ def alembic_runner(
     with pytest_alembic.runner(config=config, engine=alembic_engine) as runner:
         runner.command_executor.stamp("head")
         yield runner
+
+
+class RandomName(Protocol):
+    def __call__(self, length: Optional[int] = None) -> str:
+        ...
+
+
+@pytest.fixture
+def random_name() -> RandomName:
+    def fixture(length: Optional[int] = None) -> str:
+        if length is None:
+            length = 10
+        return "".join(random.choices(string.ascii_lowercase, k=length))
+
+    return fixture
+
+
+class CreateLibrary(Protocol):
+    def __call__(
+        self,
+        connection: Connection,
+        name: Optional[str] = None,
+        short_name: Optional[str] = None,
+    ) -> int:
+        ...
+
+
+@pytest.fixture
+def create_library(random_name: RandomName) -> CreateLibrary:
+    def fixture(
+        connection: Connection,
+        name: Optional[str] = None,
+        short_name: Optional[str] = None,
+    ) -> int:
+        if name is None:
+            name = random_name()
+        if short_name is None:
+            short_name = random_name()
+        library = connection.execute(
+            f"INSERT INTO libraries (name, short_name) VALUES ('{name}', '{short_name}') returning id"
+        ).fetchone()
+        assert library is not None
+        assert isinstance(library.id, int)
+        return library.id
+
+    return fixture
+
+
+class CreateExternalIntegration(Protocol):
+    def __call__(
+        self,
+        connection: Connection,
+        protocol: Optional[str] = None,
+        goal: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> int:
+        ...
+
+
+@pytest.fixture
+def create_external_integration(random_name: RandomName) -> CreateExternalIntegration:
+    def fixture(
+        connection: Connection,
+        protocol: Optional[str] = None,
+        goal: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> int:
+        protocol = protocol or random_name()
+        goal = goal or random_name()
+        name = name or random_name()
+        integration = connection.execute(
+            f"INSERT INTO externalintegrations (protocol, goal, name) VALUES ('{protocol}', '{goal}', '{name}') returning id"
+        ).fetchone()
+        assert integration is not None
+        assert isinstance(integration.id, int)
+        return integration.id
+
+    return fixture
+
+
+class CreateConfigSetting(Protocol):
+    def __call__(
+        self,
+        connection: Connection,
+        key: Optional[str] = None,
+        value: Optional[str] = None,
+        integration_id: Optional[int] = None,
+        library_id: Optional[int] = None,
+    ) -> int:
+        ...
+
+
+@pytest.fixture
+def create_config_setting() -> CreateConfigSetting:
+    def fixture(
+        connection: Connection,
+        key: Optional[str] = None,
+        value: Optional[str] = None,
+        integration_id: Optional[int] = None,
+        library_id: Optional[int] = None,
+    ) -> int:
+        setting = connection.execute(
+            "INSERT INTO configurationsettings (key, value, external_integration_id, library_id) VALUES (%s, %s, %s, %s) returning id",
+            (key, value, integration_id, library_id),
+        ).fetchone()
+        assert setting is not None
+        assert isinstance(setting.id, int)
+        return setting.id
+
+    return fixture

--- a/tests/migration/conftest.py
+++ b/tests/migration/conftest.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 def database() -> Generator[DatabaseFixture, None, None]:
     # This is very similar to the normal database fixture and uses the same object,
     # but because these tests are done outside a transaction, we need this fixture
-    # to have function scope, so the dataabase schema is completely reset between
+    # to have function scope, so the database schema is completely reset between
     # tests.
     app = ApplicationFixture.create()
     db = DatabaseFixture.create()

--- a/tests/migration/test_20230510_a9ed3f76d649.py
+++ b/tests/migration/test_20230510_a9ed3f76d649.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from sqlalchemy import inspect
 
 if TYPE_CHECKING:
     from pytest_alembic import MigrationContext
     from sqlalchemy.engine import Engine
+
+    from tests.migration.conftest import (
+        CreateConfigSetting,
+        CreateExternalIntegration,
+        CreateLibrary,
+    )
 
 
 def assert_tables_exist(alembic_engine: Engine) -> None:
@@ -43,9 +49,9 @@ def assert_tables_dont_exist(alembic_engine: Engine) -> None:
 def test_migration(
     alembic_runner: MigrationContext,
     alembic_engine: Engine,
-    create_library: Callable[..., int],
-    create_external_integration: Callable[..., int],
-    create_config_setting: Callable[..., int],
+    create_library: CreateLibrary,
+    create_external_integration: CreateExternalIntegration,
+    create_config_setting: CreateConfigSetting,
 ) -> None:
     # Migrate to just before our migration
     alembic_runner.migrate_down_to("a9ed3f76d649")

--- a/tests/migration/test_20230510_a9ed3f76d649.py
+++ b/tests/migration/test_20230510_a9ed3f76d649.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Callable
 
 from sqlalchemy import inspect
 
 if TYPE_CHECKING:
     from pytest_alembic import MigrationContext
-    from sqlalchemy.engine import Connection, Engine
+    from sqlalchemy.engine import Engine
 
 
 def assert_tables_exist(alembic_engine: Engine) -> None:
@@ -40,25 +40,15 @@ def assert_tables_dont_exist(alembic_engine: Engine) -> None:
         assert result.rowcount == 0
 
 
-def insert_setting(
-    connection: Connection,
-    key: str,
-    value: str,
-    integration_id: Optional[int] = None,
-    library_id: Optional[int] = None,
-) -> int:
-    id = connection.execute(
-        "INSERT INTO configurationsettings (key, value, external_integration_id, library_id) VALUES (%s, %s, %s, %s) returning id",
-        (key, value, integration_id, library_id),
-    ).fetchone()
-    assert id is not None
-    assert isinstance(id[0], int)
-    return id[0]
-
-
-def test_migration(alembic_runner: MigrationContext, alembic_engine: Engine) -> None:
+def test_migration(
+    alembic_runner: MigrationContext,
+    alembic_engine: Engine,
+    create_library: Callable[..., int],
+    create_external_integration: Callable[..., int],
+    create_config_setting: Callable[..., int],
+) -> None:
     # Migrate to just before our migration
-    alembic_runner.migrate_down_before("a9ed3f76d649")
+    alembic_runner.migrate_down_to("a9ed3f76d649")
     assert_tables_exist(alembic_engine)
 
     # Migrate down past our migration, running the downgrade migration
@@ -68,53 +58,63 @@ def test_migration(alembic_runner: MigrationContext, alembic_engine: Engine) -> 
     # Insert configuration settings for testing
     with alembic_engine.connect() as connection:
         # Set up two libraries
-        library = connection.execute(
-            "INSERT INTO libraries (name, short_name) VALUES ('test', 'test') returning id"
-        ).fetchone()[0]
-        library2 = connection.execute(
-            "INSERT INTO libraries (name, short_name) VALUES ('test2', 'test2') returning id"
-        ).fetchone()[0]
+        library = create_library(connection)
+        library2 = create_library(connection)
 
         # Set up four integrations
-        sip_integration = connection.execute(
-            "INSERT INTO externalintegrations (protocol, goal, name) VALUES ('api.sip', 'patron_auth', 'Integration 1') returning id"
-        ).fetchone()[0]
-        millenium_integration = connection.execute(
-            "INSERT INTO externalintegrations (protocol, goal, name) VALUES ('api.millenium_patron', 'patron_auth', 'Integration 2') returning id"
-        ).fetchone()[0]
-        simple_integration = connection.execute(
-            "INSERT INTO externalintegrations (protocol, goal, name) VALUES ('api.simple_authentication', 'patron_auth', 'Integration 3') returning id"
-        ).fetchone()[0]
-        unrelated_integration = connection.execute(
-            "INSERT INTO externalintegrations (protocol, goal, name) VALUES ('unrelated', 'other_goal', 'Integration 4') returning id"
-        ).fetchone()[0]
+        sip_integration = create_external_integration(
+            connection, "api.sip", "patron_auth", "Integration 1"
+        )
+        millenium_integration = create_external_integration(
+            connection, "api.millenium_patron", "patron_auth", "Integration 2"
+        )
+        simple_integration = create_external_integration(
+            connection, "api.simple_authentication", "patron_auth", "Integration 3"
+        )
+        unrelated_integration = create_external_integration(
+            connection, "unrelated", "other_goal", "Integration 4"
+        )
 
         # Add configuration settings for the sip integration
-        insert_setting(connection, "setting1", "value1", sip_integration)
-        insert_setting(connection, "url", "sip url", sip_integration)
-        insert_setting(connection, "institution_id", "institution", sip_integration)
-        insert_setting(
+        create_config_setting(connection, "setting1", "value1", sip_integration)
+        create_config_setting(connection, "url", "sip url", sip_integration)
+        create_config_setting(
+            connection, "institution_id", "institution", sip_integration
+        )
+        create_config_setting(
             connection,
             "self_test_results",
             json.dumps({"test": "test"}),
             sip_integration,
         )
-        insert_setting(connection, "patron status block", "false", sip_integration)
-        insert_setting(connection, "identifier_barcode_format", "", sip_integration)
-        insert_setting(connection, "institution_id", "bar", sip_integration, library)
+        create_config_setting(
+            connection, "patron status block", "false", sip_integration
+        )
+        create_config_setting(
+            connection, "identifier_barcode_format", "", sip_integration
+        )
+        create_config_setting(
+            connection, "institution_id", "bar", sip_integration, library
+        )
 
         # Add configuration settings for the millenium integration
-        insert_setting(connection, "setting2", "value2", millenium_integration)
-        insert_setting(connection, "url", "https://url.com", millenium_integration)
-        insert_setting(connection, "verify_certificate", "false", millenium_integration)
-        insert_setting(connection, "use_post_requests", "true", millenium_integration)
-        insert_setting(
+        create_config_setting(connection, "setting2", "value2", millenium_integration)
+        create_config_setting(
+            connection, "url", "https://url.com", millenium_integration
+        )
+        create_config_setting(
+            connection, "verify_certificate", "false", millenium_integration
+        )
+        create_config_setting(
+            connection, "use_post_requests", "true", millenium_integration
+        )
+        create_config_setting(
             connection,
             "identifier_blacklist",
             json.dumps(["a", "b", "c"]),
             millenium_integration,
         )
-        insert_setting(
+        create_config_setting(
             connection,
             "library_identifier_field",
             "foo",
@@ -123,8 +123,8 @@ def test_migration(alembic_runner: MigrationContext, alembic_engine: Engine) -> 
         )
 
         # Add configuration settings for the simple integration
-        insert_setting(connection, "test_identifier", "123", simple_integration)
-        insert_setting(connection, "test_password", "456", simple_integration)
+        create_config_setting(connection, "test_identifier", "123", simple_integration)
+        create_config_setting(connection, "test_password", "456", simple_integration)
 
         # Associate the millenium integration with the library
         connection.execute(
@@ -153,50 +153,50 @@ def test_migration(alembic_runner: MigrationContext, alembic_engine: Engine) -> 
         # Check that the sip integration was migrated correctly
         # The unknown setting 'setting1' was dropped, self test results were migrated, and the patron status block
         # setting was renamed, based on the field alias.
-        sip_integration = connection.execute(
+        sip_result = connection.execute(
             "SELECT protocol, goal, settings, self_test_results FROM integration_configurations WHERE name = %s",
             ("Integration 1",),
         ).fetchone()
-        assert sip_integration is not None
-        assert sip_integration[0] == "api.sip"
-        assert sip_integration[1] == "PATRON_AUTH_GOAL"
-        assert sip_integration[2] == {
+        assert sip_result is not None
+        assert sip_result[0] == "api.sip"
+        assert sip_result[1] == "PATRON_AUTH_GOAL"
+        assert sip_result[2] == {
             "patron_status_block": False,
             "url": "sip url",
         }
-        assert sip_integration[3] == {"test": "test"}
+        assert sip_result[3] == {"test": "test"}
 
         # Check that the millenium integration was migrated correctly
         # The unknown setting 'setting2' was dropped, the list and bool values were serialized correctly, and
         # the empty self test results were migrated as an empty dict.
-        millenium_integration = connection.execute(
+        millenium_result = connection.execute(
             "SELECT protocol, goal, settings, self_test_results, id FROM integration_configurations WHERE name = %s",
             ("Integration 2",),
         ).fetchone()
-        assert millenium_integration is not None
-        assert millenium_integration[0] == "api.millenium_patron"
-        assert millenium_integration[1] == "PATRON_AUTH_GOAL"
-        assert millenium_integration[2] == {
+        assert millenium_result is not None
+        assert millenium_result[0] == "api.millenium_patron"
+        assert millenium_result[1] == "PATRON_AUTH_GOAL"
+        assert millenium_result[2] == {
             "url": "https://url.com",
             "verify_certificate": False,
             "use_post_requests": True,
             "identifier_blacklist": ["a", "b", "c"],
         }
-        assert millenium_integration[3] == {}
+        assert millenium_result[3] == {}
 
         # Check that the simple integration was migrated correctly
-        simple_integration = connection.execute(
+        simple_result = connection.execute(
             "SELECT protocol, goal, settings, self_test_results, id FROM integration_configurations WHERE name = %s",
             ("Integration 3",),
         ).fetchone()
-        assert simple_integration is not None
-        assert simple_integration[0] == "api.simple_authentication"
-        assert simple_integration[1] == "PATRON_AUTH_GOAL"
-        assert simple_integration[2] == {
+        assert simple_result is not None
+        assert simple_result[0] == "api.simple_authentication"
+        assert simple_result[1] == "PATRON_AUTH_GOAL"
+        assert simple_result[2] == {
             "test_identifier": "123",
             "test_password": "456",
         }
-        assert simple_integration[3] == {}
+        assert simple_result[3] == {}
 
         # Check that we have the correct number of library integrations
         # The SIP integration has library settings, but no association with a library, so no
@@ -213,13 +213,13 @@ def test_migration(alembic_runner: MigrationContext, alembic_engine: Engine) -> 
             simple_library_integration,
         ] = integrations.fetchall()
         assert millenium_library_integration is not None
-        assert millenium_library_integration[0] == millenium_integration[4]
+        assert millenium_library_integration[0] == millenium_result[4]
         assert millenium_library_integration[1] == library
         assert millenium_library_integration[2] == {
             "library_identifier_field": "foo",
         }
 
         assert simple_library_integration is not None
-        assert simple_library_integration[0] == simple_integration[4]
+        assert simple_library_integration[0] == simple_result[4]
         assert simple_library_integration[1] == library2
         assert simple_library_integration[2] == {}

--- a/tests/migration/test_20230512_5a425ebe026c.py
+++ b/tests/migration/test_20230512_5a425ebe026c.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Optional
+
+import pytest
+
+if TYPE_CHECKING:
+    from pytest_alembic import MigrationContext
+    from sqlalchemy.engine import Connection, Engine
+
+    from tests.migration.conftest import CreateConfigSetting, CreateExternalIntegration
+
+
+@pytest.fixture
+def create_test_settings(
+    create_external_integration: CreateExternalIntegration,
+    create_config_setting: CreateConfigSetting,
+) -> Callable[..., int]:
+    def fixture(
+        connection: Connection,
+        url: str,
+        post: Optional[str] = None,
+        set_post: bool = True,
+    ) -> int:
+        integration = create_external_integration(
+            connection, protocol="api.millenium_patron"
+        )
+        create_config_setting(
+            connection, integration_id=integration, key="url", value=url
+        )
+        if set_post:
+            create_config_setting(
+                connection,
+                integration_id=integration,
+                key="use_post_requests",
+                value=post,
+            )
+
+        return integration
+
+    return fixture
+
+
+def assert_setting(connection: Connection, integration_id: int, value: str) -> None:
+    result = connection.execute(
+        "SELECT cs.value FROM configurationsettings cs join externalintegrations ei ON cs.external_integration_id = ei.id WHERE ei.id=%(id)s and cs.key='use_post_requests'",
+        id=integration_id,
+    )
+    assert result.fetchone()[0] == value
+
+
+def test_migration(
+    alembic_runner: MigrationContext,
+    alembic_engine: Engine,
+    create_test_settings: Callable[..., int],
+) -> None:
+    alembic_runner.migrate_down_to("5a425ebe026c")
+
+    # Test down migration
+    with alembic_engine.connect() as connection:
+        integration = create_test_settings(
+            connection, "https://vlc.thepalaceproject.org"
+        )
+
+    alembic_runner.migrate_down_one()
+
+    with alembic_engine.connect() as connection:
+        assert_setting(connection, integration, "false")
+
+    # Test up migration
+    with alembic_engine.connect() as connection:
+        integration_dev = create_test_settings(
+            connection, "http://vlc.dev.palaceproject.io/api", "false"
+        )
+        integration_staging = create_test_settings(
+            connection, "https://vlc.staging.palaceproject.io/PATRONAPI", "false"
+        )
+        integration_local1 = create_test_settings(
+            connection, "localhost:6500/PATRONAPI", "false"
+        )
+        integration_local2 = create_test_settings(
+            connection, "http://localhost:6500/api", "false"
+        )
+        integration_prod = create_test_settings(
+            connection, "https://vlc.thepalaceproject.org/anything...", "false"
+        )
+        integration_other = create_test_settings(
+            connection, "https://vendor.millenium.com/PATRONAPI", "false"
+        )
+        integration_null = create_test_settings(
+            connection, "http://vlc.dev.palaceproject.io/api"
+        )
+        integration_missing = create_test_settings(
+            connection, "http://vlc.dev.palaceproject.io/api", set_post=False
+        )
+
+    alembic_runner.migrate_up_one()
+
+    with alembic_engine.connect() as connection:
+        assert_setting(connection, integration, "true")
+        assert_setting(connection, integration_dev, "true")
+        assert_setting(connection, integration_staging, "true")
+        assert_setting(connection, integration_local1, "true")
+        assert_setting(connection, integration_local2, "true")
+        assert_setting(connection, integration_prod, "true")
+        assert_setting(connection, integration_other, "false")
+        assert_setting(connection, integration_null, "true")
+        assert_setting(connection, integration_missing, "true")
+
+    alembic_runner.migrate_down_one()
+
+    with alembic_engine.connect() as connection:
+        assert_setting(connection, integration, "false")
+        assert_setting(connection, integration_dev, "false")
+        assert_setting(connection, integration_staging, "false")
+        assert_setting(connection, integration_local1, "false")
+        assert_setting(connection, integration_local2, "false")
+        assert_setting(connection, integration_prod, "false")
+        assert_setting(connection, integration_other, "false")
+        assert_setting(connection, integration_null, "false")
+        assert_setting(connection, integration_missing, "false")


### PR DESCRIPTION
## Description

Fixes the bug with null settings in #1101. This was fixed in #1115, but there was an issue with that fix, it was doing a comparison rather then an assignment, so the fix didn't work.

## Motivation and Context

This ended up being a one line fix. The rest of the PR adds a test for this case, since I didn't see at first that this was an equality check instead of an assignment.

Since I needed some of the same helpers to set up the test, as I did in `test_20230510_a9ed3f76d649.py`, this PR turns those functions into fixtures, and refactors that test to use the fixtures as well.

## How Has This Been Tested?

Running tests locally. The tests help me find the issue with the migration, so they did their job.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
