### PR TITLE
Move from py-bcrypt to bcrypt library

### DIFF
--- a/core/model/admin.py
+++ b/core/model/admin.py
@@ -62,11 +62,16 @@ class Admin(Base, HasSessionCache):
         raise NotImplementedError("Password comparison is only with Admin.authenticate")
 
     @password.setter
-    def password(self, value):
-        self.password_hashed = str(bcrypt.hashpw(value, bcrypt.gensalt()))
+    def password(self, value: str) -> None:
+        self.password_hashed = bcrypt.hashpw(value.encode(), bcrypt.gensalt()).decode()
 
-    def has_password(self, password):
-        return self.password_hashed == bcrypt.hashpw(password, self.password_hashed)
+    def has_password(self, password: str) -> bool:
+        if self.password_hashed is None:
+            return False
+        return (
+            self.password_hashed
+            == bcrypt.hashpw(password.encode(), self.password_hashed.encode()).decode()
+        )
 
     @classmethod
     def authenticate(cls, _db, email: str, password: str) -> Admin | None:

--- a/core/model/admin.py
+++ b/core/model/admin.py
@@ -68,10 +68,7 @@ class Admin(Base, HasSessionCache):
     def has_password(self, password: str) -> bool:
         if self.password_hashed is None:
             return False
-        return (
-            self.password_hashed
-            == bcrypt.hashpw(password.encode(), self.password_hashed.encode()).decode()
-        )
+        return bcrypt.checkpw(password.encode(), self.password_hashed.encode())
 
     @classmethod
     def authenticate(cls, _db, email: str, password: str) -> Admin | None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -101,6 +101,41 @@ files = [
 pytz = ">=2015.7"
 
 [[package]]
+name = "bcrypt"
+version = "4.0.1"
+description = "Modern password hashing for your software and your servers"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:b1023030aec778185a6c16cf70f359cbb6e0c289fd564a7cfa29e727a1c38f8f"},
+    {file = "bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:08d2947c490093a11416df18043c27abe3921558d2c03e2076ccb28a116cb6d0"},
+    {file = "bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0eaa47d4661c326bfc9d08d16debbc4edf78778e6aaba29c1bc7ce67214d4410"},
+    {file = "bcrypt-4.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae88eca3024bb34bb3430f964beab71226e761f51b912de5133470b649d82344"},
+    {file = "bcrypt-4.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:a522427293d77e1c29e303fc282e2d71864579527a04ddcfda6d4f8396c6c36a"},
+    {file = "bcrypt-4.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fbdaec13c5105f0c4e5c52614d04f0bca5f5af007910daa8b6b12095edaa67b3"},
+    {file = "bcrypt-4.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ca3204d00d3cb2dfed07f2d74a25f12fc12f73e606fcaa6975d1f7ae69cacbb2"},
+    {file = "bcrypt-4.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:089098effa1bc35dc055366740a067a2fc76987e8ec75349eb9484061c54f535"},
+    {file = "bcrypt-4.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e9a51bbfe7e9802b5f3508687758b564069ba937748ad7b9e890086290d2f79e"},
+    {file = "bcrypt-4.0.1-cp36-abi3-win32.whl", hash = "sha256:2caffdae059e06ac23fce178d31b4a702f2a3264c20bfb5ff541b338194d8fab"},
+    {file = "bcrypt-4.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:8a68f4341daf7522fe8d73874de8906f3a339048ba406be6ddc1b3ccb16fc0d9"},
+    {file = "bcrypt-4.0.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf4fa8b2ca74381bb5442c089350f09a3f17797829d958fad058d6e44d9eb83c"},
+    {file = "bcrypt-4.0.1-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:67a97e1c405b24f19d08890e7ae0c4f7ce1e56a712a016746c8b2d7732d65d4b"},
+    {file = "bcrypt-4.0.1-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b3b85202d95dd568efcb35b53936c5e3b3600c7cdcc6115ba461df3a8e89f38d"},
+    {file = "bcrypt-4.0.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cbb03eec97496166b704ed663a53680ab57c5084b2fc98ef23291987b525cb7d"},
+    {file = "bcrypt-4.0.1-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:5ad4d32a28b80c5fa6671ccfb43676e8c1cc232887759d1cd7b6f56ea4355215"},
+    {file = "bcrypt-4.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b57adba8a1444faf784394de3436233728a1ecaeb6e07e8c22c8848f179b893c"},
+    {file = "bcrypt-4.0.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:705b2cea8a9ed3d55b4491887ceadb0106acf7c6387699fca771af56b1cdeeda"},
+    {file = "bcrypt-4.0.1-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:2b3ac11cf45161628f1f3733263e63194f22664bf4d0c0f3ab34099c02134665"},
+    {file = "bcrypt-4.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:3100851841186c25f127731b9fa11909ab7b1df6fc4b9f8353f4f1fd952fbf71"},
+    {file = "bcrypt-4.0.1.tar.gz", hash = "sha256:27d375903ac8261cfe4047f6709d16f7d18d39b1ec92aaf72af989552a650ebd"},
+]
+
+[package.extras]
+tests = ["pytest (>=3.2.1,!=3.3.0)"]
+typecheck = ["mypy"]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.11.1"
 description = "Screen-scraping library"
@@ -2205,17 +2240,6 @@ files = [
 ]
 
 [[package]]
-name = "py-bcrypt"
-version = "0.4"
-description = "bcrypt password hashing and key derivation"
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "py-bcrypt-0.4.tar.gz", hash = "sha256:5fa13bce551468350d66c4883694850570f3da28d6866bb638ba44fe5eabda78"},
-]
-
-[[package]]
 name = "pycodestyle"
 version = "2.8.0"
 description = "Python style guide checker"
@@ -3793,4 +3817,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "e821293306db85d9c41c13b65f9ce7d2784fd8e7052d1b47c3bca09fb31c440d"
+content-hash = "3c15c0f5dff3e4e532103934001fcbda403a327bfffb7f76cef98d9b095c9661"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,6 @@ module = [
 ignore_missing_imports = true
 module = [
     "aws_xray_sdk.ext.*",
-    "bcrypt",
     # This is ignored because the file is created when building a container
     # so it typically doesn't exist when running mypy, but since it only
     # contains a couple version strings it can be safely ignored
@@ -211,6 +210,7 @@ version = "0"  # Version number is managed with tags in git
 [tool.poetry.dependencies]
 alembic = {extras = ["tz"], version = "^1.8.1"}
 aws-xray-sdk = "~2.12"
+bcrypt = "^4.0.1"
 boto3 = "~1.18"
 botocore = "~1.21"
 certifi = "*"
@@ -236,7 +236,6 @@ opensearch-dsl = "~1.0"
 opensearch-py = "~1.1"
 palace-webpub-manifest-parser = "~3.0.1"
 Pillow = "9.5.0"
-py-bcrypt = "0.4"
 pycryptodome = "^3.18"
 pyinstrument = "<4.6"
 PyJWT = "2.4.0"

--- a/tests/core/models/test_admin.py
+++ b/tests/core/models/test_admin.py
@@ -30,7 +30,7 @@ def admin_fixture(db: DatabaseTransactionFixture) -> AdminFixture:
 class TestAdmin:
     def test_password_hashed(self, admin_fixture: AdminFixture):
         pytest.raises(NotImplementedError, lambda: admin_fixture.admin.password)
-        assert admin_fixture.admin.password_hashed.startswith("$2a$")
+        assert admin_fixture.admin.password_hashed.startswith("$2b$")
 
     def test_with_password(self, admin_fixture: AdminFixture):
         session = admin_fixture.db.session


### PR DESCRIPTION
## Description

This replaces the `py-bcrypt` package with the `bcrypt` package.

- The last release of `py-bcrypt` was in 2013 😓
- It looks like this package has been replaced by `bcrypt`, which does have wheels, and is still being developed.
- This change took some minor code changes, as the `bcrypt` package operates on `bytes` rather then `str`, so we have to do some decoding / encoding to make it work.
- There is a small change to a test, since the new library creates bcrypt hashes with a newer [version string](https://en.wikipedia.org/wiki/Bcrypt#Versioning_history). Since this new version has existed since 2014, we should probably have updated this library long ago.

## Motivation and Context

This change was originally part of https://github.com/ThePalaceProject/circulation/pull/1178. @pcustic made a good point that that PR needs to be re-worked, so I wanted to pull this piece of the PR out, because I think its a valuable change.

## How Has This Been Tested?

Running CI on change.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
