### PR TITLE
Fix log messages for logo table migration

### DIFF
--- a/alembic/versions/20230706_c471f553249b_migrate_library_logo.py
+++ b/alembic/versions/20230706_c471f553249b_migrate_library_logo.py
@@ -45,7 +45,7 @@ def upgrade() -> None:
             (library.id,),
         ).first()
         if setting and setting.value:
-            log.info("Library {library.short_name} has a logo, migrating it.")
+            log.info(f"Library {library.short_name} has a logo, migrating it.")
             logo_str = setting.value
 
             # We stored the logo with a data:image prefix before, but we


### PR DESCRIPTION
## Description

Fix the log message in `20230706_c471f553249b_migrate_library_logo.py ` migration. One of the log messages forgot to use a fstring, so log messages were not being correctly interpolated.

## Motivation and Context

When debugging https://github.com/ThePalaceProject/circulation/pull/1269 I ran this migration, and noticed that the log messages were not being formatted as I expected.

## How Has This Been Tested?

Running migration locally.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
