### PR TITLE
Possibly fix the flakiness of core.test_lanes

### DIFF
--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -4253,7 +4253,7 @@ class TestWorkListGroupsEndToEnd:
         result.lq_sf = _w(title="LQ SF", genre="Science Fiction", fiction=True)
         result.lq_sf.quality = 0.1
         result.hq_ro = _w(title="HQ Romance", genre="Romance", fiction=True)
-        result.hq_ro.quality = 0.8
+        result.hq_ro.quality = 0.79
         result.mq_ro = _w(title="MQ Romance", genre="Romance", fiction=True)
         result.mq_ro.quality = 0.6
         # This work is in a different language -- necessary to run the


### PR DESCRIPTION
## Description
Dropping the genre quality of one work in test_groups to ensure test reproducibility
hq_litfic, hq_sf and hq_romance all have quality 0.8, which means it's possible that the opensearch index may return any 2 of the 3 works we ask for.
By dropping the quality of hq_romance we ensure only the first 2 show up.
<!--- Describe your changes -->

## Motivation and Context
The test_lanes test randomly fails in the CI, but not locally, this is a hypotheses, and should be run multiple times in the CI.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This has only been tested locally, where it isn't an issue.
:warning:  The CI must run this test multiple times to ensure the test is passing.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
