### PR TITLE
Revert: initialize outside of first request

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -2,21 +2,15 @@ import logging
 import os
 import urllib.parse
 
-import flask_babel
 from flask_babel import Babel
 from flask_pydantic_spec import FlaskPydanticSpec
 
 from api.config import Configuration
 from core.flask_sqlalchemy_session import flask_scoped_session
-from core.local_analytics_provider import LocalAnalyticsProvider
 from core.log import LogConfiguration
-from core.model import ConfigurationSetting, SessionManager
-from core.model.configuration import access_exclusive_lock_configurationsettings
+from core.model import SessionManager
 from core.util import LanguageCodes
-from core.util.cache import CachedData
 
-from .admin.controller import setup_admin_controllers
-from .controller import CirculationManager
 from .util.flask import PalaceFlask
 from .util.profilers import (
     PalaceCProfileProfiler,
@@ -48,64 +42,23 @@ PalaceCProfileProfiler.configure(app)
 PalaceXrayProfiler.configure(app)
 
 
-def initialize_application() -> PalaceFlask:
-    with app.app_context(), flask_babel.force_locale("en"):
-        initialize_database()
-        initialize_circulation_manager()
-        initialize_admin()
-    return app
-
-
+@app.before_first_request
 def initialize_database(autoinitialize=True):
     testing = "TESTING" in os.environ
+
     db_url = Configuration.database_url()
     if autoinitialize:
         SessionManager.initialize(db_url)
     session_factory = SessionManager.sessionmaker(db_url)
     _db = flask_scoped_session(session_factory, app)
     app._db = _db
+
     log_level = LogConfiguration.initialize(_db, testing=testing)
     debug = log_level == "DEBUG"
     app.config["DEBUG"] = debug
     app.debug = debug
     _db.commit()
-
     logging.getLogger().info("Application debug mode==%r" % app.debug)
-
-
-def initialize_admin(_db=None):
-    if getattr(app, "manager", None) is not None:
-        setup_admin_controllers(app.manager)
-    _db = _db or app._db
-
-    with access_exclusive_lock_configurationsettings(_db) as db_session:
-        # The secret key is used for signing cookies for admin login
-        app.secret_key = ConfigurationSetting.sitewide_secret(
-            db_session, Configuration.SECRET_KEY
-        )
-        # Create a default Local Analytics service if one does not
-        # already exist.
-        local_analytics = LocalAnalyticsProvider.initialize(db_session)
-
-
-def initialize_circulation_manager():
-    if os.environ.get("AUTOINITIALIZE") == "False":
-        # It's the responsibility of the importing code to set app.manager
-        # appropriately.
-        pass
-    else:
-        if getattr(app, "manager", None) is None:
-            try:
-                app.manager = CirculationManager(app._db)
-            except Exception:
-                logging.exception("Error instantiating circulation manager!")
-                raise
-            # Make sure that any changes to the database (as might happen
-            # on initial setup) are committed before continuing.
-            app._db.commit()
-
-            # setup the cache data object
-            CachedData.initialize(app._db)
 
 
 from . import routes  # noqa
@@ -134,7 +87,6 @@ def run(url=None):
 
         socket.setdefaulttimeout(None)
 
-    initialize_application()
     logging.info("Starting app on %s:%s", host, port)
     sslContext = "adhoc" if scheme == "https" else None
     app.run(debug=debug, host=host, port=port, threaded=True, ssl_context=sslContext)

--- a/api/util/profilers.py
+++ b/api/util/profilers.py
@@ -44,6 +44,7 @@ class PalacePyInstrumentProfiler(PalaceProfiler):
         # Don't import if we are not profiling
         from pyinstrument import Profiler
 
+        @app.before_first_request
         @app.before_request
         def before_request():
             if "profiler" not in g:

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -29,8 +29,6 @@ from .constants import (
     MediaTypes,
 )
 
-CIRCULATION_ADVISORY_LOCK_ID = "1000000001"
-
 
 def flush(db):
     """Flush the database connection unless it's known to already be flushing."""
@@ -307,10 +305,6 @@ def json_serializer(*args, **kwargs) -> str:
     return json.dumps(*args, default=json_encoder, **kwargs)
 
 
-def acquire_advisory_lock(connection, lock_id):
-    connection.execute(f"SELECT pg_advisory_lock({lock_id});")
-
-
 class SessionManager:
 
     # A function that calculates recursively equivalent identifiers
@@ -357,41 +351,38 @@ class SessionManager:
             return engine, engine.connect()
 
         engine = cls.engine(url)
-        with engine.connect() as connection:
-            tx = connection.begin()
-            if initialize_schema or initialize_data:
-                acquire_advisory_lock(connection, CIRCULATION_ADVISORY_LOCK_ID)
+        if initialize_schema:
+            cls.initialize_schema(engine)
+        connection = engine.connect()
 
-            if initialize_schema:
-                cls.initialize_schema(connection)
+        # Check if the recursive equivalents function exists already.
+        query = (
+            select([literal_column("proname")])
+            .select_from(table("pg_proc"))
+            .where(literal_column("proname") == "fn_recursive_equivalents")
+        )
+        result = connection.execute(query)
+        result = list(result)
 
-            # Check if the recursive equivalents function exists already.
-            query = (
-                select([literal_column("proname")])
-                .select_from(table("pg_proc"))
-                .where(literal_column("proname") == "fn_recursive_equivalents")
+        # If it doesn't, create it.
+        if not result and initialize_data:
+            resource_file = os.path.join(
+                cls.resource_directory(), cls.RECURSIVE_EQUIVALENTS_FUNCTION
             )
-            result = connection.execute(query)
-            result = list(result)
-
-            # If it doesn't, create it.
-            if not result and initialize_data:
-                resource_file = os.path.join(
-                    cls.resource_directory(), cls.RECURSIVE_EQUIVALENTS_FUNCTION
+            if not os.path.exists(resource_file):
+                raise OSError(
+                    "Could not load recursive equivalents function from %s: file does not exist."
+                    % resource_file
                 )
-                if not os.path.exists(resource_file):
-                    raise OSError(
-                        "Could not load recursive equivalents function from %s: file does not exist."
-                        % resource_file
-                    )
-                sql = open(resource_file).read()
-                connection.execute(sql)
+            sql = open(resource_file).read()
+            connection.execute(sql)
 
-            if initialize_data:
-                session = Session(connection)
-                cls.initialize_data(session)
+        if initialize_data:
+            session = Session(connection)
+            cls.initialize_data(session)
 
-            tx.commit()
+        if connection:
+            connection.close()
 
         if initialize_schema and initialize_data:
             # Only cache the engine if all initialization has been performed.
@@ -411,7 +402,6 @@ class SessionManager:
     def initialize_schema(cls, engine):
         """Initialize the database schema."""
         # Use SQLAlchemy to create all the tables.
-
         to_create = [
             table_obj
             for name, table_obj in list(Base.metadata.tables.items())
@@ -430,16 +420,17 @@ class SessionManager:
                 initialize_schema=initialize_schema,
             )
         session = Session(connection)
+        if initialize_data:
+            session = cls.initialize_data(session)
         return session
 
     @classmethod
-    def initialize_data(cls, session):
+    def initialize_data(cls, session, set_site_configuration=True):
         # Create initial content.
         from .classification import Genre
         from .datasource import DataSource
         from .licensing import DeliveryMechanism
 
-        # otherwise  continue with the initialization
         list(DataSource.well_known_sources(session))
 
         # Create any genres not in the database.

--- a/core/model/configuration.py
+++ b/core/model/configuration.py
@@ -37,16 +37,6 @@ if TYPE_CHECKING:
     from core.model import Collection  # noqa: autoflake
 
 
-@contextmanager
-def access_exclusive_lock_configurationsettings(session: Session):
-    session.begin_nested()
-    session.execute("LOCK TABLE configurationsettings IN ACCESS EXCLUSIVE MODE;")
-    try:
-        yield session
-    finally:
-        session.commit()
-
-
 class ExternalIntegrationLink(Base, HasSessionCache):
 
     __tablename__ = "externalintegrationslinks"

--- a/docker/services/uwsgi.d/50_palace.ini
+++ b/docker/services/uwsgi.d/50_palace.ini
@@ -6,4 +6,4 @@ pythonpath = %(base)
 
 # python module to import
 module = api.app
-callable = initialize_application()
+callable = app

--- a/poetry.lock
+++ b/poetry.lock
@@ -120,18 +120,6 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-name = "blinker"
-version = "1.6.2"
-description = "Fast, simple object-to-object and broadcast signaling"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "blinker-1.6.2-py3-none-any.whl", hash = "sha256:c3d739772abb7bc2860abf5f2ec284223d9ad5c76da018234f6f50d6f31ab1f0"},
-    {file = "blinker-1.6.2.tar.gz", hash = "sha256:4afd3de66ef3a9f8067559fb7a1cbe555c17dcbe15971b05d1b625c3e7abe213"},
-]
-
-[[package]]
 name = "boto3"
 version = "1.18.65"
 description = "The AWS SDK for Python"
@@ -944,23 +932,22 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.2.2)", "diff-cover (>=7.5)", "p
 
 [[package]]
 name = "flask"
-version = "2.3.2"
+version = "2.2.5"
 description = "A simple framework for building complex web applications."
 category = "main"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "Flask-2.3.2-py3-none-any.whl", hash = "sha256:77fd4e1249d8c9923de34907236b747ced06e5467ecac1a7bb7115ae0e9670b0"},
-    {file = "Flask-2.3.2.tar.gz", hash = "sha256:8c2f9abd47a9e8df7f0c3f091ce9497d011dc3b31effcf4c85a6e2b50f4114ef"},
+    {file = "Flask-2.2.5-py3-none-any.whl", hash = "sha256:58107ed83443e86067e41eff4631b058178191a355886f8e479e347fa1285fdf"},
+    {file = "Flask-2.2.5.tar.gz", hash = "sha256:edee9b0a7ff26621bd5a8c10ff484ae28737a2410d99b0bb9a6850c7fb977aa0"},
 ]
 
 [package.dependencies]
-blinker = ">=1.6.2"
-click = ">=8.1.3"
+click = ">=8.0"
 importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
-itsdangerous = ">=2.1.2"
-Jinja2 = ">=3.1.2"
-Werkzeug = ">=2.3.3"
+itsdangerous = ">=2.0"
+Jinja2 = ">=3.0"
+Werkzeug = ">=2.2.2"
 
 [package.extras]
 async = ["asgiref (>=3.2)"]

--- a/tests/api/admin/controller/test_controller.py
+++ b/tests/api/admin/controller/test_controller.py
@@ -61,7 +61,6 @@ from tests.fixtures.api_controller import ControllerFixture
 
 class TestViewController:
     def test_setting_up(self, admin_ctrl_fixture: AdminControllerFixture):
-
         # Test that the view is in setting-up mode if there's no auth service
         # and no admin with a password.
         admin_ctrl_fixture.admin.password_hashed = None

--- a/tests/core/models/test_model.py
+++ b/tests/core/models/test_model.py
@@ -10,7 +10,6 @@ from core.model import (
     Timestamp,
     get_one,
     numericrange_to_tuple,
-    pg_advisory_lock,
     tuple_to_numericrange,
 )
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -98,28 +97,3 @@ class TestNumericRangeConversion:
         assert (2, 6) == m(two_to_six_inclusive)
         two_to_six_exclusive = NumericRange(2, 6, "()")
         assert (3, 5) == m(two_to_six_exclusive)
-
-
-class TestAdvisoryLock:
-    TEST_LOCK_ID = 999999
-
-    def _lock_exists(self, session, lock_id):
-        result = list(session.execute(f"SELECT * from pg_locks where objid={lock_id}"))
-        return len(result) != 0
-
-    def test_lock_unlock(self, db: DatabaseTransactionFixture):
-        with pg_advisory_lock(db.session, self.TEST_LOCK_ID):
-            assert self._lock_exists(db.session, self.TEST_LOCK_ID) == True
-        assert self._lock_exists(db.session, self.TEST_LOCK_ID) == False
-
-    def test_exception_case(self, db: DatabaseTransactionFixture):
-        try:
-            with pg_advisory_lock(db.session, self.TEST_LOCK_ID):
-                assert self._lock_exists(db.session, self.TEST_LOCK_ID) == True
-                raise Exception("Lock should open!!")
-        except:
-            assert self._lock_exists(db.session, self.TEST_LOCK_ID) == False
-
-    def test_no_lock_id(self, db: DatabaseTransactionFixture):
-        with pg_advisory_lock(db.session, None):
-            assert self._lock_exists(db.session, self.TEST_LOCK_ID) == False

--- a/tests/fixtures/api_admin.py
+++ b/tests/fixtures/api_admin.py
@@ -5,7 +5,7 @@ import flask
 import pytest
 
 from api.admin.controller import setup_admin_controllers
-from api.app import initialize_admin
+from api.admin.routes import setup_admin
 from api.config import Configuration
 from api.controller import CirculationManager
 from core.integration.goals import Goals
@@ -32,7 +32,7 @@ class AdminControllerFixture:
             controller_fixture.db.session, Configuration.SECRET_KEY
         ).value = "a secret"
 
-        initialize_admin(controller_fixture.db.session)
+        setup_admin(controller_fixture.db.session)
         setup_admin_controllers(controller_fixture.manager)
         self.admin, ignore = create(
             controller_fixture.db.session,


### PR DESCRIPTION
## Description

This PR reverts 3 previous PRs:
- #898 
- #1083 
- #1104 

## Motivation and Context

Once #898 was deployed out to dev we started seeing: 
```
minotaur-web    | Traceback (most recent call last):
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1276, in _execute_context
minotaur-web    |     self.dialect.do_execute(
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 608, in do_execute
minotaur-web    |     cursor.execute(statement, parameters)
minotaur-web    | psycopg2.errors.DeadlockDetected: deadlock detected
minotaur-web    | DETAIL:  Process 10517 waits for AccessExclusiveLock on relation 16897 of database 16409; blocked by process 10516.
minotaur-web    | Process 10516 waits for AccessExclusiveLock on relation 16897 of database 16409; blocked by process 10517.
minotaur-web    | HINT:  See server log for query details.
minotaur-web    |
minotaur-web    |
minotaur-web    | The above exception was the direct cause of the following exception:
minotaur-web    |
minotaur-web    | Traceback (most recent call last):
minotaur-web    |   File "/var/www/circulation/api/app.py", line 55, in initialize_application
minotaur-web    |     initialize_admin()
minotaur-web    |   File "/var/www/circulation/api/app.py", line 81, in initialize_admin
minotaur-web    |     with access_exclusive_lock_configurationsettings(_db) as db_session:
minotaur-web    |   File "/usr/lib/python3.8/contextlib.py", line 113, in __enter__
minotaur-web    |     return next(self.gen)
minotaur-web    |   File "/var/www/circulation/core/model/configuration.py", line 43, in access_exclusive_lock_configurationsettings
minotaur-web    |     session.execute("LOCK TABLE configurationsettings IN ACCESS EXCLUSIVE MODE;")
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/orm/scoping.py", line 163, in do
minotaur-web    |     return getattr(self.registry(), name)(*args, **kwargs)
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/orm/session.py", line 1295, in execute
minotaur-web    |     return self._connection_for_bind(bind, close_with_result=True).execute(
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1011, in execute
minotaur-web    |     return meth(self, multiparams, params)
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/sql/elements.py", line 298, in _execute_on_connection
minotaur-web    |     return connection._execute_clauseelement(self, multiparams, params)
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1124, in _execute_clauseelement
minotaur-web    |     ret = self._execute_context(
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1316, in _execute_context
minotaur-web    |     self._handle_dbapi_exception(
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1510, in _handle_dbapi_exception
minotaur-web    |     util.raise_(
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
minotaur-web    |     raise exception
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1276, in _execute_context
minotaur-web    |     self.dialect.do_execute(
minotaur-web    |   File "/var/www/circulation/env/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 608, in do_execute
minotaur-web    |     cursor.execute(statement, parameters)
minotaur-web    | sqlalchemy.exc.OperationalError: (psycopg2.errors.DeadlockDetected) deadlock detected
minotaur-web    | DETAIL:  Process 10517 waits for AccessExclusiveLock on relation 16897 of database 16409; blocked by process 10516.
minotaur-web    | Process 10516 waits for AccessExclusiveLock on relation 16897 of database 16409; blocked by process 10517.
minotaur-web    | HINT:  See server log for query details.
minotaur-web    |
minotaur-web    | [SQL: LOCK TABLE configurationsettings IN ACCESS EXCLUSIVE MODE;]
minotaur-web    | (Background on this error at: http://sqlalche.me/e/13/e3q8)
minotaur-web    | unable to load app 0 (mountpoint='') (callable not found or import error)
minotaur-web    | *** no app loaded. going in full dynamic mode ***
```

This lock conflict appears somewhat non-deterministic, as after a few restarts the servers would come up again. It looks like we need to investigate what is going on here before merging this code.

Because #1083 & #1104 both rely on #898, they have been rolled back as well.

## How Has This Been Tested?

Running tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
