### PR TITLE
Ensures that OPDS For Distributors Monitor results are displayed in t…

### DIFF
--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -371,6 +371,7 @@ class OPDSForDistributorsImportMonitor(OPDSImportMonitor):
     """
 
     PROTOCOL = OPDSForDistributorsImporter.NAME
+    SERVICE_NAME = "OPDS for Distributors Import Monitor"
 
     def __init__(self, _db, collection, import_class, **kwargs):
         super().__init__(_db, collection, import_class, **kwargs)


### PR DESCRIPTION
…he CM Admin.

## Description
This update overrides the SERVICE_NAME property of the OPDS for Distributors Import Monitor.  With a unique service name, the results will show up in their own "OPDS For Distributors Import Monitor" sublist.  I believe the filtering logic of the monitor reports was preventing the OPDS for Distributors from showing up. 

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-189
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tested this locally by running ./bin/opds_for_distributors_import_monitor and verifying that the results appeared in the UI as expected. It wasn't clear to me how to add a unit test to cover the fix.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have updated the documentation accordingly.
- [ x] All new and existing tests passed.
