### PR TITLE
PP-356 Test run scripts during CI

### DIFF
--- a/docker/ci/check_service_status.sh
+++ b/docker/ci/check_service_status.sh
@@ -48,7 +48,7 @@ function run_script() {
   container="$1"
   script="$2"
 
-  $(docker exec "$container" /bin/bash -c "$script")
+  output=$(docker exec "$container" /bin/bash -c "$script")
   script_status=$?
   if [[ "$script_status" != 0 ]]; then
     echo "  FAIL: script run failed"

--- a/docker/ci/check_service_status.sh
+++ b/docker/ci/check_service_status.sh
@@ -43,3 +43,17 @@ function check_crontab() {
     echo "  OK"
   fi
 }
+
+function run_script() {
+  container="$1"
+  script="$2"
+
+  $(docker exec "$container" /bin/bash -c "$script")
+  script_status=$?
+  if [[ "$script_status" != 0 ]]; then
+    echo "  FAIL: script run failed"
+    exit 1
+  else
+    echo "  OK"
+  fi
+}

--- a/docker/ci/test_scripts.sh
+++ b/docker/ci/test_scripts.sh
@@ -19,6 +19,6 @@ check_service_status "$container" /etc/service/cron
 check_crontab "$container"
 
 # Run a single script to ensure basic settings are correct
-# The search index script connects to both the DB and OpenSearch
-run_script "$container" "source ../env/bin/activate && ./search_index_refresh"
+# The opds2 import script with a "-h" will only test the DB configuration
+run_script "$container" "source ../env/bin/activate && ./opds2_import_monitor -h"
 exit 0

--- a/docker/ci/test_scripts.sh
+++ b/docker/ci/test_scripts.sh
@@ -19,6 +19,6 @@ check_service_status "$container" /etc/service/cron
 check_crontab "$container"
 
 # Run a single script to ensure basic settings are correct
-# The opds2 import script with a "-h" will only test the DB configuration
-run_script "$container" "source ../env/bin/activate && ./opds2_import_monitor -h"
+# The opds2 import script will only test the DB configuration
+run_script "$container" "source ../env/bin/activate && ./opds2_import_monitor"
 exit 0

--- a/docker/ci/test_scripts.sh
+++ b/docker/ci/test_scripts.sh
@@ -17,4 +17,8 @@ check_service_status "$container" /etc/service/cron
 
 # Ensure the installed crontab has no problems
 check_crontab "$container"
+
+# Run a single script to ensure basic settings are correct
+# The search index script connects to both the DB and OpenSearch
+run_script "$container" "source ../env/bin/activate && ./search_index_refresh"
 exit 0


### PR DESCRIPTION
## Description
The test_scripts.sh script tests for correctly configured variables as well by running a single script.
`search_index_refesh` was chosen since it hits both the DB and OpenSearch.
<!--- Describe your changes -->

## Motivation and Context
Sometimes a misconfigured environment creeps into the deployments, the CI should catch these misconfigurations.
[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-356)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Locally ran a misconfigured docker to see failures
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
