### PR TITLE
PP-356 Scripts CI test for crontab

### DIFF
--- a/docker/ci/check_service_status.sh
+++ b/docker/ci/check_service_status.sh
@@ -29,3 +29,17 @@ function check_service_status()
     echo "  OK"
   fi
 }
+
+function check_crontab() {
+  container="$1"
+
+  # Installing the crontab will reveal any errors and exit with an error code
+  $(docker exec "$container" /bin/bash -c "crontab /etc/cron.d/circulation")
+  validate_status=$?
+  if [[ "$validate_status" != 0 ]]; then
+    echo "  FAIL: crontab is incorrect"
+    exit 1
+  else
+    echo "  OK"
+  fi
+}

--- a/docker/ci/test_scripts.sh
+++ b/docker/ci/test_scripts.sh
@@ -14,4 +14,7 @@ wait_for_runit "$container"
 
 # Make sure that cron is running in the scripts container
 check_service_status "$container" /etc/service/cron
+
+# Ensure the installed crontab has no problems
+check_crontab "$container"
 exit 0

--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -121,3 +121,5 @@ HOME=/var/www/circulation
 0 8,20 * * * root core/bin/run playtime_summation >> /var/log/cron.log 2>&1
 # On the 2nd of every month
 0 4 2 * * root core/bin/run playtime_reporting >> /var/log/cron.log 2>&1
+
+9,12/2 * root echo "Testing CI" >> /var/cron/log 2>&1

--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -121,5 +121,3 @@ HOME=/var/www/circulation
 0 8,20 * * * root core/bin/run playtime_summation >> /var/log/cron.log 2>&1
 # On the 2nd of every month
 0 4 2 * * root core/bin/run playtime_reporting >> /var/log/cron.log 2>&1
-
-9,12/2 * root echo "Testing CI" >> /var/cron/log 2>&1


### PR DESCRIPTION
## Description
Crontab syntax is tested by installing the `/etc/cron.d/circulation` crontab on the container.
Any errors will result in an error of the script.

<!--- Describe your changes -->

## Motivation and Context
Some cron expressions are supported only in certain distributions, this should avoid the case where a documented syntax is not supported.
[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-356)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Locally tested the `test_scripts.sh` against a badly written crontab.
The CI was also run against the badly written crontab [here](https://github.com/ThePalaceProject/circulation/actions/runs/6071529771/job/16469795441).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
