### PR TITLE
PP-156 Switched the auto update lists to use sort key pagination

### DIFF
--- a/tests/core/test_customlist_queries.py
+++ b/tests/core/test_customlist_queries.py
@@ -4,11 +4,24 @@ from core.query.customlist import CustomListQueries
 from tests.fixtures.database import DatabaseTransactionFixture
 
 
+def page_count_property_mock(mock_page: mock.MagicMock):
+    """The next_page property should return the same pagination mock"""
+    next_page = mock.PropertyMock()
+
+    def same_page():
+        return mock_page.return_value
+
+    next_page.side_effect = same_page
+    type(mock_page.return_value).next_page = next_page
+    return next_page
+
+
+@mock.patch("core.query.customlist.SortKeyPagination")
 @mock.patch("core.query.customlist.ExternalSearchIndex")
 @mock.patch("core.query.customlist.WorkList")
 class TestCustomListQueries:
     def test_populate_query_pages_single(
-        self, mock_wl, mock_search, db: DatabaseTransactionFixture
+        self, mock_wl, mock_search, mock_page, db: DatabaseTransactionFixture
     ):
         w1 = db.work()
         mock_wl().search.side_effect = [[w1], []]
@@ -20,24 +33,28 @@ class TestCustomListQueries:
         assert [e.work_id for e in custom_list.entries] == [w1.id]
 
     def test_populate_query_multi_page(
-        self, mock_wl, mock_search, db: DatabaseTransactionFixture
+        self, mock_wl, mock_search, mock_page, db: DatabaseTransactionFixture
     ):
         w1 = db.work()
         w2 = db.work()
         mock_wl().search.side_effect = [[w1], [w2], []]
+        next_page = page_count_property_mock(mock_page)
+
         custom_list, _ = db.customlist(num_entries=0)
         custom_list.auto_update_query = "{}"
 
         assert 2 == CustomListQueries.populate_query_pages(db.session, custom_list)
         assert mock_wl().search.call_count == 3
+        assert next_page.call_count == 2
         assert [e.work_id for e in custom_list.entries] == [w1.id, w2.id]
 
     def test_populate_query_pages(
-        self, mock_wl, mock_search, db: DatabaseTransactionFixture
+        self, mock_wl, mock_search, mock_page, db: DatabaseTransactionFixture
     ):
         w1 = db.work()
         w2 = db.work()
         w3 = db.work()
+        next_page = page_count_property_mock(mock_page)
         mock_wl().search.side_effect = [[w1], [w2], [w3], []]
         custom_list, _ = db.customlist(num_entries=0)
         custom_list.auto_update_query = "{}"
@@ -45,6 +62,7 @@ class TestCustomListQueries:
         assert 1 == CustomListQueries.populate_query_pages(
             db.session, custom_list, max_pages=1, start_page=2, page_size=10
         )
-        assert mock_wl().search.call_count == 1
-        assert [e.work_id for e in custom_list.entries] == [w1.id]
-        assert mock_wl().search.call_args_list[0][1]["pagination"].offset == 10
+        # The search will be paged through from 0, but only the 2nd page onwards should be populated
+        assert mock_wl().search.call_count == 2
+        assert next_page.call_count == 2
+        assert [e.work_id for e in custom_list.entries] == [w2.id]


### PR DESCRIPTION
## Description
This allows extremely large lists to be populated via auto update.

<!--- Describe your changes -->

## Motivation and Context
The CustomListQueries.populate_query_pages method uses offset based pagination which will be limited to 10000 search results by opensearch.

[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-156)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated to expect the changed pagination
Manually tested a list of > 100K size, which is painfully slow to populate.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
