### PR TITLE
Update our relationship loading for the library class (PP-339)

### DIFF
--- a/core/model/library.py
+++ b/core/model/library.py
@@ -128,7 +128,7 @@ class Library(Base, HasSessionCache):
 
     # A Library may have many CustomLists.
     custom_lists: Mapped[List[CustomList]] = relationship(
-        "CustomList", backref="library", lazy="joined", uselist=True
+        "CustomList", backref="library", uselist=True
     )
 
     # Lists shared with this library
@@ -153,7 +153,6 @@ class Library(Base, HasSessionCache):
     external_integration_settings: Mapped[List[ConfigurationSetting]] = relationship(
         "ConfigurationSetting",
         back_populates="library",
-        lazy="joined",
         cascade="all, delete",
     )
 


### PR DESCRIPTION
## Description

Update `Library.custom_lists` and `Library.external_integration_settings` to use the [default loading strategy](https://docs.sqlalchemy.org/en/14/orm/relationship_api.html#sqlalchemy.orm.relationship.params.lazy) of lazy loading the relationship. 

## Motivation and Context

This fixes the issue we were seeing in PP-339 where the RI CM instance was using an excessive amount of memory at startup. Enough that uwsgi was immediately recycling the process,  resulting in the CM constantly cycling processes and not coming online. 

Using the [fil memory profiler](https://pythonspeed.com/fil/docs/index.html), I was able to see that RI was using 679.1 MiB of memory at startup. For comparison I also profiled the CT CM instance, since it has more libraries and more collections. The CT CM was using 279.0 MiB of memory. 

It took some digging to sort out why this is the case. I ended up turning on SQL debugging to try to understand what is coming back that could be taking up so much memory. Taking a look at the SQL emitted by sqlalchemy when querying for all our libraries gives a hint:
```
SELECT * FROM libraries LEFT OUTER JOIN customlists AS customlists_1 ON libraries.id = customlists_1.library_id LEFT OUTER JOIN configurationsettings AS configurationsettings_1 ON libraries.id = configurationsettings_1.library_id;
```

Looking at RI vs CT, it seems that RI has 805 custom lists where CT only has 195. This it what is making the difference. Because we are using a joined relationship the libraries query that we do to populate the cache was returning `53776` results on RI and only `13184` results on CT. 

Updating the relationships on Library to be lazy loaded reduces the memory usage of RI at startup to 132.6 MiB and the memory usage of CT to 163.4 MiB and in both cases it improves the startup time, since sqlalchemy doesn't have to parse through as much data to build its objects.

I'm confident that updating `external_integration_settings` is safe and shouldn't have any performance impact, because almost no usages of this property exist anymore, and it will be removed soon. 

I'm less sure about `custom_lists`. Looking back through history the change came in with this PR: https://github.com/NYPL-Simplified/server_core/pull/668. That PR added the property, so I don't think any performance impact caused the relationship loading to be set to "joined". Based on the improved load times, and reduced memory usage, I'm inclined to make this change, and if we see a negative impact on lists and lanes, do a further performance investigation then.

## How Has This Been Tested?

Local testing with fil memory profiler.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
