### PR TITLE
PP-134 Search_type and language facets links

### DIFF
--- a/core/lane.py
+++ b/core/lane.py
@@ -967,6 +967,7 @@ class SearchFacets(Facets):
         self.media_argument = media
 
         self.languages = self._ensure_list(languages)
+        self._language_from_query = kwargs.pop("language_from_query", False)
 
     @classmethod
     def default_facet(cls, ignore, group_name):
@@ -1016,6 +1017,7 @@ class SearchFacets(Facets):
         # the client's Accept-Language header.
         language_header = get_header("Accept-Language")
         languages = get_argument("language") or None
+        extra["language_from_query"] = languages is not None
         if not languages:
             if language_header:
                 languages = parse_accept_language(language_header)
@@ -1023,6 +1025,7 @@ class SearchFacets(Facets):
                 languages = list(map(LanguageCodes.iso_639_2_for_locale, languages))
                 languages = [l for l in languages if l]
             languages = languages or None
+        extra["languages"] = languages
 
         # The client can request a minimum score for search results.
         min_score = get_argument("min_score", None)
@@ -1041,12 +1044,6 @@ class SearchFacets(Facets):
         if media not in EditionConstants.KNOWN_MEDIA:
             media = None
         extra["media"] = media
-        languageQuery = get_argument("language", None)
-        # Currently, the only value passed to the language query from the client is
-        # `all`. This will remove the default browser's Accept-Language header value
-        # in the search request.
-        if languageQuery != "all":
-            extra["languages"] = languages
 
         search_type = get_argument("search_type")
         if search_type:
@@ -1105,11 +1102,15 @@ class SearchFacets(Facets):
         # We don't rely solely on the SearchFacets languages because a
         # lot of people read in languages other than the one they've
         # set for their device UI.
-        all_languages = set()
-        for language_list in (self.languages, filter.languages):
-            for language in self._ensure_list(language_list) or []:
-                all_languages.add(language)
-        filter.languages = sorted(all_languages) or None
+        #
+        # We should only modify the langauges when we've not been asked to
+        # display "all" the languages
+        if self.languages != ["all"]:
+            all_languages = set()
+            for language_list in (self.languages, filter.languages):
+                for language in self._ensure_list(language_list) or []:
+                    all_languages.add(language)
+            filter.languages = sorted(all_languages) or None
 
     def items(self):
         """Yields a 2-tuple for every active facet setting.
@@ -1123,6 +1124,13 @@ class SearchFacets(Facets):
 
         if self.min_score is not None:
             yield ("min_score", str(self.min_score))
+
+        if self.search_type is not None:
+            yield ("search_type", self.search_type)
+
+        # Only a language that came in from the request query should be reproduced
+        if self._language_from_query and self.languages:
+            yield ("language", self.languages)
 
     def navigate(self, **kwargs):
         min_score = kwargs.pop("min_score", self.min_score)

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -3019,9 +3019,7 @@ class TestEntrypointLinkInsertion:
 
         # The make_link function that was passed in calls
         # TestAnnotator.search_url() when passed an EntryPoint.
-        first_page_url = (
-            "http://wl/?available=all&collection=full&entrypoint=Book&order=relevance"
-        )
+        first_page_url = "http://wl/?available=all&collection=full&entrypoint=Book&order=relevance&search_type=default"
         assert first_page_url == make_link(EbooksEntryPoint)
 
         # Pagination information is not propagated through entry point links


### PR DESCRIPTION
`search_type` and `language` facets are added to the facet links for SearchFacets.
Language will no longer ignore the "all" keyword, "all" will truly mean all languages.
Language facets will only be added if the query specified a language, else the default Accept-Language header is always used.

Example link with facets
` <link rel="next" href="http://localhost:6500/localtest/search/?q=%7B%22query%22:%7B%22value%22:%221980-01-01%22,%22key%22:%22published%22,%22op%22:%22gt%22%7D%7D&amp;entrypoint=Book&amp;order=relevance&amp;available=all&amp;collection=full&amp;search_type=json&amp;language=spa&amp;after=100&amp;size=100"/>`

## Description
When searching for non-English titles using the list search interface, only English titles appear. Non-English titles do appear when searching via the catalog in either the Admin UI or the mobile apps.

[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-134)
<!--- Describe your changes -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested the `/search` endpoint.
All unit tests have been updated and tested.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
