### PR TITLE
Fix language code validation (PP-422)

### DIFF
--- a/core/configuration/library.py
+++ b/core/configuration/library.py
@@ -638,12 +638,17 @@ class LibrarySettings(BaseSettings):
     ) -> Optional[List[str]]:
         """Verify that collection languages are valid."""
         if value is not None:
+            languages = []
             for language in value:
-                if not LanguageCodes.string_to_alpha_3(language):
+                validated_language = LanguageCodes.string_to_alpha_3(language)
+                if validated_language is None:
                     field_label = cls.get_form_field_label(field.name)
                     raise SettingsValidationError(
                         problem_detail=UNKNOWN_LANGUAGE.detailed(
                             f'"{field_label}": "{language}" is not a valid language code.'
                         )
                     )
+                if validated_language not in languages:
+                    languages.append(validated_language)
+            return languages
         return value

--- a/tests/core/configuration/test_library.py
+++ b/tests/core/configuration/test_library.py
@@ -51,4 +51,5 @@ def test_validate_language_codes_error(
     with pytest.raises(ProblemError) as excinfo:
         library_settings(large_collection_languages=["eng", "xyz"])
 
+    assert excinfo.value.problem_detail.detail is not None
     assert '"xyz" is not a valid language code' in excinfo.value.problem_detail.detail

--- a/tests/core/configuration/test_library.py
+++ b/tests/core/configuration/test_library.py
@@ -1,0 +1,54 @@
+from functools import partial
+from typing import Callable, List, Optional
+
+import pytest
+
+from core.configuration.library import LibrarySettings
+from core.util.problem_detail import ProblemError
+
+LibrarySettingsFixture = Callable[..., LibrarySettings]
+
+
+@pytest.fixture
+def library_settings() -> LibrarySettingsFixture:
+    # Provide a default library settings object for tests, it just gives
+    # default values for required fields, so we can construct the settings
+    # without worrying about the defaults.
+    return partial(
+        LibrarySettings,
+        website="http://library.com",
+        help_web="http://library.com/help",
+    )
+
+
+@pytest.mark.parametrize(
+    "languages,expected",
+    [
+        (None, None),
+        ([], []),
+        (["English"], ["eng"]),
+        (["English", "eng", "fr", "fre", "french"], ["eng", "fre"]),
+    ],
+)
+def test_validate_language_codes(
+    languages: Optional[List[str]],
+    expected: Optional[List[str]],
+    library_settings: LibrarySettingsFixture,
+) -> None:
+    settings = library_settings(large_collection_languages=languages)
+    assert settings.large_collection_languages == expected
+
+    settings = library_settings(small_collection_languages=languages)
+    assert settings.small_collection_languages == expected
+
+    settings = library_settings(tiny_collection_languages=languages)
+    assert settings.tiny_collection_languages == expected
+
+
+def test_validate_language_codes_error(
+    library_settings: LibrarySettingsFixture,
+) -> None:
+    with pytest.raises(ProblemError) as excinfo:
+        library_settings(large_collection_languages=["eng", "xyz"])
+
+    assert '"xyz" is not a valid language code' in excinfo.value.problem_detail.detail


### PR DESCRIPTION
## Description

The previous validation code was both checking that the language was valid *and* transforming the language code that gets stored in the database to the three letter version of the code.

When I updated the validation code in https://github.com/ThePalaceProject/circulation/pull/1281, I missed the second part. So we were storing and using the full name of the language. This was causing the libraries lanes not to populate correctly.

## Motivation and Context

Support issue PP-422.

In order to fully fix this for libraries that were created after the bug was deployed, but before the fix was deployed we would need a data migration to update the libraries settings and the lane configuration. In a discussion on [slack](https://lyrasis.slack.com/archives/CCY3PH8JD/p1694089870341069), we decided that since this is only impacting one or two libraries those libraries can be fixed via manual intervention. 

For those libraries we will need to:
1. Re-save the library settings
2. Regenerate the libraries lanes

## How Has This Been Tested?

- Reproduced the issue locally
- Applied fix
- Did manual remediation steps
- Saw lanes properly generating

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
