### PR TITLE
Adds open_access column to the local exporter csv.

### DIFF
--- a/api/local_analytics_exporter.py
+++ b/api/local_analytics_exporter.py
@@ -48,6 +48,7 @@ class LocalAnalyticsExporter:
             "library_name",
             "medium",
             "distributor",
+            "open_access",
         ]
         output = BytesIO()
         writer = csv.writer(output, encoding="utf-8")
@@ -117,6 +118,7 @@ class LocalAnalyticsExporter:
                     Library.name.label("library_name"),
                     Edition.medium,
                     DataSource.name.label("distributor"),
+                    LicensePool.open_access,
                 ],
             )
             .select_from(
@@ -215,6 +217,7 @@ class LocalAnalyticsExporter:
                 events.library_name,
                 events.medium,
                 events.distributor,
+                case({True: "true", False: "false"}, value=events.open_access),
             ]
         ).select_from(events_alias)
         return query

--- a/tests/api/test_local_analytics_exporter.py
+++ b/tests/api/test_local_analytics_exporter.py
@@ -13,12 +13,15 @@ class TestLocalAnalyticsExporter:
         exporter = LocalAnalyticsExporter()
         c1 = db.collection(name="c1")
         c2 = db.collection(name="c2")
+        open_access = True
         w1 = db.work(with_open_access_download=True)
         w2 = db.work(with_open_access_download=True)
         [lp1] = w1.license_pools
         [lp2] = w2.license_pools
         lp1.collection = c1
         lp2.collection = c2
+        lp1.open_access = True
+        lp2.open_access = False
 
         edition1 = w1.presentation_edition
         edition1.publisher = "A publisher"
@@ -106,9 +109,10 @@ class TestLocalAnalyticsExporter:
             "",
             edition1.medium,
             lp1.data_source.name,
+            "true",
         ]
 
-        expected_column_count = 19
+        expected_column_count = 20
         for row in rows:
             assert expected_column_count == len(row)
             assert constant == row[2:]
@@ -151,6 +155,7 @@ class TestLocalAnalyticsExporter:
             "",
             edition1.medium,
             lp2.data_source.name,
+            "false",
         ] == rows[-1][1:]
 
         output = exporter.export(db.session, today, today)


### PR DESCRIPTION
Resolves:  https://ebce-lyrasis.atlassian.net/browse/PP-89

## Description

Adds the open_access column to the local analytics csv report.  The values are render in the csv as "true" or "false".
## Motivation and Context

https://ebce-lyrasis.atlassian.net/browse/PP-89

## How Has This Been Tested?
Covered by unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
