### PR TITLE
Fix tests that are failing at certain times of the day

### DIFF
--- a/api/admin/controller/dashboard.py
+++ b/api/admin/controller/dashboard.py
@@ -70,7 +70,7 @@ class DashboardController(CirculationManagerController):
             # _beginning_ of the asked-for day, local time.
             #
             # Unlike most places in this application we do not
-            # use UTC since the sime was selected by a human user.
+            # use UTC since the time was selected by a human user.
             today = date.today()
             value = flask.request.args.get(field, None)
             if not value:

--- a/tests/api/admin/controller/test_dashboard.py
+++ b/tests/api/admin/controller/test_dashboard.py
@@ -97,7 +97,10 @@ class TestDashboardController:
             affinity=0.2,
         )
 
-        time = utc_now() - timedelta(minutes=1)
+        # We use local time here, rather than UTC time, because we use
+        # local time when finding the correct date in bulk_circulation_events
+        # because it is a user supplied date. See the get_date method.
+        time = datetime.datetime.now() - timedelta(minutes=1)
         event, ignore = get_one_or_create(
             dashboard_fixture.ctrl.db.session,
             CirculationEvent,

--- a/tests/api/test_circulationapi.py
+++ b/tests/api/test_circulationapi.py
@@ -1,4 +1,5 @@
 """Test the CirculationAPI."""
+import datetime
 from datetime import timedelta
 from typing import Union
 from unittest.mock import MagicMock
@@ -511,7 +512,9 @@ class TestCirculationAPI:
         self, circulation_api: CirculationAPIFixture
     ):
         # This checkout would succeed...
-        now = utc_now()
+        # We use local time here, rather than UTC time, because we use
+        # local time when checking for expired cards in authorization_is_active.
+        now = datetime.datetime.now()
         loaninfo = LoanInfo(
             circulation_api.pool.collection,
             circulation_api.pool.data_source,


### PR DESCRIPTION
## Description

Convert two tests to use local time, rather then UTC, since the production code compares the dates with local time.

## Motivation and Context

Tonight when working on the CM, suddenly a test started failing for me. I've seen this when working later in the evening before. After doing some investigation, it was caused by using UTC in the dates in tests. This means that every day this test will fail when UTC and the local time zone are a different day 😓

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
