### PR TITLE
PP-57 Unlimited loan for unlimited access

### DIFF
--- a/core/opds.py
+++ b/core/opds.py
@@ -1773,7 +1773,6 @@ class AcquisitionFeed(OPDSFeed):
                 collection.default_loan_period(obj.library or obj.integration_client)
             )
         if loan:
-            print("In loan tags", loan, loan.license_pool)
             status = "available"
             since = loan.start
             if not loan.license_pool.unlimited_access:

--- a/core/opds.py
+++ b/core/opds.py
@@ -1773,9 +1773,11 @@ class AcquisitionFeed(OPDSFeed):
                 collection.default_loan_period(obj.library or obj.integration_client)
             )
         if loan:
+            print("In loan tags", loan, loan.license_pool)
             status = "available"
             since = loan.start
-            until = loan.until(default_loan_period)
+            if not loan.license_pool.unlimited_access:
+                until = loan.until(default_loan_period)
         elif hold:
             if not license_pool.open_access:
                 default_reservation_period = datetime.timedelta(

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -1998,6 +1998,18 @@ class TestAcquisitionFeed:
         assert ("holds" in tag.attrib) == False
         assert ("copies" in tag.attrib) == False
 
+    def test_unlimited_access_pool_loan(self, db: DatabaseTransactionFixture):
+        patron = db.patron()
+        feed = AcquisitionFeed(db.session, "title", "url", [], annotator=None)
+        work = db.work(unlimited_access=True, with_license_pool=True)
+        pool = work.active_license_pool()
+        loan, _ = pool.loan_to(patron)
+        tags: List[ET.Element] = feed.license_tags(pool, loan, None)
+
+        [tag] = tags
+        assert "since" in tag.attrib
+        assert "until" not in tag.attrib
+
     def test_license_tags_show_self_hosted_books(self, db: DatabaseTransactionFixture):
 
         # Arrange


### PR DESCRIPTION
## Description
For the AcquisitionFeed, in case of an unlimited access pool, we don't enforce an end date to a Loan anymore.
The LoanReaperMonitor will no longer reap unlimited access loans

<!--- Describe your changes -->

## Motivation and Context
Unlimited access loans (e.g. from BiblioBoard) have no defined end date, but the CM currently imposes a default 21 day loan period for such loans (see related issue). As a patron, I don’t want to be forced to return such loans when their use is unlimited.
[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-57)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated to match the expected behaviour.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
