### PR TITLE
Disable mypy "method-assign" errors in tests module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,15 @@ warn_unused_configs = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
+# In our tests, we often overwrite methods on classes to mock out behavior.
+# This is a common pattern in Python, but mypy doesn't like it. This override
+# silences those errors, but only for the tests module.
+# See discussion here:
+# https://github.com/python/mypy/issues/2427
+disable_error_code = "method-assign"
+module = "tests.*"
+
+[[tool.mypy.overrides]]
 # This override is the equivalent of running mypy with the --strict flag.
 # This is a work in progress, but we should try to get as many of our files
 # into the module list here as possible.

--- a/tests/api/admin/controller/test_library.py
+++ b/tests/api/admin/controller/test_library.py
@@ -679,8 +679,8 @@ class TestLibrarySettings:
     def test_process_libraries(self, controller_fixture: ControllerFixture):
         manager = MagicMock()
         controller = LibrarySettingsController(manager)
-        controller.process_get = MagicMock()  # type: ignore[method-assign]
-        controller.process_post = MagicMock()  # type: ignore[method-assign]
+        controller.process_get = MagicMock()
+        controller.process_post = MagicMock()
 
         # Make sure we call process_get for a get request
         with controller_fixture.request_context_with_library("/", method="GET"):

--- a/tests/api/saml/configuration/test_model.py
+++ b/tests/api/saml/configuration/test_model.py
@@ -68,7 +68,7 @@ class TestSAMLConfiguration:
     ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
-        metadata_parser.parse = MagicMock(side_effect=metadata_parser.parse)  # type: ignore[method-assign]
+        metadata_parser.parse = MagicMock(side_effect=metadata_parser.parse)
 
         configuration = create_saml_configuration(
             service_provider_xml_metadata=saml_strings.CORRECT_XML_WITH_ONE_SP
@@ -94,7 +94,7 @@ class TestSAMLConfiguration:
     ):
         # Arrange
         metadata_parser = SAMLMetadataParser()
-        metadata_parser.parse = MagicMock(side_effect=metadata_parser.parse)  # type: ignore[method-assign]
+        metadata_parser.parse = MagicMock(side_effect=metadata_parser.parse)
         configuration = create_saml_configuration(
             non_federated_identity_provider_xml_metadata=saml_strings.CORRECT_XML_WITH_MULTIPLE_IDPS
         )
@@ -179,7 +179,7 @@ class TestSAMLConfiguration:
         ]
 
         metadata_parser = SAMLMetadataParser()
-        metadata_parser.parse = MagicMock(side_effect=metadata_parser.parse)  # type: ignore[method-assign]
+        metadata_parser.parse = MagicMock(side_effect=metadata_parser.parse)
 
         federation = SAMLFederation("Test federation", "http://localhost")
         federated_idp_1 = SAMLFederatedIdentityProvider(

--- a/tests/api/saml/conftest.py
+++ b/tests/api/saml/conftest.py
@@ -63,10 +63,10 @@ def create_mock_onelogin_configuration(
         if configuration is None:
             configuration = create_saml_configuration()
         onelogin_configuration = SAMLOneLoginConfiguration(configuration)
-        onelogin_configuration._load_identity_providers = MagicMock(  # type: ignore[method-assign]
+        onelogin_configuration._load_identity_providers = MagicMock(
             return_value=identity_providers
         )
-        onelogin_configuration._load_service_provider = MagicMock(  # type: ignore[method-assign]
+        onelogin_configuration._load_service_provider = MagicMock(
             return_value=service_provider
         )
         return onelogin_configuration

--- a/tests/api/saml/test_controller.py
+++ b/tests/api/saml/test_controller.py
@@ -415,7 +415,7 @@ class TestSAMLController:
         authenticator.library_authenticators[
             "default"
         ].bearer_token_signing_secret = "test"
-        authenticator.create_bearer_token = MagicMock(return_value=bearer_token)  # type: ignore[method-assign]
+        authenticator.create_bearer_token = MagicMock(return_value=bearer_token)
 
         controller = SAMLController(controller_fixture.app.manager, authenticator)
 

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -864,8 +864,10 @@ class TestLibraryAuthenticator:
             neighborhood="Achewood",
         )
         basic = mock_basic(patrondata=patrondata)
-        basic.authenticate = MagicMock(return_value=patron)  # type: ignore[method-assign]
-        basic.integration = PropertyMock(return_value=MagicMock(spec=IntegrationConfiguration))  # type: ignore[method-assign]
+        basic.authenticate = MagicMock(return_value=patron)
+        basic.integration = PropertyMock(
+            return_value=MagicMock(spec=IntegrationConfiguration)
+        )
         authenticator = LibraryAuthenticator(
             _db=db.session,
             library=db.default_library(),
@@ -1480,11 +1482,11 @@ class TestBasicAuthenticationProvider:
         # more than once. This test makes sure that if we have a complete patrondata from remote_authenticate,
         # or from enforce_library_identifier_restriction, we don't call remote_patron_lookup.
         provider = mock_basic()
-        provider.remote_authenticate = MagicMock(return_value=auth_return)  # type: ignore[method-assign]
-        provider.enforce_library_identifier_restriction = MagicMock(  # type: ignore[method-assign]
+        provider.remote_authenticate = MagicMock(return_value=auth_return)
+        provider.enforce_library_identifier_restriction = MagicMock(
             return_value=enforce_return
         )
-        provider.remote_patron_lookup = MagicMock(return_value=lookup_return)  # type: ignore[method-assign]
+        provider.remote_patron_lookup = MagicMock(return_value=lookup_return)
 
         username = "a"
         password = "b"
@@ -1827,7 +1829,7 @@ class TestBasicAuthenticationProvider:
         remote_patrondata = PatronData(
             library_identifier=identifier, authorization_identifier="123"
         )
-        provider.remote_patron_lookup = MagicMock(return_value=remote_patrondata)  # type: ignore[method-assign]
+        provider.remote_patron_lookup = MagicMock(return_value=remote_patrondata)
         if expected:
             assert (
                 provider.enforce_library_identifier_restriction(local_patrondata)
@@ -1955,7 +1957,7 @@ class TestBasicAuthenticationProvider:
                 test_password="2",
             )
         )
-        missing_patron.authenticated_patron = MagicMock(return_value=None)  # type: ignore[method-assign]
+        missing_patron.authenticated_patron = MagicMock(return_value=None)
         value = missing_patron.testing_patron(db.session)
         assert (None, "2") == value
         missing_patron.authenticated_patron.assert_called_once()
@@ -1975,7 +1977,9 @@ class TestBasicAuthenticationProvider:
                 test_password="2",
             )
         )
-        problem_patron.authenticated_patron = MagicMock(return_value=PATRON_OF_ANOTHER_LIBRARY)  # type: ignore[method-assign]
+        problem_patron.authenticated_patron = MagicMock(
+            return_value=PATRON_OF_ANOTHER_LIBRARY
+        )
         value = problem_patron.testing_patron(db.session)
         assert (PATRON_OF_ANOTHER_LIBRARY, "2") == value
 
@@ -1990,7 +1994,7 @@ class TestBasicAuthenticationProvider:
         # results in something (non None) that's not a Patron
         # or a problem detail document.
         not_a_patron = "<not a patron>"
-        problem_patron.authenticated_patron = MagicMock(return_value=not_a_patron)  # type: ignore[method-assign]
+        problem_patron.authenticated_patron = MagicMock(return_value=not_a_patron)
         value = problem_patron.testing_patron(db.session)
         assert (not_a_patron, "2") == value
 
@@ -2010,7 +2014,7 @@ class TestBasicAuthenticationProvider:
                 test_password="2",
             )
         )
-        present_patron.authenticated_patron = MagicMock(return_value=patron)  # type: ignore[method-assign]
+        present_patron.authenticated_patron = MagicMock(return_value=patron)
         value = present_patron.testing_patron(db.session)
         assert (patron, "2") == value
 
@@ -2025,7 +2029,7 @@ class TestBasicAuthenticationProvider:
         # aren't even run.
         provider = mock_basic()
         exception = Exception("Nope")
-        provider.testing_patron_or_bust = MagicMock(side_effect=exception)  # type: ignore[method-assign]
+        provider.testing_patron_or_bust = MagicMock(side_effect=exception)
         [result] = list(provider._run_self_tests(_db))
         provider.testing_patron_or_bust.assert_called_once_with(_db)
         assert result.success is False
@@ -2034,8 +2038,8 @@ class TestBasicAuthenticationProvider:
         # If we can authenticate a test patron, the patron and their
         # password are passed into the next test.
         provider = mock_basic()
-        provider.testing_patron_or_bust = MagicMock(return_value=("patron", "password"))  # type: ignore[method-assign]
-        provider.update_patron_metadata = MagicMock(return_value="some metadata")  # type: ignore[method-assign]
+        provider.testing_patron_or_bust = MagicMock(return_value=("patron", "password"))
+        provider.update_patron_metadata = MagicMock(return_value="some metadata")
 
         [get_patron, update_metadata] = provider._run_self_tests(_db)
         provider.testing_patron_or_bust.assert_called_once_with(_db)
@@ -2308,7 +2312,9 @@ class TestBasicAuthenticationProviderAuthenticate:
         # set of information. If a remote patron lookup were to happen,
         # it would explode.
         provider = mock_basic(patrondata=complete_patrondata)
-        provider.remote_patron_lookup = MagicMock(side_effect=Exception("Should not be called."))  # type: ignore[method-assign]
+        provider.remote_patron_lookup = MagicMock(
+            side_effect=Exception("Should not be called.")
+        )
 
         # The patron can be authenticated.
         assert patron == provider.authenticate(db.session, self.credentials)

--- a/tests/api/test_circulationapi.py
+++ b/tests/api/test_circulationapi.py
@@ -190,7 +190,7 @@ class TestCirculationAPI:
 
         # Reset the API map, this book belongs to the "basic" collection,
         # i.e. collection without a custom CirculationAPI implementation.
-        circulation_api.circulation.api_for_license_pool = MagicMock(return_value=None)  # type: ignore[method-assign]
+        circulation_api.circulation.api_for_license_pool = MagicMock(return_value=None)
 
         # Mark the book as unlimited access.
         circulation_api.pool.unlimited_access = True
@@ -1043,7 +1043,7 @@ class TestCirculationAPI:
         are fulfilled in the same way as OA and self-hosted books."""
         # Reset the API map, this book belongs to the "basic" collection,
         # i.e. collection without a custom CirculationAPI implementation.
-        circulation_api.circulation.api_for_license_pool = MagicMock(return_value=None)  # type: ignore[method-assign]
+        circulation_api.circulation.api_for_license_pool = MagicMock(return_value=None)
 
         # Mark the book as unlimited access.
         circulation_api.pool.unlimited_access = True
@@ -1132,7 +1132,7 @@ class TestCirculationAPI:
         def yes_we_can(*args, **kwargs):
             return True
 
-        circulation_api.circulation.can_fulfill_without_loan = yes_we_can  # type: ignore[method-assign]
+        circulation_api.circulation.can_fulfill_without_loan = yes_we_can
         result = try_to_fulfill()
         assert fulfillment == result
 

--- a/tests/api/test_controller_base.py
+++ b/tests/api/test_controller_base.py
@@ -67,7 +67,7 @@ class TestBaseController:
         mock = MagicMock(
             side_effect=set_patron, return_value="return value will be ignored"
         )
-        circulation_fixture.controller.authenticated_patron_from_request = mock  # type: ignore[method-assign]
+        circulation_fixture.controller.authenticated_patron_from_request = mock
         with circulation_fixture.app.test_request_context("/"):
             assert o2 == circulation_fixture.controller.request_patron
 
@@ -692,7 +692,7 @@ class TestBaseController:
 
         # Mock Lane.accessible_to so that it always returns
         # false.
-        lane.accessible_to = MagicMock(return_value=False)  # type: ignore[method-assign]
+        lane.accessible_to = MagicMock(return_value=False)
         headers = dict(Authorization=circulation_fixture.valid_auth)
         with circulation_fixture.request_context_with_library(
             "/", headers=headers, library=circulation_fixture.db.default_library()

--- a/tests/api/test_controller_cm.py
+++ b/tests/api/test_controller_cm.py
@@ -57,7 +57,7 @@ class TestCirculationManager:
             return None
 
         old_for_library = CustomIndexView.for_library
-        CustomIndexView.for_library = mock_for_library  # type: ignore[method-assign]
+        CustomIndexView.for_library = mock_for_library
 
         # We also set up some configuration settings that will
         # be loaded.
@@ -140,7 +140,7 @@ class TestCirculationManager:
         } == manager.patron_web_domains
 
         # Restore the CustomIndexView.for_library implementation
-        CustomIndexView.for_library = old_for_library  # type: ignore[method-assign]
+        CustomIndexView.for_library = old_for_library
 
     def test_exception_during_external_search_initialization_is_stored(
         self, circulation_fixture: CirculationControllerFixture

--- a/tests/api/test_controller_crawlfeed.py
+++ b/tests/api/test_controller_crawlfeed.py
@@ -41,9 +41,9 @@ class TestCrawlableFeed:
             )
             return "An OPDS feed."
 
-        controller._crawlable_feed = mock  # type: ignore[method-assign]
+        controller._crawlable_feed = mock
         yield
-        controller._crawlable_feed = original  # type: ignore[method-assign]
+        controller._crawlable_feed = original
 
     def test_crawlable_library_feed(
         self, circulation_fixture: CirculationControllerFixture

--- a/tests/api/test_controller_loan.py
+++ b/tests/api/test_controller_loan.py
@@ -833,13 +833,13 @@ class TestLoanController:
         def mock_authenticated_patron():
             return INTEGRATION_ERROR
 
-        controller.authenticated_patron_from_request = mock_authenticated_patron  # type: ignore[method-assign]
+        controller.authenticated_patron_from_request = mock_authenticated_patron
         with loan_fixture.request_context_with_library("/"):
             problem = controller.fulfill(
                 loan_fixture.pool.id, loan_fixture.mech2.delivery_mechanism.id
             )
             assert INTEGRATION_ERROR == problem
-        controller.authenticated_patron_from_request = old_authenticated_patron  # type: ignore[method-assign]
+        controller.authenticated_patron_from_request = old_authenticated_patron
 
         # However, if can_fulfill_without_loan returns True, then
         # fulfill() will be called. If fulfill() returns a
@@ -865,7 +865,7 @@ class TestLoanController:
         # Now we're able to fulfill the book even without
         # authenticating a patron.
         with loan_fixture.request_context_with_library("/"):
-            controller.can_fulfill_without_loan = mock_can_fulfill_without_loan  # type: ignore[method-assign]
+            controller.can_fulfill_without_loan = mock_can_fulfill_without_loan
             controller.circulation.fulfill = mock_fulfill
             response = controller.fulfill(
                 loan_fixture.pool.id, loan_fixture.mech2.delivery_mechanism.id
@@ -940,8 +940,8 @@ class TestLoanController:
             None,
             content_link_redirect=True,
         )
-        controller.can_fulfill_without_loan = MagicMock(return_value=False)  # type: ignore[method-assign]
-        controller.authenticated_patron_from_request = MagicMock(return_value=patron)  # type: ignore[method-assign]
+        controller.can_fulfill_without_loan = MagicMock(return_value=False)
+        controller.authenticated_patron_from_request = MagicMock(return_value=patron)
 
         with loan_fixture.request_context_with_library(
             "/",
@@ -1137,7 +1137,7 @@ class TestLoanController:
         original_handle_conditional_request = (
             loan_fixture.controller.handle_conditional_request
         )
-        loan_fixture.manager.loans.handle_conditional_request = (  # type: ignore[method-assign]
+        loan_fixture.manager.loans.handle_conditional_request = (
             handle_conditional_request
         )
 
@@ -1176,7 +1176,7 @@ class TestLoanController:
         # the course of this test, but it will not notice any more
         # conditional requests -- the detailed behavior of
         # handle_conditional_request is tested elsewhere.
-        loan_fixture.manager.loans.handle_conditional_request = (  # type: ignore[method-assign]
+        loan_fixture.manager.loans.handle_conditional_request = (
             original_handle_conditional_request
         )
 

--- a/tests/api/test_controller_opdsfeed.py
+++ b/tests/api/test_controller_opdsfeed.py
@@ -775,7 +775,7 @@ class TestOPDSFeedController:
         # JackpotWorkList and passes it into _qa_feed.
 
         mock = MagicMock(return_value="an OPDS feed")
-        circulation_fixture.manager.opds_feeds._qa_feed = mock  # type: ignore[method-assign]
+        circulation_fixture.manager.opds_feeds._qa_feed = mock
 
         response = circulation_fixture.manager.opds_feeds.qa_feed()
         [call] = mock.mock_calls
@@ -814,7 +814,7 @@ class TestOPDSFeedController:
         # JackpotWorkList and passes it into _qa_feed.
 
         mock = MagicMock(return_value="an OPDS feed")
-        circulation_fixture.manager.opds_feeds._qa_feed = mock  # type: ignore[method-assign]
+        circulation_fixture.manager.opds_feeds._qa_feed = mock
 
         response = circulation_fixture.manager.opds_feeds.qa_feed()
         [call] = mock.mock_calls
@@ -854,7 +854,7 @@ class TestOPDSFeedController:
         # instructions to use HasSeriesFacets.
 
         mock = MagicMock(return_value="an OPDS feed")
-        circulation_fixture.manager.opds_feeds._qa_feed = mock  # type: ignore[method-assign]
+        circulation_fixture.manager.opds_feeds._qa_feed = mock
 
         response = circulation_fixture.manager.opds_feeds.qa_series_feed()
         [call] = mock.mock_calls

--- a/tests/api/test_novelist.py
+++ b/tests/api/test_novelist.py
@@ -701,7 +701,7 @@ class TestNoveListAPI:
             return MockRequestsResponse(200, content=json.dumps(mock_response))
 
         oldPut = novelist_fixture.novelist.put
-        novelist_fixture.novelist.put = mockHTTPPut  # type: ignore[method-assign]
+        novelist_fixture.novelist.put = mockHTTPPut
 
         response = novelist_fixture.novelist.put_items_novelist(
             novelist_fixture.db.default_library()
@@ -709,7 +709,7 @@ class TestNoveListAPI:
 
         assert response == mock_response
 
-        novelist_fixture.novelist.put = oldPut  # type: ignore[method-assign]
+        novelist_fixture.novelist.put = oldPut
 
     def test_make_novelist_data_object(self, novelist_fixture: NoveListFixture):
         bad_data = []  # type: ignore

--- a/tests/api/test_odilo.py
+++ b/tests/api/test_odilo.py
@@ -313,7 +313,7 @@ class TestOdiloAPI:
         def explode(*args, **kwargs):
             raise Exception("Failure!")
 
-        odilo.api.check_creds = explode  # type: ignore[method-assign]
+        odilo.api.check_creds = explode
 
         # Only one test will be run.
         [check_creds] = odilo.api._run_self_tests(odilo.db.session)

--- a/tests/api/test_opds2.py
+++ b/tests/api/test_opds2.py
@@ -326,7 +326,7 @@ class TestOPDS2WithTokens:
         loan = loans.first()
         assert isinstance(loan, Loan)
         mechanism_id = loan.license_pool.delivery_mechanisms[0].delivery_mechanism.id
-        manager.loans.authenticated_patron_from_request = lambda: patron  # type: ignore[method-assign]
+        manager.loans.authenticated_patron_from_request = lambda: patron
 
         # Fulfill (Download) the book, should redirect to an authenticated URL
         with controller_fixture.request_context_with_library("/") as ctx, patch.object(

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -234,7 +234,7 @@ class TestOverdriveAPI:
         def explode(*args, **kwargs):
             raise Exception("Failure!")
 
-        overdrive_api_fixture.api.check_creds = explode  # type: ignore[method-assign]
+        overdrive_api_fixture.api.check_creds = explode
 
         # Only one test will be run.
         [check_creds] = overdrive_api_fixture.api._run_self_tests(
@@ -1668,8 +1668,8 @@ class TestOverdriveAPI:
         od_api = OverdriveAPI(db.session, db.default_collection())
         od_api._server_nickname = OverdriveConstants.TESTING_SERVERS
         # but mock the request methods
-        od_api._do_post = MagicMock()  # type: ignore[method-assign]
-        od_api._do_get = MagicMock()  # type: ignore[method-assign]
+        od_api._do_post = MagicMock()
+        od_api._do_get = MagicMock()
         response_credential = od_api.refresh_patron_access_token(
             credential, patron, "a pin", is_fulfillment=True
         )
@@ -1705,8 +1705,8 @@ class TestOverdriveAPI:
         # use a real Overdrive API
         od_api = OverdriveAPI(db.session, db.default_collection())
         od_api._server_nickname = OverdriveConstants.TESTING_SERVERS
-        od_api.get_loan = MagicMock(return_value={"isFormatLockedIn": True})  # type: ignore[method-assign]
-        od_api.get_download_link = MagicMock(return_value=None)  # type: ignore[method-assign]
+        od_api.get_loan = MagicMock(return_value={"isFormatLockedIn": True})
+        od_api.get_download_link = MagicMock(return_value=None)
 
         exc = pytest.raises(
             CannotFulfill,
@@ -1749,14 +1749,14 @@ class TestOverdriveAPI:
             api_data = json.load(fp)
 
         # Mock out the flow
-        od_api.get_loan = MagicMock(return_value=api_data["loan"])  # type: ignore[method-assign]
+        od_api.get_loan = MagicMock(return_value=api_data["loan"])
 
         mock_lock_in_response = create_autospec(Response)
         mock_lock_in_response.status_code = 200
         mock_lock_in_response.json.return_value = api_data["lock_in"]
-        od_api.lock_in_format = MagicMock(return_value=mock_lock_in_response)  # type: ignore[method-assign]
+        od_api.lock_in_format = MagicMock(return_value=mock_lock_in_response)
 
-        od_api.get_fulfillment_link_from_download_link = MagicMock(  # type: ignore[method-assign]
+        od_api.get_fulfillment_link_from_download_link = MagicMock(
             return_value=(
                 "https://example.org/epub-redirect",
                 "application/epub+zip",

--- a/tests/api/test_scripts.py
+++ b/tests/api/test_scripts.py
@@ -712,7 +712,7 @@ class TestInstanceInitializationScript:
         with patch("scripts.SessionManager") as session_manager:
             with patch("scripts.pg_advisory_lock") as advisory_lock:
                 script = InstanceInitializationScript()
-                script.initialize = MagicMock()  # type: ignore[method-assign]
+                script.initialize = MagicMock()
                 script.run()
 
                 advisory_lock.assert_called_once_with(
@@ -727,8 +727,8 @@ class TestInstanceInitializationScript:
         # as necessary.
         with patch("scripts.inspect") as inspect:
             script = InstanceInitializationScript()
-            script.migrate_database = MagicMock()  # type: ignore[method-assign]
-            script.initialize_database = MagicMock()  # type: ignore[method-assign]
+            script.migrate_database = MagicMock()
+            script.initialize_database = MagicMock()
 
             # If the database is uninitialized, initialize_database() is called.
             inspect().has_table.return_value = False
@@ -1426,7 +1426,7 @@ class TestNovelistSnapshotScript:
             pass
 
         oldNovelistConfig = NoveListAPI.from_config
-        NoveListAPI.from_config = self.mockNoveListAPI  # type: ignore[method-assign]
+        NoveListAPI.from_config = self.mockNoveListAPI
 
         l1 = db.library()
         cmd_args = [l1.name]
@@ -1437,7 +1437,7 @@ class TestNovelistSnapshotScript:
 
         assert params[0] == l1
 
-        NoveListAPI.from_config = oldNovelistConfig  # type: ignore[method-assign]
+        NoveListAPI.from_config = oldNovelistConfig
 
 
 class TestLocalAnalyticsExportScript:

--- a/tests/api/test_sirsidynix_auth_provider.py
+++ b/tests/api/test_sirsidynix_auth_provider.py
@@ -159,10 +159,8 @@ class TestSirsiDynixAuthenticationProvider:
                 }
             }
         }
-        provider.api_read_patron_data = MagicMock(return_value=ok_patron_resp)  # type: ignore[method-assign]
-        provider.api_patron_status_info = MagicMock(  # type: ignore[method-assign]
-            return_value=patron_status_resp
-        )
+        provider.api_read_patron_data = MagicMock(return_value=ok_patron_resp)
+        provider.api_patron_status_info = MagicMock(return_value=patron_status_resp)
         patrondata = provider.remote_patron_lookup(
             SirsiDynixPatronData(permanent_id="xxxx", session_token="xxx")
         )
@@ -188,7 +186,7 @@ class TestSirsiDynixAuthenticationProvider:
 
         # Test bad patron read data
         bad_patron_resp = {"bad": "yes"}
-        provider.api_read_patron_data = MagicMock(return_value=bad_patron_resp)  # type: ignore[method-assign]
+        provider.api_read_patron_data = MagicMock(return_value=bad_patron_resp)
         patrondata = provider.remote_patron_lookup(
             SirsiDynixPatronData(permanent_id="xxxx", session_token="xxx")
         )
@@ -197,9 +195,7 @@ class TestSirsiDynixAuthenticationProvider:
         not_approved_patron_resp = {
             "fields": {"approved": False, "patronType": {"key": "testtype"}}
         }
-        provider.api_read_patron_data = MagicMock(  # type: ignore[method-assign]
-            return_value=not_approved_patron_resp
-        )
+        provider.api_read_patron_data = MagicMock(return_value=not_approved_patron_resp)
         patrondata = provider.remote_patron_lookup(
             SirsiDynixPatronData(permanent_id="xxxx", session_token="xxx")
         )
@@ -211,9 +207,7 @@ class TestSirsiDynixAuthenticationProvider:
             "fields": {"approved": True, "patronType": {"key": "testblocked"}}
         }
         provider.sirsi_disallowed_suffixes = ["blocked"]
-        provider.api_read_patron_data = MagicMock(  # type: ignore[method-assign]
-            return_value=bad_prefix_patron_resp
-        )
+        provider.api_read_patron_data = MagicMock(return_value=bad_prefix_patron_resp)
         patrondata = provider.remote_patron_lookup(
             SirsiDynixPatronData(permanent_id="xxxx", session_token="xxx")
         )
@@ -276,12 +270,12 @@ class TestSirsiDynixAuthenticationProvider:
             library_id=library.id,
             library_settings=library_settings,
         )
-        provider.remote_authenticate = MagicMock(  # type: ignore[method-assign]
+        provider.remote_authenticate = MagicMock(
             return_value=SirsiDynixPatronData(
                 permanent_id="xxxx", session_token="xxx", complete=False
             )
         )
-        provider.remote_patron_lookup = MagicMock(  # type: ignore[method-assign]
+        provider.remote_patron_lookup = MagicMock(
             return_value=PatronData(
                 permanent_id="xxxx",
                 personal_name="Test User",
@@ -357,10 +351,8 @@ class TestSirsiDynixAuthenticationProvider:
             info_copy = deepcopy(patron_info)
             info_copy.update(status)
 
-            provider.api_read_patron_data = MagicMock(  # type: ignore[method-assign]
-                return_value=ok_patron_resp
-            )
-            provider.api_patron_status_info = MagicMock(  # type: ignore[method-assign]
+            provider.api_read_patron_data = MagicMock(return_value=ok_patron_resp)
+            provider.api_patron_status_info = MagicMock(
                 return_value={"fields": info_copy}
             )
 

--- a/tests/core/models/test_before_flush_decorator.py
+++ b/tests/core/models/test_before_flush_decorator.py
@@ -102,7 +102,7 @@ def test_dirty_instances_only_called_for_directly_modified(
     instance2 = MagicMock(spec=Base)
 
     session = create_session(dirty=[instance1, instance2])
-    type(session).is_modified = MagicMock(  # type: ignore[method-assign]
+    type(session).is_modified = MagicMock(
         side_effect=lambda x, include_collections: x == instance2
     )
     before_flush_decorator.before_flush(model=Base, state=ListenerState.dirty)(mock)
@@ -128,7 +128,7 @@ def test_filter_not_called_for_new_or_deleted(
     instance3 = MagicMock(spec=Base)
 
     session = create_session(new=[instance1], deleted=[instance2], dirty=[instance3])
-    type(session).is_modified = MagicMock()  # type: ignore[method-assign]
+    type(session).is_modified = MagicMock()
 
     before_flush_decorator.before_flush(model=Base, state=ListenerState.new)(mock)
     before_flush_decorator.before_flush(model=Base, state=ListenerState.deleted)(mock)

--- a/tests/core/models/test_patron.py
+++ b/tests/core/models/test_patron.py
@@ -168,7 +168,7 @@ class TestHold:
             return "mock until"
 
         old__calculate_until = hold._calculate_until
-        Hold._calculate_until = _mock__calculate_until  # type: ignore[method-assign]
+        Hold._calculate_until = _mock__calculate_until
 
         assert "mock until" == m(one_day, two_days)
 
@@ -199,7 +199,7 @@ class TestHold:
         ) = hold.called_with
         assert pool.patrons_in_hold_queue == position
 
-        Hold._calculate_until = old__calculate_until  # type: ignore[method-assign]
+        Hold._calculate_until = old__calculate_until
 
     def test_calculate_until(self):
         start = datetime_utc(2010, 1, 1)
@@ -619,7 +619,7 @@ class TestPatron:
 
         patron = db.patron()
         mock = MagicMock(side_effect=mock_age_appropriate)
-        patron.age_appropriate_match = mock  # type: ignore[method-assign]
+        patron.age_appropriate_match = mock
         self.calls: list = []
         self.return_true_for = None
 

--- a/tests/core/models/test_work.py
+++ b/tests/core/models/test_work.py
@@ -1377,7 +1377,7 @@ class TestWork:
 
         # Otherwise, this method is a simple passthrough for
         # Patron.work_is_age_appropriate.
-        patron.work_is_age_appropriate = MagicMock(return_value="value")  # type: ignore[method-assign]
+        patron.work_is_age_appropriate = MagicMock(return_value="value")
 
         assert "value" == work.age_appropriate_for_patron(patron)
         patron.work_is_age_appropriate.assert_called_with(

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -2191,7 +2191,7 @@ class TestWorkList:
 
         # Now it depends on the return value of Patron.work_is_age_appropriate.
         # Mock that method.
-        patron.work_is_age_appropriate = MagicMock(return_value=False)  # type: ignore[method-assign]
+        patron.work_is_age_appropriate = MagicMock(return_value=False)
 
         # Since our mock returns false, so does accessible_to
         assert False == m(patron)
@@ -2205,7 +2205,7 @@ class TestWorkList:
         )
 
         # If we tell work_is_age_appropriate to always return true...
-        patron.work_is_age_appropriate = MagicMock(return_value=True)  # type: ignore[method-assign]
+        patron.work_is_age_appropriate = MagicMock(return_value=True)
 
         # ...accessible_to starts returning True.
         assert True == m(patron)
@@ -2844,7 +2844,7 @@ class TestDatabaseBackedWorkList:
         # Now we're going to do a more complicated test, with
         # faceting, pagination, and a bibliographic_filter_clauses that
         # actually does something.
-        wl.bibliographic_filter_clauses = wl.active_bibliographic_filter_clauses  # type: ignore[method-assign]
+        wl.bibliographic_filter_clauses = wl.active_bibliographic_filter_clauses
 
         class MockFacets(DatabaseBackedFacets):
             def __init__(self, wl):
@@ -4147,14 +4147,14 @@ class TestLane:
         # Now try the case where a lane is its own search target.  The
         # Facets object is propagated to the WorkList.search().
         mock.called_with = None
-        Lane.search_target = lane  # type: ignore[method-assign]
-        WorkList.search = mock.search  # type: ignore[method-assign]
+        Lane.search_target = lane
+        WorkList.search = mock.search
         lane.search(db.session, "query", None, facets=facets)
         assert facets == mock.called_with
 
         # Restore methods that were mocked.
-        Lane.search_target = old_lane_search_target  # type: ignore[method-assign]
-        WorkList.search = old_wl_search  # type: ignore[method-assign]
+        Lane.search_target = old_lane_search_target
+        WorkList.search = old_wl_search
 
     def test_explain(self, db: DatabaseTransactionFixture):
         parent = db.lane(display_name="Parent")
@@ -4191,7 +4191,7 @@ class TestLane:
         facets = FeaturedFacets(0)
         lane.groups(db.session, facets=facets)
         assert facets == lane.called_with
-        Lane._groups_for_lanes = old_value  # type: ignore[method-assign]
+        Lane._groups_for_lanes = old_value
 
     def test_suppress(self, db: DatabaseTransactionFixture):
         lane1 = db.lane()

--- a/tests/core/test_opds.py
+++ b/tests/core/test_opds.py
@@ -2856,9 +2856,9 @@ def entrypoint_link_insertion_fixture(
 
     data.annotator = MockAnnotator
     data.old_add_entrypoint_links = AcquisitionFeed.add_entrypoint_links
-    AcquisitionFeed.add_entrypoint_links = data.mock.add_entrypoint_links  # type: ignore[method-assign]
+    AcquisitionFeed.add_entrypoint_links = data.mock.add_entrypoint_links
     yield data
-    AcquisitionFeed.add_entrypoint_links = data.old_add_entrypoint_links  # type: ignore[method-assign]
+    AcquisitionFeed.add_entrypoint_links = data.old_add_entrypoint_links
 
 
 class TestEntrypointLinkInsertion:

--- a/tests/migration/test_instance_init_script.py
+++ b/tests/migration/test_instance_init_script.py
@@ -74,8 +74,8 @@ def test_initialize(application: ApplicationFixture) -> None:
     assert len(inspector.get_table_names()) == 0
 
     script = InstanceInitializationScript()
-    script.initialize_database = Mock(wraps=script.initialize_database)  # type: ignore[method-assign]
-    script.migrate_database = Mock(wraps=script.migrate_database)  # type: ignore[method-assign]
+    script.initialize_database = Mock(wraps=script.initialize_database)
+    script.migrate_database = Mock(wraps=script.migrate_database)
     script.run()
 
     inspector = inspect(engine)
@@ -103,8 +103,8 @@ def test_migrate(alembic_runner: MigrationContext) -> None:
     assert alembic_runner.current != alembic_runner.heads[0]
 
     script = InstanceInitializationScript()
-    script.initialize_database = Mock(wraps=script.initialize_database)  # type: ignore[method-assign]
-    script.migrate_database = Mock(wraps=script.migrate_database)  # type: ignore[method-assign]
+    script.initialize_database = Mock(wraps=script.initialize_database)
+    script.migrate_database = Mock(wraps=script.migrate_database)
     script.run()
 
     # Make sure we have upgraded


### PR DESCRIPTION
## Description

Add mypy override for our tests module, that disables the "method-assign" error, and remove existing comments that are disabling this check.

## Motivation and Context

In our tests, we often overwrite methods on classes with MagicMock to mock out some behaviour. Mypy doesn't like this and throws a "method-assign" error. Until now, we've been adding `# type: ignore[method-assign]` comments to disable this where we need to use mocks. 

This PR instead removes those existing comments, and disables this check for the tests package. It is still enabled for our normal code, where we should not be mocking like this.

This is the recommended work-around from the mypy issue here: https://github.com/python/mypy/issues/2427

## How Has This Been Tested?

- Running mypy locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
