### PR TITLE
PP-120 Fix the test_groups method of the lanes test cases

### DIFF
--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -4094,13 +4094,13 @@ class TestWorkListGroupsEndToEnd:
 
         # Create children works.
         result.children_with_age = _w(
-            title="Children work with set target age",
+            title="Children work with target age",
             audience=Classifier.AUDIENCE_CHILDREN,
         )
-        result.children_with_age.target_age = (0, 3)
+        result.children_with_age.target_age = tuple_to_numericrange((0, 3))
 
         result.children_without_age = _w(
-            title="Children work without target age",
+            title="Children work with out target age",
             audience=Classifier.AUDIENCE_CHILDREN,
         )
 
@@ -4136,9 +4136,6 @@ class TestWorkListGroupsEndToEnd:
         result.staff_picks_list.add_entry(result.mq_sf)
         return result
 
-    # TODO: This test needs to be fixed. It fails roughly one out of five runs. For
-    #  now I'm just marking it so it doesn't fail our CI every time it fails.
-    @pytest.mark.xfail()
     def test_groups(
         self,
         end_to_end_search_fixture: EndToEndSearchFixture,
@@ -4148,8 +4145,6 @@ class TestWorkListGroupsEndToEnd:
             fixture.external_search.db,
             fixture.external_search.db.session,
         )
-        if not fixture.external_search.search:
-            return
 
         # Tell the fixture to call our populate_works method.
         data = self.populate_works(fixture)
@@ -4183,7 +4178,8 @@ class TestWorkListGroupsEndToEnd:
 
         # "Children", which will contain one book, the one with audience children and defined target age.
         children = db.lane("Children")
-        children.audience = Classifier.AUDIENCE_CHILDREN
+        children.audiences = Classifier.AUDIENCE_CHILDREN
+        children.target_age = (0, 4)
 
         # Since we have a bunch of lanes and works, plus an
         # Opensearch index, let's take this opportunity to verify that
@@ -4327,9 +4323,7 @@ class TestWorkListGroupsEndToEnd:
         # When a lane's audience is "Children" we need work to have explicit target_age to be included in the lane
         assert_contents(
             make_groups(children),
-            [
-                (data.children_with_age, children),
-            ],
+            [(data.children_with_age, children)],
         )
 
         # If we make the lanes thirstier for content, we see slightly


### PR DESCRIPTION
## Description
The model seems to have moved on since the tests, so some changes were required
The sorting of the 2 databases seems to have drifted in some way so similarly named works had to be named a certain way.
<!--- Describe your changes -->

## Motivation and Context
While working on tests for different ticket I noticed we have one test in `tests/core/test_lane.py → TestWorkListGroupsEndToEnd::test_groups` that is occasionally failing but it is marked with pytest.mark.xfail so it is not failing our CI system.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
The unit test now passes. No changes were made in the application.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
