### PR TITLE
PP-165 Temporarily removed the basic-token authentication capabilities

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -414,12 +414,6 @@ class LibraryAuthenticator:
         ):
             raise CannotLoadConfiguration("Two basic auth providers configured")
         self.basic_auth_provider = provider
-        if self.library is not None:
-            self.access_token_authentication_provider = (
-                BasicTokenAuthenticationProvider(
-                    self._db, self.library, self.basic_auth_provider
-                )
-            )
 
     def register_saml_provider(
         self,

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -22,7 +22,6 @@ from werkzeug.datastructures import Authorization
 
 from api.annotations import AnnotationWriter
 from api.announcements import Announcements
-from api.authentication.access_token import AccessTokenProvider
 from api.authentication.base import PatronData
 from api.authentication.basic import (
     BarcodeFormats,
@@ -924,21 +923,6 @@ class TestLibraryAuthenticator:
             assert response == "foo"
             assert saml.authenticated_patron.call_count == 1
 
-    def test_authenticated_patron_bearer_access_token(
-        self, db: DatabaseTransactionFixture, mock_basic: MockBasicFixture
-    ):
-        basic = mock_basic()
-        authenticator = LibraryAuthenticator(
-            _db=db.session, library=db.default_library(), basic_auth_provider=basic
-        )
-        patron = db.patron()
-        token = AccessTokenProvider.generate_token(db.session, patron, "pass")
-        auth = Authorization(auth_type="bearer", token=token)
-
-        auth_patron = authenticator.authenticated_patron(db.session, auth)
-        assert type(auth_patron) == Patron
-        assert auth_patron.id == patron.id
-
     def test_authenticated_patron_unsupported_mechanism(
         self, db: DatabaseTransactionFixture
     ):
@@ -973,16 +957,6 @@ class TestLibraryAuthenticator:
             basic_auth_provider=None,
         )
         assert authenticator.get_credential_from_header(credential) is None
-
-        authenticator = LibraryAuthenticator(
-            _db=db.session,
-            library=db.default_library(),
-            basic_auth_provider=basic,
-        )
-        patron = db.patron()
-        token = AccessTokenProvider.generate_token(db.session, patron, "passworx")
-        credential = Authorization(auth_type="bearer", token=token)
-        assert authenticator.get_credential_from_header(credential) == "passworx"
 
     def test_create_authentication_document(
         self, db: DatabaseTransactionFixture, mock_basic: MockBasicFixture
@@ -1134,7 +1108,7 @@ class TestLibraryAuthenticator:
             # The main thing we need to test is that the
             # authentication sub-documents are assembled properly and
             # placed in the right position.
-            [token_doc, basic_doc] = doc["authentication"]
+            [basic_doc] = doc["authentication"]
 
             expect_basic = basic.authentication_flow_document(db.session)
             assert expect_basic == basic_doc


### PR DESCRIPTION
## Description
Also deleted the associated tests of the Authenticator class
To add the authentication back, simply revert this commit
<!--- Describe your changes -->

## Motivation and Context
The iOS App needs to make some changes in it's parsing of the authentication document before it can support the basic-token type.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Basic authentication still works, manually tested this.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
