### PR TITLE
Add timeout to our weekly baseimage docker build

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -15,6 +15,7 @@ jobs:
   docker-build-baseimage:
     name: Build Base Image
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Description

Add `timeout-minutes: 60` to our `build-base-image.yml` workflow.

## Motivation and Context

Our last baseimage build froze for some reason, and hit the github actions build timeout of 6 hours. Since our base image build usually only takes about 30 minutes, we can add the `timeout-minutes` setting so we fail faster if we run into this issue again.

## How Has This Been Tested?

- Running CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
