### PR TITLE
Correctly handle list and menu collection settings.

### DIFF
--- a/api/admin/controller/collection_settings.py
+++ b/api/admin/controller/collection_settings.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
 import flask
 from flask import Response
@@ -20,6 +20,7 @@ from api.admin.problem_details import (
     NO_PROTOCOL_FOR_NEW_SERVICE,
     NO_SUCH_LIBRARY,
     PROTOCOL_DOES_NOT_SUPPORT_PARENTS,
+    PROTOCOL_DOES_NOT_SUPPORT_SETTINGS,
     UNKNOWN_PROTOCOL,
 )
 from api.integration.registry.license_providers import LicenseProvidersRegistry
@@ -305,8 +306,12 @@ class CollectionSettingsController(SettingsController):
                 )
             )
 
-    def process_settings(self, settings, collection):
-        """Go through the settings that the user has just submitted for this collection,
+    def process_settings(
+        self, settings: List[Dict[str, Any]], collection: Collection
+    ) -> Optional[ProblemDetail]:
+        """Process the settings for the given collection.
+
+        Go through the settings that the user has just submitted for this collection,
         and check that each setting is valid and that no required settings are missing.  If
         the setting passes all of the validations, go ahead and set it for this collection.
         """
@@ -315,10 +320,14 @@ class CollectionSettingsController(SettingsController):
             collection.protocol,
             is_child=(flask.request.form.get("parent_id") is not None),
         )
+        if isinstance(settings_class, ProblemDetail):
+            return settings_class
+        if settings_class is None:
+            return PROTOCOL_DOES_NOT_SUPPORT_SETTINGS
         collection_settings = {}
         for setting in settings:
-            key = setting.get("key")
-            value = flask.request.form.get(key)
+            key = setting["key"]
+            value = self._extract_form_setting_value(setting, flask.request.form)
             if key == "external_account_id":
                 error = self.validate_external_account_id_setting(value, setting)
                 if error:
@@ -334,9 +343,16 @@ class CollectionSettingsController(SettingsController):
 
                 if isinstance(external_integration_link, ProblemDetail):
                     return external_integration_link
-            elif key in flask.request.form:
+            elif value is not None:
                 # Only if the key was present in the request should we add it
                 collection_settings[key] = value
+            else:
+                # Keep existing setting value, when present, if a value is not specified.
+                # This can help prevent accidental loss of settings due to some programming errors.
+                if key in collection.integration_configuration.settings_dict:
+                    collection_settings[
+                        key
+                    ] = collection.integration_configuration.settings_dict[key]
 
         # validate then apply
         try:
@@ -344,6 +360,7 @@ class CollectionSettingsController(SettingsController):
         except ProblemError as ex:
             return ex.problem_detail
         collection.integration_configuration.settings_dict = collection_settings
+        return None
 
     def _set_external_integration_link(
         self,

--- a/api/admin/controller/settings.py
+++ b/api/admin/controller/settings.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
-from typing import Optional, Type, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Type, cast
 
 import flask
 from flask import Response
@@ -50,6 +50,9 @@ from core.opds_import import OPDSImporter, OPDSImportMonitor
 from core.s3 import S3UploaderConfiguration
 from core.selftest import BaseHasSelfTests
 from core.util.problem_detail import ProblemDetail
+
+if TYPE_CHECKING:
+    from werkzeug.datastructures import ImmutableMultiDict
 
 
 class SettingsController(CirculationManagerController, AdminPermissionsControllerMixin):
@@ -305,18 +308,27 @@ class SettingsController(CirculationManagerController, AdminPermissionsControlle
 
         return values
 
-    def _set_integration_setting(self, integration, setting):
-        setting_key = setting.get("key")
+    def _extract_form_setting_value(
+        self, setting: Dict[str, Any], form_data: ImmutableMultiDict
+    ) -> Optional[Any]:
+        """Extract the value of a setting from form data."""
+
+        key = setting.get("key")
         setting_type = setting.get("type")
 
+        value: Optional[Any]
         if setting_type == "list" and not setting.get("options"):
-            value = [item for item in flask.request.form.getlist(setting_key) if item]
-            if value:
-                value = json.dumps(value)
+            value = [item for item in form_data.getlist(key) if item]
         elif setting_type == "menu":
-            value = self._get_menu_values(setting_key, flask.request.form)
+            value = self._get_menu_values(key, form_data)
         else:
-            value = flask.request.form.get(setting_key)
+            value = form_data.get(key)
+        return value
+
+    def _set_integration_setting(self, integration, setting):
+        value = self._extract_form_setting_value(setting, flask.request.form)
+        if value and setting.get("type") == "list":
+            value = json.dumps(value)
 
         if value and setting.get("options"):
             # This setting can only take on values that are in its
@@ -352,7 +364,7 @@ class SettingsController(CirculationManagerController, AdminPermissionsControlle
         if isinstance(value, list):
             value = json.dumps(value)
 
-        integration.setting(setting_key).value = value
+        integration.setting(setting.get("key")).value = value
 
     def _set_configuration_library(
         self,

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -225,6 +225,15 @@ PROTOCOL_DOES_NOT_SUPPORT_PARENTS = pd(
     ),
 )
 
+PROTOCOL_DOES_NOT_SUPPORT_SETTINGS = pd(
+    "http://librarysimplified.org/terms/problem/protocol-does-not-support-settings",
+    status_code=400,
+    title=_("Protocol does not support settings"),
+    detail=_(
+        "You attempted to update settings for a protocol that does not support settings."
+    ),
+)
+
 MISSING_PARENT = pd(
     "http://librarysimplified.org/terms/problem/missing-parent",
     status_code=400,


### PR DESCRIPTION
## Description

- Collection `list` and `menu` setting types are correctly handled.
- If a value for an existing setting is not present in the submitted form, then the previous value of the setting is used. This should improve the chances that a setting is not lost if there is a programming error.

## Motivation and Context

- `list` and `menu` type settings were not being captured from the form data.

[Jira [PP-354](https://ebce-lyrasis.atlassian.net/browse/PP-354)]

## How Has This Been Tested?

- Manual testing in local development environment.
- ["Test & Build" CI checks](https://github.com/ThePalaceProject/circulation/actions/runs/5927339898) passed for this branch.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-354]: https://ebce-lyrasis.atlassian.net/browse/PP-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ