### PR TITLE
Remove loads_unsafe method from the reset password flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ grant all privileges on database circ to palace;
 To let the application know which database to use set the `SIMPLIFIED_PRODUCTION_DATABASE` env variable.
 
 ```sh
-export SIMPLIFIED_PRODUCTION_DATABASE="postgres://palace:test@localhost:5432/circ"
+export SIMPLIFIED_PRODUCTION_DATABASE="postgresql://palace:test@localhost:5432/circ"
 ```
 
 ### Email sending
@@ -518,7 +518,7 @@ Make sure the ports and usernames are updated to reflect the local configuration
 
 ```sh
 # Set environment variables
-export SIMPLIFIED_TEST_DATABASE="postgres://simplified_test:test@localhost:9005/simplified_circulation_test"
+export SIMPLIFIED_TEST_DATABASE="postgresql://simplified_test:test@localhost:9005/simplified_circulation_test"
 export SIMPLIFIED_TEST_OPENSEARCH="http://localhost:9200"
 
 # Run tox

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -756,12 +756,15 @@ class ResetPasswordController(AdminController):
         reset_password_url = url_for(
             "admin_reset_password",
             reset_password_token=reset_password_token,
+            admin_id=admin.id,
             _external=True,
         )
 
         return reset_password_url
 
-    def reset_password(self, reset_password_token: str) -> Optional[WerkzeugResponse]:
+    def reset_password(
+        self, reset_password_token: str, admin_id: int
+    ) -> Optional[WerkzeugResponse]:
         """Shows reset password page or process the reset password request"""
         auth = self.admin_auth_provider(PasswordAdminAuthenticationProvider.NAME)
         if not auth:
@@ -782,7 +785,7 @@ class ResetPasswordController(AdminController):
             return admin_view_redirect
 
         admin_from_token = auth.validate_token_and_extract_admin(
-            reset_password_token, self._db
+            reset_password_token, admin_id, self._db
         )
 
         if isinstance(admin_from_token, ProblemDetail):
@@ -796,7 +799,7 @@ class ResetPasswordController(AdminController):
 
         if flask.request.method == "GET":
             auth_provider_html = auth.reset_password_template(
-                reset_password_token, admin_view_redirect
+                reset_password_token, admin_id, admin_view_redirect
             )
 
             html = self.RESET_PASSWORD_TEMPLATE % dict(
@@ -825,6 +828,7 @@ class ResetPasswordController(AdminController):
                     url_for(
                         "admin_reset_password",
                         reset_password_token=reset_password_token,
+                        admin_id=admin_id,
                     ),
                     "Try again",
                     is_error=True,

--- a/api/admin/password_admin_authentication_provider.py
+++ b/api/admin/password_admin_authentication_provider.py
@@ -52,9 +52,11 @@ class PasswordAdminAuthenticationProvider(AdminAuthenticationProvider):
             redirect=redirect, forgot_password_url=forgot_password_url
         )
 
-    def reset_password_template(self, reset_password_token, redirect):
+    def reset_password_template(self, reset_password_token, admin_id, redirect):
         reset_password_url = url_for(
-            "admin_reset_password", reset_password_token=reset_password_token
+            "admin_reset_password",
+            reset_password_token=reset_password_token,
+            admin_id=admin_id,
         )
         return self.RESET_PASSWORD_TEMPLATE % dict(
             redirect=redirect, reset_password_url=reset_password_url
@@ -109,10 +111,10 @@ class PasswordAdminAuthenticationProvider(AdminAuthenticationProvider):
         EmailManager.send_email(subject, receivers, text=mail_text, html=mail_html)
 
     def validate_token_and_extract_admin(
-        self, reset_password_token: str, _db: Session
+        self, reset_password_token: str, admin_id: int, _db: Session
     ) -> Union[Admin, ProblemDetail]:
         secret_key = ConfigurationSetting.sitewide_secret(_db, Configuration.SECRET_KEY)
 
         return Admin.validate_reset_password_token_and_fetch_admin(
-            reset_password_token, _db, secret_key
+            reset_password_token, admin_id, _db, secret_key
         )

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -140,11 +140,13 @@ def admin_forgot_password():
     return app.manager.admin_reset_password_controller.forgot_password()
 
 
-@app.route("/admin/reset_password/<reset_password_token>", methods=["GET", "POST"])
+@app.route(
+    "/admin/reset_password/<reset_password_token>/<admin_id>", methods=["GET", "POST"]
+)
 @returns_problem_detail
-def admin_reset_password(reset_password_token):
+def admin_reset_password(reset_password_token, admin_id):
     return app.manager.admin_reset_password_controller.reset_password(
-        reset_password_token
+        reset_password_token, admin_id
     )
 
 

--- a/core/config.py
+++ b/core/config.py
@@ -328,7 +328,7 @@ class Configuration(ConfigurationConstants):
             # Improve the error message by giving a guide as to what's
             # likely to work.
             raise ArgumentError(
-                "Bad format for database URL (%s). Expected something like postgres://[username]:[password]@[hostname]:[port]/[database name]"
+                "Bad format for database URL (%s). Expected something like postgresql://[username]:[password]@[hostname]:[port]/[database name]"
                 % url
             )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "6500:80"
     environment:
-      SIMPLIFIED_PRODUCTION_DATABASE: "postgres://palace:test@pg:5432/circ"
+      SIMPLIFIED_PRODUCTION_DATABASE: "postgresql://palace:test@pg:5432/circ"
 
   scripts:
     build:
@@ -18,7 +18,7 @@ services:
       dockerfile: docker/Dockerfile
       target: scripts
     environment:
-      SIMPLIFIED_PRODUCTION_DATABASE: "postgres://palace:test@pg:5432/circ"
+      SIMPLIFIED_PRODUCTION_DATABASE: "postgresql://palace:test@pg:5432/circ"
 
   pg:
     image: "postgres:12"

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,7 +19,7 @@ Once the webapp Docker image is built, we can run it in a container with the fol
 # about the values listed here and their alternatives.
 $ docker run --name webapp -d \
     --p 80:80 \
-    -e SIMPLIFIED_PRODUCTION_DATABASE='postgres://[username]:[password]@[host]:[port]/[database_name]' \
+    -e SIMPLIFIED_PRODUCTION_DATABASE='postgresql://[username]:[password]@[host]:[port]/[database_name]' \
     ghcr.io/thepalaceproject/circ-webapp:main
 ```
 
@@ -30,7 +30,7 @@ to access them as bellow:
 docker run \
 --link pg --link os \
 --name circ \
--e SIMPLIFIED_PRODUCTION_DATABASE='postgres://[username]:[password]@[host]:[port]/[database_name]' \
+-e SIMPLIFIED_PRODUCTION_DATABASE='postgresql://[username]:[password]@[host]:[port]/[database_name]' \
 -d -p 6500:80 \
 ghcr.io/thepalaceproject/circ-webapp:main
 ```
@@ -48,7 +48,7 @@ Once the scripts Docker image is built, we can run it in a container with the fo
 # about the values listed here and their alternatives.
 $ docker run --name scripts -d \
     -e TZ='YOUR_TIMEZONE_STRING' \
-    -e SIMPLIFIED_PRODUCTION_DATABASE='postgres://[username]:[password]@[host]:[port]/[database_name]' \
+    -e SIMPLIFIED_PRODUCTION_DATABASE='postgresql://[username]:[password]@[host]:[port]/[database_name]' \
     ghcr.io/thepalaceproject/circ-scripts:main
 ```
 
@@ -73,7 +73,7 @@ external log aggregator if you wish to capture logs from the job.
 # about the values listed here and their alternatives.
 $ docker run --name search_index_refresh -it \
     -e SIMPLIFIED_SCRIPT_NAME='refresh_materialized_views' \
-    -e SIMPLIFIED_PRODUCTION_DATABASE='postgres://[username]:[password]@[host]:[port]/[database_name]' \
+    -e SIMPLIFIED_PRODUCTION_DATABASE='postgresql://[username]:[password]@[host]:[port]/[database_name]' \
     ghcr.io/thepalaceproject/circ-exec:main
 ```
 

--- a/tests/core/models/test_admin.py
+++ b/tests/core/models/test_admin.py
@@ -190,7 +190,7 @@ class TestAdmin:
         # Random manually generated token - unsuccessful validation
         random_token = "random"
         invalid_token = Admin.validate_reset_password_token_and_fetch_admin(
-            random_token, db_session, secret_key
+            random_token, admin.id, db_session, secret_key
         )
         assert isinstance(invalid_token, ProblemDetail)
         assert invalid_token == INVALID_RESET_PASSWORD_TOKEN
@@ -198,7 +198,7 @@ class TestAdmin:
         # Generated valid token but manually changed - unsuccessful validation
         tampered_token = f"tampered-{admin.generate_reset_password_token(secret_key)}"
         invalid_token = Admin.validate_reset_password_token_and_fetch_admin(
-            tampered_token, db_session, secret_key
+            tampered_token, admin.id, db_session, secret_key
         )
         assert isinstance(invalid_token, ProblemDetail)
         assert invalid_token == INVALID_RESET_PASSWORD_TOKEN
@@ -209,16 +209,24 @@ class TestAdmin:
             utc_now() + timedelta(seconds=Admin.RESET_PASSWORD_TOKEN_MAX_AGE + 1)
         ):
             expired_token = Admin.validate_reset_password_token_and_fetch_admin(
-                valid_token, db_session, secret_key
+                valid_token, admin.id, db_session, secret_key
             )
             assert isinstance(expired_token, ProblemDetail)
             assert expired_token.uri == INVALID_RESET_PASSWORD_TOKEN.uri
             assert "expired" in expired_token.detail
 
-        # Valid token - admin is successfully extracted from token
+        # Valid token but invalid admin id - unsuccessful validation
         valid_token = admin.generate_reset_password_token(secret_key)
+        invalid_admin_id = admin.id + 1
+        invalid_token = Admin.validate_reset_password_token_and_fetch_admin(
+            valid_token, invalid_admin_id, db_session, secret_key
+        )
+        assert isinstance(invalid_token, ProblemDetail)
+        assert invalid_token == INVALID_RESET_PASSWORD_TOKEN
+
+        # Valid token - admin is successfully extracted from token
         extracted_admin = Admin.validate_reset_password_token_and_fetch_admin(
-            valid_token, db_session, secret_key
+            valid_token, admin.id, db_session, secret_key
         )
         assert isinstance(extracted_admin, Admin)
         assert extracted_admin == admin

--- a/tests/core/models/test_admin.py
+++ b/tests/core/models/test_admin.py
@@ -224,7 +224,16 @@ class TestAdmin:
         assert isinstance(invalid_token, ProblemDetail)
         assert invalid_token == INVALID_RESET_PASSWORD_TOKEN
 
+        # Valid token but the admin email has changed in the meantime - strange situation - unsuccessful validation
+        admin.email = "changed@email.com"
+        invalid_email = Admin.validate_reset_password_token_and_fetch_admin(
+            valid_token, admin.id, db_session, secret_key
+        )
+        assert isinstance(invalid_email, ProblemDetail)
+        assert invalid_email == INVALID_RESET_PASSWORD_TOKEN
+
         # Valid token - admin is successfully extracted from token
+        valid_token = admin.generate_reset_password_token(secret_key)
         extracted_admin = Admin.validate_reset_password_token_and_fetch_admin(
             valid_token, admin.id, db_session, secret_key
         )

--- a/tests/core/test_opds_import.py
+++ b/tests/core/test_opds_import.py
@@ -2858,5 +2858,7 @@ class TestOPDSImportMonitor:
 
                 # Ensure that the correct retry count had been passed.
                 retry_constructor_mock.assert_called_once_with(
-                    total=retry_count, status_forcelist=[429, 500, 502, 503, 504], backoff_factor=1.0
+                    total=retry_count,
+                    status_forcelist=[429, 500, 502, 503, 504],
+                    backoff_factor=1.0,
                 )


### PR DESCRIPTION
## Description

This PR adds admin id to the reset password link that is sent to user which wants to reset password without logging in. Admin id is appended to the current reset password url. When CM receives request to that url it uses admin id to fetch the admin and uses admin data to validate token. 

PR also contains some leftovers from migration to SQLAlchemy 1.4 when not all `postgres://` were migrated to `postgresql://`.

<!--- Describe your changes -->

## Motivation and Context

When adding reset password functionality to the CM I introduced `loads_unsafe` method from the `itsdangerous` library so we can load received token in unsafe manner first, and then using admin data load and check the token. The method is actually safe but wording from the itsdangerous docs wasn't assuring that the method will stay safe in the future. To be on the safe side we implemented one of the suggested solutions from the previous discussion and added admin id to the reset password link.

[Notion](https://www.notion.so/lyrasis/Remove-loads_unsafe-method-from-forgot-reset-password-functionality-9f177add00da4581a5eb38f44e74d91d)
[Reset password feature PR](https://github.com/ThePalaceProject/circulation/pull/773) 
[PR discussion](https://github.com/ThePalaceProject/circulation/pull/773#discussion_r1114915773) 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Manually triggered password reset. Changed existing test to use admin id and added few more situations with bad admin id.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
