### PR TITLE
Fixes a minor bug in the overdrive account script which was not caugh…

### DIFF
--- a/core/scripts.py
+++ b/core/scripts.py
@@ -2927,8 +2927,8 @@ class GenerateOverdriveAdvantageAccountList(InputScript):
         super().__init__(_db, args, kwargs)
         self._data: List[List[str]] = list()
 
-    def _create_overdrive_api(self, c: Collection):
-        return OverdriveCoreAPI(_db=self._db, collection=c)
+    def _create_overdrive_api(self, collection: Collection):
+        return OverdriveCoreAPI(_db=self._db, collection=collection)
 
     def do_run(self, *args, **kwargs):
         parsed = GenerateOverdriveAdvantageAccountList.parse_command_line(


### PR DESCRIPTION
…t by the unit test due to the monkey patch.

## Description

When I went to run the Overdrive Advantage Account script (./bin/informational/overdrive_advantage_accounts) I ran into a little hitch with the method signature of a method that is patched in the unit test.  This update fixes the issue.

See details below. 
```
{"host": "4434bca2e18d", "app": "simplified", "name": "root", "level": "ERROR", "filename": "scripts.py", "message": "Fatal exception while running script: _create_overdrive_api() got an unexpected keyword argument 'collection'", "timestamp": "2023-08-08T23:06:05.742220+00:00", "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/core/scripts.py\", line 138, in run\n    timestamp_data = self.do_run()\n  File \"/var/www/circulation/core/scripts.py\", line 2866, in do_run\n    api = self._create_overdrive_api(collection=collection)\nTypeError: _create_overdrive_api() got an unexpected keyword argument 'collection'"}
Traceback (most recent call last):
  File "./informational/overdrive-advantage-accounts", line 11, in <module>
    GenerateOverdriveAdvantageAccountList().run()
  File "/var/www/circulation/core/scripts.py", line 138, in run
    timestamp_data = self.do_run()
  File "/var/www/circulation/core/scripts.py", line 2866, in do_run
    api = self._create_overdrive_api(collection=collection)
```
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This fix was manually tested. I wasn't sure how to modify the unit test to verify the fix.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
