### PR TITLE
Update poetry version to match what dependabot is using

### DIFF
--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: "Version of poetry to install"
     required: false
-    default: "1.3.2"
+    default: "1.5.1"
 
 outputs:
   version:

--- a/docker/Dockerfile.baseimage
+++ b/docker/Dockerfile.baseimage
@@ -19,8 +19,6 @@ RUN go get -v github.com/readium/readium-lcp-server/lcpencrypt
 # https://github.com/phusion/baseimage-docker
 FROM phusion/baseimage:focal-1.2.0 As baseimage
 
-ARG POETRY_VERSION=1.3.2
-
 # Copy LCP binary from builder into image.
 COPY --from=lcp-builder /go/bin/lcpencrypt /go/bin/lcpencrypt
 
@@ -28,6 +26,8 @@ COPY --from=lcp-builder /go/bin/lcpencrypt /go/bin/lcpencrypt
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends -o Dpkg::Options::="--force-confold" && \
     /bd_build/cleanup.sh
+
+ARG POETRY_VERSION=1.5.1
 
 # Install required packages including python, pip, compiliers and libraries needed
 # to build the python wheels we need and poetry.


### PR DESCRIPTION
## Description

Dependabot [bumped the version](https://github.com/dependabot/dependabot-core/pull/7350) of poetry they use up to 1.5.1. 

## Motivation and Context

We are seeing large diffs in the lock file, since 1.5.1 drop some keys in the lock file. Good to keep our version of Poetry roughly aligned with what Dependabot is using.

## How Has This Been Tested?

Running CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
