### PR TITLE
Data migration edge case fix b88367

### DIFF
--- a/alembic/versions/20230531_b883671b7bc5_add_the_license_type_goal.py
+++ b/alembic/versions/20230531_b883671b7bc5_add_the_license_type_goal.py
@@ -6,6 +6,7 @@ Create Date: 2023-05-31 10:50:32.045821+00:00
 
 """
 import sqlalchemy as sa
+from sqlalchemy.exc import ProgrammingError
 
 from alembic import op
 
@@ -20,26 +21,45 @@ def upgrade() -> None:
     # We need to use an autocommit blcok since the next migration is going to use
     # the new enum value immediately, so we must ensure the value is commited
     # before the next migration runs
+    # Additionally, since we are autocommiting this change we MUST ensure we
+    # assume the schemas may already exist while upgrading to this change.
+    # This happens incase the data migration in 0af587 fails and an automatic rollback occurs.
+    # In which case, due to the autocommit, these schema changes will not get rolled back
     with op.get_context().autocommit_block():
         op.execute(f"ALTER TYPE goals ADD VALUE IF NOT EXISTS 'LICENSE_GOAL'")
-        op.add_column(
-            "collections",
-            sa.Column("integration_configuration_id", sa.Integer(), nullable=True),
-        )
-        op.create_index(
-            op.f("ix_collections_integration_configuration_id"),
-            "collections",
-            ["integration_configuration_id"],
-            unique=True,
-        )
-        op.create_foreign_key(
-            None,
-            "collections",
-            "integration_configurations",
-            ["integration_configuration_id"],
-            ["id"],
-            ondelete="SET NULL",
-        )
+
+        try:
+            op.add_column(
+                "collections",
+                sa.Column("integration_configuration_id", sa.Integer(), nullable=True),
+            )
+        except ProgrammingError as ex:
+            if "DuplicateColumn" not in str(ex):
+                raise
+
+        try:
+            op.create_index(
+                op.f("ix_collections_integration_configuration_id"),
+                "collections",
+                ["integration_configuration_id"],
+                unique=True,
+            )
+        except ProgrammingError as ex:
+            if "DuplicateTable" not in str(ex):
+                raise
+
+        try:
+            op.create_foreign_key(
+                None,
+                "collections",
+                "integration_configurations",
+                ["integration_configuration_id"],
+                ["id"],
+                ondelete="SET NULL",
+            )
+        except ProgrammingError as ex:
+            if "DuplicateColumn" not in str(ex):
+                raise
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Description
Since we are autocommiting this change we MUST ensure we
assume the schemas may already exist while upgrading to this change.
This happens incase the data migration in 0af587 fails and an automatic rollback occurs.
In which case, due to the autocommit, these schema changes will not get rolled back
<!--- Describe your changes -->

## Motivation and Context
data migration failures on cerberus caused the deployment to fail. This is the failsafe.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Upgraded to and including b88367, then stamped the version just below it.
Re-ran the upgrade to b88367, no failures.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
