### PR TITLE
Fix flaky test - TestIndividualAdmins.test_individual_admins_get

### DIFF
--- a/tests/api/admin/controller/test_individual_admins.py
+++ b/tests/api/admin/controller/test_individual_admins.py
@@ -43,60 +43,47 @@ class TestIndividualAdmins:
                 settings_ctrl_fixture.manager.admin_individual_admin_settings_controller.process_get()
             )
             admins = response.get("individualAdmins")
-            assert sorted(
-                [
+
+            expected = {
+                "admin1@nypl.org": [{"role": AdminRole.SYSTEM_ADMIN}],
+                "admin2@nypl.org": [
                     {
-                        "email": "admin1@nypl.org",
-                        "roles": [{"role": AdminRole.SYSTEM_ADMIN}],
+                        "role": AdminRole.LIBRARY_MANAGER,
+                        "library": db.default_library().short_name,
                     },
-                    {
-                        "email": "admin2@nypl.org",
-                        "roles": [
-                            {
-                                "role": AdminRole.LIBRARY_MANAGER,
-                                "library": db.default_library().short_name,
-                            },
-                            {"role": AdminRole.SITEWIDE_LIBRARIAN},
-                        ],
-                    },
-                    {
-                        "email": "admin3@nypl.org",
-                        "roles": [
-                            {
-                                "role": AdminRole.LIBRARIAN,
-                                "library": db.default_library().short_name,
-                            }
-                        ],
-                    },
-                    {
-                        "email": "admin4@l2.org",
-                        "roles": [
-                            {
-                                "role": AdminRole.LIBRARY_MANAGER,
-                                "library": library2.short_name,
-                            }
-                        ],
-                    },
-                    {
-                        "email": "admin5@l2.org",
-                        "roles": [
-                            {
-                                "role": AdminRole.LIBRARIAN,
-                                "library": library2.short_name,
-                            }
-                        ],
-                    },
-                    {
-                        "email": "admin6@l2.org",
-                        "roles": [
-                            {
-                                "role": AdminRole.SITEWIDE_LIBRARY_MANAGER,
-                            }
-                        ],
-                    },
+                    {"role": AdminRole.SITEWIDE_LIBRARIAN},
                 ],
-                key=lambda x: x["email"],
-            ) == sorted(admins, key=lambda x: x["email"])
+                "admin3@nypl.org": [
+                    {
+                        "role": AdminRole.LIBRARIAN,
+                        "library": db.default_library().short_name,
+                    }
+                ],
+                "admin4@l2.org": [
+                    {
+                        "role": AdminRole.LIBRARY_MANAGER,
+                        "library": library2.short_name,
+                    }
+                ],
+                "admin5@l2.org": [
+                    {
+                        "role": AdminRole.LIBRARIAN,
+                        "library": library2.short_name,
+                    }
+                ],
+                "admin6@l2.org": [
+                    {
+                        "role": AdminRole.SITEWIDE_LIBRARY_MANAGER,
+                    }
+                ],
+            }
+
+            assert len(admins) == len(expected)
+            for admin in admins:
+                assert admin["email"] in expected
+                assert sorted(admin["roles"], key=lambda x: x["role"]) == sorted(
+                    expected[admin["email"]], key=lambda x: x["role"]
+                )
 
         with settings_ctrl_fixture.request_context_with_admin("/", admin=admin2):
             # A sitewide librarian or library manager can also see all admins' roles.


### PR DESCRIPTION
## Description

Seems like its just a flaky test, since its depending on the ordering of `roles`, and the order there isn't guaranteed.

## Motivation and Context

Saw this test fail in CI here: 
https://github.com/ThePalaceProject/circulation/actions/runs/5269226097/jobs/9527046094?pr=1197#step:8:427

Trying to make sure we clean these up as we see them, so we have less test failures happening.

## How Has This Been Tested?

Ran tests locally and in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
