### PR TITLE
Fix issue with 2b672c6fb2b9 migration (PP-428)

### DIFF
--- a/alembic/versions/20230905_2b672c6fb2b9_type_coerce_collection_settings.py
+++ b/alembic/versions/20230905_2b672c6fb2b9_type_coerce_collection_settings.py
@@ -6,9 +6,11 @@ Create Date: 2023-09-05 06:40:35.739869+00:00
 
 """
 import json
-from typing import Any, Callable, Dict, Type
+import logging
+from copy import deepcopy
+from typing import Any, Dict, Optional, Tuple
 
-from pydantic import parse_obj_as
+from pydantic import PositiveInt, ValidationError, parse_obj_as
 
 from alembic import op
 
@@ -19,61 +21,90 @@ branch_labels = None
 depends_on = None
 
 
-def _bool(value):
-    return value in ("true", "True", True)
+log = logging.getLogger(f"palace.migration.{revision}")
+log.setLevel(logging.INFO)
+log.disabled = False
 
 
 # All the settings types that have non-str types
-ALL_SETTING_TYPES: Dict[str, Type[Any]] = {
-    "verify_certificate": bool,
-    "default_reservation_period": int,
-    "loan_limit": int,
-    "hold_limit": int,
-    "max_retry_count": int,
-    "ebook_loan_duration": int,
-    "default_loan_duration": int,
+ALL_SETTING_TYPES: Dict[str, Any] = {
+    "verify_certificate": Optional[bool],
+    "default_reservation_period": Optional[PositiveInt],
+    "loan_limit": Optional[PositiveInt],
+    "hold_limit": Optional[PositiveInt],
+    "max_retry_count": Optional[PositiveInt],
+    "ebook_loan_duration": Optional[PositiveInt],
+    "default_loan_duration": Optional[PositiveInt],
 }
 
 
-def _coerce_types(settings: dict) -> None:
+def _coerce_types(original_settings: Dict[str, Any]) -> Tuple[bool, Dict[str, Any]]:
     """Coerce the types, in-place"""
-    setting_type: Callable
+    modified = False
+    modified_settings = deepcopy(original_settings)
     for setting_name, setting_type in ALL_SETTING_TYPES.items():
-        if setting_name in settings:
-            settings[setting_name] = parse_obj_as(setting_type, settings[setting_name])
+        if setting_name in original_settings:
+            # If the setting is an empty string, we set it to None
+            if original_settings[setting_name] == "":
+                setting = None
+            else:
+                setting = original_settings[setting_name]
+
+            try:
+                modified = True
+                modified_settings[setting_name] = parse_obj_as(setting_type, setting)
+            except ValidationError as e:
+                log.error(
+                    f"Error while parsing setting {setting_name}. Settings: {original_settings}."
+                )
+                raise e
+
+    return modified, modified_settings
 
 
 def upgrade() -> None:
     connection = op.get_bind()
     # Fetch all integration settings with the 'licenses' goal
     results = connection.execute(
-        f"SELECT id, settings from integration_configurations where goal='LICENSE_GOAL';"
+        "SELECT id, settings from integration_configurations where goal='LICENSE_GOAL';"
     ).fetchall()
 
     # For each integration setting, we check id any of the non-str
     # keys are present in the DB
     # We then type-coerce that value
     for settings_id, settings in results:
-        _coerce_types(settings)
-        connection.execute(
-            "UPDATE integration_configurations SET settings=%s where id=%s",
-            json.dumps(settings),
-            settings_id,
-        )
+        modified, updated_settings = _coerce_types(settings)
+        if modified:
+            log.info(
+                f"Updating settings for integration_configuration (id:{settings_id}). "
+                f"Original settings: {settings}. New settings: {updated_settings}."
+            )
+            # If any of the values were modified, we update the DB
+            connection.execute(
+                "UPDATE integration_configurations SET settings=%s where id=%s",
+                json.dumps(updated_settings),
+                settings_id,
+            )
 
     # Do the same for any Library settings
     results = connection.execute(
-        f"SELECT parent_id, library_id, settings from integration_library_configurations;"
+        "SELECT ilc.parent_id, ilc.library_id, ilc.settings from integration_library_configurations ilc "
+        "join integration_configurations ic on ilc.parent_id = ic.id where ic.goal='LICENSE_GOAL';"
     ).fetchall()
 
-    for settings_id, library_id, settings in results:
-        _coerce_types(settings)
-        connection.execute(
-            "UPDATE integration_library_configurations SET settings=%s where parent_id=%s and library_id=%s",
-            json.dumps(settings),
-            settings_id,
-            library_id,
-        )
+    for parent_id, library_id, settings in results:
+        modified, updated_settings = _coerce_types(settings)
+        if modified:
+            log.info(
+                f"Updating settings for integration_library_configuration (parent_id:{parent_id}/library_id:{library_id}). "
+                f"Original settings: {settings}. New settings: {updated_settings}."
+            )
+            connection.execute(
+                "UPDATE integration_library_configurations SET settings=%s where parent_id=%s and library_id=%s",
+                json.dumps(updated_settings),
+                parent_id,
+                library_id,
+            )
 
 
 def downgrade() -> None:

--- a/alembic/versions/20230905_2b672c6fb2b9_type_coerce_collection_settings.py
+++ b/alembic/versions/20230905_2b672c6fb2b9_type_coerce_collection_settings.py
@@ -26,7 +26,7 @@ def _bool(value):
 # All the settings types that have non-str types
 ALL_SETTING_TYPES: Dict[str, Type[Any]] = {
     "verify_certificate": bool,
-    "default_reservation_period": bool,
+    "default_reservation_period": int,
     "loan_limit": int,
     "hold_limit": int,
     "max_retry_count": int,
@@ -63,15 +63,16 @@ def upgrade() -> None:
 
     # Do the same for any Library settings
     results = connection.execute(
-        f"SELECT parent_id, settings from integration_library_configurations;"
+        f"SELECT parent_id, library_id, settings from integration_library_configurations;"
     ).fetchall()
 
-    for settings_id, settings in results:
+    for settings_id, library_id, settings in results:
         _coerce_types(settings)
         connection.execute(
-            "UPDATE integration_library_configurations SET settings=%s where parent_id=%s",
+            "UPDATE integration_library_configurations SET settings=%s where parent_id=%s and library_id=%s",
             json.dumps(settings),
             settings_id,
+            library_id,
         )
 
 


### PR DESCRIPTION
## Description
Fixed the type for default_reservation_period
Fixed the primary key queries for the library integration configurations

<!--- Describe your changes -->

## Motivation and Context
The migration did not have the query for both primary keys when created.
This would cause incorrect settings migrations.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Updated the unit test to with the additional use cases
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
