### PR TITLE
PP-411 Fix incorrectly formatted FCM notification

### DIFF
--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -70,7 +70,7 @@ class PushNotifications:
         for token in tokens:
             msg = messaging.Message(
                 token=token.device_token,
-                notification=dict(title=title, body=body),
+                notification=messaging.Notification(title=title, body=body),
                 data=dict(
                     title=title,
                     body=body,
@@ -136,7 +136,7 @@ class PushNotifications:
             for token in tokens:
                 msg = messaging.Message(
                     token=token.device_token,
-                    notification=dict(title=title),
+                    notification=messaging.Notification(title=title),
                     data=dict(
                         title=title,
                         event_type=NotificationConstants.HOLD_AVAILABLE_TYPE,

--- a/tests/core/util/test_notifications.py
+++ b/tests/core/util/test_notifications.py
@@ -52,7 +52,7 @@ class TestPushNotifications:
                 (),
                 {
                     "token": "atoken",
-                    "notification": dict(
+                    "notification": messaging.Notification(
                         title="Only 1 day left on your loan!",
                         body=f"Your loan on {work.presentation_edition.title} is expiring soon",
                     ),
@@ -180,7 +180,7 @@ class TestPushNotifications:
         assert messaging.Message.call_args_list == [
             mock.call(
                 token="test-token-1",
-                notification=dict(
+                notification=messaging.Notification(
                     title=f'Your hold on "{work1.title}" is available!',
                 ),
                 data=dict(
@@ -196,7 +196,7 @@ class TestPushNotifications:
             ),
             mock.call(
                 token="test-token-2",
-                notification=dict(
+                notification=messaging.Notification(
                     title=f'Your hold on "{work1.title}" is available!',
                 ),
                 data=dict(
@@ -212,7 +212,7 @@ class TestPushNotifications:
             ),
             mock.call(
                 token="test-token-3",
-                notification=dict(
+                notification=messaging.Notification(
                     title=f'Your hold on "{work2.title}" is available!',
                 ),
                 data=dict(


### PR DESCRIPTION
## Description
Fixed the `fcm_admin` method call, this wasn't caught during testing because `fcm_admin` is mocked and cannot be realistically tested in the unit tests.
<!--- Describe your changes -->

## Motivation and Context
The desired behaviour was not occurring  after the previous fix, investigations led to the the discovery of a badly formatted API call.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested the FCM notification syntax with a dev token.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
