### PR TITLE
Fix bug with settings in MARCExporter (PP-306)

### DIFF
--- a/core/marc.py
+++ b/core/marc.py
@@ -616,7 +616,7 @@ class MARCExporter:
             # Only add an integration to choose from if it has a
             # MARC File Bucket field in its settings.
             configuration_settings = [
-                s for s in integration.settings_dict if s.key == "marc_bucket"
+                s for s in integration.settings if s.key == "marc_bucket"
             ]
 
             if configuration_settings:


### PR DESCRIPTION
## Description

In https://github.com/ThePalaceProject/circulation/pull/1303 I mistakenly updated a call to `settings` on an `ExternalIntegration` to a call to `settings_dict`.

This PR fixes the issue, and adds a test for the function that the issue occurred in, since it wasn't tested before.

## Motivation and Context

Minotaur failed to start after updating overnight, due to https://github.com/ThePalaceProject/circulation/pull/1303 being merged.

## How Has This Been Tested?

Local testing with Minotaur DB.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
