### PR TITLE
PP-398 Maintain type coercions during collections settings mutation

### DIFF
--- a/alembic/versions/20230905_2b672c6fb2b9_type_coerce_collection_settings.py
+++ b/alembic/versions/20230905_2b672c6fb2b9_type_coerce_collection_settings.py
@@ -6,7 +6,9 @@ Create Date: 2023-09-05 06:40:35.739869+00:00
 
 """
 import json
-from typing import Callable, Dict
+from typing import Any, Callable, Dict, Type
+
+from pydantic import parse_obj_as
 
 from alembic import op
 
@@ -22,9 +24,9 @@ def _bool(value):
 
 
 # All the settings types that have non-str types
-ALL_SETTING_TYPES: Dict[str, Callable] = {
-    "verify_certificate": _bool,
-    "default_reservation_period": _bool,
+ALL_SETTING_TYPES: Dict[str, Type[Any]] = {
+    "verify_certificate": bool,
+    "default_reservation_period": bool,
     "loan_limit": int,
     "hold_limit": int,
     "max_retry_count": int,
@@ -38,7 +40,7 @@ def _coerce_types(settings: dict) -> None:
     setting_type: Callable
     for setting_name, setting_type in ALL_SETTING_TYPES.items():
         if setting_name in settings:
-            settings[setting_name] = setting_type(settings[setting_name])
+            settings[setting_name] = parse_obj_as(setting_type, settings[setting_name])
 
 
 def upgrade() -> None:

--- a/alembic/versions/20230905_2b672c6fb2b9_type_coerce_collection_settings.py
+++ b/alembic/versions/20230905_2b672c6fb2b9_type_coerce_collection_settings.py
@@ -6,6 +6,7 @@ Create Date: 2023-09-05 06:40:35.739869+00:00
 
 """
 import json
+from typing import Callable, Dict
 
 from alembic import op
 
@@ -21,7 +22,7 @@ def _bool(value):
 
 
 # All the settings types that have non-str types
-ALL_SETTING_TYPES = {
+ALL_SETTING_TYPES: Dict[str, Callable] = {
     "verify_certificate": _bool,
     "default_reservation_period": _bool,
     "loan_limit": int,
@@ -34,6 +35,7 @@ ALL_SETTING_TYPES = {
 
 def _coerce_types(settings: dict) -> None:
     """Coerce the types, in-place"""
+    setting_type: Callable
     for setting_name, setting_type in ALL_SETTING_TYPES.items():
         if setting_name in settings:
             settings[setting_name] = setting_type(settings[setting_name])

--- a/alembic/versions/20230905_2b672c6fb2b9_type_coerce_collection_settings.py
+++ b/alembic/versions/20230905_2b672c6fb2b9_type_coerce_collection_settings.py
@@ -1,0 +1,75 @@
+"""Type coerce collection settings
+
+Revision ID: 2b672c6fb2b9
+Revises: 0df58829fc1a
+Create Date: 2023-09-05 06:40:35.739869+00:00
+
+"""
+import json
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2b672c6fb2b9"
+down_revision = "0df58829fc1a"
+branch_labels = None
+depends_on = None
+
+
+def _bool(value):
+    return value in ("true", "True", True)
+
+
+# All the settings types that have non-str types
+ALL_SETTING_TYPES = {
+    "verify_certificate": _bool,
+    "default_reservation_period": _bool,
+    "loan_limit": int,
+    "hold_limit": int,
+    "max_retry_count": int,
+    "ebook_loan_duration": int,
+    "default_loan_duration": int,
+}
+
+
+def _coerce_types(settings: dict) -> None:
+    """Coerce the types, in-place"""
+    for setting_name, setting_type in ALL_SETTING_TYPES.items():
+        if setting_name in settings:
+            settings[setting_name] = setting_type(settings[setting_name])
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    # Fetch all integration settings with the 'licenses' goal
+    results = connection.execute(
+        f"SELECT id, settings from integration_configurations where goal='LICENSE_GOAL';"
+    ).fetchall()
+
+    # For each integration setting, we check id any of the non-str
+    # keys are present in the DB
+    # We then type-coerce that value
+    for settings_id, settings in results:
+        _coerce_types(settings)
+        connection.execute(
+            "UPDATE integration_configurations SET settings=%s where id=%s",
+            json.dumps(settings),
+            settings_id,
+        )
+
+    # Do the same for any Library settings
+    results = connection.execute(
+        f"SELECT parent_id, settings from integration_library_configurations;"
+    ).fetchall()
+
+    for settings_id, settings in results:
+        _coerce_types(settings)
+        connection.execute(
+            "UPDATE integration_library_configurations SET settings=%s where parent_id=%s",
+            json.dumps(settings),
+            settings_id,
+        )
+
+
+def downgrade() -> None:
+    """There is no need to revert the types back to strings"""

--- a/api/admin/controller/collection_settings.py
+++ b/api/admin/controller/collection_settings.py
@@ -356,10 +356,10 @@ class CollectionSettingsController(SettingsController):
 
         # validate then apply
         try:
-            settings_class(**collection_settings)
+            validated_settings = settings_class(**collection_settings)
         except ProblemError as ex:
             return ex.problem_detail
-        collection.integration_configuration.settings_dict = collection_settings
+        collection.integration_configuration.settings_dict = validated_settings.dict()
         return None
 
     def _set_external_integration_link(

--- a/api/admin/controller/settings.py
+++ b/api/admin/controller/settings.py
@@ -382,10 +382,10 @@ class SettingsController(CirculationManagerController, AdminPermissionsControlle
         config = None
 
         # Validate first
-        protocol_class.library_settings_class()(**info_copy)
+        validated_data = protocol_class.library_settings_class()(**info_copy)
         # Attach the configuration
         config = configuration.for_library(cast(int, library.id), create=True)
-        config.settings_dict = info_copy
+        config.settings_dict = validated_data.dict()
         return config
 
     def _set_integration_library(self, integration, library_info, protocol):

--- a/core/model/collection.py
+++ b/core/model/collection.py
@@ -325,10 +325,11 @@ class Collection(Base, HasSessionCache):
         that someone who borrows a non-open-access item from this
         collection has it for this number of days.
         """
-        return (
+        value = (
             self.default_loan_period_setting(library, medium)
             or self.STANDARD_DEFAULT_LOAN_PERIOD
         )
+        return int(value) if value is not None else None
 
     @classmethod
     def loan_period_key(cls, medium=EditionConstants.BOOK_MEDIUM):

--- a/core/model/collection.py
+++ b/core/model/collection.py
@@ -329,7 +329,7 @@ class Collection(Base, HasSessionCache):
             self.default_loan_period_setting(library, medium)
             or self.STANDARD_DEFAULT_LOAN_PERIOD
         )
-        return int(value) if value is not None else None
+        return value
 
     @classmethod
     def loan_period_key(cls, medium=EditionConstants.BOOK_MEDIUM):

--- a/tests/core/models/test_collection.py
+++ b/tests/core/models/test_collection.py
@@ -333,12 +333,6 @@ class TestCollection:
         example_collection_fixture.set_default_loan_period(audio, 606, library=library)
         assert 606 == test_collection.default_loan_period(library, audio)
 
-        # String values should be coerced to int
-        example_collection_fixture.set_default_loan_period(
-            audio, "690", library=library
-        )
-        assert 690 == test_collection.default_loan_period(library, audio)
-
     def test_default_reservation_period(
         self, example_collection_fixture: ExampleCollectionFixture
     ):

--- a/tests/core/models/test_collection.py
+++ b/tests/core/models/test_collection.py
@@ -333,6 +333,12 @@ class TestCollection:
         example_collection_fixture.set_default_loan_period(audio, 606, library=library)
         assert 606 == test_collection.default_loan_period(library, audio)
 
+        # String values should be coerced to int
+        example_collection_fixture.set_default_loan_period(
+            audio, "690", library=library
+        )
+        assert 690 == test_collection.default_loan_period(library, audio)
+
     def test_default_reservation_period(
         self, example_collection_fixture: ExampleCollectionFixture
     ):

--- a/tests/migration/test_20230905_2b672c6fb2b9.py
+++ b/tests/migration/test_20230905_2b672c6fb2b9.py
@@ -1,0 +1,110 @@
+import json
+from dataclasses import dataclass
+from typing import Protocol
+
+import pytest
+from pytest_alembic import MigrationContext
+from sqlalchemy.engine import Connection, Engine
+
+from tests.migration.conftest import CreateLibrary
+
+
+@dataclass
+class IntegrationConfiguration:
+    id: int
+    settings: dict
+
+
+class CreateConfiguration(Protocol):
+    def __call__(
+        self, connection: Connection, protocol: str, name: str, settings: dict
+    ) -> IntegrationConfiguration:
+        ...
+
+
+@pytest.fixture
+def create_integration_configuration() -> CreateConfiguration:
+    def insert_config(
+        connection: Connection, protocol: str, name: str, settings: dict
+    ) -> IntegrationConfiguration:
+        connection.execute(
+            "INSERT INTO integration_configurations (goal, protocol, name, settings, self_test_results) VALUES (%s, %s, %s, %s, '{}')",
+            "LICENSE_GOAL",
+            protocol,
+            name,
+            json.dumps(settings),
+        )
+        return fetch_config(connection, name=name)
+
+    return insert_config
+
+
+def fetch_config(
+    connection: Connection, name=None, parent_id=None
+) -> IntegrationConfiguration:
+    if name is not None:
+        _id, settings = connection.execute(
+            "SELECT id, settings FROM integration_configurations where name=%s", name
+        ).fetchone()
+    else:
+        _id, settings = connection.execute(
+            "SELECT parent_id, settings FROM integration_library_configurations where parent_id=%s",
+            parent_id,
+        ).fetchone()
+    return IntegrationConfiguration(_id, settings)
+
+
+MIGRATION_UID = "2b672c6fb2b9"
+
+
+def test_settings_coersion(
+    alembic_runner: MigrationContext,
+    alembic_engine: Engine,
+    create_library: CreateLibrary,
+    create_integration_configuration: CreateConfiguration,
+):
+    alembic_runner.migrate_down_to(MIGRATION_UID)
+    alembic_runner.migrate_down_one()
+
+    with alembic_engine.connect() as connection:
+        config = create_integration_configuration(
+            connection,
+            "Axis 360",
+            "axis-test-1",
+            dict(
+                verify_certificate="true",
+                loan_limit="20",
+                key="value",
+            ),
+        )
+
+        library_id = create_library(connection)
+
+        library_settings = dict(
+            hold_limit="30",
+            max_retry_count="2",
+            ebook_loan_duration="10",
+            default_loan_duration="11",
+            unchanged="value",
+        )
+        connection.execute(
+            "INSERT INTO integration_library_configurations (library_id, parent_id, settings) VALUES (%s, %s, %s)",
+            library_id,
+            config.id,
+            json.dumps(library_settings),
+        )
+        alembic_runner.migrate_up_one()
+
+        axis_config = fetch_config(connection, name="axis-test-1")
+        assert axis_config.settings["verify_certificate"] == True
+        assert axis_config.settings["loan_limit"] == 20
+        # Unknown settings remain as-is
+        assert axis_config.settings["key"] == "value"
+
+        odl_config = fetch_config(connection, parent_id=config.id)
+        assert odl_config.settings["hold_limit"] == 30
+        assert odl_config.settings["max_retry_count"] == 2
+        assert odl_config.settings["ebook_loan_duration"] == 10
+        assert odl_config.settings["default_loan_duration"] == 11
+        # Unknown settings remain as-is
+        assert odl_config.settings["unchanged"] == "value"


### PR DESCRIPTION
## Description
The Admin CollectionSettingsController was not maintain type coercion from the pydantic configuration models.
This change ensures the type coercion is saved to the database as well.
Along with this we ensure the default loan period method always casts the response to an int.

<!--- Describe your changes -->

## Motivation and Context
Not coercing the types would result in always saving the values as strings, which is incorrect.
[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-398)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Updated the unit tests.
Manually tested the "ebook load duration" setting in ODL collections.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
