### PR TITLE
Fix exception when first running app

### DIFF
--- a/api/admin/controller/individual_admin_settings.py
+++ b/api/admin/controller/individual_admin_settings.py
@@ -48,7 +48,10 @@ class IndividualAdminSettingsController(SettingsController):
         return highest_role if has_auth else None
 
     def process_get(self):
-        logged_in_admin: Admin = flask.request.admin
+        logged_in_admin: Optional[Admin] = getattr(flask.request, "admin", None)
+        if not logged_in_admin:
+            return {}
+
         highest_role: AdminRole = self._highest_authorized_role()
 
         if not highest_role:


### PR DESCRIPTION
## Description

When you first start the app, I've been noticing in the logs since https://github.com/ThePalaceProject/circulation/pull/372 went in, that we see an exception because the admin does not exist yet. This should fix that exception.

Here is an example of the exception: 
```
023-07-20T01:02:19.995517+00:00", "traceback": "Traceback (most recent call last):
  File \"circulation/lib/python3.9/site-packages/flask/app.py\", line 1484, in full_dispatch_request
    rv = self.dispatch_request()
  File \"circulation/lib/python3.9/site-packages/flask/app.py\", line 1469, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File \"circulation/api/admin/routes.py\", line 86, in decorated
    v = f(*args, **kwargs)
  File \"circulation/api/admin/routes.py\", line 30, in decorated
    return f(*args, setting_up=setting_up, **kwargs)
  File \"circulation/api/admin/routes.py\", line 58, in decorated
    return f(*args, **kwargs)
  File \"circulation/api/admin/routes.py\", line 76, in decorated
    return f(*args, **kwargs)
  File \"circulation/api/admin/routes.py\", line 394, in individual_admins
    app.manager.admin_individual_admin_settings_controller.process_individual_admins()
  File \"circulation/api/admin/controller/individual_admin_settings.py\", line 20, in process_individual_admins
    return self.process_get()
  File \"circulation/api/admin/controller/individual_admin_settings.py\", line 51, in process_get
    logged_in_admin: Admin = flask.request.admin
AttributeError: 'Request' object has no attribute 'admin'"}
```

## Motivation and Context

Exception is a distraction in the logs when setting up a new instance.

## How Has This Been Tested?

- Tested setting up new instance locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
