### PR TITLE
Speed up API tests

### DIFF
--- a/tests/fixtures/api_admin.py
+++ b/tests/fixtures/api_admin.py
@@ -39,7 +39,11 @@ class AdminControllerFixture:
             Admin,
             email="example@nypl.org",
         )
-        self.admin.password = "password"
+        # This is a hash for 'password', we use the hash directly to avoid the cost
+        # of doing the password hashing during test setup.
+        self.admin.password_hashed = (
+            "$2a$12$Dw74btoAgh49.vtOB56xPuumtcOY9HCZKS3RYImR42lR5IiT7PIOW"
+        )
 
     @contextmanager
     def request_context_with_admin(self, route, *args, **kwargs):


### PR DESCRIPTION
## Description

This is the same change that was made in this PR: 
https://github.com/ThePalaceProject/circulation/pull/871

From that PR: 
> Doing a bit more profiling of our code, it seems that the single most expensive function we call when running the tests is now the call to set password in AdminControllerTest. This removes the need to hash this password on each test setup, by directly setting the the hashed password.

> This doesn't speed up the tests dramatically, but does shave about a minute off the test run on my machine.

## Motivation and Context

I noticed when working on https://github.com/ThePalaceProject/circulation/pull/1178 that this change was lost when we moved to pytest fixtures. Its not a huge speed increase, but I think its worth adding back in. Its nice to save a bit of time since our tests take so long anyway.

## How Has This Been Tested?

Running tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
