### PR TITLE
PP-159 CDN feed urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ export SIMPLIFIED_FCM_CREDENTIALS_FILE="/opt/credentials/fcm_credentials.json"
 The FCM credentials can be downloaded once a Google Service account has been created.
 More details in the [FCM documentation](https://firebase.google.com/docs/admin/setup#set-up-project-and-service-account)
 
+##### CDN caching
+
+OPDS1 and OPDS2 feeds can have cacheable links using the following variables
+
+```sh
+export SIMPLIFIED_CDN_BASE_URL=https://cdn.host.tld
+export SIMPLIFIED_CDN_OPDS1_ENABLED=TRUE
+export SIMPLIFIED_CDN_OPDS2_ENABLED=TRUE
+```
+
+Any value that is not a case-variant of "TRUE" indicates a False to the application.
+
 ### Email sending
 
 To use the features that require sending emails, for example to reset the password for logged-out users, you will need

--- a/api/opds2.py
+++ b/api/opds2.py
@@ -29,7 +29,7 @@ class OPDS2PublicationsAnnotator(OPDS2Annotator):
     def loan_link(self, edition: Edition) -> dict:
         identifier: Identifier = edition.primary_identifier
         return {
-            "href": url_for(
+            "href": self.url_for(
                 "borrow",
                 identifier_type=identifier.type,
                 identifier=identifier.identifier,
@@ -41,7 +41,7 @@ class OPDS2PublicationsAnnotator(OPDS2Annotator):
     def self_link(self, edition: Edition) -> dict:
         identifier: Identifier = edition.primary_identifier
         return {
-            "href": url_for(
+            "href": self.url_for(
                 "permalink",
                 identifier_type=identifier.type,
                 identifier=identifier.identifier,
@@ -50,12 +50,12 @@ class OPDS2PublicationsAnnotator(OPDS2Annotator):
             "rel": "self",
         }
 
-    @classmethod
-    def facet_url(cls, facets: Facets) -> str:
+    def facet_url(self, facets: Facets) -> str:
         name = facets.library.short_name if facets.library else None
-        return url_for(
+        return self.url_for(
             "opds2_publications",
             _external=True,
+            cdn=True,
             library_short_name=name,
             **dict(facets.items()),
         )

--- a/api/util/url.py
+++ b/api/util/url.py
@@ -1,4 +1,7 @@
+import re
 from urllib.parse import ParseResult, urlencode, urlparse
+
+from core.config import Configuration
 
 
 class URLUtility:
@@ -28,3 +31,18 @@ class URLUtility:
         )
 
         return result.geturl()
+
+
+class CDNUtils:
+    @classmethod
+    def replace_host(cls, url: str) -> str:
+        cdn_url = Configuration.cdn_base_url()
+        if url.startswith("http") and cdn_url:
+            # Find the hostname to replace
+            replace = re.compile("(^https?://.*?)/")
+            matches = replace.match(url)
+            if matches:
+                # Replace the group
+                url = url.replace(matches.group(1), cdn_url)
+
+        return url

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -5,6 +5,7 @@ register_assert_rewrite("tests.fixtures.files")
 register_assert_rewrite("tests.fixtures.vendor_id")
 
 pytest_plugins = [
+    "tests.fixtures.environment",
     "tests.fixtures.announcements",
     "tests.fixtures.api_admin",
     "tests.fixtures.api_axis_files",

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -261,3 +261,41 @@ class TestConfiguration:
             match=r"Cannot parse value of FCM credential environment variable .* as JSON.",
         ):
             Configuration.fcm_credentials()
+
+    def test_cdn_config(self):
+        with patch.object(os, "environ", new=dict()):
+            os.environ[
+                Configuration.CDN_BASE_URL_ENVIRONMENT_VARIABLE
+            ] = "http://cdn.localhost"
+            os.environ[Configuration.CDN_OPDS1_ENABLED_ENVIRONMENT_VARIABLE] = "true"
+            assert Configuration.cdn_base_url() == "http://cdn.localhost"
+            assert Configuration.cdn_enabled("OPDS1") == True
+
+            Configuration.cdn_base_url.cache_clear()
+            Configuration.cdn_enabled.cache_clear()
+
+            os.environ[Configuration.CDN_OPDS1_ENABLED_ENVIRONMENT_VARIABLE] = "True"
+            assert Configuration.cdn_enabled("OPDS1") == True
+
+            Configuration.cdn_enabled.cache_clear()
+
+            os.environ[Configuration.CDN_OPDS2_ENABLED_ENVIRONMENT_VARIABLE] = "True"
+            assert Configuration.cdn_enabled("OPDS2") == True
+
+            Configuration.cdn_enabled.cache_clear()
+
+            os.environ[
+                Configuration.CDN_OPDS1_ENABLED_ENVIRONMENT_VARIABLE
+            ] = "Not True"
+            assert Configuration.cdn_enabled("OPDS1") == False
+
+            Configuration.cdn_enabled.cache_clear()
+
+            del os.environ[Configuration.CDN_OPDS1_ENABLED_ENVIRONMENT_VARIABLE]
+            assert Configuration.cdn_enabled("OPDS1") == False
+
+            Configuration.cdn_base_url.cache_clear()
+            Configuration.cdn_enabled.cache_clear()
+
+            del os.environ[Configuration.CDN_BASE_URL_ENVIRONMENT_VARIABLE]
+            assert Configuration.cdn_base_url() == None

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,4 +1,5 @@
 pytest_plugins = [
+    "tests.fixtures.environment",
     "tests.fixtures.api_config",
     "tests.fixtures.csv_files",
     "tests.fixtures.database",

--- a/tests/fixtures/environment.py
+++ b/tests/fixtures/environment.py
@@ -1,0 +1,17 @@
+import os
+
+import pytest
+
+from core.config import Configuration
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clear_unneeded_environment_variables():
+    """The testing environment may have variables that leak from the application space"""
+    for key in (
+        Configuration.CDN_BASE_URL_ENVIRONMENT_VARIABLE,
+        Configuration.CDN_OPDS1_ENABLED_ENVIRONMENT_VARIABLE,
+        Configuration.CDN_OPDS2_ENABLED_ENVIRONMENT_VARIABLE,
+    ):
+        if os.environ.get(key):
+            del os.environ[key]


### PR DESCRIPTION
## Description
CDN urls options are available for OPDS1 and OPDS2 feeds

The feed only cdnify's urls if explicitly asked to, like the links to other feeds
- search url
- contributor url
- facet url
- etc..
Any action oriented url is not cdn'd, eg. borrow links

CDN options are picked up from the environment
The Readme has been updated to reflect the new environment variables

<!--- Describe your changes -->

## Motivation and Context
We should have CloudFront CDN caching for the OPDS 2 crawlable feeds so our systems are not negatively impacted when the feeds are harvested.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated for the new functionality
OPDS1 and 2 feeds were manually tested locally

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
