### PR TITLE
Fix flaky test - TestLaneCreation::test_create_world_languages_lane

### DIFF
--- a/tests/api/test_lanes.py
+++ b/tests/api/test_lanes.py
@@ -181,7 +181,7 @@ class TestLaneCreation:
         # from all three languages mentioned in its children.
         top_level = db.session.query(Lane).filter(Lane.parent == None).one()
         assert "World Languages" == top_level.display_name
-        assert {"spa", "fre", "eng"} == top_level.languages
+        assert {"spa", "fre", "eng"} == set(top_level.languages)
 
         # It has two children -- one for the small English collection and
         # one for the tiny Spanish/French collection.,
@@ -190,7 +190,7 @@ class TestLaneCreation:
         assert ["eng"] == small.languages
 
         assert "espa\xf1ol/fran\xe7ais" == tiny.display_name
-        assert ["spa", "fre"] == tiny.languages
+        assert {"spa", "fre"} == set(tiny.languages)
 
         # The tiny collection has no sublanes, but the small one has
         # three.  These lanes are tested in more detail in


### PR DESCRIPTION
## Description

I saw this test failure today, it appears to just be a flaky test, since we are comparing a set to a list. Making both sets fixes the test and makes sure that ordering won't cause this test to fail.

## Motivation and Context

```
  =========================== short test summary info ============================
  FAILED tests/api/test_lanes.py::TestLaneCreation::test_create_world_languages_lane - AssertionError: assert {'eng', 'fre', 'spa'} == ['spa', 'eng', 'fre']
    Full diff:
    - ['spa', 'eng', 'fre']
    + {'spa', 'fre', 'eng'}

```

## How Has This Been Tested?

Running in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
