### PR TITLE
Type hint Circulation API Classes (PP-95)

### DIFF
--- a/api/odl.py
+++ b/api/odl.py
@@ -260,7 +260,7 @@ class ODLAPI(
         :param db: Database session
         :return: External integration associated with this object
         """
-        return self.collection(db).external_integration
+        return self.collection.external_integration
 
     def internal_format(self, delivery_mechanism):
         """Each consolidated copy is only available in one format, so we don't need
@@ -268,13 +268,14 @@ class ODLAPI(
         """
         return delivery_mechanism
 
-    def collection(self, db) -> Collection:
+    @property
+    def collection(self) -> Collection:
         """Return a collection associated with this object.
 
         :param db: Database session
         :return: Collection associated with this object
         """
-        collection = get_one(db, Collection, id=self.collection_id)
+        collection = super().collection
         if not collection:
             raise ValueError(f"Collection not found: {self.collection_id}")
         return collection
@@ -329,7 +330,7 @@ class ODLAPI(
         else:
             id = loan.license.identifier
             checkout_id = str(uuid.uuid1())
-            default_loan_period = self.collection(_db).default_loan_period(
+            default_loan_period = self.collection.default_loan_period(
                 loan.patron.library
             )
 
@@ -671,9 +672,10 @@ class ODLAPI(
         # need it to calculate the end date.
         original_position = holdinfo.hold_position
         self._update_hold_position(holdinfo, pool)
+        assert holdinfo.hold_position is not None
 
-        default_loan_period = self.collection(_db).default_loan_period(library)
-        default_reservation_period = self.collection(_db).default_reservation_period
+        default_loan_period = self.collection.default_loan_period(library)
+        default_reservation_period = self.collection.default_reservation_period
 
         # If the hold was already to check out and already has an end date,
         # it doesn't need an update.

--- a/api/opds2.py
+++ b/api/opds2.py
@@ -12,7 +12,7 @@ from core.lane import Facets
 from core.model import ExternalIntegration
 from core.model.edition import Edition
 from core.model.identifier import Identifier
-from core.model.licensing import DeliveryMechanism
+from core.model.licensing import LicensePoolDeliveryMechanism
 from core.model.resource import Hyperlink
 from core.opds2 import OPDS2Annotator
 from core.problem_details import INVALID_CREDENTIALS
@@ -99,7 +99,7 @@ class TokenAuthenticationFulfillmentProcessor(CirculationFulfillmentPostProcesso
         patron: Patron,
         pin: str,
         licensepool: LicensePool,
-        delivery_mechanism: DeliveryMechanism | None,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
         fulfillment: FulfillmentInfo,
     ) -> FulfillmentInfo:
         if not fulfillment.content_link:

--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -96,7 +96,6 @@ class OPDSForDistributorsAPI(
 
     def __init__(self, _db, collection):
         super().__init__(_db, collection)
-        self.collection_id = collection.id
         self.external_integration_id = collection.external_integration.id
 
         config = self.configuration()
@@ -208,7 +207,7 @@ class OPDSForDistributorsAPI(
             _db,
             self.data_source_name,
             self.BEARER_TOKEN_CREDENTIAL_TYPE,
-            collection=Collection.by_id(_db, self.collection_id),
+            collection=self.collection,
             patron=None,
             refresher_method=refresh,
         )

--- a/api/saml/wayfless.py
+++ b/api/saml/wayfless.py
@@ -109,9 +109,17 @@ class SAMLWAYFlessAcquisitionLinkProcessor(
                 SAMLWAYFlessConstants.IDP_PLACEHOLDER,
                 urllib.parse.quote(saml_subject.idp, safe=""),
             )
+            if fulfillment.content_link is None:
+                self._logger.warning(
+                    f"Fulfillment {fulfillment} has no content link, unable to transform it"
+                )
+                content_link = ""
+            else:
+                content_link = fulfillment.content_link
+
             acquisition_link = acquisition_link.replace(
                 SAMLWAYFlessConstants.ACQUISITION_LINK_PLACEHOLDER,
-                urllib.parse.quote(fulfillment.content_link, safe=""),
+                urllib.parse.quote(content_link, safe=""),
             )
 
             self._logger.debug(

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 import logging
 import uuid
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 from psycopg2.extras import NumericRange
 from sqlalchemy import (
@@ -546,7 +546,9 @@ class Loan(Base, LoanAndHoldMixin):
     license_id = Column(Integer, ForeignKey("licenses.id"), index=True, nullable=True)
 
     fulfillment_id = Column(Integer, ForeignKey("licensepooldeliveries.id"))
-    fulfillment: LicensePoolDeliveryMechanism
+    fulfillment: Mapped[Optional[LicensePoolDeliveryMechanism]] = relationship(
+        "LicensePoolDeliveryMechanism", back_populates="fulfills"
+    )
     start = Column(DateTime(timezone=True), index=True)
     end = Column(DateTime(timezone=True), index=True)
     # Some distributors (e.g. Feedbooks) may have an identifier that can

--- a/core/model/resource.py
+++ b/core/model/resource.py
@@ -88,7 +88,7 @@ class Resource(Base):
         List[LicensePoolDeliveryMechanism]
     ] = relationship(
         "LicensePoolDeliveryMechanism",
-        backref="resource",
+        back_populates="resource",
         foreign_keys=[LicensePoolDeliveryMechanism.resource_id],
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ module = [
     "api.admin.form_data",
     "api.admin.model.dashboard_statistics",
     "api.adobe_vendor_id",
+    "api.circulation",
     "api.integration.*",
     "core.integration.*",
     "core.model.announcements",

--- a/tests/api/test_axis.py
+++ b/tests/api/test_axis.py
@@ -1357,6 +1357,7 @@ class TestAvailabilityResponseParser:
         parser = AvailabilityResponseParser(axis360parsers.api)
         activity = list(parser.process_all(data))
         hold, loan, reserved = sorted(activity, key=lambda x: x.identifier)
+        assert axis360parsers.api.collection is not None
         assert axis360parsers.api.collection.id == hold.collection_id
         assert Identifier.AXIS_360_ID == hold.identifier_type
         assert "0012533119" == hold.identifier
@@ -1380,6 +1381,7 @@ class TestAvailabilityResponseParser:
         parser = AvailabilityResponseParser(axis360parsers.api)
         [loan] = list(parser.process_all(data))
 
+        assert axis360parsers.api.collection is not None
         assert axis360parsers.api.collection.id == loan.collection_id
         assert "0015176429" == loan.identifier
         assert None == loan.fulfillment_info

--- a/tests/api/test_axis.py
+++ b/tests/api/test_axis.py
@@ -44,6 +44,7 @@ from core.metadata_layer import (
 )
 from core.mock_analytics_provider import MockAnalyticsProvider
 from core.model import (
+    Collection,
     Contributor,
     DataSource,
     DeliveryMechanism,
@@ -1217,11 +1218,9 @@ class Axis360FixturePlusParsers(Axis360Fixture):
         # these classes, but we do need to test that whatever object
         # we _claim_ is a Collection will have its id put into the
         # right spot of HoldInfo and LoanInfo objects.
-        class MockCollection:
-            pass
 
-        self.default_collection = MockCollection()
-        self.default_collection.id = object()  # type: ignore
+        self.default_collection = MagicMock(spec=Collection)
+        type(self.default_collection).id = PropertyMock(return_value=1337)
 
 
 @pytest.fixture(scope="function")
@@ -1295,7 +1294,7 @@ class TestCheckoutResponseParser:
         parser = CheckoutResponseParser(axis360parsers.default_collection)
         parsed = parser.process_all(data)
         assert isinstance(parsed, LoanInfo)
-        assert axis360parsers.default_collection.id == parsed.collection_id  # type: ignore
+        assert axis360parsers.default_collection.id == parsed.collection_id
         assert DataSource.AXIS_360 == parsed.data_source_name
         assert Identifier.AXIS_360_ID == parsed.identifier_type
         assert datetime_utc(2015, 8, 11, 18, 57, 42) == parsed.end_date
@@ -1326,7 +1325,7 @@ class TestHoldResponseParser:
 
         # The HoldInfo is given the Collection object we passed into
         # the HoldResponseParser.
-        assert axis360parsers.default_collection.id == parsed.collection_id  # type: ignore
+        assert axis360parsers.default_collection.id == parsed.collection_id
 
     def test_parse_already_on_hold(self, axis360parsers: Axis360FixturePlusParsers):
         data = axis360parsers.sample_data("already_on_hold.xml")

--- a/tests/api/test_bibliotheca.py
+++ b/tests/api/test_bibliotheca.py
@@ -606,6 +606,7 @@ class TestBibliothecaAPI:
 
         # The document sent by the 'Findaway' server has been
         # converted into a web publication manifest.
+        assert fulfillment.content is not None
         manifest = json.loads(fulfillment.content)
 
         # The conversion process is tested more fully in
@@ -835,7 +836,7 @@ class TestPatronCirculationParser:
         holds = [x for x in loans_and_holds if isinstance(x, HoldInfo)]
         assert 2 == len(loans)
         assert 2 == len(holds)
-        [l1, l2] = sorted(loans, key=lambda x: x.identifier)
+        [l1, l2] = sorted(loans, key=lambda x: str(x.identifier))
         assert "1ad589" == l1.identifier
         assert "cgaxr9" == l2.identifier
         expect_loan_start = datetime_utc(2015, 3, 20, 18, 50, 22)
@@ -843,7 +844,7 @@ class TestPatronCirculationParser:
         assert expect_loan_start == l1.start_date
         assert expect_loan_end == l1.end_date
 
-        [h1, h2] = sorted(holds, key=lambda x: x.identifier)
+        [h1, h2] = sorted(holds, key=lambda x: str(x.identifier))
 
         # This is the book on reserve.
         assert collection.id == h1.collection_id

--- a/tests/api/test_controller_loan.py
+++ b/tests/api/test_controller_loan.py
@@ -201,7 +201,7 @@ class TestLoanController:
                 if x["rel"] == OPDSFeed.ACQUISITION_REL
             ]
 
-            assert loan_fixture.mech1.resource is not None  # type: ignore
+            assert loan_fixture.mech1.resource is not None
 
             # Make sure the two delivery mechanisms are incompatible.
             loan_fixture.mech1.delivery_mechanism.drm_scheme = "DRM Scheme 1"
@@ -223,9 +223,9 @@ class TestLoanController:
 
             # Make sure the first delivery mechanism has the data necessary
             # to carry out an open source fulfillment.
-            assert loan_fixture.mech1.resource is not None  # type: ignore
-            assert loan_fixture.mech1.resource.representation is not None  # type: ignore
-            assert loan_fixture.mech1.resource.representation.url is not None  # type: ignore
+            assert loan_fixture.mech1.resource is not None
+            assert loan_fixture.mech1.resource.representation is not None
+            assert loan_fixture.mech1.resource.representation.url is not None
 
             # Now let's try to fulfill the loan using the first delivery mechanism.
             assert isinstance(loan_fixture.pool.id, int)
@@ -238,7 +238,7 @@ class TestLoanController:
                 raise Exception(repr(j))
             assert 302 == response.status_code
             assert (
-                fulfillable_mechanism.resource.representation.public_url  # type: ignore
+                fulfillable_mechanism.resource.representation.public_url
                 == response.headers.get("Location")
             )
 
@@ -256,8 +256,8 @@ class TestLoanController:
                 loan_fixture.pool.data_source,
                 loan_fixture.pool.identifier.type,
                 loan_fixture.pool.identifier.identifier,
-                content_link=fulfillable_mechanism.resource.url,  # type: ignore
-                content_type=fulfillable_mechanism.resource.representation.media_type,  # type: ignore
+                content_link=fulfillable_mechanism.resource.url,
+                content_type=fulfillable_mechanism.resource.representation.media_type,
                 content=None,
                 content_expires=None,
             )
@@ -274,7 +274,7 @@ class TestLoanController:
             )
             assert 200 == response.status_code
             assert "I am an ACSM file" == response.get_data(as_text=True)
-            assert http.requests == [fulfillable_mechanism.resource.url]  # type: ignore
+            assert http.requests == [fulfillable_mechanism.resource.url]
 
             # But we can't use some other mechanism -- we're stuck with
             # the first one we chose.

--- a/tests/api/test_coverage.py
+++ b/tests/api/test_coverage.py
@@ -100,6 +100,7 @@ class TestOPDSImportCoverageProvider:
             identifier.identifier,
             collection=db.default_collection(),
         )
+        assert pool is not None
         assert None == pool.work
 
         # Here's a second Edition/LicensePool that's going to cause a

--- a/tests/api/test_enki.py
+++ b/tests/api/test_enki.py
@@ -534,6 +534,7 @@ class TestEnkiAPI:
         assert fulfillment.identifier == pool.identifier.identifier
         assert fulfillment.collection_id == pool.collection.id
         assert DeliveryMechanism.ADOBE_DRM == fulfillment.content_type
+        assert fulfillment.content_link is not None
         assert fulfillment.content_link.startswith(
             "http://afs.enkilibrary.org/fulfillment/URLLink.acsm"
         )

--- a/tests/api/test_odl.py
+++ b/tests/api/test_odl.py
@@ -357,6 +357,7 @@ class TestODLAPI:
         assert odl_api_test_fixture.pool.data_source.name == loan.data_source_name
         assert odl_api_test_fixture.pool.identifier.type == loan.identifier_type
         assert odl_api_test_fixture.pool.identifier.identifier == loan.identifier
+        assert loan.start_date is not None
         assert loan.start_date > utc_now() - datetime.timedelta(minutes=1)
         assert loan.start_date < utc_now() + datetime.timedelta(minutes=1)
         assert datetime_utc(3017, 10, 21, 11, 12, 13) == loan.end_date
@@ -399,6 +400,7 @@ class TestODLAPI:
         assert odl_api_test_fixture.pool.data_source.name == loan.data_source_name
         assert odl_api_test_fixture.pool.identifier.type == loan.identifier_type
         assert odl_api_test_fixture.pool.identifier.identifier == loan.identifier
+        assert loan.start_date is not None
         assert loan.start_date > utc_now() - datetime.timedelta(minutes=1)
         assert loan.start_date < utc_now() + datetime.timedelta(minutes=1)
         assert datetime_utc(3017, 10, 21, 11, 12, 13) == loan.end_date

--- a/tests/core/models/test_licensing.py
+++ b/tests/core/models/test_licensing.py
@@ -524,6 +524,8 @@ class TestLicensePool:
             "541",
             collection=db.collection(),
         )
+        assert pool is not None
+        assert pool.availability_time is not None
         assert (pool.availability_time - now).total_seconds() < 2
         assert True == was_new
         assert DataSource.GUTENBERG == pool.data_source.name
@@ -644,6 +646,7 @@ class TestLicensePool:
             "1",
             collection=db.default_collection(),
         )
+        assert p1 is not None
 
         p2, ignore = LicensePool.for_foreign_id(
             db.session,
@@ -652,6 +655,7 @@ class TestLicensePool:
             "2",
             collection=db.default_collection(),
         )
+        assert p2 is not None
 
         work = db.work(title="Foo")
         p1.work = work

--- a/tests/core/models/test_work.py
+++ b/tests/core/models/test_work.py
@@ -1920,6 +1920,7 @@ class TestWorkConsolidation:
             "1",
             collection=collection,
         )
+        assert pool is not None
         work, created = pool.calculate_work()
         assert None == work
 


### PR DESCRIPTION
## Description

Add type hinting to all the classes in the Circulation API code, so it is easier to refactor. This is another step along the way to moving mirror integration to integration settings, and completely moving circulation providers to use configuration settings.

## Motivation and Context

This was needed to help with the refactoring necessary in (PP-95).

## How Has This Been Tested?

Running tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
