### PR TITLE
Re-add token authentication (PP-200)

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -401,6 +401,12 @@ class LibraryAuthenticator:
         ):
             raise CannotLoadConfiguration("Two basic auth providers configured")
         self.basic_auth_provider = provider
+        if self.library is not None:
+            self.access_token_authentication_provider = (
+                BasicTokenAuthenticationProvider(
+                    self._db, self.library, self.basic_auth_provider
+                )
+            )
 
     def register_saml_provider(
         self,

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 from werkzeug.datastructures import Authorization
 
 from api.annotations import AnnotationWriter
+from api.authentication.access_token import AccessTokenProvider
 from api.authentication.base import PatronData
 from api.authentication.basic import (
     BarcodeFormats,
@@ -922,6 +923,21 @@ class TestLibraryAuthenticator:
             assert response == "foo"
             assert saml.authenticated_patron.call_count == 1
 
+    def test_authenticated_patron_bearer_access_token(
+        self, db: DatabaseTransactionFixture, mock_basic: MockBasicFixture
+    ):
+        basic = mock_basic()
+        authenticator = LibraryAuthenticator(
+            _db=db.session, library=db.default_library(), basic_auth_provider=basic
+        )
+        patron = db.patron()
+        token = AccessTokenProvider.generate_token(db.session, patron, "pass")
+        auth = Authorization(auth_type="bearer", token=token)
+
+        auth_patron = authenticator.authenticated_patron(db.session, auth)
+        assert type(auth_patron) == Patron
+        assert auth_patron.id == patron.id
+
     def test_authenticated_patron_unsupported_mechanism(
         self, db: DatabaseTransactionFixture
     ):
@@ -956,6 +972,16 @@ class TestLibraryAuthenticator:
             basic_auth_provider=None,
         )
         assert authenticator.get_credential_from_header(credential) is None
+
+        authenticator = LibraryAuthenticator(
+            _db=db.session,
+            library=db.default_library(),
+            basic_auth_provider=basic,
+        )
+        patron = db.patron()
+        token = AccessTokenProvider.generate_token(db.session, patron, "passworx")
+        credential = Authorization(auth_type="bearer", token=token)
+        assert authenticator.get_credential_from_header(credential) == "passworx"
 
     def test_create_authentication_document(
         self,
@@ -1077,7 +1103,7 @@ class TestLibraryAuthenticator:
             # The main thing we need to test is that the
             # authentication sub-documents are assembled properly and
             # placed in the right position.
-            [basic_doc] = doc["authentication"]
+            [token_doc, basic_doc] = doc["authentication"]
 
             expect_basic = basic.authentication_flow_document(db.session)
             assert expect_basic == basic_doc


### PR DESCRIPTION
## Description

This reverts commit 308c4db755a9f314c7efc8be4eea2b300546e52b (https://github.com/ThePalaceProject/circulation/pull/1249) and adds back in token auth.

## Motivation and Context

We reverted this code, since it was causing issues on iOS. In order to resolve these issues, we need a version of the CM with token auth deployed somewhere, we will deploy from this branch, then merge the PR once the iOS work is complete.

Setting this as a draft PR for now, until its ready to be merged.

## How Has This Been Tested?

It hasn't, just reverted the other commit with git.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
