### PR TITLE
PP-62 Facets with distributors and collections

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1066,6 +1066,7 @@ class OPDSFeedController(CirculationManagerController):
         )
 
         annotator = self.manager.annotator(lane, facets=facets)
+        max_age = flask.request.args.get("max_age")
         return feed_class.page(
             _db=self._db,
             title=lane.display_name,
@@ -1075,6 +1076,7 @@ class OPDSFeedController(CirculationManagerController):
             facets=facets,
             pagination=pagination,
             search_engine=search_engine,
+            max_age=int(max_age) if max_age else None,
         )
 
     def navigation(self, lane_identifier):

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1364,6 +1364,7 @@ class CrawlableFacets(Facets):
         Facets.AVAILABILITY_FACET_GROUP_NAME: Facets.AVAILABLE_ALL,
         Facets.COLLECTION_FACET_GROUP_NAME: Facets.COLLECTION_FULL,
         Facets.DISTRIBUTOR_FACETS_GROUP_NAME: Facets.DISTRIBUTOR_ALL,
+        Facets.COLLECTION_NAME_FACETS_GROUP_NAME: Facets.COLLECTION_NAME_ALL,
     }
 
     @classmethod

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1363,6 +1363,7 @@ class CrawlableFacets(Facets):
         Facets.ORDER_FACET_GROUP_NAME: Facets.ORDER_LAST_UPDATE,
         Facets.AVAILABILITY_FACET_GROUP_NAME: Facets.AVAILABLE_ALL,
         Facets.COLLECTION_FACET_GROUP_NAME: Facets.COLLECTION_FULL,
+        Facets.DISTRIBUTOR_FACETS_GROUP_NAME: Facets.DISTRIBUTOR_ALL,
     }
 
     @classmethod

--- a/api/opds2.py
+++ b/api/opds2.py
@@ -8,6 +8,7 @@ from uritemplate import URITemplate
 
 from api.circulation import CirculationFulfillmentPostProcessor, FulfillmentInfo
 from api.circulation_exceptions import CannotFulfill
+from core.lane import Facets
 from core.model import ExternalIntegration
 from core.model.edition import Edition
 from core.model.identifier import Identifier
@@ -48,6 +49,16 @@ class OPDS2PublicationsAnnotator(OPDS2Annotator):
             ),
             "rel": "self",
         }
+
+    @classmethod
+    def facet_url(cls, facets: Facets) -> str:
+        name = facets.library.short_name if facets.library else None
+        return url_for(
+            "opds2_publications",
+            _external=True,
+            library_short_name=name,
+            **dict(facets.items()),
+        )
 
 
 class OPDS2NavigationsAnnotator(OPDS2Annotator):

--- a/core/facets.py
+++ b/core/facets.py
@@ -63,6 +63,9 @@ class FacetConstants:
     DISTRIBUTOR_FACETS_GROUP_NAME = "distributor"
     DISTRIBUTOR_ALL = "All"
 
+    COLLECTION_NAME_FACETS_GROUP_NAME = "collectionName"
+    COLLECTION_NAME_ALL = "All"
+
     FACETS_BY_GROUP = {
         COLLECTION_FACET_GROUP_NAME: COLLECTION_FACETS,
         AVAILABILITY_FACET_GROUP_NAME: AVAILABILITY_FACETS,
@@ -74,6 +77,7 @@ class FacetConstants:
         AVAILABILITY_FACET_GROUP_NAME: _("Availability"),
         COLLECTION_FACET_GROUP_NAME: _("Collection"),
         DISTRIBUTOR_FACETS_GROUP_NAME: _("Distributor"),
+        COLLECTION_NAME_FACETS_GROUP_NAME: _("Collection Name"),
     }
 
     GROUP_DESCRIPTIONS = {
@@ -81,6 +85,9 @@ class FacetConstants:
         AVAILABILITY_FACET_GROUP_NAME: _("Allow patrons to filter availability to"),
         COLLECTION_FACET_GROUP_NAME: _("Allow patrons to filter collection to"),
         DISTRIBUTOR_FACETS_GROUP_NAME: _("Allow patrons to filter by distributor"),
+        COLLECTION_NAME_FACETS_GROUP_NAME: _(
+            "Allow patrons to filter by collection name"
+        ),
     }
 
     FACET_DISPLAY_TITLES = {
@@ -100,6 +107,7 @@ class FacetConstants:
     # For titles generated based on some runtime value
     FACET_DISPLAY_TITLES_DYNAMIC = {
         DISTRIBUTOR_FACETS_GROUP_NAME: lambda facet: facet.distributor,
+        COLLECTION_NAME_FACETS_GROUP_NAME: lambda facet: facet.collection_name,
     }
 
     # Unless a library offers an alternate configuration, patrons will
@@ -113,6 +121,7 @@ class FacetConstants:
         ],
         COLLECTION_FACET_GROUP_NAME: [COLLECTION_FULL, COLLECTION_FEATURED],
         DISTRIBUTOR_FACETS_GROUP_NAME: [DISTRIBUTOR_ALL],
+        COLLECTION_NAME_FACETS_GROUP_NAME: [COLLECTION_NAME_ALL],
     }
 
     # Unless a library offers an alternate configuration, these
@@ -122,6 +131,7 @@ class FacetConstants:
         AVAILABILITY_FACET_GROUP_NAME: AVAILABLE_ALL,
         COLLECTION_FACET_GROUP_NAME: COLLECTION_FULL,
         DISTRIBUTOR_FACETS_GROUP_NAME: DISTRIBUTOR_ALL,
+        COLLECTION_NAME_FACETS_GROUP_NAME: COLLECTION_NAME_ALL,
     }
 
     SORT_ORDER_TO_OPENSEARCH_FIELD_NAME = {

--- a/core/facets.py
+++ b/core/facets.py
@@ -60,6 +60,9 @@ class FacetConstants:
     # these dates should be ordered descending by default (new->old).
     ORDER_DESCENDING_BY_DEFAULT = [ORDER_ADDED_TO_COLLECTION, ORDER_LAST_UPDATE]
 
+    DISTRIBUTOR_FACETS_GROUP_NAME = "distributor"
+    DISTRIBUTOR_ALL = "All"
+
     FACETS_BY_GROUP = {
         COLLECTION_FACET_GROUP_NAME: COLLECTION_FACETS,
         AVAILABILITY_FACET_GROUP_NAME: AVAILABILITY_FACETS,
@@ -70,12 +73,14 @@ class FacetConstants:
         ORDER_FACET_GROUP_NAME: _("Sort by"),
         AVAILABILITY_FACET_GROUP_NAME: _("Availability"),
         COLLECTION_FACET_GROUP_NAME: _("Collection"),
+        DISTRIBUTOR_FACETS_GROUP_NAME: _("Distributor"),
     }
 
     GROUP_DESCRIPTIONS = {
         ORDER_FACET_GROUP_NAME: _("Allow patrons to sort by"),
         AVAILABILITY_FACET_GROUP_NAME: _("Allow patrons to filter availability to"),
         COLLECTION_FACET_GROUP_NAME: _("Allow patrons to filter collection to"),
+        DISTRIBUTOR_FACETS_GROUP_NAME: _("Allow patrons to filter by distributor"),
     }
 
     FACET_DISPLAY_TITLES = {
@@ -92,6 +97,11 @@ class FacetConstants:
         COLLECTION_FEATURED: _("Popular Books"),
     }
 
+    # For titles generated based on some runtime value
+    FACET_DISPLAY_TITLES_DYNAMIC = {
+        DISTRIBUTOR_FACETS_GROUP_NAME: lambda facet: facet.distributor,
+    }
+
     # Unless a library offers an alternate configuration, patrons will
     # see these facet groups.
     DEFAULT_ENABLED_FACETS = {
@@ -102,6 +112,7 @@ class FacetConstants:
             AVAILABLE_OPEN_ACCESS,
         ],
         COLLECTION_FACET_GROUP_NAME: [COLLECTION_FULL, COLLECTION_FEATURED],
+        DISTRIBUTOR_FACETS_GROUP_NAME: [DISTRIBUTOR_ALL],
     }
 
     # Unless a library offers an alternate configuration, these
@@ -110,6 +121,7 @@ class FacetConstants:
         ORDER_FACET_GROUP_NAME: ORDER_AUTHOR,
         AVAILABILITY_FACET_GROUP_NAME: AVAILABLE_ALL,
         COLLECTION_FACET_GROUP_NAME: COLLECTION_FULL,
+        DISTRIBUTOR_FACETS_GROUP_NAME: DISTRIBUTOR_ALL,
     }
 
     SORT_ORDER_TO_OPENSEARCH_FIELD_NAME = {

--- a/core/model/library.py
+++ b/core/model/library.py
@@ -313,6 +313,13 @@ class Library(Base, HasSessionCache):
 
     def enabled_facets(self, group_name):
         """Look up the enabled facets for a given facet group."""
+        if group_name == FacetConstants.DISTRIBUTOR_FACETS_GROUP_NAME:
+            enabled = []
+            for collection in self.collections:
+                if collection.data_source and collection.data_source.name:
+                    enabled.append(collection.data_source.name)
+            return list(set(enabled))
+
         setting = self.enabled_facets_setting(group_name)
         value = None
 

--- a/core/model/library.py
+++ b/core/model/library.py
@@ -320,6 +320,12 @@ class Library(Base, HasSessionCache):
                     enabled.append(collection.data_source.name)
             return list(set(enabled))
 
+        if group_name == FacetConstants.COLLECTION_NAME_FACETS_GROUP_NAME:
+            enabled = []
+            for collection in self.collections:
+                enabled.append(collection.name)
+            return enabled
+
         setting = self.enabled_facets_setting(group_name)
         value = None
 

--- a/core/opds.py
+++ b/core/opds.py
@@ -583,7 +583,6 @@ class VerboseAnnotator(Annotator):
 
 
 class AcquisitionFeed(OPDSFeed):
-
     FACET_REL = "http://opds-spec.org/facet"
 
     @classmethod
@@ -1230,6 +1229,9 @@ class AcquisitionFeed(OPDSFeed):
                 continue
             group_title = Facets.GROUP_DISPLAY_TITLES.get(group)
             facet_title = Facets.FACET_DISPLAY_TITLES.get(value)
+            if not facet_title:
+                display_lambda = Facets.FACET_DISPLAY_TITLES_DYNAMIC.get(group)
+                facet_title = display_lambda(new_facets) if display_lambda else None
             if not (group_title and facet_title):
                 # This facet group or facet, is not recognized by the
                 # system. It may be left over from an earlier version,
@@ -1977,7 +1979,6 @@ class NavigationFeed(OPDSFeed):
 
     @classmethod
     def _generate_navigation(cls, _db, title, url, worklist, annotator):
-
         feed = NavigationFeed(title, url)
 
         if not worklist.children:

--- a/scripts.py
+++ b/scripts.py
@@ -469,6 +469,7 @@ class CacheFacetListsPerLane(CacheRepresentationPerLane):
                             library=library,
                             collection=collection,
                             availability=availability,
+                            distributor=None,  # All distributors always
                             entrypoint=entrypoint,
                             entrypoint_is_default=(
                                 top_level

--- a/scripts.py
+++ b/scripts.py
@@ -470,6 +470,7 @@ class CacheFacetListsPerLane(CacheRepresentationPerLane):
                             collection=collection,
                             availability=availability,
                             distributor=None,  # All distributors always
+                            collection_name=None,  # All collections
                             entrypoint=entrypoint,
                             entrypoint_is_default=(
                                 top_level

--- a/tests/api/test_controller_opdsfeed.py
+++ b/tests/api/test_controller_opdsfeed.py
@@ -172,7 +172,8 @@ class TestOPDSFeedController:
 
         sort_key = ["sort", "pagination", "key"]
         with circulation_fixture.request_context_with_library(
-            "/?entrypoint=Audio&size=36&key=%s&order=added" % (json.dumps(sort_key))
+            "/?entrypoint=Audio&size=36&key=%s&order=added&max_age=10"
+            % (json.dumps(sort_key))
         ):
             response = circulation_fixture.manager.opds_feeds.feed(
                 circulation_fixture.english_adult_fiction.id, feed_class=Mock
@@ -223,6 +224,9 @@ class TestOPDSFeedController:
         assert circulation_fixture.manager.external_search == kwargs.pop(
             "search_engine"
         )
+
+        # max age
+        assert 10 == kwargs.pop("max_age")
 
         # No other arguments were passed into page().
         assert {} == kwargs

--- a/tests/api/test_controller_work.py
+++ b/tests/api/test_controller_work.py
@@ -139,7 +139,7 @@ class TestWorkController:
         facet_links = [
             link for link in links if link["rel"] == "http://opds-spec.org/facet"
         ]
-        assert 8 == len(facet_links)
+        assert 10 == len(facet_links)
 
         # The feed was cached.
         cached = work_fixture.db.session.query(CachedFeed).one()
@@ -906,7 +906,7 @@ class TestWorkController:
         facet_links = [
             link for link in links if link["rel"] == "http://opds-spec.org/facet"
         ]
-        assert 9 == len(facet_links)
+        assert 11 == len(facet_links)
 
         # The facet link we care most about is the default sort order,
         # put into place by SeriesFacets.

--- a/tests/api/test_opds2.py
+++ b/tests/api/test_opds2.py
@@ -1,7 +1,7 @@
 import io
 import json
 from unittest.mock import patch
-from urllib.parse import quote
+from urllib.parse import parse_qs, quote, urlparse
 
 import pytest
 from requests import Response
@@ -116,6 +116,26 @@ class TestOPDS2PublicationAnnotator:
                 )
                 == link["href"]
             )
+
+    def test_facet_url(
+        self, opds2_publication_annotator: OPDS2PublicationAnnotatorFixture
+    ):
+        db = opds2_publication_annotator.db
+        facet = Facets(
+            db.default_library(), Facets.COLLECTION_FEATURED, None, None, None, None
+        )
+        with app.test_request_context("/"):
+            link = opds2_publication_annotator.annotator.facet_url(facet)
+        parsed = urlparse(link)
+        assert parsed.hostname == "localhost"
+        assert parsed.path == f"/{db.default_library().short_name}/opds2/publications"
+        assert parse_qs(parsed.query) == dict(
+            order=["author"],
+            available=["all"],
+            collection=["featured"],
+            distributor=["All"],
+            collectionName=["All"],
+        )
 
 
 class OPDS2NavigationAnnotatorFixture:

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -1163,7 +1163,11 @@ class TestExternalSearchWithWorks:
             """
             pagination = SortKeyPagination(size=2)
             facets = Facets(
-                transaction.default_library(), None, None, order=Facets.ORDER_TITLE
+                transaction.default_library(),
+                None,
+                None,
+                order=Facets.ORDER_TITLE,
+                distributor=None,
             )
             pages = []
             while pagination:
@@ -1367,6 +1371,7 @@ class TestFacetFilters:
                 availability,
                 collection,
                 order=Facets.ORDER_TITLE,
+                distributor=None,
             )
             fixture.expect_results(works, None, Filter(facets=facets), ordered=False)
 
@@ -1642,6 +1647,7 @@ class TestSearchOrder:
                 Facets.COLLECTION_FULL,
                 Facets.AVAILABLE_ALL,
                 order=sort_field,
+                distributor=None,
                 order_ascending=True,
             )
             expect(order, None, Filter(facets=facets, **filter_kwargs))
@@ -2723,7 +2729,7 @@ class TestQuery:
             return built
 
         # When using the 'featured' collection...
-        built = from_facets(Facets.COLLECTION_FEATURED, None, None)
+        built = from_facets(Facets.COLLECTION_FEATURED, None, None, None)
 
         # There is no nested filter.
         assert [] == built.nested_filter_calls
@@ -2738,7 +2744,9 @@ class TestQuery:
         assert Q("bool", must=[quality_range], must_not=[RESEARCH]) == quality_filter
 
         # When using the AVAILABLE_OPEN_ACCESS availability restriction...
-        built = from_facets(Facets.COLLECTION_FULL, Facets.AVAILABLE_OPEN_ACCESS, None)
+        built = from_facets(
+            Facets.COLLECTION_FULL, Facets.AVAILABLE_OPEN_ACCESS, None, None
+        )
 
         # An additional nested filter is applied.
         [available_now] = built.nested_filter_calls
@@ -2751,7 +2759,7 @@ class TestQuery:
         assert nested_filter.to_dict() == {"bool": {"filter": [open_access]}}
 
         # When using the AVAILABLE_NOW restriction...
-        built = from_facets(Facets.COLLECTION_FULL, Facets.AVAILABLE_NOW, None)
+        built = from_facets(Facets.COLLECTION_FULL, Facets.AVAILABLE_NOW, None, None)
 
         # An additional nested filter is applied.
         [available_now] = built.nested_filter_calls
@@ -2776,7 +2784,9 @@ class TestQuery:
         }
 
         # When using the AVAILABLE_NOT_NOW restriction...
-        built = from_facets(Facets.COLLECTION_FULL, Facets.AVAILABLE_NOT_NOW, None)
+        built = from_facets(
+            Facets.COLLECTION_FULL, Facets.AVAILABLE_NOT_NOW, None, None
+        )
 
         # An additional nested filter is applied.
         [not_available_now] = built.nested_filter_calls
@@ -2797,6 +2807,17 @@ class TestQuery:
             }
         }
 
+        # Distributor builds
+        _id = DataSource.lookup(db.session, DataSource.OVERDRIVE).id
+        built = from_facets(
+            Facets.COLLECTION_FULL, Facets.AVAILABLE_ALL, None, DataSource.OVERDRIVE
+        )
+        [datasource_only] = built.nested_filter_calls
+        nested_filter = datasource_only["query"]
+        assert nested_filter.to_dict() == {
+            "bool": {"filter": [{"terms": {"licensepools.data_source_id": [_id]}}]}
+        }
+
         # If the Filter specifies script fields, those fields are
         # added to the Query through a call to script_fields()
         script_fields = dict(field1="Definition1", field2="Definition2")
@@ -2809,7 +2830,11 @@ class TestQuery:
         # used to convert it to appropriate Opensearch syntax, and
         # the MockSearch object is modified appropriately.
         built = from_facets(
-            None, None, order=Facets.ORDER_AUTHOR, order_ascending=False
+            None,
+            None,
+            order=Facets.ORDER_AUTHOR,
+            distributor=None,
+            order_ascending=False,
         )
 
         # We asked for sorting by author, and that's the primary
@@ -2846,7 +2871,6 @@ class TestQuery:
         # to find the most likely hypothesis for any given book.
 
         class Mock(Query):
-
             _match_phrase_called_with = []
             _boosts = {}
             _filters = {}

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -762,13 +762,13 @@ class TestOPDS:
         def link_for_facets(facets):
             return [x for x in facet_links if facets.query_string in x["href"]]
 
-        facets = Facets(library, None, None, None, None)
+        facets = Facets(library, None, None, None, None, None)
         for i1, i2, new_facets, selected in facets.facet_groups:
             links = link_for_facets(new_facets)
             if selected:
                 # This facet set is already selected, so it should
                 # show up three times--once for every facet group.
-                assert 3 == len(links)
+                assert 4 == len(links)
             else:
                 # This facet set is not selected, so it should have one
                 # transition link.
@@ -2946,9 +2946,7 @@ class TestEntrypointLinkInsertion:
         # The make_link function that was passed in calls
         # TestAnnotator.feed_url() when passed an EntryPoint. The
         # Facets object's other facet groups are propagated in this URL.
-        first_page_url = (
-            "http://wl/?available=all&collection=full&entrypoint=Book&order=author"
-        )
+        first_page_url = "http://wl/?available=all&collection=full&collectionName=All&distributor=All&entrypoint=Book&order=author"
         assert first_page_url == make_link(EbooksEntryPoint)
 
         # Pagination information is not propagated through entry point links

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -762,7 +762,7 @@ class TestOPDS:
         def link_for_facets(facets):
             return [x for x in facet_links if facets.query_string in x["href"]]
 
-        facets = Facets(library, None, None, None)
+        facets = Facets(library, None, None, None, None)
         for i1, i2, new_facets, selected in facets.facet_groups:
             links = link_for_facets(new_facets)
             if selected:


### PR DESCRIPTION
## Description
Facets with distributor filtering on `Datasource.name` and collectioName filtering on `Collection.name`.
The distributor and collectionName facet options show up as part of the feed as well.
Added the facets metadata to the OPDS2 publications feed as per the [OPDS2 Spec](https://drafts.opds.io/opds-2.0.html#14-facets).

The group name `collectionName` is awfully similar to the existing `collection` group name, but I couldn't quite think of anything better. I am open to name changes that are better suited and less ambiguous.

Example OPDS1 Facet links
```
<link href="http://localhost:6500/localtest/feed/?entrypoint=Book&amp;order=author&amp;available=all&amp;collection=full&amp;distributor=ProQuest&amp;collectionName=All" title="ProQuest" rel="http://opds-spec.org/facet" opds:facetGroup="Distributor"/>
<link href="http://localhost:6500/localtest/feed/?entrypoint=Book&amp;order=author&amp;available=all&amp;collection=full&amp;distributor=Axis+360&amp;collectionName=All" title="Axis 360" rel="http://opds-spec.org/facet" opds:facetGroup="Distributor"/>
<link href="http://localhost:6500/localtest/feed/?entrypoint=Book&amp;order=author&amp;available=all&amp;collection=full&amp;distributor=All&amp;collectionName=All" title="All" rel="http://opds-spec.org/facet" opds:facetGroup="Collection Name" opds:activeFacet="true"/>
<link href="http://localhost:6500/localtest/feed/?entrypoint=Book&amp;order=author&amp;available=all&amp;collection=full&amp;distributor=All&amp;collectionName=TEST+biblioboard" title="TEST biblioboard" rel="http://opds-spec.org/facet" opds:facetGroup="Collection Name"/>
<link href="http://localhost:6500/localtest/feed/?entrypoint=Book&amp;order=author&amp;available=all&amp;collection=full&amp;distributor=All&amp;collectionName=PQ+Sample+Auth+Token+Feed" title="PQ Sample Auth Token Feed" rel="http://opds-spec.org/facet" opds:facetGroup="Collection Name"/>
```

Example OPDS2 Facet metadata
```
{
    "metadata": {
        "title": "Distributor"
    },
    "links": [
        {
            "href": "http://localhost:6500/localtest/opds2/publications?entrypoint=Book&max_age=0&order=author&available=all&collection=full&distributor=All&collectionName=All",
            "title": "All",
            "type": "application/opds+json",
            "rel": "self"
        },
        {
            "href": "http://localhost:6500/localtest/opds2/publications?entrypoint=Book&max_age=0&order=author&available=all&collection=full&distributor=Palace+Marketplace&collectionName=All",
            "title": "Palace Marketplace",
            "type": "application/opds+json"
        },
        {
            "href": "http://localhost:6500/localtest/opds2/publications?entrypoint=Book&max_age=0&order=author&available=all&collection=full&distributor=ELDR&collectionName=All",
            "title": "ELDR",
            "type": "application/opds+json"
        }
        ...
```

<!--- Describe your changes -->

## Motivation and Context
The Current Palace Manager used to provide an OPDS 1 crawable feed. The New feed is in OPDS 2. It is fine for crawling in its entirety. However, for use by discovery systems it needs to support more targeted harvesting such as by distributor or collection name.

[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-62)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested the OPDS1.2 "page" and 2.0 "publications" feed.
Unit tests have been updated to match the expected behaviour.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
