### PR TITLE
Remove AdobeAuth/devices links from feeds (PP-176) 

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -67,14 +67,6 @@ class CirculationPatronProfileStorage(PatronProfileStorage):
             ] = "http://librarysimplified.org/terms/drm/scheme/ACS"
             drm.append(adobe_drm)
 
-            device_link["rel"] = "http://librarysimplified.org/terms/drm/rel/devices"
-            device_link["href"] = self.url_for(
-                "adobe_drm_devices",
-                library_short_name=self.patron.library.short_name,
-                _external=True,
-            )
-            links.append(device_link)
-
             annotations_link = dict(
                 rel="http://www.w3.org/ns/oa#annotationService",
                 type=AnnotationWriter.CONTENT_TYPE,

--- a/api/opds.py
+++ b/api/opds.py
@@ -1343,20 +1343,6 @@ class LibraryAnnotator(CirculationManagerAnnotator):
                 patron_key = OPDSFeed.makeelement("{%s}clientToken" % OPDSFeed.DRM_NS)
                 patron_key.text = token
                 drm_licensor.append(patron_key)
-
-                # Add the link to the DRM Device Management Protocol
-                # endpoint. See:
-                # https://github.com/NYPL-Simplified/Simplified/wiki/DRM-Device-Management
-                device_list_link = OPDSFeed.makeelement("link")
-                device_list_link.attrib[
-                    "rel"
-                ] = "http://librarysimplified.org/terms/drm/rel/devices"
-                device_list_link.attrib["href"] = self.url_for(
-                    "adobe_drm_devices",
-                    library_short_name=self.library.short_name,
-                    _external=True,
-                )
-                drm_licensor.append(device_list_link)
                 cached = [drm_licensor]
 
             self._adobe_id_tags[cache_key] = cached

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -458,14 +458,7 @@ class TestCirculationPatronProfileStorage:
         assert (
             adobe["drm:scheme"] == "http://librarysimplified.org/terms/drm/scheme/ACS"
         )
-        [device_link, annotations_link] = doc["links"]
-        assert (
-            device_link["rel"] == "http://librarysimplified.org/terms/drm/rel/devices"
-        )
-        assert (
-            device_link["href"]
-            == "http://host/adobe_drm_devices?library_short_name=default"
-        )
+        [annotations_link] = doc["links"]
         assert annotations_link["rel"] == "http://www.w3.org/ns/oa#annotationService"
         assert (
             annotations_link["href"]

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -656,7 +656,7 @@ class TestLibraryAnnotator:
         key = "{http://librarysimplified.org/terms/drm}vendor"
         assert vendor_id_fixture.TEST_VENDOR_ID == element.attrib[key]
 
-        [token, device_management_link] = element
+        [token] = element
 
         assert "{http://librarysimplified.org/terms/drm}clientToken" == token.tag
         # token.text is a token which we can decode, since we know
@@ -669,16 +669,6 @@ class TestLibraryAnnotator:
             Configuration.WEBSITE_URL, library
         ).value
         assert (expected_url, patron_identifier) == decoded
-
-        assert "link" == device_management_link.tag
-        assert (
-            "http://librarysimplified.org/terms/drm/rel/devices"
-            == device_management_link.attrib["rel"]
-        )
-        expect_url = annotator_fixture.annotator.url_for(
-            "adobe_drm_devices", library_short_name=library.short_name, _external=True
-        )
-        assert expect_url == device_management_link.attrib["href"]
 
         # If we call adobe_id_tags again we'll get a distinct tag
         # object that renders to the same XML.
@@ -1282,7 +1272,7 @@ class TestLibraryAnnotator:
             vendor_id_fixture.TEST_VENDOR_ID
             == licensor.attrib["{http://librarysimplified.org/terms/drm}vendor"]
         )
-        [client_token, device_management_link] = licensor
+        [client_token] = licensor
         expected = ConfigurationSetting.for_library_and_externalintegration(
             annotator_fixture.db.session,
             ExternalIntegration.USERNAME,
@@ -1291,11 +1281,6 @@ class TestLibraryAnnotator:
         ).value.upper()
         assert client_token.text.startswith(expected)
         assert adobe_patron_identifier in client_token.text
-        assert "{http://www.w3.org/2005/Atom}link" == device_management_link.tag
-        assert (
-            "http://librarysimplified.org/terms/drm/rel/devices"
-            == device_management_link.attrib["rel"]
-        )
 
         # Unlike other places this tag shows up, we use the
         # 'scheme' attribute to explicitly state that this


### PR DESCRIPTION
## Description

Remove the `http://librarysimplified.org/terms/drm/rel/devices` links from the CM `/loans` and `/patrons/me` feeds. This link is no longer needed, because we removed the Adobe device activation code in https://github.com/ThePalaceProject/circulation/pull/1230.

We preserve the `drm` tag, that communicates the adobe vendor ID details.

## Motivation and Context

From JIRA: 
> I am unable to sign out of the Minotaur Test Library on either iOS or Android. iOS screenshot attached. On Android, the error manifests as a 500 error.

Looking at server logs, this is because we are getting a 500 response when requesting `/patrons/me` because the CM is trying to create the link for the `adobe_drm_devices` endpoint. 

```json
{"type": "http://librarysimplified.org/terms/problem/internal-server-error", "title": "Internal server error.", "status": 500, "detail": "Internal server error", "debug_message": "Could not build url for endpoint 'adobe_drm_devices' with values ['library_short_name']. Did you mean 'patron_devices' instead?"}
```

## How Has This Been Tested?

Tested locally, and ran CM tests. The tricky part of getting this fixed is to actually test the full workflow with the mobile apps. Once this gets merged, I'll do some testing with the mobile apps to see if they have any issues with these links being removed from the feeds.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
