### PR TITLE
PP65: Opensearch migrations

### DIFF
--- a/api/admin/controller/custom_lists.py
+++ b/api/admin/controller/custom_lists.py
@@ -283,7 +283,12 @@ class CustomListsController(
         if membership_change:
             # We need to update the search index entries for works that caused a membership change,
             # so the upstream counts can be calculated correctly.
-            self.search_engine.bulk_update(works_to_update_in_search)
+            documents = self.search_engine.create_search_documents_from_works(
+                works_to_update_in_search
+            )
+            self.search_engine.search_service().index_submit_documents(
+                self.search_engine._search_write_pointer, documents
+            )
 
             # If this list was used to populate any lanes, those lanes need to have their counts updated.
             for lane in Lane.affected_by_customlist(list):

--- a/api/admin/controller/custom_lists.py
+++ b/api/admin/controller/custom_lists.py
@@ -286,9 +286,9 @@ class CustomListsController(
             documents = self.search_engine.create_search_documents_from_works(
                 works_to_update_in_search
             )
-            self.search_engine.search_service().index_submit_documents(
-                self.search_engine._search_write_pointer, documents
-            )
+            index = self.search_engine.start_updating_search_documents()
+            index.add_documents(documents)
+            index.finish()
 
             # If this list was used to populate any lanes, those lanes need to have their counts updated.
             for lane in Lane.affected_by_customlist(list):

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -227,19 +227,12 @@ class BaseCoverageProvider:
         """
         return self.OPERATION
 
-    def on_completely_finished(self):
-        """A method called when run() has completely finished."""
-
     def run(self):
-        try:
-            start = utc_now()
-            result = self.run_once_and_update_timestamp()
-
-            result = result or CoverageProviderProgress()
-            self.finalize_timestampdata(result, start=start)
-            return result
-        finally:
-            self.on_completely_finished()
+        start = utc_now()
+        result = self.run_once_and_update_timestamp()
+        result = result or CoverageProviderProgress()
+        self.finalize_timestampdata(result, start=start)
+        return result
 
     def run_once_and_update_timestamp(self):
         # First prioritize items that have never had a coverage attempt before.

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -181,12 +181,6 @@ class ExternalSearchIndex(HasSelfTests):
         if not integration:
             raise CannotLoadConfiguration("No search integration configured.")
 
-        # Determine the URL that is going to be used to connect to the search server.
-        if isinstance(url, ExternalIntegration):
-            # This is how the self-test initializes this object.
-            integration = url
-            url = integration.url
-
         if not url:
             url = url or integration.url
             test_search_term = integration.setting(self.TEST_SEARCH_TERM_KEY).value

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -2802,10 +2802,16 @@ class SearchIndexCoverageProvider(RemovesSearchCoverage, WorkPresentationProvide
             self.remove_search_coverage_records()
 
     def on_completely_finished(self):
-        super().on_completely_finished()
         # Tell the search migrator that no more documents are going to show up.
         target: SearchDocumentReceiverType = self.migration or self.receiver
         target.finish()
+
+    def run_once_and_update_timestamp(self):
+        try:
+            result = super().run_once_and_update_timestamp()
+            return result
+        finally:
+            self.on_completely_finished()
 
     def process_batch(self, works) -> List[Work | CoverageFailure]:
         target: SearchDocumentReceiverType = self.migration or self.receiver

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -2807,11 +2807,11 @@ class SearchIndexCoverageProvider(RemovesSearchCoverage, WorkPresentationProvide
         target.finish()
 
     def run_once_and_update_timestamp(self):
-        try:
-            result = super().run_once_and_update_timestamp()
-            return result
-        finally:
-            self.on_completely_finished()
+        # We do not catch exceptions here, so that the on_completely finished should not run
+        # if there was a runtime error
+        result = super().run_once_and_update_timestamp()
+        self.on_completely_finished()
+        return result
 
     def process_batch(self, works) -> List[Work | CoverageFailure]:
         target: SearchDocumentReceiverType = self.migration or self.receiver

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import datetime
 import json
@@ -284,7 +286,9 @@ class ExternalSearchIndex(HasSelfTests):
         else:
             query = Query(query_string, filter)
 
-        search = query.build(self._search_service.search_client(), pagination)
+        search = query.build(
+            self._search_service.search_client(self._search_read_pointer), pagination
+        )
         if debug:
             search = search.extra(explain=True)
 
@@ -361,7 +365,7 @@ class ExternalSearchIndex(HasSelfTests):
             (query string, Filter, Pagination) 3-tuple.
         """
         # Create a MultiSearch.
-        multi = self._search_service.search_multi_client()
+        multi = self._search_service.search_multi_client(self._search_read_pointer)
 
         # Give it a Search object for every query definition passed in
         # as part of `queries`.
@@ -489,7 +493,7 @@ class ExternalSearchIndex(HasSelfTests):
 
         def _count_docs():
             service = self.search_service()
-            client = service.search_client()
+            client = service.search_client(self._search_read_pointer)
             return str(client.count())
 
         yield self.run_test(

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -2713,8 +2713,6 @@ class RebuildSearchIndexScript(RunWorkCoverageProviderScript, RemovesSearchCover
         super().__init__(SearchIndexCoverageProvider, *args, **kwargs)
 
     def do_run(self):
-        # Calling setup_index will destroy the index and recreate it
-        # empty.
         self.search.clear_search_documents()
 
         # Remove all search coverage records so the

--- a/core/search/coverage_remover.py
+++ b/core/search/coverage_remover.py
@@ -1,0 +1,33 @@
+from core.model.coverage import WorkCoverageRecord
+
+
+class RemovesSearchCoverage:
+    """Mix-in class for a script that might remove all coverage records
+    for the search engine.
+    """
+
+    def remove_search_coverage_records(self):
+        """Delete all search coverage records from the database.
+
+        :return: The number of records deleted.
+        """
+        wcr = WorkCoverageRecord
+        clause = wcr.operation == wcr.UPDATE_SEARCH_INDEX_OPERATION
+        count = self._db.query(wcr).filter(clause).count()
+
+        # We want records to be updated in ascending order in order to avoid deadlocks.
+        # To guarantee lock order, we explicitly acquire locks by using a subquery with FOR UPDATE (with_for_update).
+        # Please refer for my details to this SO article:
+        # https://stackoverflow.com/questions/44660368/postgres-update-with-order-by-how-to-do-it
+        self._db.execute(
+            wcr.__table__.delete().where(
+                wcr.id.in_(
+                    self._db.query(wcr.id)
+                    .with_for_update()
+                    .filter(clause)
+                    .order_by(WorkCoverageRecord.id)
+                )
+            )
+        )
+
+        return count

--- a/core/search/document.py
+++ b/core/search/document.py
@@ -92,7 +92,7 @@ def date() -> SearchMappingFieldTypeParameterized:
 # See: https://opensearch.org/docs/latest/field-types/supported-field-types/keyword/
 def keyword() -> SearchMappingFieldTypeParameterized:
     mapping = SearchMappingFieldTypeParameterized("keyword")
-    mapping._parameters["normalizer"] = "filterable_string"
+    mapping.parameters["normalizer"] = "filterable_string"
     return mapping
 
 
@@ -226,7 +226,6 @@ class SearchMappingDocument:
     """
 
     def __init__(self):
-        super().__init__()
         self._settings: Dict[str, dict] = {}
         self._fields: Dict[str, SearchMappingFieldType] = {}
         self._scripts: Dict[str, str] = {}
@@ -253,7 +252,4 @@ class SearchMappingDocument:
         return {"settings": self.settings, "mappings": output_mappings}
 
     def serialize_properties(self):
-        output_properties: dict = {}
-        for name, prop in self._fields.items():
-            output_properties[name] = prop.serialize()
-        return output_properties
+        return {name: prop.serialize() for name, prop in self._fields.items()}

--- a/core/search/document.py
+++ b/core/search/document.py
@@ -91,7 +91,9 @@ def date() -> SearchMappingFieldTypeParameterized:
 
 # See: https://opensearch.org/docs/latest/field-types/supported-field-types/keyword/
 def keyword() -> SearchMappingFieldTypeParameterized:
-    return SearchMappingFieldTypeParameterized("keyword")
+    mapping = SearchMappingFieldTypeParameterized("keyword")
+    mapping._parameters["normalizer"] = "filterable_string"
+    return mapping
 
 
 # See: https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu-collation-keyword-field.html

--- a/core/search/migrator.py
+++ b/core/search/migrator.py
@@ -52,7 +52,9 @@ class SearchDocumentReceiver(SearchDocumentReceiverType):
 
     def finish(self) -> None:
         """Make sure all changes are committed."""
+        self._logger.info("Finishing search documents.")
         self._service.refresh()
+        self._logger.info("Finished search documents.")
 
 
 class SearchMigrationInProgress(SearchDocumentReceiverType):

--- a/core/search/migrator.py
+++ b/core/search/migrator.py
@@ -141,6 +141,7 @@ class SearchMigrator:
             # Does the read pointer exist? Point it at the empty index if not.
             read = self._service.read_pointer(base_name)
             if read is None:
+                self._logger.info("Read pointer did not exist.")
                 self._service.read_pointer_set_empty(base_name)
 
             # We're probably going to have to do a migration. We might end up returning
@@ -152,6 +153,9 @@ class SearchMigrator:
             # Does the write pointer exist?
             write = self._service.write_pointer(base_name)
             if write is None or (not write.version == version):
+                self._logger.info(
+                    f"Write pointer does not point to the desired version: {write} != {version}."
+                )
                 # Either the write pointer didn't exist, or it's pointing at a version
                 # other than the one we want. Create a new index for the version we want.
                 self._service.index_create(base_name, target)
@@ -159,6 +163,7 @@ class SearchMigrator:
 
                 # The index now definitely exists, but it might not be populated. Populate it if necessary.
                 if not self._service.index_is_populated(base_name, target):
+                    self._logger.info("Write index is not populated.")
                     return in_progress
 
             # If we didn't need to return the migration, finish it here. This will

--- a/core/search/migrator.py
+++ b/core/search/migrator.py
@@ -86,16 +86,8 @@ class SearchMigrationInProgress(SearchDocumentReceiverType):
         self._receiver.finish()
         # Update the write pointer to point to the now-populated index.
         self._service.write_pointer_set(self._base_name, self._revision)
-        self._logger.info(
-            f"Write pointer {self._service.write_pointer_name(self._base_name)} "
-            f"-> {self._service.write_pointer(self._base_name).target_name}"
-        )
         # Set the read pointer to point at the now-populated index
         self._service.read_pointer_set(self._base_name, self._revision)
-        self._logger.info(
-            f"Read pointer {self._service.read_pointer_name(self._base_name)} "
-            f"-> {self._service.read_pointer(self._base_name)}"
-        )
         self._logger.info(f"Completed migration to {self._revision.version}")
 
     def cancel(self) -> None:

--- a/core/search/migrator.py
+++ b/core/search/migrator.py
@@ -88,6 +88,7 @@ class SearchMigrationInProgress(SearchDocumentReceiverType):
         self._service.write_pointer_set(self._base_name, self._revision)
         # Set the read pointer to point at the now-populated index
         self._service.read_pointer_set(self._base_name, self._revision)
+        self._service.refresh()
         self._logger.info(f"Completed migration to {self._revision.version}")
 
     def cancel(self) -> None:

--- a/core/search/migrator.py
+++ b/core/search/migrator.py
@@ -112,8 +112,8 @@ class SearchMigrator:
     ) -> Optional[SearchMigrationInProgress]:
         """
         Migrate to the given version using the given base name (such as 'circulation-works'). The function returns
-        a generator that expects to receive batches of search documents used to populate any new index. When all
-        the batches of documents have been sent to the generator, callers must send `[]` to indicate to the search
+        an object that expects to receive batches of search documents used to populate any new index. When all
+        the batches of documents have been sent to the object, callers must call 'finish' to indicate to the search
         migrator that no more documents are coming. Only at this point will the migrator consider the new index to be
         "populated".
 

--- a/core/search/migrator.py
+++ b/core/search/migrator.py
@@ -86,6 +86,8 @@ class SearchMigrationInProgress(SearchDocumentReceiverType):
         self._logger.info(f"Completing migration to {self._revision.version}")
         # Make sure all changes are committed.
         self._receiver.finish()
+        # Create the "indexed" alias.
+        self._service.index_set_populated(self._base_name, self._revision)
         # Update the write pointer to point to the now-populated index.
         self._service.write_pointer_set(self._base_name, self._revision)
         # Set the read pointer to point at the now-populated index

--- a/core/search/migrator.py
+++ b/core/search/migrator.py
@@ -86,8 +86,17 @@ class SearchMigrationInProgress(SearchDocumentReceiverType):
         self._receiver.finish()
         # Update the write pointer to point to the now-populated index.
         self._service.write_pointer_set(self._base_name, self._revision)
+        self._logger.info(
+            f"Write pointer {self._service.write_pointer_name(self._base_name)} "
+            f"-> {self._service.write_pointer(self._base_name).target_name}"
+        )
         # Set the read pointer to point at the now-populated index
         self._service.read_pointer_set(self._base_name, self._revision)
+        self._logger.info(
+            f"Read pointer {self._service.read_pointer_name(self._base_name)} "
+            f"-> {self._service.read_pointer(self._base_name)}"
+        )
+        self._logger.info(f"Completed migration to {self._revision.version}")
 
     def cancel(self) -> None:
         """Cancel the migration, leaving the read and write pointers untouched."""

--- a/core/search/migrator.py
+++ b/core/search/migrator.py
@@ -175,4 +175,4 @@ class SearchMigrator:
         except Exception as e:
             raise SearchMigrationException(
                 fatal=True, message=f"Service raised exception: {repr(e)}"
-            )
+            ) from e

--- a/core/search/revision.py
+++ b/core/search/revision.py
@@ -32,3 +32,6 @@ class SearchSchemaRevision(ABC):
         """Produce the name of the "indexed pointer" as it will appear in Opensearch,
         such as 'circulation-works-v5-indexed'."""
         return f"{base_name}-v{self.version}-indexed"
+
+    def script_name(self, script_name):
+        return f"simplified.{script_name}.v{self.version}"

--- a/core/search/revision.py
+++ b/core/search/revision.py
@@ -15,6 +15,8 @@ class SearchSchemaRevision(ABC):
     SEARCH_VERSION: int
 
     def __init__(self):
+        if self.SEARCH_VERSION is None:
+            raise ValueError("The SEARCH_VERSION must be defined with an integer value")
         self._version = self.SEARCH_VERSION
 
     @abstractmethod

--- a/core/search/revision.py
+++ b/core/search/revision.py
@@ -11,9 +11,11 @@ class SearchSchemaRevision(ABC):
     """
 
     _version: int
+    # The SEARCH_VERSION variable MUST be populated in the implemented child classes
+    SEARCH_VERSION: int
 
-    def __init__(self, version: int):
-        self._version = version
+    def __init__(self):
+        self._version = self.SEARCH_VERSION
 
     @abstractmethod
     def mapping_document(self) -> SearchMappingDocument:

--- a/core/search/revision_directory.py
+++ b/core/search/revision_directory.py
@@ -10,7 +10,7 @@ class SearchRevisionDirectory:
 
     @staticmethod
     def _create_revisions() -> Mapping[int, SearchSchemaRevision]:
-        return dict(map(lambda r: (r.version, r), [SearchV5()]))
+        return {r.version: r for r in [SearchV5()]}
 
     def __init__(self, available: Mapping[int, SearchSchemaRevision]):
         self._available = available

--- a/core/search/revision_directory.py
+++ b/core/search/revision_directory.py
@@ -4,13 +4,24 @@ from core.config import CannotLoadConfiguration
 from core.search.revision import SearchSchemaRevision
 from core.search.v5 import SearchV5
 
+REVISIONS = [SearchV5()]
+
 
 class SearchRevisionDirectory:
     """A directory of the supported search index schemas."""
 
     @staticmethod
     def _create_revisions() -> Mapping[int, SearchSchemaRevision]:
-        return {r.version: r for r in [SearchV5()]}
+        numbers = set()
+        revisions = {}
+        for r in REVISIONS:
+            if r.version in numbers:
+                raise ValueError(
+                    f"Revision version {r.version} is defined multiple times"
+                )
+            numbers.add(r.version)
+            revisions[r.version] = r
+        return revisions
 
     def __init__(self, available: Mapping[int, SearchSchemaRevision]):
         self._available = available

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -243,7 +243,7 @@ class SearchServiceOpensearch1(SearchService):
     def index_create(self, base_name: str, revision: SearchSchemaRevision) -> None:
         try:
             index_name = revision.name_for_index(base_name)
-            self._logger.debug(f"creating index {index_name}")
+            self._logger.info(f"creating index {index_name}")
             self._client.indices.create(
                 index=index_name,
                 body=revision.mapping_document().serialize(),

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -137,6 +137,15 @@ class SearchServiceOpensearch1(SearchService):
         self._multi_search = MultiSearch(using=self._client)
         self._indexes_created: List[str] = []
 
+        # Documents are not allowed to automatically create indexes.
+        self._client.cluster.put_settings(body={
+            'persistent': {
+                'action': {
+                    'auto_create_index': "false"
+                }
+            }
+        })
+
     def indexes_created(self) -> List[str]:
         return self._indexes_created
 

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -144,11 +144,11 @@ class SearchService(ABC):
         """Clear all search documents in the given index."""
 
     @abstractmethod
-    def search_client(self) -> Search:
+    def search_client(self, pointer_name: str) -> Search:
         """Return the underlying search client."""
 
     @abstractmethod
-    def search_multi_client(self) -> MultiSearch:
+    def search_multi_client(self, pointer_name: str) -> MultiSearch:
         """Return the underlying search client."""
 
     @abstractmethod

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -338,11 +338,11 @@ class SearchServiceOpensearch1(SearchService):
         except NotFoundError:
             return None
 
-    def search_client(self) -> Search:
-        return self._search
+    def search_client(self, pointer_name: str) -> Search:
+        return self._search.index(pointer_name)
 
-    def search_multi_client(self) -> MultiSearch:
-        return self._multi_search
+    def search_multi_client(self, pointer_name: str) -> MultiSearch:
+        return self._multi_search.index(pointer_name)
 
     def read_pointer_name(self, base_name: str) -> str:
         return f"{base_name}-search-read"

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -155,6 +155,10 @@ class SearchService(ABC):
     def index_remove_document(self, pointer: str, id: int):
         """Remove a specific document from the given index."""
 
+    @abstractmethod
+    def is_pointer_empty(self, base_name: str, pointer: str):
+        """Check to see if a pointer points to an empty index"""
+
 
 class SearchServiceOpensearch1(SearchService):
     """The real Opensearch 1.x service."""
@@ -364,3 +368,6 @@ class SearchServiceOpensearch1(SearchService):
 
     def index_remove_document(self, pointer: str, id: int):
         self._client.delete(index=pointer, id=id, doc_type="_doc")
+
+    def is_pointer_empty(self, base_name: str, pointer: str) -> bool:
+        return pointer == self._empty(base_name)

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -58,7 +58,13 @@ class SearchServiceFailedDocument:
                 error_exception="<unavailable>",
             )
         else:
-            raise NotImplementedError
+            # Not exactly ideal, but we really have no idea what the bulk API can return.
+            return SearchServiceFailedDocument(
+                id=-1,
+                error_message="Unrecognized error returned from Opensearch bulk API.",
+                error_status=-1,
+                error_exception=f"{error}",
+            )
 
 
 class SearchService(ABC):

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -273,7 +273,7 @@ class SearchServiceOpensearch1(SearchService):
             script = dict(script=dict(lang="painless", source=body))
             if not name.startswith("simplified"):
                 name = revision.script_name(name)
-            self._client.put_script(name, script)
+            self._client.put_script(name, script)  # type: ignore [misc] ## Seems the types aren't up to date
 
     def index_submit_documents(
         self, pointer: str, documents: Iterable[dict]

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -266,6 +266,9 @@ class SearchServiceOpensearch1(SearchService):
         index_name = revision.name_for_index(base_name)
         self._logger.debug(f"setting mappings for index {index_name}")
         self._client.indices.put_mapping(index=index_name, body=data)
+        for name, body in revision.mapping_document().scripts.items():
+            script = dict(script=dict(lang="painless", source=body))
+            self._client.put_script(name, script, pretty=True)
 
     def index_submit_documents(
         self, pointer: str, documents: Iterable[dict]

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -254,7 +254,7 @@ class SearchServiceOpensearch1(SearchService):
         # See: Sources for "streaming_bulk":
         # https://github.com/opensearch-project/opensearch-py/blob/db972e615b9156b4e364091d6a893d64fb3ef4f3/opensearchpy/helpers/actions.py#L267
         # The documentation is incredibly vague about what the function actually returns, but these
-        # parameters _should_ cause it to return a tuple containing the number of successfully documents
+        # parameters _should_ cause it to return a tuple containing the number of successfully indexed documents
         # and a list of documents that failed. Unfortunately, the type checker disagrees and the documentation
         # gives no hint as to what an "int" might mean for errors.
         (success_count, errors) = opensearchpy.helpers.bulk(

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -222,8 +222,12 @@ class SearchServiceOpensearch1(SearchService):
     ) -> List[SearchServiceFailedDocument]:
         self._logger.info(f"submitting documents to index {pointer}")
 
+        # Specifically override the target in all documents to the target pointer
+        # Add a hard requirement that the target be an alias (this prevents documents from implicitly creating
+        # indexes).
         for document in documents:
             document["_index"] = pointer
+            document["_require_alias"] = True
 
         # See: Sources for "streaming_bulk":
         # https://github.com/opensearch-project/opensearch-py/blob/db972e615b9156b4e364091d6a893d64fb3ef4f3/opensearchpy/helpers/actions.py#L267

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -138,13 +138,9 @@ class SearchServiceOpensearch1(SearchService):
         self._indexes_created: List[str] = []
 
         # Documents are not allowed to automatically create indexes.
-        self._client.cluster.put_settings(body={
-            'persistent': {
-                'action': {
-                    'auto_create_index': "false"
-                }
-            }
-        })
+        self._client.cluster.put_settings(
+            body={"persistent": {"action": {"auto_create_index": "false"}}}
+        )
 
     def indexes_created(self) -> List[str]:
         return self._indexes_created

--- a/core/search/v5.py
+++ b/core/search/v5.py
@@ -18,6 +18,7 @@ from core.search.revision import SearchSchemaRevision
 
 
 class SearchV5(SearchSchemaRevision):
+    SEARCH_VERSION = 5
     """
     The body of this mapping looks for bibliographic information in
     the core document, primarily used for matching search
@@ -99,7 +100,7 @@ return champion;
         AUTHOR_CHAR_FILTER_NAMES.append(name)
 
     def __init__(self):
-        super().__init__(5)
+        super().__init__()
 
         self._normalizers = {}
         self._char_filters = {}

--- a/core/search/v5.py
+++ b/core/search/v5.py
@@ -293,5 +293,7 @@ return champion;
             analyzer=dict(self._analyzers),
         )
         document.properties = self._fields
-        document.scripts["work_last_update"] = SearchV5.WORK_LAST_UPDATE_SCRIPT
+        document.scripts[
+            self.script_name("work_last_update")
+        ] = SearchV5.WORK_LAST_UPDATE_SCRIPT
         return document

--- a/scripts.py
+++ b/scripts.py
@@ -888,25 +888,7 @@ class InstanceInitializationScript:
             )
             self.log.error(f"Error: {ex}")
             return False
-        service = search.search_service()
-        read_pointer = service.read_pointer(search._revision_base_name)
-        if not read_pointer or read_pointer == service._empty(
-            search._revision_base_name
-        ):
-            # A read pointer does not exist, or points to the empty index
-            # This means either this is a new deployment or the first time
-            # the new opensearch code was deployed.
-            # In both cases doing a migration to the latest version is safe.
-            migration = search.start_migration()
-            if migration is not None:
-                migration.finish()
-            else:
-                self.log.warning(
-                    "Read pointer was set to empty, but no migration was available."
-                )
-                return False
-
-        return True
+        return search.initialize_indices()
 
     def initialize(self, connection: Connection):
         """Initialize the database if necessary."""

--- a/tests/api/admin/controller/test_custom_lists.py
+++ b/tests/api/admin/controller/test_custom_lists.py
@@ -585,7 +585,7 @@ class TestCustomListsController:
         )
 
         search_service: SearchServiceFake = (
-            admin_librarian_fixture.ctrl.controller.search_engine.search_service()
+            admin_librarian_fixture.ctrl.controller.search_engine.search_service()  # type: ignore [assignment]
         )
         external_search = admin_librarian_fixture.ctrl.controller.search_engine
 

--- a/tests/api/admin/controller/test_custom_lists.py
+++ b/tests/api/admin/controller/test_custom_lists.py
@@ -36,6 +36,7 @@ from core.query.customlist import CustomListQueries
 from core.util.problem_detail import ProblemDetail
 from tests.core.util.test_flask_util import add_request_context
 from tests.fixtures.api_admin import AdminLibrarianFixture
+from tests.mocks.search import ExternalSearchIndexFake, SearchServiceFake
 
 
 class TestCustomListsController:
@@ -559,8 +560,6 @@ class TestCustomListsController:
         lane.customlists.append(list)
         lane.size = 350
 
-        admin_librarian_fixture.ctrl.controller.search_engine.docs = {}
-
         w1 = admin_librarian_fixture.ctrl.db.work(
             title="Alpha", with_license_pool=True, language="eng"
         )
@@ -578,19 +577,17 @@ class TestCustomListsController:
 
         list.add_entry(w1)
         list.add_entry(w2)
-        admin_librarian_fixture.ctrl.controller.search_engine.bulk_update([w1, w2, w3])
 
-        # All three works should be indexed, but only w1 and w2 should be related to the list
-        assert len(admin_librarian_fixture.ctrl.controller.search_engine.docs) == 3
-        currently_indexed_on_list = [
-            v["title"]
-            for (
-                k,
-                v,
-            ) in admin_librarian_fixture.ctrl.controller.search_engine.docs.items()
-            if v["customlists"] is not None
-        ]
-        assert sorted(currently_indexed_on_list) == ["Alpha", "Bravo"]
+        # All asserts in this test case depend on the external search being mocked
+        assert isinstance(
+            admin_librarian_fixture.ctrl.controller.search_engine,
+            ExternalSearchIndexFake,
+        )
+
+        search_service: SearchServiceFake = (
+            admin_librarian_fixture.ctrl.controller.search_engine.search_service()
+        )
+        external_search = admin_librarian_fixture.ctrl.controller.search_engine
 
         new_entries = [
             dict(
@@ -626,6 +623,9 @@ class TestCustomListsController:
         # Test fails without expiring the ORM cache
         admin_librarian_fixture.ctrl.db.session.expire_all()
 
+        # Mock the right count
+        external_search.mock_count_works(2)
+
         with admin_librarian_fixture.request_context_with_library_and_admin(
             "/", method="POST"
         ):
@@ -648,18 +648,8 @@ class TestCustomListsController:
             )
             assert isinstance(response, flask.Response)
 
-        # The works associated with the list in ES should have changed, though the total
-        # number of documents in the index should be the same.
-        assert len(admin_librarian_fixture.ctrl.controller.search_engine.docs) == 3
-        currently_indexed_on_list = [
-            v["title"]
-            for (
-                k,
-                v,
-            ) in admin_librarian_fixture.ctrl.controller.search_engine.docs.items()
-            if v["customlists"] is not None
-        ]
-        assert sorted(currently_indexed_on_list) == ["Bravo", "Charlie"]
+        # Two works are indexed again
+        assert len(search_service.documents_all()) == 2
 
         assert 200 == response.status_code
         assert list.id == int(response.get_data(as_text=True))
@@ -668,13 +658,7 @@ class TestCustomListsController:
         assert {w2, w3} == {entry.work for entry in list.entries}
         assert new_collections == list.collections
 
-        # If we were using a real search engine instance, the lane's size would be set
-        # to 2, since that's the number of works that would be associated with the
-        # custom list that the lane is based on. In this case we're using an instance of
-        # MockExternalSearchIndex, whose count_works() method (called in Lane.update_size())
-        # returns the number of items in search_engine.docs. Testing that lane.size is now
-        # set to 3 shows that .update_size() was called during the call to custom_list().
-        assert lane.size == 3
+        assert lane.size == 2
 
         # Edit for auto update values
         update_query = {"query": {"key": "title", "value": "title"}}
@@ -861,17 +845,6 @@ class TestCustomListsController:
         assert None == get_one(
             admin_librarian_fixture.ctrl.db.session, Lane, id=lane.id
         )
-
-        # The second and third lanes were not removed, because they
-        # weren't based solely on this specific list. But their .size
-        # attributes were updated to reflect the removal of the list from
-        # the lane.
-        #
-        # In the context of this test, this means that
-        # MockExternalSearchIndex.count_works() was called, and we set
-        # it up to always return 2.
-        assert 2 == lane2.size
-        assert 2 == lane3.size
 
     def test_custom_list_delete_errors(
         self, admin_librarian_fixture: AdminLibrarianFixture

--- a/tests/api/admin/controller/test_dashboard.py
+++ b/tests/api/admin/controller/test_dashboard.py
@@ -26,7 +26,7 @@ class DashboardFixture(AdminControllerFixture):
         self.english_1.license_pools[0].collection = self.ctrl.collection
         self.works = [self.english_1]
 
-        self.manager.external_search.bulk_update(self.works)
+        self.manager.external_search.mock_query_works(self.works)
 
 
 @pytest.fixture(scope="function")

--- a/tests/api/admin/controller/test_lanes.py
+++ b/tests/api/admin/controller/test_lanes.py
@@ -348,7 +348,6 @@ class TestLanesController:
             assert [list2] == lane.customlists
             assert True == lane.inherit_parent_restrictions
             assert None == lane.media
-            assert 2 == lane.size
 
     def test_default_lane_edit(self, alm_fixture: AdminLibraryManagerFixture):
         """Default lanes only allow the display_name to be edited"""

--- a/tests/api/admin/controller/test_work_editor.py
+++ b/tests/api/admin/controller/test_work_editor.py
@@ -58,7 +58,7 @@ class WorkFixture(AdminControllerFixture):
         self.english_1.license_pools[0].collection = self.ctrl.collection
         self.works = [self.english_1]
 
-        self.manager.external_search.bulk_update(self.works)
+        self.manager.external_search.mock_query_works(self.works)
 
         self.admin.add_role(AdminRole.LIBRARIAN, self.ctrl.db.default_library())
 
@@ -970,11 +970,6 @@ class TestWorkController:
             assert list == work.custom_list_entries[0].customlist
             assert True == work.custom_list_entries[0].featured
 
-            # Lane.size will not be updated until the work is
-            # reindexed with its new list memebership and lane sizes
-            # are recalculated.
-            assert 2 == lane.size
-
         # Now remove the work from the list.
         work_fixture.ctrl.controller.search_engine.docs = dict(id1="doc1")
         with work_fixture.request_context_with_library_and_admin("/", method="POST"):
@@ -989,9 +984,6 @@ class TestWorkController:
         assert 200 == response.status_code
         assert 0 == len(work.custom_list_entries)
         assert 0 == len(list.entries)
-
-        # The lane size was recalculated once again.
-        assert 1 == lane.size
 
         # Add a list that didn't exist before.
         with work_fixture.request_context_with_library_and_admin("/", method="POST"):

--- a/tests/api/feed/test_library_annotator.py
+++ b/tests/api/feed/test_library_annotator.py
@@ -20,7 +20,6 @@ from core.classifier import (  # type: ignore[attr-defined]
     Urban_Fantasy,
 )
 from core.entrypoint import AudiobooksEntryPoint, EbooksEntryPoint, EverythingEntryPoint
-from core.external_search import MockExternalSearchIndex
 from core.feed.acquisition import OPDSAcquisitionFeed
 from core.feed.annotator.circulation import LibraryAnnotator
 from core.feed.annotator.loan_and_hold import LibraryLoanAndHoldAnnotator
@@ -800,7 +799,6 @@ class TestLibraryAnnotator:
         work.presentation_edition.add_contributor("Oprah", Contributor.AUTHOR_ROLE)
         work.calculate_presentation(
             PresentationCalculationPolicy(regenerate_opds_entries=True),
-            MockExternalSearchIndex(),
         )
         [entry] = self.get_parsed_feed(annotator_fixture, [work]).entries
         contributor_links = [
@@ -820,7 +818,6 @@ class TestLibraryAnnotator:
         annotator_fixture.db.session.commit()
         work.calculate_presentation(
             PresentationCalculationPolicy(regenerate_opds_entries=True),
-            MockExternalSearchIndex(),
         )
         [entry] = self.get_parsed_feed(annotator_fixture, [work]).entries
         assert [] == [l.link for l in entry.computed.authors if l.link]

--- a/tests/api/feed/test_opds_acquisition_feed.py
+++ b/tests/api/feed/test_opds_acquisition_feed.py
@@ -15,7 +15,6 @@ from core.entrypoint import (
     EverythingEntryPoint,
     MediumEntryPoint,
 )
-from core.external_search import MockExternalSearchIndex
 from core.facets import FacetConstants
 from core.feed.acquisition import LookupAcquisitionFeed, OPDSAcquisitionFeed
 from core.feed.annotator.base import Annotator
@@ -38,7 +37,6 @@ from core.util.flask_util import OPDSEntryResponse, OPDSFeedResponse
 from core.util.opds_writer import OPDSFeed, OPDSMessage
 from tests.api.feed.fixtures import PatchedUrlFor, patch_url_for  # noqa
 from tests.fixtures.database import DatabaseTransactionFixture
-from tests.fixtures.search import ExternalSearchPatchFixture
 
 
 class TestOPDSFeedProtocol:
@@ -170,7 +168,6 @@ class TestOPDSAcquisitionFeed:
     def test_page(
         self,
         db,
-        external_search_patch_fixture: ExternalSearchPatchFixture,
     ):
         session = db.session
 
@@ -187,7 +184,7 @@ class TestOPDSAcquisitionFeed:
             CirculationManagerAnnotator(None),
             None,
             None,
-            None,
+            MagicMock(),
         ).as_response(max_age=10, private=private)
 
         # The result is an OPDSFeedResponse. The 'private' argument,
@@ -1065,7 +1062,6 @@ class TestEntrypointLinkInsertion:
     def test_groups(
         self,
         entrypoint_link_insertion_fixture: TestEntrypointLinkInsertionFixture,
-        external_search_patch_fixture: ExternalSearchPatchFixture,
     ):
         data, db, session = (
             entrypoint_link_insertion_fixture,
@@ -1081,7 +1077,8 @@ class TestEntrypointLinkInsertion:
             was called with.
             """
             data.mock.called_with = None
-            search = MockExternalSearchIndex()
+            search = MagicMock()
+            search.query_works_multi.return_value = [[]]
             feed = OPDSAcquisitionFeed.groups(
                 session,
                 "title",
@@ -1142,7 +1139,7 @@ class TestEntrypointLinkInsertion:
                 data.annotator(),
                 facets,
                 pagination,
-                MockExternalSearchIndex(),
+                MagicMock(),
             )
 
             return data.mock.called_with

--- a/tests/api/mockapi/circulation.py
+++ b/tests/api/mockapi/circulation.py
@@ -2,13 +2,10 @@ import logging
 from abc import ABC
 from collections import defaultdict
 
-from pydantic import BaseSettings
-
 from api.circulation import BaseCirculationAPI, CirculationAPI, HoldInfo, LoanInfo
 from api.controller import CirculationManager
-from core.integration.settings import BaseSettings
-from core.model import DataSource, Hold, Loan
 from core.external_search import ExternalSearchIndex
+from core.integration.settings import BaseSettings
 from core.model import DataSource, Hold, Loan, get_one_or_create
 from core.model.configuration import ExternalIntegration
 from tests.mocks.search import ExternalSearchIndexFake

--- a/tests/api/mockapi/circulation.py
+++ b/tests/api/mockapi/circulation.py
@@ -11,7 +11,7 @@ from core.model import DataSource, Hold, Loan
 from core.external_search import ExternalSearchIndex
 from core.model import DataSource, Hold, Loan, get_one_or_create
 from core.model.configuration import ExternalIntegration
-from tests.mocks.search import SearchServiceFake
+from tests.mocks.search import ExternalSearchIndexFake
 
 
 class MockBaseCirculationAPI(BaseCirculationAPI, ABC):
@@ -185,7 +185,7 @@ class MockCirculationManager(CirculationManager):
             ExternalSearchIndex.TEST_SEARCH_TERM_KEY, "a search term"
         )
         integration.url = "http://does-not-exist.com/"
-        return ExternalSearchIndex(self._db, custom_client_service=SearchServiceFake())
+        return ExternalSearchIndexFake(self._db)
 
     def setup_circulation(self, library, analytics):
         """Set up the Circulation object."""

--- a/tests/api/mockapi/circulation.py
+++ b/tests/api/mockapi/circulation.py
@@ -2,11 +2,16 @@ import logging
 from abc import ABC
 from collections import defaultdict
 
+from pydantic import BaseSettings
+
 from api.circulation import BaseCirculationAPI, CirculationAPI, HoldInfo, LoanInfo
 from api.controller import CirculationManager
-from core.external_search import MockExternalSearchIndex
 from core.integration.settings import BaseSettings
 from core.model import DataSource, Hold, Loan
+from core.external_search import ExternalSearchIndex
+from core.model import DataSource, Hold, Loan, get_one_or_create
+from core.model.configuration import ExternalIntegration
+from tests.mocks.search import SearchServiceFake
 
 
 class MockBaseCirculationAPI(BaseCirculationAPI, ABC):
@@ -167,7 +172,20 @@ class MockCirculationManager(CirculationManager):
 
     def setup_search(self):
         """Set up a search client."""
-        return MockExternalSearchIndex()
+        integration, _ = get_one_or_create(
+            self._db,
+            ExternalIntegration,
+            goal=ExternalIntegration.SEARCH_GOAL,
+            protocol=ExternalIntegration.OPENSEARCH,
+        )
+        integration.set_setting(
+            ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY, "test_index"
+        )
+        integration.set_setting(
+            ExternalSearchIndex.TEST_SEARCH_TERM_KEY, "a search term"
+        )
+        integration.url = "http://does-not-exist.com/"
+        return ExternalSearchIndex(self._db, custom_client_service=SearchServiceFake())
 
     def setup_circulation(self, library, analytics):
         """Set up the Circulation object."""

--- a/tests/api/test_controller_cm.py
+++ b/tests/api/test_controller_cm.py
@@ -5,7 +5,6 @@ from api.config import Configuration
 from api.controller import CirculationManager
 from api.custom_index import CustomIndexView
 from api.problem_details import *
-from core.external_search import MockExternalSearchIndex
 from core.feed.annotator.circulation import (
     CirculationManagerAnnotator,
     LibraryAnnotator,
@@ -19,6 +18,7 @@ from core.util.problem_detail import ProblemDetail
 # TODO: we can drop this when we drop support for Python 3.6 and 3.7
 from tests.fixtures.api_controller import CirculationControllerFixture
 from tests.fixtures.database import IntegrationConfigurationFixture
+from tests.mocks.search import SearchServiceFake
 
 
 class TestCirculationManager:
@@ -110,7 +110,7 @@ class TestCirculationManager:
         )
 
         # The ExternalSearch object has been reset.
-        assert isinstance(manager.external_search, MockExternalSearchIndex)
+        assert isinstance(manager.external_search.search_service(), SearchServiceFake)
 
         # So have the patron web domains, and their paths have been
         # removed.

--- a/tests/api/test_controller_crawlfeed.py
+++ b/tests/api/test_controller_crawlfeed.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import feedparser
 from flask import url_for
+from opensearch_dsl.response.hit import Hit
 
 from api.lanes import (
     CrawlableCollectionBasedLane,
@@ -13,7 +14,7 @@ from api.lanes import (
     DynamicLane,
 )
 from api.problem_details import NO_SUCH_COLLECTION, NO_SUCH_LIST
-from core.external_search import MockSearchResult, SortKeyPagination
+from core.external_search import SortKeyPagination
 from core.feed.acquisition import OPDSAcquisitionFeed
 from core.feed.annotator.circulation import CirculationManagerAnnotator
 from core.problem_details import INVALID_INPUT
@@ -207,7 +208,14 @@ class TestCrawlableFeed:
                 # It's not necessary for this test to call it with a
                 # realistic value, but we might as well.
                 results = [
-                    MockSearchResult(work.sort_title, work.sort_author, {}, work.id)
+                    Hit(
+                        {
+                            "_source": {
+                                "work_id": work.id,
+                            },
+                            "_sort": [work.sort_title, work.sort_author, work.id],
+                        }
+                    )
                 ]
                 pagination.page_loaded(results)
                 return [work]

--- a/tests/api/test_controller_opdsfeed.py
+++ b/tests/api/test_controller_opdsfeed.py
@@ -97,6 +97,7 @@ class TestOPDSFeedController:
         with circulation_fixture.request_context_with_library(
             "/?entrypoint=Book&size=10"
         ):
+
             response = circulation_fixture.manager.opds_feeds.feed(
                 circulation_fixture.english_adult_fiction.id
             )

--- a/tests/api/test_controller_opdsfeed.py
+++ b/tests/api/test_controller_opdsfeed.py
@@ -97,7 +97,6 @@ class TestOPDSFeedController:
         with circulation_fixture.request_context_with_library(
             "/?entrypoint=Book&size=10"
         ):
-
             response = circulation_fixture.manager.opds_feeds.feed(
                 circulation_fixture.english_adult_fiction.id
             )

--- a/tests/api/test_lanes.py
+++ b/tests/api/test_lanes.py
@@ -1012,16 +1012,17 @@ class TestCrawlableCollectionBasedLane:
         lane = CrawlableCollectionBasedLane()
         lane.initialize([db.default_collection()])
         search = external_search_fake_fixture.external_search
+        search.query_works = MagicMock(return_value=[])
         lane.works(
             db.session, facets=CrawlableFacets.default(None), search_engine=search
         )
 
-        assert len(search.queries) == 1
-        filter = search.queries[0][1]
+        queries = search.query_works.call_args[1]
+        assert search.query_works.call_count == 1
         # Only target a single collection
-        assert filter.collection_ids == [db.default_collection().id]
+        assert queries["filter"].collection_ids == [db.default_collection().id]
         # without any search query
-        assert None == search.queries[0][0]
+        assert None == queries["query_string"]
 
 
 class TestCrawlableCustomListBasedLane:

--- a/tests/api/test_lanes.py
+++ b/tests/api/test_lanes.py
@@ -1012,7 +1012,7 @@ class TestCrawlableCollectionBasedLane:
         lane = CrawlableCollectionBasedLane()
         lane.initialize([db.default_collection()])
         search = external_search_fake_fixture.external_search
-        search.query_works = MagicMock(return_value=[])
+        search.query_works = MagicMock(return_value=[])  # type: ignore [method-assign]
         lane.works(
             db.session, facets=CrawlableFacets.default(None), search_engine=search
         )

--- a/tests/api/test_scripts.py
+++ b/tests/api/test_scripts.py
@@ -16,11 +16,7 @@ from api.config import Configuration
 from api.marc import LibraryAnnotator as MARCLibraryAnnotator
 from api.novelist import NoveListAPI
 from core.entrypoint import AudiobooksEntryPoint, EbooksEntryPoint
-from core.external_search import (
-    ExternalSearchIndex,
-    mock_search_index,
-)
-from core.entrypoint import AudiobooksEntryPoint, EbooksEntryPoint, EntryPoint
+from core.external_search import ExternalSearchIndex, mock_search_index
 from core.lane import Facets, FeaturedFacets, Pagination, WorkList
 from core.marc import MARCExporter
 from core.model import (

--- a/tests/api/test_scripts.py
+++ b/tests/api/test_scripts.py
@@ -754,6 +754,7 @@ class TestInstanceInitializationScript:
             caplog.set_level(logging.ERROR)
             script.migrate_database = MagicMock(side_effect=CommandError("test"))
             script.initialize_database = MagicMock()
+            script.initialize_search_indexes = MagicMock()
 
             # If the database is initialized, migrate_database() is called.
             inspect().has_table.return_value = True

--- a/tests/api/test_scripts.py
+++ b/tests/api/test_scripts.py
@@ -408,6 +408,7 @@ class TestCacheOPDSGroupFeedPerLane:
         external_search_fixture: ExternalSearchFixture,
     ):
         db = lane_script_fixture.db
+        external_search_fixture.init_indices()
         # When it's time to generate a feed, AcquisitionFeed.groups
         # is called with the right arguments.
 
@@ -818,8 +819,8 @@ class TestInstanceInitializationScript:
         def mockable_search(*args):
             return _mockable_search
 
-        # Initially this should be an empty index
-        assert search.search_service().read_pointer() == f"{base_name}-empty"
+        # Initially this should not exist, if InstanceInit has not been run
+        assert search.search_service().read_pointer() == None
 
         with patch("scripts.ExternalSearchIndex", new=mockable_search):
             # To fake "no migration is available", mock all the values

--- a/tests/api/test_scripts.py
+++ b/tests/api/test_scripts.py
@@ -818,7 +818,7 @@ class TestInstanceInitializationScript:
             return _mockable_search
 
         # Initially this should be an empty index
-        assert search.search_service().read_pointer(base_name) == f"{base_name}-empty"
+        assert search.search_service().read_pointer() == f"{base_name}-empty"
 
         with patch("scripts.ExternalSearchIndex", new=mockable_search):
             # To fake "no migration is available", mock all the values
@@ -847,9 +847,10 @@ class TestInstanceInitializationScript:
         # Initialization should work now
         assert script.initialize_search_indexes(db.session) == True
         # Then we have the latest version index
-        assert search.search_service().read_pointer(
-            base_name
-        ) == search._revision.name_for_index(base_name)
+        assert (
+            search.search_service().read_pointer()
+            == search._revision.name_for_index(base_name)
+        )
 
     def test_initialize_search_indexes_no_integration(
         self, db: DatabaseTransactionFixture

--- a/tests/api/test_scripts.py
+++ b/tests/api/test_scripts.py
@@ -328,7 +328,9 @@ class TestCacheFacetListsPerLane:
     ):
         db = lane_script_fixture.db
         migration = end_to_end_search_fixture.external_search_index.start_migration()
-        migration and migration.finish()
+        assert migration is not None
+        migration.finish()
+
         # When it's time to generate a feed, AcquisitionFeed.page
         # is called with the right arguments.
         class MockAcquisitionFeed:
@@ -524,7 +526,7 @@ class TestCacheOPDSGroupFeedPerLane:
             genres=["Science Fiction"],
         )
         search_engine = external_search_fake_fixture.external_search
-        search_engine.query_works_multi = MagicMock(
+        search_engine.query_works_multi = MagicMock(  # type: ignore [method-assign]
             return_value=[fake_hits([work]), fake_hits([work])]
         )
         with mock_search_index(search_engine):

--- a/tests/api/test_scripts.py
+++ b/tests/api/test_scripts.py
@@ -727,8 +727,9 @@ class TestInstanceInitializationScript:
         # as necessary.
         with patch("scripts.inspect") as inspect:
             script = InstanceInitializationScript()
-            script.migrate_database = MagicMock()
-            script.initialize_database = MagicMock()
+            script.migrate_database = MagicMock()  # type: ignore[method-assign]
+            script.initialize_database = MagicMock()  # type: ignore[method-assign]
+            script.initialize_search_indexes = MagicMock()  # type: ignore[method-assign]
 
             # If the database is uninitialized, initialize_database() is called.
             inspect().has_table.return_value = False

--- a/tests/core/models/test_work.py
+++ b/tests/core/models/test_work.py
@@ -479,13 +479,6 @@ class TestWork:
         work = db.work(with_license_pool=True)
 
         search = external_search_fake_fixture.external_search
-        # This is how the work will be represented in the dummy search
-        # index.
-        index_key = (
-            external_search_fake_fixture.write_index_name(),
-            work.id,
-        )
-
         presentation = work.presentation_edition
         work.set_presentation_ready_based_on_content(search_index_client=search)
         assert True == work.presentation_ready

--- a/tests/core/search/test_documents.py
+++ b/tests/core/search/test_documents.py
@@ -64,7 +64,13 @@ class TestDocuments:
         t.parameters["x"] = "a"
         t.parameters["y"] = "b"
         t.parameters["z"] = "c"
-        assert {"type": "keyword", "x": "a", "y": "b", "z": "c"} == t.serialize()
+        assert {
+            "type": "keyword",
+            "normalizer": "filterable_string",
+            "x": "a",
+            "y": "b",
+            "z": "c",
+        } == t.serialize()
 
     def test_icu_collation_keyword(self):
         t = icu_collation_keyword()

--- a/tests/core/search/test_migration_states.py
+++ b/tests/core/search/test_migration_states.py
@@ -1,0 +1,119 @@
+"""Explicitly test the different states of migration, and ensure we are adhering to the principles set out.
+These tests do have some overlap with the unit tests for the search migration, but these are specific to the migration use cases.
+Initial Case
+- No pointers or indices are available
+- The System comes online for the first time and some prep work must be done
+- The initial versioned indices and pointers should be prepped by the init_instance script
+- The ExternalSearchIndex should not be hindered by this
+Migration Case
+- Pointers exist, indices exist
+- The migration contains a new version for the index
+- The search_index_refresh script, when run, should create and populate the indices, and move the red/write pointers
+- The ExternalSearchIndex should not be hindered by this, and should continue to work with the pointers, regardless of where they point
+"""
+
+import pytest
+
+from core.external_search import ExternalSearchIndex, SearchIndexCoverageProvider
+from core.scripts import RunWorkCoverageProviderScript
+from core.search.document import SearchMappingDocument
+from core.search.revision import SearchSchemaRevision
+from core.search.revision_directory import SearchRevisionDirectory
+from scripts import InstanceInitializationScript
+from tests.fixtures.search import ExternalSearchFixture
+
+
+class TestMigrationStates:
+    def test_initial_migration_case(
+        self, external_search_fixture: ExternalSearchFixture
+    ):
+        fx = external_search_fixture
+        db = fx.db
+
+        # Ensure we are in the initial state, no test indices and pointer available
+        prefix = fx.integration.setting(
+            ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY
+        ).value
+        all_indices = fx.search.indices.get("*")
+        for index_name in all_indices.keys():
+            assert prefix not in index_name
+
+        client = ExternalSearchIndex(db.session)
+
+        # We cannot make any requests before we intitialize
+        with pytest.raises(Exception) as raised:
+            client.query_works("")
+        assert "index_not_found" in str(raised.value)
+
+        # When a new sytem comes up the first code to run is the InstanceInitailization script
+        # This preps the DB and the search indices/pointers
+        InstanceInitializationScript().initialize(db.session.connection())
+
+        # Ensure we have created the index and pointers
+        new_index_name = client._revision.name_for_index(client._revision_base_name)
+        empty_index_name = client.search_service()._empty(client._revision_base_name)  # type: ignore [attr-defined]
+        all_indices = fx.search.indices.get("*")
+
+        assert prefix in new_index_name
+        assert new_index_name in all_indices.keys()
+        assert empty_index_name in all_indices.keys()
+        assert fx.search.indices.exists_alias(
+            client._search_read_pointer, index=new_index_name
+        )
+        assert fx.search.indices.exists_alias(
+            client._search_write_pointer, index=new_index_name
+        )
+
+        # The same client should work without issue once the pointers are setup
+        assert client.query_works("").hits == []
+
+    def test_migration_case(self, external_search_fixture: ExternalSearchFixture):
+        fx = external_search_fixture
+        db = fx.db
+
+        # The initial indices setup
+        InstanceInitializationScript().initialize(db.session.connection())
+
+        MOCK_VERSION = 1000001
+
+        class MockSchema(SearchSchemaRevision):
+            def __init__(self, v: int):
+                self.SEARCH_VERSION = v
+                super().__init__()
+
+            def mapping_document(self) -> SearchMappingDocument:
+                return SearchMappingDocument()
+
+        client = ExternalSearchIndex(
+            db.session,
+            revision_directory=SearchRevisionDirectory(
+                {MOCK_VERSION: MockSchema(MOCK_VERSION)}
+            ),
+        )
+        # The search client works just fine
+        assert client.query_works("") is not None
+        receiver = client.start_updating_search_documents()
+        receiver.add_documents([{"work_id": 123}])
+        receiver.finish()
+
+        mock_index_name = client._revision.name_for_index(client._revision_base_name)
+        assert str(MOCK_VERSION) in mock_index_name
+
+        # The mock index does not exist yet
+        with pytest.raises(Exception) as raised:
+            fx.search.indices.get(mock_index_name)
+        assert "index_not_found" in str(raised.value)
+
+        # This should run the migration
+        RunWorkCoverageProviderScript(
+            SearchIndexCoverageProvider, db.session, search_index_client=client
+        ).run()
+
+        # The new version is created, and the aliases point to the right index
+        assert fx.search.indices.get(mock_index_name) is not None
+        assert mock_index_name in fx.search.indices.get_alias(
+            name=client._search_read_pointer
+        )
+        assert mock_index_name in fx.search.indices.get_alias(
+            name=client._search_write_pointer
+        )

--- a/tests/core/search/test_migrator.py
+++ b/tests/core/search/test_migrator.py
@@ -10,8 +10,11 @@ from core.search.service import SearchWritePointer
 
 
 class EmptyRevision(SearchSchemaRevision):
+    SEARCH_VERSION = 0
+
     def __init__(self, version: int):
-        super().__init__(version)
+        self.SEARCH_VERSION = version
+        super().__init__()
 
     def mapping_document(self) -> SearchMappingDocument:
         return SearchMappingDocument()

--- a/tests/core/search/test_migrator.py
+++ b/tests/core/search/test_migrator.py
@@ -42,18 +42,18 @@ class TestMigrator:
         migration.finish()
 
         # The sequence of expected calls.
-        service.create_empty_index.assert_called_with("works")
-        service.read_pointer.assert_called_with("works")
+        service.create_empty_index.assert_called_with()
+        service.read_pointer.assert_called_with()
         # The read pointer didn't exist, so it's set to the empty index
-        service.read_pointer_set_empty.assert_called_with("works")
-        service.write_pointer.assert_called_with("works")
+        service.read_pointer_set_empty.assert_called_with()
+        service.write_pointer.assert_called_with()
         # The new index is created and populated.
-        service.index_create.assert_called_with("works", revision)
+        service.index_create.assert_called_with(revision)
         service.populate_index.assert_not_called()
         # Both the read and write pointers are set.
-        service.write_pointer_set.assert_called_with("works", revision)
-        service.read_pointer_set.assert_called_with("works", revision)
-        service.index_set_populated.assert_called_with("works", revision)
+        service.write_pointer_set.assert_called_with(revision)
+        service.read_pointer_set.assert_called_with(revision)
+        service.index_set_populated.assert_called_with(revision)
 
     def test_migrate_upgrade(self):
         """Index 2 exists, and we can migrate to 3."""
@@ -76,13 +76,13 @@ class TestMigrator:
         docs.finish()
 
         # The sequence of expected calls.
-        service.create_empty_index.assert_called_with("works")
+        service.create_empty_index.assert_called_with()
         # The read pointer existed, so it's left alone for now.
-        service.read_pointer.assert_called_with("works")
-        service.write_pointer.assert_called_with("works")
+        service.read_pointer.assert_called_with()
+        service.write_pointer.assert_called_with()
         # The index for version 3 is created and populated.
-        service.index_create.assert_called_with("works", revision)
-        service.index_set_mapping.assert_called_with("works", revision)
+        service.index_create.assert_called_with(revision)
+        service.index_set_mapping.assert_called_with(revision)
         service.index_submit_documents.assert_has_calls(
             [
                 call(
@@ -100,9 +100,9 @@ class TestMigrator:
             ]
         )
         # Both the read and write pointers are set.
-        service.write_pointer_set.assert_called_with("works", revision)
-        service.read_pointer_set.assert_called_with("works", revision)
-        service.index_set_populated.assert_called_with("works", revision)
+        service.write_pointer_set.assert_called_with(revision)
+        service.read_pointer_set.assert_called_with(revision)
+        service.index_set_populated.assert_called_with(revision)
 
     def test_migrate_upgrade_cancel(self):
         """Cancelling a migration leaves the pointers untouched."""
@@ -125,13 +125,13 @@ class TestMigrator:
         docs.cancel()
 
         # The sequence of expected calls.
-        service.create_empty_index.assert_called_with("works")
+        service.create_empty_index.assert_called_with()
         # The read pointer existed, so it's left alone for now.
-        service.read_pointer.assert_called_with("works")
-        service.write_pointer.assert_called_with("works")
+        service.read_pointer.assert_called_with()
+        service.write_pointer.assert_called_with()
         # The index for version 3 is created and populated.
-        service.index_create.assert_called_with("works", revision)
-        service.index_set_mapping.assert_called_with("works", revision)
+        service.index_create.assert_called_with(revision)
+        service.index_set_mapping.assert_called_with(revision)
         service.index_submit_documents.assert_has_calls(
             [
                 call(
@@ -168,19 +168,19 @@ class TestMigrator:
         assert docs is None
 
         # The sequence of expected calls.
-        service.create_empty_index.assert_called_with("works")
+        service.create_empty_index.assert_called_with()
         # The read pointer existed, so it's left alone for now.
-        service.read_pointer.assert_called_with("works")
-        service.write_pointer.assert_called_with("works")
+        service.read_pointer.assert_called_with()
+        service.write_pointer.assert_called_with()
         # The index for version 3 already exists and is populated, so nothing happens.
         service.index_create.assert_not_called()
         service.index_set_mapping.assert_not_called()
         # The write pointer is set redundantly.
-        service.write_pointer_set.assert_called_with("works", revision)
+        service.write_pointer_set.assert_called_with(revision)
         # The read pointer is set redundantly.
-        service.read_pointer_set.assert_called_with("works", revision)
+        service.read_pointer_set.assert_called_with(revision)
         # The "indexed" flag is set redundantly.
-        service.index_set_populated.assert_called_with("works", revision)
+        service.index_set_populated.assert_called_with(revision)
 
     def test_migrate_from_indexed_2_to_3_unpopulated(self):
         """Index 3 exists but is not populated. Migrating involves populating it."""
@@ -198,13 +198,13 @@ class TestMigrator:
         migration.finish()
 
         # The sequence of expected calls.
-        service.create_empty_index.assert_called_with("works")
+        service.create_empty_index.assert_called_with()
         # The read pointer existed, so it's left alone for now.
-        service.read_pointer.assert_called_with("works")
-        service.write_pointer.assert_called_with("works")
+        service.read_pointer.assert_called_with()
+        service.write_pointer.assert_called_with()
         # The index for version 3 exists but isn't populated, so it is populated.
-        service.index_create.assert_called_with("works", revision)
-        service.index_set_mapping.assert_called_with("works", revision)
+        service.index_create.assert_called_with(revision)
+        service.index_set_mapping.assert_called_with(revision)
         service.index_submit_documents.assert_has_calls(
             [
                 call(
@@ -214,9 +214,9 @@ class TestMigrator:
             ]
         )
         # Both the read and write pointers are updated.
-        service.write_pointer_set.assert_called_with("works", revision)
-        service.read_pointer_set.assert_called_with("works", revision)
-        service.index_set_populated.assert_called_with("works", revision)
+        service.write_pointer_set.assert_called_with(revision)
+        service.read_pointer_set.assert_called_with(revision)
+        service.index_set_populated.assert_called_with(revision)
 
     def test_migrate_from_indexed_2_to_3_write_unset(self):
         """Index 3 exists and is populated, but the write pointer is unset."""
@@ -233,15 +233,15 @@ class TestMigrator:
         assert docs is None
 
         # The sequence of expected calls.
-        service.create_empty_index.assert_called_with("works")
+        service.create_empty_index.assert_called_with()
         # The read pointer existed, so it's left alone for now.
-        service.read_pointer.assert_called_with("works")
+        service.read_pointer.assert_called_with()
         # The write pointer is completely unset.
-        service.write_pointer.assert_called_with("works")
+        service.write_pointer.assert_called_with()
         # The index for version 3 exists and is populated. The create call is redundant but harmless.
-        service.index_create.assert_called_with("works", revision)
+        service.index_create.assert_called_with(revision)
         service.populate_index.assert_not_called()
         # Both the read and write pointers are updated.
-        service.write_pointer_set.assert_called_with("works", revision)
-        service.read_pointer_set.assert_called_with("works", revision)
-        service.index_set_populated.assert_called_with("works", revision)
+        service.write_pointer_set.assert_called_with(revision)
+        service.read_pointer_set.assert_called_with(revision)
+        service.index_set_populated.assert_called_with(revision)

--- a/tests/core/search/test_migrator.py
+++ b/tests/core/search/test_migrator.py
@@ -32,6 +32,7 @@ class TestMigrator:
         service.read_pointer = MagicMock(return_value=None)
         service.write_pointer = MagicMock(return_value=None)
         service.index_is_populated = MagicMock(return_value=False)
+        service.index_set_populated = MagicMock()
 
         revision = EmptyRevision(3)
         revisions = SearchRevisionDirectory({revision.version: revision})
@@ -52,6 +53,7 @@ class TestMigrator:
         # Both the read and write pointers are set.
         service.write_pointer_set.assert_called_with("works", revision)
         service.read_pointer_set.assert_called_with("works", revision)
+        service.index_set_populated.assert_called_with("works", revision)
 
     def test_migrate_upgrade(self):
         """Index 2 exists, and we can migrate to 3."""
@@ -61,6 +63,7 @@ class TestMigrator:
         service.index_is_populated = MagicMock(return_value=False)
         service.index_set_mapping = MagicMock()
         service.index_submit_documents = MagicMock()
+        service.index_set_populated = MagicMock()
 
         revision = EmptyRevision(3)
         revisions = SearchRevisionDirectory({revision.version: revision})
@@ -99,6 +102,7 @@ class TestMigrator:
         # Both the read and write pointers are set.
         service.write_pointer_set.assert_called_with("works", revision)
         service.read_pointer_set.assert_called_with("works", revision)
+        service.index_set_populated.assert_called_with("works", revision)
 
     def test_migrate_upgrade_cancel(self):
         """Cancelling a migration leaves the pointers untouched."""
@@ -108,6 +112,7 @@ class TestMigrator:
         service.index_is_populated = MagicMock(return_value=False)
         service.index_set_mapping = MagicMock()
         service.index_submit_documents = MagicMock()
+        service.index_set_populated = MagicMock()
 
         revision = EmptyRevision(3)
         revisions = SearchRevisionDirectory({revision.version: revision})
@@ -146,6 +151,7 @@ class TestMigrator:
         # Both the read and write pointers are left untouched.
         service.write_pointer_set.assert_not_called()
         service.read_pointer_set.assert_not_called()
+        service.index_set_populated.assert_not_called()
 
     def test_migrate_no_op(self):
         """Index 3 already exists, so migrating to 3 is a no-op."""
@@ -153,6 +159,7 @@ class TestMigrator:
         service.read_pointer = MagicMock(return_value="works-v3")
         service.write_pointer = MagicMock(return_value=SearchWritePointer("works", 3))
         service.index_is_populated = MagicMock(return_value=True)
+        service.index_set_populated = MagicMock()
 
         revision = EmptyRevision(3)
         revisions = SearchRevisionDirectory({revision.version: revision})
@@ -172,6 +179,8 @@ class TestMigrator:
         service.write_pointer_set.assert_called_with("works", revision)
         # The read pointer is set redundantly.
         service.read_pointer_set.assert_called_with("works", revision)
+        # The "indexed" flag is set redundantly.
+        service.index_set_populated.assert_called_with("works", revision)
 
     def test_migrate_from_indexed_2_to_3_unpopulated(self):
         """Index 3 exists but is not populated. Migrating involves populating it."""
@@ -179,6 +188,7 @@ class TestMigrator:
         service.read_pointer = MagicMock(return_value="works-v2")
         service.write_pointer = MagicMock(return_value=SearchWritePointer("works", 2))
         service.index_is_populated = MagicMock(return_value=False)
+        service.index_set_populated = MagicMock()
 
         revision = EmptyRevision(3)
         revisions = SearchRevisionDirectory({revision.version: revision})
@@ -206,6 +216,7 @@ class TestMigrator:
         # Both the read and write pointers are updated.
         service.write_pointer_set.assert_called_with("works", revision)
         service.read_pointer_set.assert_called_with("works", revision)
+        service.index_set_populated.assert_called_with("works", revision)
 
     def test_migrate_from_indexed_2_to_3_write_unset(self):
         """Index 3 exists and is populated, but the write pointer is unset."""
@@ -213,6 +224,7 @@ class TestMigrator:
         service.read_pointer = MagicMock(return_value="works-v2")
         service.write_pointer = MagicMock(return_value=None)
         service.index_is_populated = MagicMock(return_value=True)
+        service.index_set_populated = MagicMock()
 
         revision = EmptyRevision(3)
         revisions = SearchRevisionDirectory({revision.version: revision})
@@ -232,3 +244,4 @@ class TestMigrator:
         # Both the read and write pointers are updated.
         service.write_pointer_set.assert_called_with("works", revision)
         service.read_pointer_set.assert_called_with("works", revision)
+        service.index_set_populated.assert_called_with("works", revision)

--- a/tests/core/search/test_search_revision_directory.py
+++ b/tests/core/search/test_search_revision_directory.py
@@ -1,0 +1,50 @@
+from unittest import mock
+
+import pytest
+
+from core.search.document import SearchMappingDocument
+from core.search.revision import SearchSchemaRevision
+from core.search.revision_directory import SearchRevisionDirectory
+
+
+class AnyNumberRevision(SearchSchemaRevision):
+    def __init__(self, number):
+        self.SEARCH_VERSION = number
+        super().__init__()
+
+    def mapping_document(self) -> SearchMappingDocument:
+        return SearchMappingDocument()
+
+
+class TestSearchRevisionDirectory:
+    def test_create(self):
+        """Also tests _create_revisions"""
+        with mock.patch("core.search.revision_directory.REVISIONS", new=[]):
+            assert SearchRevisionDirectory.create().available == {}
+
+        with mock.patch(
+            "core.search.revision_directory.REVISIONS",
+            new=[AnyNumberRevision(1), AnyNumberRevision(2)],
+        ):
+            assert list(SearchRevisionDirectory.create().available.keys()) == [1, 2]
+
+        with mock.patch(
+            "core.search.revision_directory.REVISIONS",
+            new=[AnyNumberRevision(1), AnyNumberRevision(1)],
+        ):
+            with pytest.raises(ValueError) as raised:
+                SearchRevisionDirectory.create()
+            assert str(raised.value) == "Revision version 1 is defined multiple times"
+
+    def test_highest(self):
+        with mock.patch(
+            "core.search.revision_directory.REVISIONS",
+            new=[AnyNumberRevision(1), AnyNumberRevision(2)],
+        ):
+            assert SearchRevisionDirectory.create().highest().version == 2
+
+        with mock.patch(
+            "core.search.revision_directory.REVISIONS",
+            new=[AnyNumberRevision(17), AnyNumberRevision(2)],
+        ):
+            assert SearchRevisionDirectory.create().highest().version == 17

--- a/tests/core/search/test_service.py
+++ b/tests/core/search/test_service.py
@@ -28,7 +28,7 @@ class TestService:
         service.create_empty_index("base")
 
         # Log the index so that the fixture cleans it up afterward.
-        external_search_fixture.indexes.append("base-empty")
+        external_search_fixture.record_index("base-empty")
 
         service.create_empty_index("base")
 
@@ -46,7 +46,7 @@ class TestService:
         service.index_create("base", revision)
 
         # Log the index so that the fixture cleans it up afterward.
-        external_search_fixture.indexes.append("base-v23")
+        external_search_fixture.record_index("base-v23")
 
         indices = external_search_fixture.search.indices.client.indices
         assert indices is not None
@@ -69,7 +69,7 @@ class TestService:
         service.index_create("base", revision)
 
         # Log the index so that the fixture cleans it up afterward.
-        external_search_fixture.indexes.append("base-v23")
+        external_search_fixture.record_index("base-v23")
 
         service.read_pointer_set("base", revision)
         assert "base-v23" == service.read_pointer("base")
@@ -82,7 +82,7 @@ class TestService:
         service.create_empty_index("base")
 
         # Log the index so that the fixture cleans it up afterward.
-        external_search_fixture.indexes.append("base-empty")
+        external_search_fixture.record_index("base-empty")
 
         service.read_pointer_set_empty("base")
         assert "base-empty" == service.read_pointer("base")
@@ -94,7 +94,7 @@ class TestService:
         service.index_create("base", revision)
 
         # Log the index so that the fixture cleans it up afterward.
-        external_search_fixture.indexes.append("base-v23")
+        external_search_fixture.record_index("base-v23")
 
         service.write_pointer_set("base", revision)
 
@@ -140,7 +140,7 @@ class TestService:
         service.index_create("base", revision)
 
         # Log the index so that the fixture cleans it up afterward.
-        external_search_fixture.indexes.append("base-v23")
+        external_search_fixture.record_index("base-v23")
         service.index_submit_documents("base-v23", documents)
         service.index_submit_documents("base-v23", documents)
 

--- a/tests/core/search/test_service.py
+++ b/tests/core/search/test_service.py
@@ -7,8 +7,11 @@ from tests.fixtures.search import ExternalSearchFixture
 
 
 class BasicMutableRevision(SearchSchemaRevision):
+    SEARCH_VERSION = 0
+
     def __init__(self, version: int):
-        super().__init__(version)
+        self.SEARCH_VERSION = version
+        super().__init__()
         self.document = SearchMappingDocument()
 
     def mapping_document(self) -> SearchMappingDocument:

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -4765,18 +4765,24 @@ class TestSearchErrors:
             external_search_fake_fixture.db,
         )
 
-        search.search.set_failing_mode(mode=SearchServiceFailureMode.FAIL_INDEXING_DOCUMENTS_TIMEOUT)
+        search.search.set_failing_mode(
+            mode=SearchServiceFailureMode.FAIL_INDEXING_DOCUMENTS_TIMEOUT
+        )
         work = transaction.work()
         work.set_presentation_ready()
 
         docs = search.external_search.start_updating_search_documents()
-        failures = docs.add_documents(search.external_search.create_search_documents_from_works([work]))
+        failures = docs.add_documents(
+            search.external_search.create_search_documents_from_works([work])
+        )
         assert 1 == len(failures)
         assert work.id == failures[0].id
         assert "Connection Timeout!" == failures[0].error_message
 
         # Submissions are not retried by the base service
-        assert [work.id] == [docs["_id"] for docs in search.search.document_submission_attempts]
+        assert [work.id] == [
+            docs["_id"] for docs in search.search.document_submission_attempts
+        ]
 
     def test_search_single_document_error(
         self, external_search_fixture: ExternalSearchFixture

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -54,6 +54,7 @@ from core.model import (
 from core.model.classification import Subject
 from core.model.work import Work
 from core.problem_details import INVALID_INPUT
+from core.search.revision_directory import SearchRevisionDirectory
 from core.search.v5 import SearchV5
 from core.util.cache import CachedData
 from core.util.datetime_helpers import datetime_utc, from_timestamp
@@ -4182,8 +4183,10 @@ class TestFilter:
         assert {} == sort
 
         # The script is the 'simplified.work_last_update' stored script.
-        # assert CurrentMapping.script_name("work_last_update") == script.pop("stored")
-        assert False
+        script_name = (
+            SearchRevisionDirectory.create().highest().script_name("work_last_update")
+        )
+        assert script_name == script.pop("stored")
 
         # Two parameters are passed into the script -- the IDs of the
         # collections and the lists relevant to the query. This is so

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -4999,7 +4999,7 @@ class TestSearchIndexCoverageProvider:
         directory = search._revision_directory
 
         # Create a new highest version
-        directory._available[10000] = SearchV10000(10000)
+        directory._available[10000] = SearchV10000()
         search._revision = directory._available[10000]
         search._search_service.index_is_populated = lambda x: False
 
@@ -5029,6 +5029,8 @@ class TestSearchIndexCoverageProvider:
 
 
 class SearchV10000(SearchSchemaRevision):
+    SEARCH_VERSION = 10000
+
     def mapping_document(self) -> SearchMappingDocument:
         return {}
 

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -5001,7 +5001,7 @@ class TestSearchIndexCoverageProvider:
         # Create a new highest version
         directory._available[10000] = SearchV10000(10000)
         search._revision = directory._available[10000]
-        search._search_service.index_is_populated = lambda x, y: False
+        search._search_service.index_is_populated = lambda x: False
 
         mock_db = MagicMock()
         provider = SearchIndexCoverageProvider(mock_db, search_index_client=search)

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -64,7 +64,11 @@ from tests.fixtures.database import (
     PerfTimer,
 )
 from tests.fixtures.library import LibraryFixture
-from tests.fixtures.search import EndToEndSearchFixture, ExternalSearchFixture, ExternalSearchFixtureFake
+from tests.fixtures.search import (
+    EndToEndSearchFixture,
+    ExternalSearchFixture,
+    ExternalSearchFixtureFake,
+)
 from tests.mocks.search import SearchServiceFailureMode, SearchServiceFake
 
 RESEARCH = Term(audience=Classifier.AUDIENCE_RESEARCH.lower())

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -996,7 +996,7 @@ class TestExternalSearchWithWorks:
             while pagination:
                 pages.append(
                     worklist.works(
-                        session, facets, pagination, fixture.external_search.search
+                        session, facets, pagination, fixture.external_search_index
                     )
                 )
                 pagination = pagination.next_page

--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -4983,23 +4983,12 @@ class TestSearchIndexCoverageProvider:
         db: DatabaseTransactionFixture,
         external_search_fake_fixture: ExternalSearchFixtureFake,
     ):
-        class DoomedExternalSearchIndex:
-            """All documents sent to this index will fail."""
-
-            def bulk(self, docs, **kwargs):
-                return 0, [
-                    dict(
-                        data=dict(_id=failing_work["_id"]),
-                        error="There was an error!",
-                        exception="Exception",
-                    )
-                    for failing_work in docs
-                ]
-
         work = db.work()
         work.set_presentation_ready()
         index = external_search_fake_fixture.external_search
-        external_search_fake_fixture.search.set_failing_mode()
+        external_search_fake_fixture.search.set_failing_mode(
+            SearchServiceFailureMode.FAIL_INDEXING_DOCUMENTS
+        )
 
         provider = SearchIndexCoverageProvider(db.session, search_index_client=index)
         results = provider.process_batch([work])

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -4098,6 +4098,7 @@ class TestLane:
         lane = db.lane()
         search_client = end_to_end_search_fixture.external_search_index
         docs = end_to_end_search_fixture.external_search_index.start_migration()
+        assert docs is not None
         docs.add_documents(search_client.create_search_documents_from_works([work]))
         docs.finish()
 
@@ -4302,7 +4303,7 @@ class TestWorkListGroupsEndToEnd:
             fixture.external_search.db,
             fixture.external_search.db.session,
         )
-        fixture.external_search_index.start_migration().finish()
+        fixture.external_search_index.start_migration().finish()  # type: ignore [union-attr]
 
         # Tell the fixture to call our populate_works method.
         # In this library, the groups feed includes at most two books

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -4303,9 +4303,6 @@ class TestWorkListGroupsEndToEnd:
             fixture.external_search.db.session,
         )
 
-        # Migrate to the latest search schema.
-        end_to_end_search_fixture.external_search_index.start_migration().finish()
-
         # Tell the fixture to call our populate_works method.
         # In this library, the groups feed includes at most two books
         # for each lane.

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -4364,8 +4364,17 @@ class TestWorkListGroupsEndToEnd:
             discredited_nonfiction,
             children,
         ]:
-            t1 = [x.id for x in lane.works(session, facets)]
+            t1 = [
+                x.id
+                for x in lane.works(
+                    session,
+                    facets,
+                    search_engine=end_to_end_search_fixture.external_search_index,
+                )
+            ]
             t2 = [x.id for x in lane.works_from_database(session, facets)]
+            print(f"t1: {t1}")
+            print(f"t2: {t2}")
             assert t1 == t2
 
         def assert_contents(g, expect):

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -4302,6 +4302,7 @@ class TestWorkListGroupsEndToEnd:
             fixture.external_search.db,
             fixture.external_search.db.session,
         )
+        fixture.external_search_index.start_migration().finish()
 
         # Tell the fixture to call our populate_works method.
         # In this library, the groups feed includes at most two books
@@ -4615,9 +4616,9 @@ class TestWorkListGroups:
     def test_groups_for_lanes_adapts_facets(
         self,
         random_seed_fixture: RandomSeedFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
-        db = external_search_fake_fixture.db
+        db = end_to_end_search_fixture.db
 
         # Verify that _groups_for_lanes gives each of a WorkList's
         # non-queryable children the opportunity to adapt the incoming

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -2296,7 +2296,9 @@ class TestWorkList:
         # 2-tuples; one for each work featured by one of its children
         # WorkLists. Note that the same work appears twice, through two
         # different children.
-        [wwl1, wwl2, wwl3] = wl.groups(db.session, search_engine=external_search_fake_fixture.external_search)
+        [wwl1, wwl2, wwl3] = wl.groups(
+            db.session, search_engine=external_search_fake_fixture.external_search
+        )
         assert (w1, child1) == wwl1
         assert (w2, child2) == wwl2
         assert (w1, child2) == wwl3

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -4409,7 +4409,7 @@ class TestWorkListGroupsEndToEnd:
             return lane.groups(
                 session,
                 facets=facets,
-                search_engine=fixture.external_search.search,
+                search_engine=fixture.external_search_index,
                 debug=True,
                 **kwargs,
             )

--- a/tests/core/test_marc.py
+++ b/tests/core/test_marc.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 from pymarc import MARCReader, Record
 
 from core.config import CannotLoadConfiguration
-from core.external_search import ExternalSearchIndex, Filter
+from core.external_search import Filter
 from core.lane import WorkList
 from core.marc import Annotator, MARCExporter, MARCExporterFacets
 from core.model import (
@@ -28,7 +28,7 @@ from core.s3 import MockS3Uploader
 from core.util.datetime_helpers import datetime_utc, utc_now
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.search import ExternalSearchFixtureFake
-from tests.mocks.search import SearchServiceFake
+from tests.mocks.search import ExternalSearchIndexFake
 
 
 class TestAnnotator:
@@ -591,6 +591,7 @@ class TestMARCExporter:
         db: DatabaseTransactionFixture,
         external_search_fake_fixture: ExternalSearchFixtureFake,
     ):
+        # external_search_fake_fixture is used only for the integration it creates
         integration = self._integration(db)
         now = utc_now()
         exporter = MARCExporter.from_config(db.default_library())
@@ -599,10 +600,8 @@ class TestMARCExporter:
         w1 = db.work(genre="Mystery", with_open_access_download=True)
         w2 = db.work(genre="Mystery", with_open_access_download=True)
 
-        search_engine = external_search_fake_fixture.external_search
-        docs = search_engine.start_updating_search_documents()
-        docs.add_documents(search_engine.create_search_documents_from_works([w1, w2]))
-        docs.finish()
+        search_engine = ExternalSearchIndexFake(db.session)
+        search_engine.mock_query_works([w1, w2])
 
         # If there's a storage protocol but not corresponding storage integration,
         # it raises an exception.
@@ -662,6 +661,7 @@ class TestMARCExporter:
 
         db.session.delete(cache)
 
+        search_engine.mock_query_works([w1, w2])
         # It also works with a WorkList instead of a Lane, in which case
         # there will be no lane in the CachedMARCFile.
         worklist = WorkList()
@@ -745,9 +745,7 @@ class TestMARCExporter:
         # If the search engine returns no contents for the lane,
         # nothing will be mirrored, but a CachedMARCFile is still
         # created to track that we checked for updates.
-        empty_search_engine = ExternalSearchIndex(
-            _db=db, custom_client_service=SearchServiceFake()
-        )
+        search_engine.mock_query_works([])
 
         mirror = MockS3Uploader()
         exporter.records(
@@ -755,7 +753,7 @@ class TestMARCExporter:
             annotator,
             mirror_integration,
             mirror=mirror,
-            search_engine=empty_search_engine,
+            search_engine=search_engine,
         )
 
         assert [] == mirror.content[0]

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -3,6 +3,7 @@ import logging
 import xml.etree.ElementTree as ET
 from io import StringIO
 from typing import Any, Callable, Generator, List, Type
+from unittest.mock import MagicMock, Mock
 
 import feedparser
 import pytest
@@ -1786,6 +1787,16 @@ class TestAcquisitionFeed:
         external_search_fake_fixture: ExternalSearchFixtureFake,
     ):
         session = db.session
+        client = external_search_fake_fixture.search.search_multi_client()
+
+        # The search client is supposed to return a set of result sets.
+        fake_work = MagicMock()
+        fake_work.work_id = 23
+        client.execute = Mock(return_value=[[fake_work]])
+        # The code calls "add" on the search client, which is supposed to return a new
+        # search client with the old search client embedded into it. We don't do that
+        # here as we're completely faking the search results anyway.
+        client.add = Mock(return_value=client)
 
         # Verify that AcquisitionFeed.page() returns an appropriate OPDSFeedResponse
 

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -54,7 +54,7 @@ from core.util.datetime_helpers import datetime_utc, utc_now
 from core.util.flask_util import OPDSEntryResponse, OPDSFeedResponse, Response
 from core.util.opds_writer import AtomFeed, OPDSFeed, OPDSMessage
 from tests.fixtures.database import DatabaseTransactionFixture, DBStatementCounter
-from tests.fixtures.search import ExternalSearchFixtureFake
+from tests.fixtures.search import EndToEndSearchFixture, ExternalSearchFixtureFake
 
 
 class TestBaseAnnotator:
@@ -1718,7 +1718,7 @@ class TestOPDS:
     def test_cache(
         self,
         opds_fixture: TestOPDSFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         data, db, session = (
             opds_fixture,
@@ -1733,7 +1733,7 @@ class TestOPDS:
         )
         fantasy_lane = data.fantasy
 
-        search_engine = external_search_fake_fixture.external_search
+        search_engine = end_to_end_search_fixture.external_search_index
         docs = search_engine.start_updating_search_documents()
         docs.add_documents(search_engine.create_search_documents_from_works([work1]))
         docs.finish()

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -754,6 +754,7 @@ class TestOPDS:
         facets = Facets.default(db.default_library())
 
         migration = end_to_end_search_fixture.external_search_index.start_migration()
+        assert migration is not None
         migration.finish()
 
         cached_feed = AcquisitionFeed.page(
@@ -1263,6 +1264,7 @@ class TestOPDS:
 
         search_engine = end_to_end_search_fixture.external_search_index
         docs = search_engine.start_migration()
+        assert docs is not None
         docs.add_documents(
             search_engine.create_search_documents_from_works([work1, work2])
         )
@@ -1346,6 +1348,7 @@ class TestOPDS:
 
         search_engine = end_to_end_search_fixture.external_search_index
         docs = search_engine.start_migration()
+        assert docs is not None
         docs.add_documents(
             search_engine.create_search_documents_from_works([work1, work2])
         )
@@ -1596,6 +1599,7 @@ class TestOPDS:
         )
         search_engine = end_to_end_search_fixture.external_search_index
         docs = search_engine.start_migration()
+        assert docs is not None
         docs.finish()
 
         # Test the case where a grouped feed turns up nothing.
@@ -1745,6 +1749,7 @@ class TestOPDS:
 
         search_engine = end_to_end_search_fixture.external_search_index
         docs = search_engine.start_migration()
+        assert docs is not None
         errors = docs.add_documents(
             search_engine.create_search_documents_from_works([work1])
         )
@@ -1773,9 +1778,9 @@ class TestOPDS:
             genre=Epic_Fantasy,
             with_open_access_download=True,
         )
-        docs = search_engine.start_updating_search_documents()
-        docs.add_documents(search_engine.create_search_documents_from_works([work2]))
-        docs.finish()
+        recv = search_engine.start_updating_search_documents()
+        recv.add_documents(search_engine.create_search_documents_from_works([work2]))
+        recv.finish()
 
         # The new work does not show up in the feed because
         # we get the old cached version.
@@ -2928,7 +2933,7 @@ class TestEntrypointLinkInsertion:
             entrypoint_link_insertion_fixture.db,
             entrypoint_link_insertion_fixture.db.session,
         )
-        end_to_end_search_fixture.external_search_index.start_migration().finish()
+        end_to_end_search_fixture.external_search_index.start_migration().finish()  # type: ignore [union-attr]
 
         # When AcquisitionFeed.groups() generates a grouped
         # feed, it will link to different entry points into the feed,

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -57,6 +57,7 @@ from core.util.flask_util import OPDSEntryResponse, OPDSFeedResponse, Response
 from core.util.opds_writer import AtomFeed, OPDSFeed, OPDSMessage
 from tests.fixtures.database import DatabaseTransactionFixture, DBStatementCounter
 from tests.fixtures.search import EndToEndSearchFixture, ExternalSearchFixtureFake
+from tests.mocks.search import ExternalSearchIndexFake
 
 
 class TestBaseAnnotator:
@@ -1651,12 +1652,8 @@ class TestOPDS:
         work2 = db.work(genre=Epic_Fantasy, with_open_access_download=True)
 
         pagination = Pagination(size=1)
-        search_client = end_to_end_search_fixture.external_search_index
-        docs = search_client.start_migration()
-        docs.add_documents(
-            search_client.create_search_documents_from_works([work1, work2])
-        )
-        docs.finish()
+        search_client = ExternalSearchIndexFake(session)
+        search_client.mock_query_works([work1, work2])
         facets = SearchFacets(order="author", min_score=10)
 
         private = object()

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -736,7 +736,7 @@ class TestOPDS:
     def test_lane_feed_contains_facet_links(
         self,
         opds_fixture: TestOPDSFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         data, db, session = (
             opds_fixture,
@@ -754,7 +754,7 @@ class TestOPDS:
             lane,
             MockAnnotator,
             facets=facets,
-            search_engine=external_search_fake_fixture.external_search,
+            search_engine=end_to_end_search_fixture.external_search_index,
         )
 
         u = str(cached_feed)
@@ -1238,7 +1238,7 @@ class TestOPDS:
     def test_page_feed(
         self,
         opds_fixture: TestOPDSFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         data, db, session = (
             opds_fixture,
@@ -1252,7 +1252,7 @@ class TestOPDS:
         work1 = db.work(genre=Contemporary_Romance, with_open_access_download=True)
         work2 = db.work(genre=Contemporary_Romance, with_open_access_download=True)
 
-        search_engine = external_search_fake_fixture.external_search
+        search_engine = end_to_end_search_fixture.external_search_index
         docs = search_engine.start_updating_search_documents()
         docs.add_documents(
             search_engine.create_search_documents_from_works([work1, work2])
@@ -1321,7 +1321,7 @@ class TestOPDS:
     def test_page_feed_for_worklist(
         self,
         opds_fixture: TestOPDSFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         data, db, session = (
             opds_fixture,
@@ -1335,7 +1335,7 @@ class TestOPDS:
         work1 = db.work(genre=Contemporary_Romance, with_open_access_download=True)
         work2 = db.work(genre=Contemporary_Romance, with_open_access_download=True)
 
-        search_engine = external_search_fake_fixture.external_search
+        search_engine = end_to_end_search_fixture.external_search_index
         docs = search_engine.start_updating_search_documents()
         docs.add_documents(
             search_engine.create_search_documents_from_works([work1, work2])
@@ -1623,7 +1623,7 @@ class TestOPDS:
     def test_search_feed(
         self,
         opds_fixture: TestOPDSFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         data, db, session = (
             opds_fixture,
@@ -1638,7 +1638,7 @@ class TestOPDS:
         work2 = db.work(genre=Epic_Fantasy, with_open_access_download=True)
 
         pagination = Pagination(size=1)
-        search_client = external_search_fake_fixture.external_search
+        search_client = end_to_end_search_fixture.external_search_index
         docs = search_client.start_updating_search_documents()
         docs.add_documents(
             search_client.create_search_documents_from_works([work1, work2])

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -1803,7 +1803,7 @@ class TestAcquisitionFeed:
         external_search_fake_fixture: ExternalSearchFixtureFake,
     ):
         session = db.session
-        client = external_search_fake_fixture.search.search_multi_client()
+        client = external_search_fake_fixture.search.search_multi_client("read-pointer")
 
         # The search client is supposed to return a set of result sets.
         fake_work = MagicMock()

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -1805,7 +1805,7 @@ class TestAcquisitionFeed:
         external_search_fake_fixture: ExternalSearchFixtureFake,
     ):
         session = db.session
-        client = external_search_fake_fixture.search.search_multi_client("read-pointer")
+        client = external_search_fake_fixture.search.search_multi_client()
 
         # The search client is supposed to return a set of result sets.
         fake_work = MagicMock()

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -1474,7 +1474,7 @@ class TestOPDS:
     def test_groups_feed(
         self,
         opds_fixture: TestOPDSFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         data, db, session = (
             opds_fixture,
@@ -1494,7 +1494,7 @@ class TestOPDS:
         # of the work don't matter. It just needs to have a LicensePool
         # so it'll show up in the OPDS feed.
         work = db.work(title="An epic tome", with_open_access_download=True)
-        search_engine = external_search_fake_fixture.external_search
+        search_engine = end_to_end_search_fixture.external_search_index
         docs = search_engine.start_migration()
         docs.add_documents(search_engine.create_search_documents_from_works([work]))
         docs.finish()
@@ -1734,8 +1734,11 @@ class TestOPDS:
         fantasy_lane = data.fantasy
 
         search_engine = end_to_end_search_fixture.external_search_index
-        docs = search_engine.start_updating_search_documents()
-        docs.add_documents(search_engine.create_search_documents_from_works([work1]))
+        docs = search_engine.start_migration()
+        errors = docs.add_documents(
+            search_engine.create_search_documents_from_works([work1])
+        )
+        assert errors == []
         docs.finish()
 
         def make_page():

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -1574,22 +1574,23 @@ class TestOPDS:
     def test_empty_groups_feed(
         self,
         opds_fixture: TestOPDSFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         data, db, session = (
             opds_fixture,
             opds_fixture.db,
             opds_fixture.db.session,
         )
+        search_engine = end_to_end_search_fixture.external_search_index
+        docs = search_engine.start_migration()
+        docs.finish()
 
         # Test the case where a grouped feed turns up nothing.
 
         # A Lane, and a Work not in the Lane.
         test_lane = db.lane("Test Lane", genres=["Mystery"])
 
-        # Mock search index and Annotator.
-        search_engine = external_search_fake_fixture.external_search
-
+        # Mock Annotator.
         class Mock(MockAnnotator):
             def annotate_feed(self, feed, worklist):
                 self.called = True

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -2914,13 +2914,14 @@ class TestEntrypointLinkInsertion:
     def test_groups(
         self,
         entrypoint_link_insertion_fixture: TestEntrypointLinkInsertionFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         data, db, session = (
             entrypoint_link_insertion_fixture,
             entrypoint_link_insertion_fixture.db,
             entrypoint_link_insertion_fixture.db.session,
         )
+        end_to_end_search_fixture.external_search_index.start_migration().finish()
 
         # When AcquisitionFeed.groups() generates a grouped
         # feed, it will link to different entry points into the feed,
@@ -2938,7 +2939,7 @@ class TestEntrypointLinkInsertion:
                 data.annotator,
                 max_age=0,
                 facets=facets,
-                search_engine=external_search_fake_fixture.external_search,
+                search_engine=end_to_end_search_fixture.external_search_index,
             )
             return data.mock.called_with
 

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -1253,7 +1253,7 @@ class TestOPDS:
         work2 = db.work(genre=Contemporary_Romance, with_open_access_download=True)
 
         search_engine = end_to_end_search_fixture.external_search_index
-        docs = search_engine.start_updating_search_documents()
+        docs = search_engine.start_migration()
         docs.add_documents(
             search_engine.create_search_documents_from_works([work1, work2])
         )
@@ -1336,7 +1336,7 @@ class TestOPDS:
         work2 = db.work(genre=Contemporary_Romance, with_open_access_download=True)
 
         search_engine = end_to_end_search_fixture.external_search_index
-        docs = search_engine.start_updating_search_documents()
+        docs = search_engine.start_migration()
         docs.add_documents(
             search_engine.create_search_documents_from_works([work1, work2])
         )
@@ -1495,7 +1495,7 @@ class TestOPDS:
         # so it'll show up in the OPDS feed.
         work = db.work(title="An epic tome", with_open_access_download=True)
         search_engine = external_search_fake_fixture.external_search
-        docs = search_engine.start_updating_search_documents()
+        docs = search_engine.start_migration()
         docs.add_documents(search_engine.create_search_documents_from_works([work]))
         docs.finish()
 
@@ -1639,7 +1639,7 @@ class TestOPDS:
 
         pagination = Pagination(size=1)
         search_client = end_to_end_search_fixture.external_search_index
-        docs = search_client.start_updating_search_documents()
+        docs = search_client.start_migration()
         docs.add_documents(
             search_client.create_search_documents_from_works([work1, work2])
         )

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -748,11 +748,12 @@ class TestOPDS:
 
         cached_feed = AcquisitionFeed.page(
             session,
-            "title", "http://the-url.com/",
+            "title",
+            "http://the-url.com/",
             lane,
             MockAnnotator,
             facets=facets,
-            search_engine=external_search_fake_fixture.external_search
+            search_engine=external_search_fake_fixture.external_search,
         )
 
         u = str(cached_feed)

--- a/tests/core/test_opds2.py
+++ b/tests/core/test_opds2.py
@@ -26,6 +26,7 @@ class TestOPDS2FeedFixture:
     transaction: DatabaseTransactionFixture
     search_engine: ExternalSearchIndex
     fiction: Lane
+    search_fixture: EndToEndSearchFixture
 
 
 @pytest.fixture
@@ -55,6 +56,7 @@ class TestOPDS2Feed:
         )
 
         docs = data.search_engine.start_migration()
+        assert docs is not None
         docs.add_documents(
             data.search_engine.create_search_documents_from_works([work])
         )
@@ -107,6 +109,7 @@ class TestOPDS2Feed:
         ]
 
         docs = data.search_engine.start_migration()
+        assert docs is not None
         docs.add_documents(data.search_engine.create_search_documents_from_works(works))
         docs.finish()
 
@@ -164,6 +167,7 @@ class TestOPDS2AnnotatorFixture:
     search_engine: ExternalSearchIndex
     fiction: Lane
     annotator: OPDS2Annotator
+    search_integration: ExternalIntegration
 
 
 @pytest.fixture

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -2090,8 +2090,9 @@ class TestRebuildSearchIndexScript:
         [progress] = script.do_run()
 
         # The mock methods were called with the values we expect.
-        assert True == index.setup_index_called
-        assert {work, work2} == set(index.bulk_update_called_with)
+        assert {work.id, work2.id} == set(
+            map(lambda d: d["_id"], external_search_fake_fixture.search.documents_all())
+        )
 
         # The script returned a list containing a single
         # CoverageProviderProgress object containing accurate

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -1634,7 +1634,7 @@ class TestWhereAreMyBooksScript:
     def test_overall_structure(
         self,
         db: DatabaseTransactionFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         # Verify that run() calls the methods we expect.
 
@@ -1701,7 +1701,7 @@ class TestWhereAreMyBooksScript:
     def test_check_library(
         self,
         db: DatabaseTransactionFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         # Give the default library a collection and a lane.
         library = db.default_library()
@@ -1709,7 +1709,7 @@ class TestWhereAreMyBooksScript:
         lane = db.lane(library=library)
 
         script = MockWhereAreMyBooks(
-            _db=db.session, search=external_search_fake_fixture.external_search
+            _db=db.session, search=end_to_end_search_fixture.external_search_index
         )
         script.check_library(library)
 
@@ -1730,7 +1730,7 @@ class TestWhereAreMyBooksScript:
     def test_delete_cached_feeds(
         self,
         db: DatabaseTransactionFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         groups = CachedFeed(type=CachedFeed.GROUPS_TYPE, pagination="")
         db.session.add(groups)
@@ -1740,7 +1740,7 @@ class TestWhereAreMyBooksScript:
         assert 2 == db.session.query(CachedFeed).count()
 
         script = MockWhereAreMyBooks(
-            _db=db.session, search=external_search_fake_fixture.search
+            _db=db.session, search=end_to_end_search_fixture.external_search_index
         )
         script.delete_cached_feeds()
         how_many, theyre_gone = script.output
@@ -1763,7 +1763,7 @@ class TestWhereAreMyBooksScript:
     @staticmethod
     def check_explanation(
         db: DatabaseTransactionFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
         presentation_ready=1,
         not_presentation_ready=0,
         no_delivery_mechanisms=0,
@@ -1775,7 +1775,7 @@ class TestWhereAreMyBooksScript:
         """Runs explain_collection() and verifies expected output."""
         script = MockWhereAreMyBooks(
             _db=db.session,
-            search=external_search_fake_fixture.external_search,
+            search=end_to_end_search_fixture.external_search_index,
             **kwargs,
         )
         script.explain_collection(db.default_collection())
@@ -1821,16 +1821,16 @@ class TestWhereAreMyBooksScript:
     def test_no_presentation_ready_works(
         self,
         db: DatabaseTransactionFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         # This work is not presentation-ready.
         work = db.work(with_license_pool=True)
         work.presentation_ready = False
         script = MockWhereAreMyBooks(
-            _db=db.session, search=external_search_fake_fixture.external_search
+            _db=db.session, search=end_to_end_search_fixture.external_search_index
         )
         self.check_explanation(
-            external_search_fake_fixture=external_search_fake_fixture,
+            end_to_end_search_fixture=end_to_end_search_fixture,
             presentation_ready=0,
             not_presentation_ready=1,
             db=db,
@@ -1839,7 +1839,7 @@ class TestWhereAreMyBooksScript:
     def test_no_delivery_mechanisms(
         self,
         db: DatabaseTransactionFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         # This work has a license pool, but no delivery mechanisms.
         work = db.work(with_license_pool=True)
@@ -1848,13 +1848,13 @@ class TestWhereAreMyBooksScript:
         self.check_explanation(
             no_delivery_mechanisms=1,
             db=db,
-            external_search_fake_fixture=external_search_fake_fixture,
+            end_to_end_search_fixture=end_to_end_search_fixture,
         )
 
     def test_suppressed_pool(
         self,
         db: DatabaseTransactionFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         # This work has a license pool, but it's suppressed.
         work = db.work(with_license_pool=True)
@@ -1862,13 +1862,13 @@ class TestWhereAreMyBooksScript:
         self.check_explanation(
             suppressed=1,
             db=db,
-            external_search_fake_fixture=external_search_fake_fixture,
+            end_to_end_search_fixture=end_to_end_search_fixture,
         )
 
     def test_no_licenses(
         self,
         db: DatabaseTransactionFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         # This work has a license pool, but no licenses owned.
         work = db.work(with_license_pool=True)
@@ -1876,16 +1876,16 @@ class TestWhereAreMyBooksScript:
         self.check_explanation(
             not_owned=1,
             db=db,
-            external_search_fake_fixture=external_search_fake_fixture,
+            end_to_end_search_fixture=end_to_end_search_fixture,
         )
 
     def test_search_engine(
         self,
         db: DatabaseTransactionFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
         output = StringIO()
-        search = external_search_fake_fixture.external_search
+        search = end_to_end_search_fixture.external_search_index
         work = db.work(with_license_pool=True)
         work.presentation_ready = True
 
@@ -1899,7 +1899,7 @@ class TestWhereAreMyBooksScript:
             search=search,
             in_search_index=1,
             db=db,
-            external_search_fake_fixture=external_search_fake_fixture,
+            end_to_end_search_fixture=end_to_end_search_fixture,
         )
 
 

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -1884,19 +1884,16 @@ class TestWhereAreMyBooksScript:
         db: DatabaseTransactionFixture,
         end_to_end_search_fixture: EndToEndSearchFixture,
     ):
-        output = StringIO()
         search = end_to_end_search_fixture.external_search_index
         work = db.work(with_license_pool=True)
         work.presentation_ready = True
 
-        docs = search.start_updating_search_documents()
+        docs = search.start_migration()
         docs.add_documents(search.create_search_documents_from_works([work]))
         docs.finish()
 
-        # This MockExternalSearchIndex will always claim there is one
-        # result.
+        # This search index will always claim there is one result.
         self.check_explanation(
-            search=search,
             in_search_index=1,
             db=db,
             end_to_end_search_fixture=end_to_end_search_fixture,

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -2139,11 +2139,14 @@ class TestSearchIndexCoverageRemover:
 
 
 class TestUpdateLaneSizeScript:
-    def test_do_run(self, db, external_search_fake_fixture: ExternalSearchFixtureFake):
+    def test_do_run(self, db, end_to_end_search_fixture: EndToEndSearchFixture):
+        end_to_end_search_fixture.external_search_index.start_migration().finish()
+
         lane = db.lane()
         lane.size = 100
         UpdateLaneSizeScript(
-            db.session, search_index_client=external_search_fake_fixture.external_search
+            db.session,
+            search_index_client=end_to_end_search_fixture.external_search_index,
         ).do_run(cmd_args=[])
         assert 0 == lane.size
 
@@ -2165,15 +2168,18 @@ class TestUpdateLaneSizeScript:
     def test_site_configuration_has_changed(
         self,
         db: DatabaseTransactionFixture,
-        external_search_fake_fixture: ExternalSearchFixtureFake,
+        end_to_end_search_fixture: EndToEndSearchFixture,
     ):
+        end_to_end_search_fixture.external_search_index.start_migration().finish()
+
         library = db.default_library()
         lane1 = db.lane()
         lane2 = db.lane()
 
         # Run the script to create all the default config settings.
         UpdateLaneSizeScript(
-            db.session, search_index_client=external_search_fake_fixture.external_search
+            db.session,
+            search_index_client=end_to_end_search_fixture.external_search_index,
         ).do_run(cmd_args=[])
 
         # Set the lane sizes

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -1825,6 +1825,7 @@ class TestWhereAreMyBooksScript:
     ):
         # This work is not presentation-ready.
         work = db.work(with_license_pool=True)
+        end_to_end_search_fixture.external_search_index.initialize_indices()
         work.presentation_ready = False
         script = MockWhereAreMyBooks(
             _db=db.session, search=end_to_end_search_fixture.external_search_index
@@ -1843,6 +1844,7 @@ class TestWhereAreMyBooksScript:
     ):
         # This work has a license pool, but no delivery mechanisms.
         work = db.work(with_license_pool=True)
+        end_to_end_search_fixture.external_search_index.initialize_indices()
         for lpdm in work.license_pools[0].delivery_mechanisms:
             db.session.delete(lpdm)
         self.check_explanation(
@@ -1858,6 +1860,7 @@ class TestWhereAreMyBooksScript:
     ):
         # This work has a license pool, but it's suppressed.
         work = db.work(with_license_pool=True)
+        end_to_end_search_fixture.external_search_index.initialize_indices()
         work.license_pools[0].suppressed = True
         self.check_explanation(
             suppressed=1,
@@ -1872,6 +1875,7 @@ class TestWhereAreMyBooksScript:
     ):
         # This work has a license pool, but no licenses owned.
         work = db.work(with_license_pool=True)
+        end_to_end_search_fixture.external_search_index.initialize_indices()
         work.license_pools[0].licenses_owned = 0
         self.check_explanation(
             not_owned=1,

--- a/tests/fixtures/api_controller.py
+++ b/tests/fixtures/api_controller.py
@@ -331,7 +331,9 @@ class CirculationControllerFixture(ControllerFixture):
             setattr(self, spec.variable_name, work)
             work.license_pools[0].collection = self.collection
             self.works.append(work)
-        self.manager.external_search.bulk_update(self.works)
+        self.manager.external_search.search_service().index_submit_documents(
+            self.manager.external_search._search_write_pointer, [self.works]
+        )
 
     def assert_bad_search_index_gives_problem_detail(self, test_function):
         """Helper method to test that a controller method serves a problem

--- a/tests/fixtures/api_controller.py
+++ b/tests/fixtures/api_controller.py
@@ -331,9 +331,11 @@ class CirculationControllerFixture(ControllerFixture):
             setattr(self, spec.variable_name, work)
             work.license_pools[0].collection = self.collection
             self.works.append(work)
+
         self.manager.external_search.search_service().index_submit_documents(
             self.manager.external_search._search_write_pointer, [self.works]
         )
+        self.manager.external_search.mock_query_works_multi(self.works)
 
     def assert_bad_search_index_gives_problem_detail(self, test_function):
         """Helper method to test that a controller method serves a problem

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -82,6 +82,10 @@ class ExternalSearchFixture:
         work.set_presentation_ready()
         return work
 
+    def init_indices(self):
+        client = ExternalSearchIndex(self.db.session)
+        client.initialize_indices()
+
 
 @pytest.fixture(scope="function")
 def external_search_fixture(

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -260,7 +260,7 @@ def external_search_fake_fixture(
         url="http://does-not-exist.com/",
         settings={
             ExternalSearchIndex.WORKS_INDEX_PREFIX_KEY: "test_index",
-            ExternalSearchIndex.TEST_SEARCH_TERM_KEY: "test_search_term",
+            ExternalSearchIndex.TEST_SEARCH_TERM_KEY: "a search term",
         },
     )
     data.search = SearchServiceFake()

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -253,6 +253,7 @@ def external_search_fake_fixture(
 ) -> ExternalSearchFixtureFake:
     """Ask for an external search system that can be populated with data for end-to-end tests."""
     data = ExternalSearchFixtureFake()
+    data.db = db
     data.integration = db.external_integration(
         ExternalIntegration.OPENSEARCH,
         goal=ExternalIntegration.SEARCH_GOAL,

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -98,6 +98,7 @@ class EndToEndSearchFixture:
     """Tests are expected to call the `populate()` method to populate the fixture with test-specific data."""
     external_search: ExternalSearchFixture
     external_search_index: ExternalSearchIndex
+    db: DatabaseTransactionFixture
 
     def __init__(self):
         self._logger = logging.getLogger(EndToEndSearchFixture.__name__)
@@ -105,6 +106,7 @@ class EndToEndSearchFixture:
     @classmethod
     def create(cls, transaction: DatabaseTransactionFixture) -> "EndToEndSearchFixture":
         data = EndToEndSearchFixture()
+        data.db = transaction
         data.external_search = ExternalSearchFixture.create(transaction)
         data.external_search_index = ExternalSearchIndex(transaction.session)
         return data

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -65,6 +65,8 @@ class ExternalSearchFixture:
             except Exception as e:
                 self._logger.info(f"Failed to delete index {index}: {e}")
 
+        self._logger.info("Waiting for operations to complete.")
+        self.search.indices.refresh()
         return None
 
     def default_work(self, *args, **kwargs):

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -65,6 +65,8 @@ class ExternalSearchFixture:
             except Exception as e:
                 self._logger.info(f"Failed to delete index {index}: {e}")
 
+        # Force test index deletion
+        self.search.indices.delete("test_index*")
         self._logger.info("Waiting for operations to complete.")
         self.search.indices.refresh()
         return None

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -258,9 +258,6 @@ class ExternalSearchFixtureFake:
     search: SearchServiceFake
     external_search: ExternalSearchIndex
 
-    def write_index_name(self) -> str:
-        return self.search.write_pointer_name(base_name="test_index")
-
 
 @pytest.fixture(scope="function")
 def external_search_fake_fixture(

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -252,8 +252,12 @@ def end_to_end_search_fixture(
 ) -> Iterable[EndToEndSearchFixture]:
     """Ask for an external search system that can be populated with data for end-to-end tests."""
     data = EndToEndSearchFixture.create(db)
-    yield data
-    data.close()
+    try:
+        yield data
+    except Exception:
+        raise
+    finally:
+        data.close()
 
 
 class ExternalSearchFixtureFake:

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -40,6 +40,7 @@ class SearchServiceFake(SearchService):
     _document_submission_attempts: List[dict]
 
     def __init__(self):
+        self.base_name = "test_index"
         self._failing = SearchServiceFailureMode.NOT_FAILING
         self._documents_by_index = {}
         self._read_pointer: Optional[str] = None
@@ -84,52 +85,48 @@ class SearchServiceFake(SearchService):
         self._fail_if_necessary()
         return
 
-    def read_pointer_name(self, base_name: str) -> str:
+    def read_pointer_name(self) -> str:
         self._fail_if_necessary()
-        return f"{base_name}-search-read"
+        return f"{self.base_name}-search-read"
 
-    def write_pointer_name(self, base_name: str) -> str:
+    def write_pointer_name(self) -> str:
         self._fail_if_necessary()
-        return f"{base_name}-search-write"
+        return f"{self.base_name}-search-write"
 
-    def read_pointer(self, base_name: str) -> Optional[str]:
+    def read_pointer(self) -> Optional[str]:
         self._fail_if_necessary()
         return self._read_pointer
 
-    def write_pointer(self, base_name: str) -> Optional[SearchWritePointer]:
+    def write_pointer(self) -> Optional[SearchWritePointer]:
         self._fail_if_necessary()
         return self._write_pointer
 
-    def create_empty_index(self, base_name: str) -> None:
+    def create_empty_index(self) -> None:
         self._fail_if_necessary()
-        self._indexes_created.append(f"{base_name}-empty")
+        self._indexes_created.append(f"{self.base_name}-empty")
         return None
 
-    def read_pointer_set(self, base_name: str, revision: SearchSchemaRevision) -> None:
+    def read_pointer_set(self, revision: SearchSchemaRevision) -> None:
         self._fail_if_necessary()
-        self._read_pointer = f"{revision.name_for_indexed_pointer(base_name)}"
+        self._read_pointer = f"{revision.name_for_indexed_pointer(self.base_name)}"
 
-    def index_set_populated(
-        self, base_name: str, revision: SearchSchemaRevision
-    ) -> None:
+    def index_set_populated(self, revision: SearchSchemaRevision) -> None:
         self._fail_if_necessary()
 
-    def read_pointer_set_empty(self, base_name: str) -> None:
+    def read_pointer_set_empty(self) -> None:
         self._fail_if_necessary()
-        self._read_pointer = f"{base_name}-empty"
+        self._read_pointer = f"{self.base_name}-empty"
 
-    def index_create(self, base_name: str, revision: SearchSchemaRevision) -> None:
+    def index_create(self, revision: SearchSchemaRevision) -> None:
         self._fail_if_necessary()
-        self._indexes_created.append(revision.name_for_index(base_name))
+        self._indexes_created.append(revision.name_for_index(self.base_name))
         return None
 
-    def index_is_populated(
-        self, base_name: str, revision: SearchSchemaRevision
-    ) -> bool:
+    def index_is_populated(self, revision: SearchSchemaRevision) -> bool:
         self._fail_if_necessary()
         return True
 
-    def index_set_mapping(self, base_name: str, revision: SearchSchemaRevision) -> None:
+    def index_set_mapping(self, revision: SearchSchemaRevision) -> None:
         self._fail_if_necessary()
 
     def index_submit_documents(
@@ -177,20 +174,24 @@ class SearchServiceFake(SearchService):
 
         return []
 
-    def write_pointer_set(self, base_name: str, revision: SearchSchemaRevision) -> None:
+    def write_pointer_set(self, revision: SearchSchemaRevision) -> None:
         self._fail_if_necessary()
-        self._write_pointer = SearchWritePointer(base_name, revision.version)
+        self._write_pointer = SearchWritePointer(self.base_name, revision.version)
 
     def index_clear_documents(self, pointer: str):
         self._fail_if_necessary()
         if pointer in self._documents_by_index:
             self._documents_by_index[pointer] = []
 
-    def search_client(self, pointer_name: str) -> Search:
-        return self._search_client.index(pointer_name)
+    def search_client(self, write=False) -> Search:
+        return self._search_client.index(
+            self.read_pointer_name() if not write else self.write_pointer_name()
+        )
 
-    def search_multi_client(self, pointer_name: str) -> MultiSearch:
-        return self._multi_search_client.index(pointer_name)
+    def search_multi_client(self, write=False) -> MultiSearch:
+        return self._multi_search_client.index(
+            self.read_pointer_name() if not write else self.write_pointer_name()
+        )
 
     def index_remove_document(self, pointer: str, id: int):
         self._fail_if_necessary()

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -1,0 +1,159 @@
+from enum import Enum
+from typing import Optional, Iterable, List, Dict
+from unittest.mock import MagicMock
+
+from opensearch_dsl import Search, MultiSearch
+from opensearchpy import OpenSearchException
+
+from core.search.revision import SearchSchemaRevision
+from core.search.service import SearchService, SearchWritePointer, SearchServiceFailedDocument
+
+
+class SearchServiceFailureMode(Enum):
+    """The simulated failure modes for the search service."""
+    NOT_FAILING = 0
+    FAIL_INDEXING_DOCUMENTS = 1
+    FAIL_ENTIRELY = 2
+
+
+class SearchServiceFake(SearchService):
+    """A search service that doesn't speak to a real service."""
+
+    _documents_by_index: Dict[str, List[dict]]
+    _failing: SearchServiceFailureMode
+    _search_client: Search
+    _multi_search_client: MultiSearch
+    _indexes_created: List[str]
+
+    def __init__(self):
+        self._failing = SearchServiceFailureMode.NOT_FAILING
+        self._documents_by_index = {}
+        self._read_pointer: Optional[str] = None
+        self._write_pointer: Optional[SearchWritePointer] = None
+        self._search_client = Search(using=MagicMock())
+        self._multi_search_client = MultiSearch(using=MagicMock())
+        self._indexes_created = []
+
+    def indexes_created(self) -> List[str]:
+        return self._indexes_created
+
+    def _fail_if_necessary(self):
+        if self._failing == SearchServiceFailureMode.FAIL_ENTIRELY:
+            raise OpenSearchException('Search index is on fire.')
+
+    def set_failing_mode(self, mode: SearchServiceFailureMode):
+        self._failing = mode
+
+    def documents_for_index(self, index_name: str) -> List[dict]:
+        self._fail_if_necessary()
+
+        if not (index_name in self._documents_by_index):
+            return []
+        return self._documents_by_index[index_name]
+
+    def documents_all(self) -> List[dict]:
+        self._fail_if_necessary()
+
+        results: List[dict] = []
+        for documents in self._documents_by_index.values():
+            for document in documents:
+                results.append(document)
+
+        return results
+
+    def refresh(self):
+        self._fail_if_necessary()
+        return
+
+    def read_pointer_name(self, base_name: str) -> str:
+        self._fail_if_necessary()
+        return f"{base_name}-search-read"
+
+    def write_pointer_name(self, base_name: str) -> str:
+        self._fail_if_necessary()
+        return f"{base_name}-search-write"
+
+    def read_pointer(self, base_name: str) -> Optional[str]:
+        self._fail_if_necessary()
+        return self._read_pointer
+
+    def write_pointer(self, base_name: str) -> Optional[SearchWritePointer]:
+        self._fail_if_necessary()
+        return self._write_pointer
+
+    def create_empty_index(self, base_name: str) -> None:
+        self._fail_if_necessary()
+        self._indexes_created.append(f'{base_name}-empty')
+        return None
+
+    def read_pointer_set(self, base_name: str, revision: SearchSchemaRevision) -> None:
+        self._fail_if_necessary()
+        self._read_pointer = f'{revision.name_for_indexed_pointer(base_name)}'
+
+    def read_pointer_set_empty(self, base_name: str) -> None:
+        self._fail_if_necessary()
+        self._read_pointer = f'{base_name}-empty'
+
+    def index_create(self, base_name: str, revision: SearchSchemaRevision) -> None:
+        self._fail_if_necessary()
+        self._indexes_created.append(revision.name_for_index(base_name))
+        return None
+
+    def index_is_populated(
+        self, base_name: str, revision: SearchSchemaRevision
+    ) -> bool:
+        self._fail_if_necessary()
+        return True
+
+    def index_set_mapping(self, base_name: str, revision: SearchSchemaRevision) -> None:
+        self._fail_if_necessary()
+        pass
+
+    def index_submit_documents(
+        self, pointer: str, documents: Iterable[dict]
+    ) -> List[SearchServiceFailedDocument]:
+        self._fail_if_necessary()
+        if self._failing:
+            results: List[SearchServiceFailedDocument] = []
+            for document in documents:
+                results.append(SearchServiceFailedDocument(
+                    document['_id'],
+                    error_message='There was an error!',
+                    error_status=500,
+                    error_exception='Exception'
+                ))
+            return results
+
+        if not (pointer in self._documents_by_index):
+            self._documents_by_index[pointer] = []
+
+        for document in documents:
+            self._documents_by_index[pointer].append(document)
+
+        return []
+
+    def write_pointer_set(self, base_name: str, revision: SearchSchemaRevision) -> None:
+        self._fail_if_necessary()
+        self._write_pointer = SearchWritePointer(base_name, revision.version)
+
+    def index_clear_documents(self, pointer: str):
+        self._fail_if_necessary()
+        if pointer in self._documents_by_index:
+            self._documents_by_index[pointer] = []
+
+    def search_client(self) -> Search:
+        return self._search_client
+
+    def search_multi_client(self) -> MultiSearch:
+        return self._multi_search_client
+
+    def index_remove_document(self, pointer: str, id: int):
+        self._fail_if_necessary()
+        if pointer in self._documents_by_index:
+            items = self._documents_by_index[pointer]
+            to_remove = []
+            for item in items:
+                if item.get('_id') == id:
+                    to_remove.append(item)
+            for item in to_remove:
+                items.remove(item)

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -1,16 +1,21 @@
 from enum import Enum
-from typing import Optional, Iterable, List, Dict
+from typing import Dict, Iterable, List, Optional
 from unittest.mock import MagicMock
 
-from opensearch_dsl import Search, MultiSearch
+from opensearch_dsl import MultiSearch, Search
 from opensearchpy import OpenSearchException
 
 from core.search.revision import SearchSchemaRevision
-from core.search.service import SearchService, SearchWritePointer, SearchServiceFailedDocument
+from core.search.service import (
+    SearchService,
+    SearchServiceFailedDocument,
+    SearchWritePointer,
+)
 
 
 class SearchServiceFailureMode(Enum):
     """The simulated failure modes for the search service."""
+
     NOT_FAILING = 0
     FAIL_INDEXING_DOCUMENTS = 1
     FAIL_ENTIRELY = 2
@@ -39,7 +44,7 @@ class SearchServiceFake(SearchService):
 
     def _fail_if_necessary(self):
         if self._failing == SearchServiceFailureMode.FAIL_ENTIRELY:
-            raise OpenSearchException('Search index is on fire.')
+            raise OpenSearchException("Search index is on fire.")
 
     def set_failing_mode(self, mode: SearchServiceFailureMode):
         self._failing = mode
@@ -83,16 +88,16 @@ class SearchServiceFake(SearchService):
 
     def create_empty_index(self, base_name: str) -> None:
         self._fail_if_necessary()
-        self._indexes_created.append(f'{base_name}-empty')
+        self._indexes_created.append(f"{base_name}-empty")
         return None
 
     def read_pointer_set(self, base_name: str, revision: SearchSchemaRevision) -> None:
         self._fail_if_necessary()
-        self._read_pointer = f'{revision.name_for_indexed_pointer(base_name)}'
+        self._read_pointer = f"{revision.name_for_indexed_pointer(base_name)}"
 
     def read_pointer_set_empty(self, base_name: str) -> None:
         self._fail_if_necessary()
-        self._read_pointer = f'{base_name}-empty'
+        self._read_pointer = f"{base_name}-empty"
 
     def index_create(self, base_name: str, revision: SearchSchemaRevision) -> None:
         self._fail_if_necessary()
@@ -107,7 +112,6 @@ class SearchServiceFake(SearchService):
 
     def index_set_mapping(self, base_name: str, revision: SearchSchemaRevision) -> None:
         self._fail_if_necessary()
-        pass
 
     def index_submit_documents(
         self, pointer: str, documents: Iterable[dict]
@@ -116,12 +120,14 @@ class SearchServiceFake(SearchService):
         if self._failing:
             results: List[SearchServiceFailedDocument] = []
             for document in documents:
-                results.append(SearchServiceFailedDocument(
-                    document['_id'],
-                    error_message='There was an error!',
-                    error_status=500,
-                    error_exception='Exception'
-                ))
+                results.append(
+                    SearchServiceFailedDocument(
+                        document["_id"],
+                        error_message="There was an error!",
+                        error_status=500,
+                        error_exception="Exception",
+                    )
+                )
             return results
 
         if not (pointer in self._documents_by_index):
@@ -153,7 +159,7 @@ class SearchServiceFake(SearchService):
             items = self._documents_by_index[pointer]
             to_remove = []
             for item in items:
-                if item.get('_id') == id:
+                if item.get("_id") == id:
                     to_remove.append(item)
             for item in to_remove:
                 items.remove(item)

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -217,6 +217,10 @@ def fake_hits(works: List[Work]):
 
 
 class ExternalSearchIndexFake(ExternalSearchIndex):
+    """A fake search index, to be used where we do not care what the search does, just that the results match what we expect
+    Eg. Testing a Feed object doesn't need to test the search index, it just needs the search index to report correctly
+    """
+
     def __init__(
         self,
         _db,
@@ -262,7 +266,9 @@ class ExternalSearchIndexFake(ExternalSearchIndex):
                         this_result = []
                 else:
                     # Else just assume offset pagination
-                    this_result = this_result[pagination.offset : pagination.size]
+                    this_result = this_result[
+                        pagination.offset : pagination.offset + pagination.size
+                    ]
 
                 pagination.page_loaded(this_result)
                 result.append(this_result)

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -102,6 +102,11 @@ class SearchServiceFake(SearchService):
         self._fail_if_necessary()
         self._read_pointer = f"{revision.name_for_indexed_pointer(base_name)}"
 
+    def index_set_populated(
+        self, base_name: str, revision: SearchSchemaRevision
+    ) -> None:
+        self._fail_if_necessary()
+
     def read_pointer_set_empty(self, base_name: str) -> None:
         self._fail_if_necessary()
         self._read_pointer = f"{base_name}-empty"

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -9,6 +9,7 @@ from opensearch_dsl.response.hit import Hit
 from opensearchpy import OpenSearchException
 
 from core.external_search import ExternalSearchIndex
+from core.model import Work
 from core.model.work import Work
 from core.search.revision import SearchSchemaRevision
 from core.search.revision_directory import SearchRevisionDirectory
@@ -229,6 +230,7 @@ class ExternalSearchIndexFake(ExternalSearchIndex):
         )
 
         self._mock_multi_works = []
+        self._mock_count_works = 0
 
     def mock_query_works(self, works: List[Work]):
         self.mock_query_works_multi(works)
@@ -241,6 +243,13 @@ class ExternalSearchIndexFake(ExternalSearchIndex):
         for ix, (query_string, filter, pagination) in enumerate(queries):
             pagination.page_loaded(self._mock_multi_works[ix])
         return self._mock_multi_works
+
+    def mock_count_works(self, count):
+        self._mock_count_works = count
+
+    def count_works(self, filter):
+        """So far this is not required in the tests"""
+        return self._mock_count_works
 
     def __repr__(self) -> str:
         return f"Expected Results({id(self)}): {self._mock_multi_works}"

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -203,6 +203,9 @@ class SearchServiceFake(SearchService):
             for item in to_remove:
                 items.remove(item)
 
+    def is_pointer_empty(*args):
+        return False
+
 
 def fake_hits(works: List[Work]):
     return [

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -179,11 +179,11 @@ class SearchServiceFake(SearchService):
         if pointer in self._documents_by_index:
             self._documents_by_index[pointer] = []
 
-    def search_client(self) -> Search:
-        return self._search_client
+    def search_client(self, pointer_name: str) -> Search:
+        return self._search_client.index(pointer_name)
 
-    def search_multi_client(self) -> MultiSearch:
-        return self._multi_search_client
+    def search_multi_client(self, pointer_name: str) -> MultiSearch:
+        return self._multi_search_client.index(pointer_name)
 
     def index_remove_document(self, pointer: str, id: int):
         self._fail_if_necessary()

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -117,7 +117,7 @@ class SearchServiceFake(SearchService):
         self, pointer: str, documents: Iterable[dict]
     ) -> List[SearchServiceFailedDocument]:
         self._fail_if_necessary()
-        if self._failing:
+        if self._failing == SearchServiceFailureMode.FAIL_INDEXING_DOCUMENTS:
             results: List[SearchServiceFailedDocument] = []
             for document in documents:
                 results.append(

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -126,8 +126,14 @@ class SearchServiceFake(SearchService):
         self._fail_if_necessary()
 
         _should_fail = False
-        _should_fail = _should_fail or self._failing == SearchServiceFailureMode.FAIL_INDEXING_DOCUMENTS
-        _should_fail = _should_fail or self._failing == SearchServiceFailureMode.FAIL_INDEXING_DOCUMENTS_TIMEOUT
+        _should_fail = (
+            _should_fail
+            or self._failing == SearchServiceFailureMode.FAIL_INDEXING_DOCUMENTS
+        )
+        _should_fail = (
+            _should_fail
+            or self._failing == SearchServiceFailureMode.FAIL_INDEXING_DOCUMENTS_TIMEOUT
+        )
 
         if _should_fail:
             results: List[SearchServiceFailedDocument] = []
@@ -141,13 +147,13 @@ class SearchServiceFake(SearchService):
                         error_exception="Exception",
                     )
                 else:
-                    _error  = SearchServiceFailedDocument(
+                    _error = SearchServiceFailedDocument(
                         document["_id"],
                         error_message="Connection Timeout!",
                         error_status=0,
                         error_exception="ConnectionTimeout",
                     )
-                results.append(_error )
+                results.append(_error)
 
             return results
 

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -230,6 +230,9 @@ class ExternalSearchIndexFake(ExternalSearchIndex):
 
         self._mock_multi_works = []
 
+    def mock_query_works(self, works: List[Work]):
+        self.mock_query_works_multi(works)
+
     def mock_query_works_multi(self, works: List[Work], *args: List[Work]):
         self._mock_multi_works = [fake_hits(works)]
         self._mock_multi_works.extend([fake_hits(arg_works) for arg_works in args])
@@ -238,3 +241,6 @@ class ExternalSearchIndexFake(ExternalSearchIndex):
         for ix, (query_string, filter, pagination) in enumerate(queries):
             pagination.page_loaded(self._mock_multi_works[ix])
         return self._mock_multi_works
+
+    def __repr__(self) -> str:
+        return f"Expected Results({id(self)}): {self._mock_multi_works}"

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from functools import partial
 from typing import Dict, Iterable, List, Optional
 from unittest.mock import MagicMock
 
@@ -8,6 +9,7 @@ from opensearch_dsl import MultiSearch, Search
 from opensearch_dsl.response.hit import Hit
 from opensearchpy import OpenSearchException
 
+from core.external_search import ExternalSearchIndex
 from core.model.work import Work
 from core.search.revision import SearchSchemaRevision
 from core.search.service import (
@@ -203,3 +205,8 @@ class SearchServiceFake(SearchService):
 
 def fake_hits(works: List[Work]):
     return [Hit({"_source": {"work_id": work.id}}) for work in works]
+
+
+ExternalSearchIndexFake = partial(
+    ExternalSearchIndex, custom_client_service=SearchServiceFake()
+)

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 from enum import Enum
 from typing import Dict, Iterable, List, Optional
 from unittest.mock import MagicMock
 
 from opensearch_dsl import MultiSearch, Search
+from opensearch_dsl.response.hit import Hit
 from opensearchpy import OpenSearchException
 
+from core.model.work import Work
 from core.search.revision import SearchSchemaRevision
 from core.search.service import (
     SearchService,
@@ -195,3 +199,7 @@ class SearchServiceFake(SearchService):
                     to_remove.append(item)
             for item in to_remove:
                 items.remove(item)
+
+
+def fake_hits(works: List[Work]):
+    return [Hit({"_source": {"work_id": work.id}}) for work in works]

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -233,9 +233,9 @@ class ExternalSearchIndexFake(ExternalSearchIndex):
             _db, url, test_search_term, revision_directory, version, SearchServiceFake()
         )
 
-        self._mock_multi_works = []
+        self._mock_multi_works: List[Dict] = []
         self._mock_count_works = 0
-        self._queries = []
+        self._queries: List[tuple] = []
 
     def mock_query_works(self, works: List[Work]):
         self.mock_query_works_multi(works)


### PR DESCRIPTION
## Description

This is the bulk of the herculean task required to perform safe Opensearch migrations. The general outline is detailed in this document:

https://ataxia.io7m.com/2023/06/08/search/

The main changes here:

* We now treat schemas ("mappings" in Opensearch terminology) as immutable. If a field needs to change type, or if a new field needs to be added, that requires a schema upgrade.
* Schema revisions are represented by (subclasses of) the `SearchSchemaRevision` class. All of the code required to set up mappings for a single schema version are in the class for that version. Currently, the only defined version is version `5` (`SearchV5`).
* Schema version classes are aggregated into a directory (`SearchRevisionDirectory`) with the system picking the "best" (read: highest) available version as the version to which the system will attempt to migrate when instructed.
* Atomic read/write pointers are used to ensure that we can always read search documents from old indexes if the migration to the new index didn't succeed, or is in progress and is taking all night.
* Migration is performed by the `SearchMigrator` class.
* ~~Code no longer mocks the `ExternalSearchIndex`. There was a lot of confusing code around this class, including lots of injection of mock classes into it, layering violations, code reaching into the internals, and some very confused tests that appeared to be testing the behaviour of mocks alone. :shrug:~~ We mock the search index, but have no special tests for the mocks, we only expect the mocked search index to provide specific data when testing some other functionality
* All communication with Opensearch is encapsulated in a `SearchServiceOpensearch1` class, which is a subclass of an abstract `SearchService` class. If behaviour needs to be mocked, the correct approach is to produce mock implementations of the `SearchService` class as that encapsulates all of the actual side effects that need to be mocked.
* The `SearchServiceOpensearch1` class does not do any retries if an entire batch of documents fails to be submitted (perhaps due to a timeout). This is something that will need to be added back in if we need it. Thankfully, there's only a single method that would require updates, as there's no longer a free-for-all all over the codebase of submitting search documents through the bulk API. :angry: 

This required quite an obscene amount of debugging and untangling of code.

~~There are currently 12 test failures that I don't understand. One existing test had to be marked as skipped, because despite consisting mostly of mocks, the test itself would hang somewhere inside the bowels of `pytest` and require a `SIGKILL` to stop.~~

## Motivation and Context

We have no way to safely and atomically upgrade (or downgrade) our search indexes. If a search index fails for any reason, we have an outage until the new index is populated.

Affects: https://ebce-lyrasis.atlassian.net/browse/PP-65

## How Has This Been Tested?

This has been tested extensively locally, and lots of new tests were written.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
