### PR TITLE
PP-411 Added notification information to the push notifications

### DIFF
--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -65,12 +65,15 @@ class PushNotifications:
         edition: Edition = loan.license_pool.presentation_edition
         identifier: Identifier = loan.license_pool.identifier
         library_short_name = loan.library and loan.library.short_name
+        title = f"Only {days_to_expiry} {'days' if days_to_expiry != 1 else 'day'} left on your loan!"
+        body = f"Your loan on {edition.title} is expiring soon"
         for token in tokens:
             msg = messaging.Message(
                 token=token.device_token,
+                notification=dict(title=title, body=body),
                 data=dict(
-                    title=f"Only {days_to_expiry} {'days' if days_to_expiry != 1 else 'day'} left on your loan!",
-                    body=f"Your loan on {edition.title} is expiring soon",
+                    title=title,
+                    body=body,
                     event_type=NotificationConstants.LOAN_EXPIRY_TYPE,
                     loans_endpoint=f"{url}/{loan.library.short_name}/loans",
                     external_identifier=loan.patron.external_identifier,
@@ -129,11 +132,13 @@ class PushNotifications:
             loans_api = f"{url}/{hold.patron.library.short_name}/loans"
             work: Work = hold.work
             identifier: Identifier = hold.license_pool.identifier
+            title = f'Your hold on "{work.title}" is available!'
             for token in tokens:
                 msg = messaging.Message(
                     token=token.device_token,
+                    notification=dict(title=title),
                     data=dict(
-                        title=f'Your hold on "{work.title}" is available!',
+                        title=title,
                         event_type=NotificationConstants.HOLD_AVAILABLE_TYPE,
                         loans_endpoint=loans_api,
                         external_identifier=hold.patron.external_identifier,

--- a/tests/core/util/test_notifications.py
+++ b/tests/core/util/test_notifications.py
@@ -52,6 +52,10 @@ class TestPushNotifications:
                 (),
                 {
                     "token": "atoken",
+                    "notification": dict(
+                        title="Only 1 day left on your loan!",
+                        body=f"Your loan on {work.presentation_edition.title} is expiring soon",
+                    ),
                     "data": dict(
                         title="Only 1 day left on your loan!",
                         body=f"Your loan on {work.presentation_edition.title} is expiring soon",
@@ -176,6 +180,9 @@ class TestPushNotifications:
         assert messaging.Message.call_args_list == [
             mock.call(
                 token="test-token-1",
+                notification=dict(
+                    title=f'Your hold on "{work1.title}" is available!',
+                ),
                 data=dict(
                     title=f'Your hold on "{work1.title}" is available!',
                     event_type=NotificationConstants.HOLD_AVAILABLE_TYPE,
@@ -189,6 +196,9 @@ class TestPushNotifications:
             ),
             mock.call(
                 token="test-token-2",
+                notification=dict(
+                    title=f'Your hold on "{work1.title}" is available!',
+                ),
                 data=dict(
                     title=f'Your hold on "{work1.title}" is available!',
                     event_type=NotificationConstants.HOLD_AVAILABLE_TYPE,
@@ -202,6 +212,9 @@ class TestPushNotifications:
             ),
             mock.call(
                 token="test-token-3",
+                notification=dict(
+                    title=f'Your hold on "{work2.title}" is available!',
+                ),
                 data=dict(
                     title=f'Your hold on "{work2.title}" is available!',
                     event_type=NotificationConstants.HOLD_AVAILABLE_TYPE,


### PR DESCRIPTION
## Description
The "notification" key has been added to the FCM push notifications.
This should cause the Apps to automatically display notifications without code interactions.
<!--- Describe your changes -->

## Motivation and Context
iOS apps do not allow terminated Apps to receive any data notifications, so we must depend on the automatically displayed `alert` type notifications, which are represented in FCM by the "notification" key.
[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-411?focusedCommentId=11169)
[FCM documentation](https://firebase.google.com/docs/cloud-messaging/concept-options)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Without the Apps, manual testing is not possible.
Unit tests have been updated.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
