### PR TITLE
Resolve admin UI tag to a version via jsdelivr api (PP-164)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ disallow_untyped_decorators = true
 disallow_untyped_defs = true
 module = [
     "api.admin.announcement_list_validator",
+    "api.admin.config",
     "api.admin.controller.library_settings",
     "api.admin.controller.patron_auth_services",
     "api.admin.form_data",

--- a/tests/api/admin/test_config.py
+++ b/tests/api/admin/test_config.py
@@ -1,7 +1,10 @@
+import logging
 import os
 from typing import Optional
+from unittest.mock import MagicMock, patch
 
 import pytest
+from requests import RequestException
 
 from api.admin.config import Configuration as AdminConfig
 from api.admin.config import OperationalMode
@@ -14,6 +17,71 @@ class TestAdminUI:
             monkeypatch.setenv(key, value)
         elif key in os.environ:
             monkeypatch.delenv(key)
+
+    def test_package_version_cached(self, monkeypatch):
+        with patch(
+            "api.admin.config.Configuration.env_package_version"
+        ) as env_package_version:
+            env_package_version.return_value = None
+
+            # The first call to package_version() should call env_package_version()
+            assert AdminConfig.package_version() == AdminConfig.PACKAGE_VERSION
+            assert env_package_version.call_count == 1
+            env_package_version.reset_mock()
+
+            # The second call to package_version() should not call env_package_version()
+            # because the result is cached.
+            assert AdminConfig.package_version() == AdminConfig.PACKAGE_VERSION
+            assert env_package_version.call_count == 0
+
+    @pytest.mark.parametrize(
+        "package_version, resolves, expected_result",
+        [
+            ["1.0.0", False, "1.0.0"],
+            ["latest", True, "x.x.x"],
+            ["next", True, "x.x.x"],
+            ["dev", True, "x.x.x"],
+            [None, False, None],
+        ],
+    )
+    def test_env_package_version(
+        self,
+        monkeypatch,
+        package_version: Optional[str],
+        resolves: bool,
+        expected_result: Optional[str],
+    ):
+        with patch(
+            "api.admin.config.Configuration.resolve_package_version"
+        ) as resolve_package_version:
+            resolve_package_version.return_value = "x.x.x"
+            self._set_env(
+                monkeypatch, "TPP_CIRCULATION_ADMIN_PACKAGE_VERSION", package_version
+            )
+            assert AdminConfig.env_package_version() == expected_result
+            assert resolve_package_version.call_count == (1 if resolves else 0)
+
+    def test_resolve_package_version(self, caplog):
+        with patch("api.admin.config.HTTP") as http_patch:
+            http_patch.get_with_timeout.return_value = MagicMock(
+                status_code=200, json=MagicMock(return_value={"version": "1.0.0"})
+            )
+            assert (
+                AdminConfig.resolve_package_version("some-package", "latest") == "1.0.0"
+            )
+            http_patch.get_with_timeout.assert_called_once_with(
+                "https://data.jsdelivr.com/v1/packages/npm/some-package/resolved?specifier=latest"
+            )
+
+            # If there is an exception while trying to resolve the package version, return the default.
+            caplog.set_level(logging.ERROR)
+            http_patch.get_with_timeout.side_effect = RequestException()
+            assert (
+                AdminConfig.resolve_package_version("some-package", "latest")
+                == "latest"
+            )
+            assert len(caplog.records) == 1
+            assert "Failed to resolve package version" in caplog.text
 
     @pytest.mark.parametrize(
         "package_name, package_version, mode, expected_result_startswith",
@@ -55,6 +123,8 @@ class TestAdminUI:
         )
         result = AdminConfig.package_url(_operational_mode=mode)
         assert result.startswith(expected_result_startswith)
+        # Reset the cached version
+        AdminConfig._version = None
 
     @pytest.mark.parametrize(
         "package_name, package_version, expected_result",


### PR DESCRIPTION
## Description

Instead of just using the tag that we pass via the environment, we resolve that tag to a particular version. This has two benefits:
- The `version.json` endpoint can correctly report the version
- Browser cache knows there is a change, because the URL changes

The result of this lookup is cached, so it will only happen on startup, and it will only happen if a tag is specified via ENV, otherwise we just directly use the version.

## Motivation and Context

Eventually it would be nice to publish a 'next' tag for the admin UI so changes are deployed on merge.

This change helps set us up for PP-164

## How Has This Been Tested?

Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
