### PR TITLE
Allow FCM credential via JSON string in env var.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,15 +153,31 @@ grant all privileges on database circ to palace;
 
 #### Environment variables
 
-To let the application know which database to use set the `SIMPLIFIED_PRODUCTION_DATABASE` env variable.
-The `SIMPLIFIED_FCM_CREDENTIALS_FILE` env variable should hold the path to the JSON format GCP service account key
+##### Database
+
+To let the application know which database to use, set the `SIMPLIFIED_PRODUCTION_DATABASE` environment variable.
 
 ```sh
 export SIMPLIFIED_PRODUCTION_DATABASE="postgresql://palace:test@localhost:5432/circ"
+```
+
+##### Firebase Cloud Messaging
+
+For Firebase Cloud Messaging (FCM) support (e.g., for notifications), `one` (and only one) of the following should be set:
+- `SIMPLIFIED_FCM_CREDENTIALS_JSON` - the JSON-format Google Cloud Platform (GCP) service account key  or
+- `SIMPLIFIED_FCM_CREDENTIALS_FILE` - the name of the file containing that key.
+
+```sh
+export SIMPLIFIED_FCM_CREDENTIALS_JSON='{"type":"service_account","project_id":"<id>", "private_key_id":"f8...d1", ...}'
+```
+
+...or...
+
+```sh
 export SIMPLIFIED_FCM_CREDENTIALS_FILE="/opt/credentials/fcm_credentials.json"
 ```
 
-The FCM credentials file can be downloaded once a Google Service account is created
+The FCM credentials can be downloaded once a Google Service account has been created.
 More details in the [FCM documentation](https://firebase.google.com/docs/admin/setup#set-up-project-and-service-account)
 
 ### Email sending
@@ -406,13 +422,15 @@ the search index and feed caches.
 
 #### hold_notifications
 
-Requires the `SIMPLIFIED_FCM_CREDENTIALS_FILE` to be present
-and the sitewide `PUSH_NOTIFICATIONS_STATUS` setting to be either `unset` or `true`
+Requires one of [the Firebase Cloud Messaging credentials environment variables (described above)](#firebase-cloud-messaging)
+to be present and non-empty.
+In addition, the site-wide `PUSH_NOTIFICATIONS_STATUS` setting must be either `unset` or `true`.
 
 #### loan_notifications
 
-Requires the `SIMPLIFIED_FCM_CREDENTIALS_FILE` to be present
-and the sitewide `PUSH_NOTIFICATIONS_STATUS` setting to be either `unset` or `true`
+Requires one of [the Firebase Cloud Messaging credentials environment variables (described above](#firebase-cloud-messaging)
+to be present and non-empty.
+In addition, the site-wide `PUSH_NOTIFICATIONS_STATUS` setting must be either `unset` or `true`.
 
 ## Code Style
 

--- a/core/config.py
+++ b/core/config.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from typing import Dict
@@ -54,8 +55,9 @@ class Configuration(ConfigurationConstants):
     DATABASE_TEST_ENVIRONMENT_VARIABLE = "SIMPLIFIED_TEST_DATABASE"
     DATABASE_PRODUCTION_ENVIRONMENT_VARIABLE = "SIMPLIFIED_PRODUCTION_DATABASE"
 
-    # Environment variable for FCM service account key
+    # Environment variables for Firebase Cloud Messaging (FCM) service account key
     FCM_CREDENTIALS_FILE_ENVIRONMENT_VARIABLE = "SIMPLIFIED_FCM_CREDENTIALS_FILE"
+    FCM_CREDENTIALS_JSON_ENVIRONMENT_VARIABLE = "SIMPLIFIED_FCM_CREDENTIALS_JSON"
 
     # Environment variable for Overdrive fulfillment keys
     OD_PREFIX_PRODUCTION_PREFIX = "SIMPLIFIED"
@@ -359,15 +361,47 @@ class Configuration(ConfigurationConstants):
         return url
 
     @classmethod
-    def fcm_credentials_file(cls):
-        fcm_file = os.environ.get(cls.FCM_CREDENTIALS_FILE_ENVIRONMENT_VARIABLE)
-        if not fcm_file:
+    def fcm_credentials(cls) -> Dict[str, str]:
+        """Returns a dictionary containing Firebase Cloud Messaging credentials.
+
+        Credentials are provided as a JSON string, either (1) directly in an environment
+        variable or (2) in a file that is specified in another environment variable.  may be obtained from either (1) directly an environment variable
+        """
+        config_json = os.environ.get(cls.FCM_CREDENTIALS_JSON_ENVIRONMENT_VARIABLE)
+        config_file = os.environ.get(cls.FCM_CREDENTIALS_FILE_ENVIRONMENT_VARIABLE)
+        if not config_json and not config_file:
             raise CannotLoadConfiguration(
-                f"FCM Credentials File not defined in environment variable {cls.FCM_CREDENTIALS_FILE_ENVIRONMENT_VARIABLE}"
+                "FCM Credentials configuration environment variable not defined. "
+                f"Use either '{cls.FCM_CREDENTIALS_JSON_ENVIRONMENT_VARIABLE}' "
+                f"or '{cls.FCM_CREDENTIALS_FILE_ENVIRONMENT_VARIABLE}'."
             )
-        if not os.path.exists(fcm_file):
-            raise FileNotFoundError(f"The file at {fcm_file} does not exist")
-        return fcm_file
+        if config_json and config_file:
+            raise CannotLoadConfiguration(
+                f"Both JSON ('{cls.FCM_CREDENTIALS_JSON_ENVIRONMENT_VARIABLE}') "
+                f"and file-based ('{cls.FCM_CREDENTIALS_FILE_ENVIRONMENT_VARIABLE}') "
+                "FCM Credential environment variables are defined, but only one is allowed."
+            )
+        if config_json:
+            try:
+                return json.loads(config_json, strict=False)
+            except:
+                raise CannotLoadConfiguration(
+                    "Cannot parse value of FCM credential environment variable "
+                    f"'{cls.FCM_CREDENTIALS_JSON_ENVIRONMENT_VARIABLE}' as JSON."
+                )
+
+        # If we make it this far, we are dealing with a configuration file.
+        if not os.path.exists(config_file):
+            raise FileNotFoundError(
+                f"The FCM credentials file ('{config_file}') does not exist."
+            )
+        with open(config_file) as f:
+            try:
+                return json.load(f)
+            except:
+                raise CannotLoadConfiguration(
+                    f"Cannot parse contents of FCM credentials file ('{config_file}') as JSON."
+                )
 
     @classmethod
     def overdrive_fulfillment_keys(cls, testing=False) -> Dict[str, str]:

--- a/core/config.py
+++ b/core/config.py
@@ -365,10 +365,10 @@ class Configuration(ConfigurationConstants):
         """Returns a dictionary containing Firebase Cloud Messaging credentials.
 
         Credentials are provided as a JSON string, either (1) directly in an environment
-        variable or (2) in a file that is specified in another environment variable.  may be obtained from either (1) directly an environment variable
+        variable or (2) in a file that is specified in another environment variable.
         """
-        config_json = os.environ.get(cls.FCM_CREDENTIALS_JSON_ENVIRONMENT_VARIABLE)
-        config_file = os.environ.get(cls.FCM_CREDENTIALS_FILE_ENVIRONMENT_VARIABLE)
+        config_json = os.environ.get(cls.FCM_CREDENTIALS_JSON_ENVIRONMENT_VARIABLE, "")
+        config_file = os.environ.get(cls.FCM_CREDENTIALS_FILE_ENVIRONMENT_VARIABLE, "")
         if not config_json and not config_file:
             raise CannotLoadConfiguration(
                 "FCM Credentials configuration environment variable not defined. "

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -39,7 +39,7 @@ class PushNotifications:
     def fcm_app(cls):
         if not cls._fcm_app:
             cls._fcm_app = firebase_admin.initialize_app(
-                credentials.Certificate(Configuration.fcm_credentials_file())
+                credentials.Certificate(Configuration.fcm_credentials())
             )
         return cls._fcm_app
 
@@ -117,7 +117,7 @@ class PushNotifications:
 
     @classmethod
     def send_holds_notifications(cls, holds: list[Hold]) -> list[str]:
-        """Send out notifcations to all patron devices that their hold is ready for checkout"""
+        """Send out notifications to all patron devices that their hold is ready for checkout."""
         if not holds:
             return []
 

--- a/tests/core/files/util/notifications/fcm-credentials-valid-json.json
+++ b/tests/core/files/util/notifications/fcm-credentials-valid-json.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "example-project",
+  "private_key_id": "a123456789abcdef",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIE...\n...\n-----END PRIVATE KEY-----\n",
+  "client_email": "service-account@example.iam.gserviceaccount.com",
+  "client_id": "0123456789",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/service-account%40example.iam.gserviceaccount.com"
+}

--- a/tests/core/files/util/notifications/not-valid-json.txt
+++ b/tests/core/files/util/notifications/not-valid-json.txt
@@ -1,0 +1,4 @@
+{
+  type: service_account,
+  project_id: example-project
+}


### PR DESCRIPTION
## Description

- Adds ability to configure FCM credentials via a JSON string as an alternative to configuring with a file.

## Motivation and Context

Support configuration via AWS parameter store secret for ECS instances as part of [PP-41](https://ebce-lyrasis.atlassian.net/browse/PP-41).

## How Has This Been Tested?

- Manually verified that dictionary could be used to configure `firebase_admin` credentials.
- Updated tests for new test cases.
- CI passes for the PR's branch.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-41]: https://ebce-lyrasis.atlassian.net/browse/PP-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ