### PR TITLE
Ensure that lane SQLAlchemy models are properly registered.

### DIFF
--- a/core/lane.py
+++ b/core/lane.py
@@ -2783,7 +2783,7 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
     )
 
     # Only the books on these specific CustomLists will be shown.
-    customlists = relationship(
+    customlists: Mapped[List[CustomList]] = relationship(
         "CustomList", secondary=lambda: lanes_customlists, backref="lane"  # type: ignore
     )
 

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -585,4 +585,5 @@ from .resource import Hyperlink, Representation, Resource, ResourceTransformatio
 from .time_tracking import PlaytimeEntry, PlaytimeSummary
 from .work import Work, WorkGenre
 
+# Import order important here to avoid an import cycle.
 from core.lane import Lane, LaneGenre  # isort:skip

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -584,3 +584,5 @@ from .patron import (
 from .resource import Hyperlink, Representation, Resource, ResourceTransformation
 from .time_tracking import PlaytimeEntry, PlaytimeSummary
 from .work import Work, WorkGenre
+
+from core.lane import Lane, LaneGenre  # isort:skip


### PR DESCRIPTION
## Description

Ensures that `core.model` loads the lane models by explicitly importing them, though probably any import from `core.lane` would probably do the trick.

NB: The order of the import is important here.

## Motivation and Context

`core.model.production_session` needs the `Lane` model to be loaded so that it gets registered. This was not always failing in many cases because sometimes it would be loaded as a side effect of some other import. But it was failing in some cases, notably when running the `./bin/hold_notifications` and `./bin/patron_activity_sync_notifications` scripts.

[Jira [PP-166](https://ebce-lyrasis.atlassian.net/browse/PP-166)]

## How Has This Been Tested?

- Manual testing in local development environment.
- CI test for this branch pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-166]: https://ebce-lyrasis.atlassian.net/browse/PP-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ