### PR TITLE
Refactor AdminCirculationManagerController into mixin class (PP-94)

### DIFF
--- a/api/admin/controller/base.py
+++ b/api/admin/controller/base.py
@@ -17,7 +17,6 @@ from api.admin.problem_details import (
     INVALID_CSRF_TOKEN,
 )
 from api.config import Configuration
-from api.controller import CirculationManagerController
 from core.model import (
     Admin,
     AdminRole,
@@ -128,8 +127,8 @@ class AdminController:
         return base64.b64encode(os.urandom(24)).decode("utf-8")
 
 
-class AdminCirculationManagerController(CirculationManagerController):
-    """Parent class that provides methods for verifying an admin's roles."""
+class AdminPermissionsControllerMixin:
+    """Mixin that provides methods for verifying an admin's roles."""
 
     def require_system_admin(self):
         admin = getattr(flask.request, "admin", None)

--- a/api/admin/controller/custom_lists.py
+++ b/api/admin/controller/custom_lists.py
@@ -10,7 +10,7 @@ from flask_babel import lazy_gettext as _
 from flask_pydantic_spec.flask_backend import Context
 from pydantic import BaseModel
 
-from api.admin.controller.base import AdminCirculationManagerController
+from api.admin.controller.base import AdminPermissionsControllerMixin
 from api.admin.problem_details import (
     ADMIN_NOT_AUTHORIZED,
     AUTO_UPDATE_CUSTOM_LIST_CANNOT_HAVE_ENTRIES,
@@ -21,6 +21,7 @@ from api.admin.problem_details import (
     MISSING_COLLECTION,
     MISSING_CUSTOM_LIST,
 )
+from api.controller import CirculationManagerController
 from api.problem_details import CANNOT_DELETE_SHARED_LIST
 from core.app_server import load_pagination_from_request
 from core.lane import Lane, WorkList
@@ -42,7 +43,9 @@ from core.util.flask_util import OPDSFeedResponse
 from core.util.problem_detail import ProblemDetail
 
 
-class CustomListsController(AdminCirculationManagerController):
+class CustomListsController(
+    CirculationManagerController, AdminPermissionsControllerMixin
+):
     class CustomListSharePostResponse(BaseModel):
         successes: int = 0
         failures: int = 0

--- a/api/admin/controller/feed.py
+++ b/api/admin/controller/feed.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 import flask
 from flask import url_for
 
-from api.admin.controller.base import AdminCirculationManagerController
+from api.admin.controller.base import AdminPermissionsControllerMixin
 from api.admin.opds import AdminAnnotator, AdminFeed
+from api.controller import CirculationManagerController
 from core.app_server import load_pagination_from_request
 from core.classifier import genres
 from core.util.flask_util import OPDSFeedResponse
 from core.util.problem_detail import ProblemDetail
 
 
-class FeedController(AdminCirculationManagerController):
+class FeedController(CirculationManagerController, AdminPermissionsControllerMixin):
     def suppressed(self):
         self.require_librarian(flask.request.library)
 

--- a/api/admin/controller/lanes.py
+++ b/api/admin/controller/lanes.py
@@ -6,7 +6,7 @@ import flask
 from flask import Response
 from flask_babel import lazy_gettext as _
 
-from api.admin.controller.base import AdminCirculationManagerController
+from api.admin.controller.base import AdminPermissionsControllerMixin
 from api.admin.problem_details import (
     CANNOT_EDIT_DEFAULT_LANE,
     CANNOT_SHOW_LANE_WITH_HIDDEN_PARENT,
@@ -16,12 +16,13 @@ from api.admin.problem_details import (
     NO_CUSTOM_LISTS_FOR_LANE,
     NO_DISPLAY_NAME_FOR_LANE,
 )
+from api.controller import CirculationManagerController
 from api.lanes import create_default_lanes
 from core.lane import Lane
 from core.model import CustomList, Library, create, get_one
 
 
-class LanesController(AdminCirculationManagerController):
+class LanesController(CirculationManagerController, AdminPermissionsControllerMixin):
     def lanes(self):
         library = flask.request.library
         self.require_librarian(library)

--- a/api/admin/controller/library_settings.py
+++ b/api/admin/controller/library_settings.py
@@ -33,10 +33,10 @@ from ...config import Configuration
 from ...controller import CirculationManager
 from ..announcement_list_validator import AnnouncementListValidator
 from ..form_data import ProcessFormData
-from .base import AdminCirculationManagerController
+from .base import AdminPermissionsControllerMixin
 
 
-class LibrarySettingsController(AdminCirculationManagerController):
+class LibrarySettingsController(AdminPermissionsControllerMixin):
     def __init__(self, manager: CirculationManager):
         self._db = manager._db
 

--- a/api/admin/controller/patron.py
+++ b/api/admin/controller/patron.py
@@ -4,15 +4,16 @@ import flask
 from flask import Response
 from flask_babel import lazy_gettext as _
 
-from api.admin.controller.base import AdminCirculationManagerController
+from api.admin.controller.base import AdminPermissionsControllerMixin
 from api.admin.problem_details import NO_SUCH_PATRON
 from api.adobe_vendor_id import AuthdataUtility
 from api.authentication.base import CannotCreateLocalPatron, PatronData
 from api.authenticator import LibraryAuthenticator
+from api.controller import CirculationManagerController
 from core.util.problem_detail import ProblemDetail
 
 
-class PatronController(AdminCirculationManagerController):
+class PatronController(CirculationManagerController, AdminPermissionsControllerMixin):
     def _load_patrondata(self, authenticator=None):
         """Extract a patron identifier from an incoming form submission,
         and ask the library's LibraryAuthenticator to turn it into a

--- a/api/admin/controller/patron_auth_services.py
+++ b/api/admin/controller/patron_auth_services.py
@@ -7,7 +7,7 @@ import flask
 from flask import Response
 from flask_babel import lazy_gettext as _
 
-from api.admin.controller.base import AdminCirculationManagerController
+from api.admin.controller.base import AdminPermissionsControllerMixin
 from api.admin.form_data import ProcessFormData
 from api.admin.problem_details import *
 from api.authentication.base import AuthenticationProvider
@@ -32,7 +32,7 @@ from core.util.cache import memoize
 from core.util.problem_detail import ProblemDetail, ProblemError
 
 
-class PatronAuthServicesController(AdminCirculationManagerController):
+class PatronAuthServicesController(AdminPermissionsControllerMixin):
     def __init__(
         self,
         manager: CirculationManager,

--- a/api/admin/controller/settings.py
+++ b/api/admin/controller/settings.py
@@ -9,7 +9,7 @@ import flask
 from flask import Response
 from flask_babel import lazy_gettext as _
 
-from api.admin.controller.base import AdminCirculationManagerController
+from api.admin.controller.base import AdminPermissionsControllerMixin
 from api.admin.problem_details import (
     CANNOT_CHANGE_PROTOCOL,
     DUPLICATE_INTEGRATION,
@@ -25,6 +25,7 @@ from api.admin.problem_details import (
     UNKNOWN_PROTOCOL,
 )
 from api.admin.validator import Validator
+from api.controller import CirculationManagerController
 from api.integration.registry.license_providers import LicenseProvidersRegistry
 from core.external_search import ExternalSearchIndex
 from core.integration.base import (
@@ -51,7 +52,7 @@ from core.selftest import BaseHasSelfTests
 from core.util.problem_detail import ProblemDetail
 
 
-class SettingsController(AdminCirculationManagerController):
+class SettingsController(CirculationManagerController, AdminPermissionsControllerMixin):
     METADATA_SERVICE_URI_TYPE = "application/opds+json;profile=https://librarysimplified.org/rel/profile/metadata-service"
 
     NO_MIRROR_INTEGRATION = "NO_MIRROR"

--- a/api/admin/controller/timestamps.py
+++ b/api/admin/controller/timestamps.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from api.admin.controller.base import AdminCirculationManagerController
+from api.admin.controller.base import AdminPermissionsControllerMixin
+from api.controller import CirculationManagerController
 from core.model import Timestamp
 
 
-class TimestampsController(AdminCirculationManagerController):
+class TimestampsController(
+    CirculationManagerController, AdminPermissionsControllerMixin
+):
     """Returns a dict: each key is a type of service (script, monitor, or coverage provider);
     each value is a nested dict in which timestamps are organized by service name and then by collection ID.
     """

--- a/api/admin/controller/work_editor.py
+++ b/api/admin/controller/work_editor.py
@@ -12,7 +12,6 @@ from flask import Response
 from flask_babel import lazy_gettext as _
 from PIL import Image, ImageDraw, ImageFont
 
-from api.admin.controller.base import AdminCirculationManagerController
 from api.admin.opds import AdminAnnotator
 from api.admin.problem_details import *
 from api.admin.validator import Validator
@@ -43,8 +42,11 @@ from core.util import LanguageCodes
 from core.util.datetime_helpers import strptime_utc, utc_now
 from core.util.problem_detail import ProblemDetail
 
+from ...controller import CirculationManagerController
+from .base import AdminPermissionsControllerMixin
 
-class WorkController(AdminCirculationManagerController):
+
+class WorkController(CirculationManagerController, AdminPermissionsControllerMixin):
 
     STAFF_WEIGHT = 1000
 

--- a/tests/api/admin/controller/test_base.py
+++ b/tests/api/admin/controller/test_base.py
@@ -5,7 +5,7 @@ from core.model import AdminRole
 from tests.fixtures.api_admin import AdminControllerFixture
 
 
-class TestAdminCirculationManagerController:
+class TestAdminPermissionsControllerMixin:
     def test_require_system_admin(self, admin_ctrl_fixture: AdminControllerFixture):
         with admin_ctrl_fixture.request_context_with_admin("/admin"):
             pytest.raises(


### PR DESCRIPTION
## Description

The PR breaks out `AdminPermissionsControllerMixin`, which replaces `AdminCirculationManagerController`. It updates existing classes that depend on `AdminCirculationManagerController` to use the new mixin class, and updates classes that don't need the functionalities of the base class to just use the mixin class.

## Motivation and Context

`AdminCirculationManagerController` sits in the middle of a fairly nested class hierarchy:
`AdminCirculationManagerController` -> `CirculationManagerController` -> `BaseCirculationManagerController`

The refactored controller classes that implement integration configuration don't need all the functionality of this class hierarchy, they only need a couple methods to check permissions that are part of `AdminCirculationManagerController`.

## How Has This Been Tested?

- Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
