### PR TITLE
Fixes syntax error in cron job definitions due to use of non-standard…

### DIFF
--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -118,6 +118,6 @@ HOME=/var/www/circulation
 
 # Audiobook playtimes
 # Every 12 hours, but spaced after hour 8 to reduce job cluttering
-0 8/12 * * * root core/bin/run playtime_summation >> /var/log/cron.log 2>&1
+0 8,20 * * * root core/bin/run playtime_summation >> /var/log/cron.log 2>&1
 # On the 2nd of every month
 0 4 2 * * root core/bin/run playtime_reporting >> /var/log/cron.log 2>&1


### PR DESCRIPTION
… "/" in hour field.

Resolves: https://ebce-lyrasis.atlassian.net/browse/PP-351

## Description

Uses a more widely supported syntax for running playtime_summation script  every 12 hours starting at 8am.

<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-351
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
So the following did not produce the error as expected.
```
git checkout v7.3.1
docker-compose build
docker-compose up -d
docker logs circulation-scripts-1
```
despite the fact that I confirmed the line is question was in fact in the crontab definition. 

So, I went to minotaur-scripts and confirmed the error is occurring there.  I manually updated the /etc/cron.d/circulation cron script with the fix in this PR.  Then I restarted the scripts docker container  and verified the error went away.
I tried to reproduce the error locally, but strangely I didn't see it.  I'm guessing it may have something to do with differences 
in my local container and the docker container on ec2 (even though I thought that was the whole point of docker!)

Comparing /proc/version on the two instances, I can see that the kernels of the docker containers are not identical:

```
dbernstein@tpp-dev-scripts-minotaur:~$ docker exec -it minotaur-scripts bash
root@334a40aa5f79:/var/www/circulation/bin# cat /proc/version
Linux version 5.15.0-1040-aws (buildd@lcy02-amd64-013) (gcc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0, GNU ld (GNU Binutils for Ubuntu) 2.34) #45~20.04.1-Ubuntu SMP Tue Jul 11 19:08:13 UTC 2023
```
VS: 
my local deployment
```
docker exec -it circulation-scripts-1 bash
root@f921ada72813:/var/www/circulation/bin# cat /proc/version
Linux version 5.15.49-linuxkit-pr (root@buildkitsandbox) (gcc (Alpine 10.2.1_pre1) 10.2.1 20201203, GNU ld (GNU Binutils) 2.35.2) #1 SMP PREEMPT Thu May 25 07:27:39 UTC 2023
```
However,  I am confident the fix in the PR will resolve the issue since it worked on minotaur scripts container.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
