### PR TITLE
Allow "is not equal" operator in distributor query clauses.

### DIFF
--- a/core/external_search.py
+++ b/core/external_search.py
@@ -2050,7 +2050,7 @@ class JSONQuery(Query):
         "licensepools.availability_time": dict(path="licensepools", **_LONG_TYPE),
         "licensepools.collection_id": dict(path="licensepools", **_LONG_TYPE),
         "licensepools.data_source_id": dict(
-            path="licensepools", ops=[Operators.EQ], **_LONG_TYPE
+            path="licensepools", ops=[Operators.EQ, Operators.NEQ], **_LONG_TYPE
         ),
         "licensepools.licensed": dict(path="licensepools", **_BOOL_TYPE),
         "licensepools.medium": dict(path="licensepools"),


### PR DESCRIPTION
## Description
This PR enables the use of the "is not equal to" or `neq` operator when constructing query clauses with the `distributor` field in the UI.  Under the covers the distributor maps to the data_source field.  I've added a test to verify that this works as well as modified a test that broke as a result of my changes.

I tested the functionality manually and verified that it works.  It wasn't clear to me from the code why data_source was restricted to the 'eq' operator only.   

So while the fix appears to work, I'm not 100% confident that there wasn't a good reason to restrict the `neq` operator.

@RishiDiwanTT :  Perhaps you have some insight into why datasource was heretofore restricted to `eq`?

<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-220
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
See above.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
