### PR TITLE
Output logs on docker build fail

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -202,6 +202,10 @@ jobs:
       - name: Run tests
         run: ./docker/ci/test_${{ matrix.image }}.sh test_container
 
+      - name: Output logs
+        if: failure()
+        run: docker logs test_container
+
       - name: Stop container
         if: always()
         run: docker stop test_container

--- a/docker/ci/test_webapp.sh
+++ b/docker/ci/test_webapp.sh
@@ -16,6 +16,9 @@ wait_for_runit "$container"
 check_service_status "$container" /etc/service/nginx
 check_service_status "$container" /home/simplified/service/uwsgi
 
+# Wait for UWSGI to be ready to accept connections.
+timeout 120s grep -q 'WSGI app .* ready in [0-9]* seconds' <(docker logs "$container" -f 2>&1)
+
 # Make sure the web server is running.
 healthcheck=$(docker exec "$container" curl --write-out "%{http_code}" --silent --output /dev/null http://localhost/healthcheck.html)
 if ! [[ ${healthcheck} == "200" ]]; then


### PR DESCRIPTION
## Description

There are two changes here: 
- Output the docker container logs when if our container build tests fail. This helps with debugging to understand what went wrong in the container. 
- Wait for UWSGI to signal its ready before running the webapp tests, since uwsgi can be up, but not ready yet and this can cause spurious test failures.

## Motivation and Context

These are some small changes I made as part of https://github.com/ThePalaceProject/circulation/pull/1155. I think they are valuable on their own for debugging, so I made them into their own PR. Since https://github.com/ThePalaceProject/circulation/pull/1155 is experimental and might not get merged.

## How Has This Been Tested?

Running tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
