### PR TITLE
Add `start` and `until` date arguments to playback time reporting. (PP-273)

### DIFF
--- a/tests/core/jobs/test_playtime_entries.py
+++ b/tests/core/jobs/test_playtime_entries.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import datetime, timedelta
 from typing import List
 from unittest.mock import MagicMock, call, patch
@@ -19,7 +20,7 @@ from core.model.collection import Collection
 from core.model.identifier import Identifier
 from core.model.library import Library
 from core.model.time_tracking import PlaytimeEntry, PlaytimeSummary
-from core.util.datetime_helpers import previous_months, utc_now
+from core.util.datetime_helpers import datetime_utc, previous_months, utc_now
 from tests.fixtures.database import DatabaseTransactionFixture
 
 
@@ -315,41 +316,148 @@ class TestPlaytimeEntriesEmailReportsScript:
     @pytest.mark.parametrize(
         "current_utc_time, start_arg, expected_start, until_arg, expected_until",
         [
-            # [datetime(2020, 1, 1, 0, 0, 0), None, datetime(2019, 10, 1, 0, 0, 0), None, datetime(2020, 1, 1, 0, 0, 0)],
-            # [datetime(2020, 1, 31, 0, 0, 0), None, datetime(2019, 10, 1, 0, 0, 0), None, datetime(2020, 1, 1, 0, 0, 0)],
+            # Default values from two dates within the same month (next two cases).
             [
                 datetime(2020, 1, 1, 0, 0, 0),
                 None,
-                datetime(2019, 10, 1, 0, 0, 0),
+                datetime_utc(2019, 10, 1, 0, 0, 0),
                 None,
-                datetime(2020, 1, 1, 0, 0, 0),
+                datetime_utc(2020, 1, 1, 0, 0, 0),
             ],
             [
                 datetime(2020, 1, 31, 0, 0, 0),
                 None,
-                datetime(2019, 10, 1, 0, 0, 0),
+                datetime_utc(2019, 10, 1, 0, 0, 0),
                 None,
-                datetime(2020, 1, 1, 0, 0, 0),
+                datetime_utc(2020, 1, 1, 0, 0, 0),
+            ],
+            # `start` specified, `until` defaulted.
+            [
+                datetime(2020, 1, 31, 0, 0, 0),
+                "2019-06-11",
+                datetime_utc(2019, 6, 11, 0, 0, 0),
+                None,
+                datetime_utc(2020, 1, 1, 0, 0, 0),
+            ],
+            # `start` defaulted, `until` specified.
+            [
+                datetime(2020, 1, 31, 0, 0, 0),
+                None,
+                datetime_utc(2019, 10, 1, 0, 0, 0),
+                "2019-11-20",
+                datetime_utc(2019, 11, 20, 0, 0, 0),
+            ],
+            # When both dates are specified, the current datetime doesn't matter.
+            # Both dates specified, but we test at a specific time here anyway.
+            [
+                datetime(2020, 1, 31, 0, 0, 0),
+                "2018-07-03",
+                datetime_utc(2018, 7, 3, 0, 0, 0),
+                "2019-04-30",
+                datetime_utc(2019, 4, 30, 0, 0, 0),
+            ],
+            # The same dates are specified, but we test at the actual current time.
+            [
+                utc_now(),
+                "2018-07-03",
+                datetime_utc(2018, 7, 3, 0, 0, 0),
+                "2019-04-30",
+                datetime_utc(2019, 4, 30, 0, 0, 0),
+            ],
+            # The same dates are specified, but we test at the actual current time.
+            [
+                utc_now(),
+                "4099-07-03",
+                datetime_utc(4099, 7, 3, 0, 0, 0),
+                "4150-04-30",
+                datetime_utc(4150, 4, 30, 0, 0, 0),
             ],
         ],
     )
     def test_parse_command_line(
         self,
-        db: DatabaseTransactionFixture,
-        current_utc_time,
-        start_arg,
-        expected_start,
-        until_arg,
-        expected_until,
+        current_utc_time: datetime,
+        start_arg: str | None,
+        expected_start: datetime,
+        until_arg: str | None,
+        expected_until: datetime,
     ):
         start_args = ["--start", start_arg] if start_arg else []
         until_args = ["--until", until_arg] if until_arg else []
         cmd_args = start_args + until_args
 
-        at_time: str | datetime = current_utc_time or utc_now()
-        with freeze_time(at_time):
+        with freeze_time(current_utc_time):
             parsed = PlaytimeEntriesEmailReportsScript.parse_command_line(
-                db.session, cmd_args
+                cmd_args=cmd_args
             )
         assert expected_start == parsed.start
         assert expected_until == parsed.until
+        assert pytz.UTC == parsed.start.tzinfo
+        assert pytz.UTC == parsed.until.tzinfo
+
+    @pytest.mark.parametrize(
+        "current_utc_time, start_arg, expected_start, until_arg, expected_until",
+        [
+            # `start` specified, `until` defaulted.
+            [
+                datetime(2020, 1, 31, 0, 0, 0),
+                "2020-02-01",
+                datetime_utc(2020, 2, 1, 0, 0, 0),
+                None,
+                datetime_utc(2020, 1, 1, 0, 0, 0),
+            ],
+            # `start` defaulted, `until` specified.
+            [
+                datetime(2020, 1, 31, 0, 0, 0),
+                None,
+                datetime_utc(2019, 10, 1, 0, 0, 0),
+                "2019-06-11",
+                datetime_utc(2019, 6, 11, 0, 0, 0),
+            ],
+            # When both dates are specified, the current datetime doesn't matter.
+            # Both dates specified, but we test at a specific time here anyway.
+            [
+                datetime(2020, 1, 31, 0, 0, 0),
+                "2019-04-30",
+                datetime_utc(2019, 4, 30, 0, 0, 0),
+                "2018-07-03",
+                datetime_utc(2018, 7, 3, 0, 0, 0),
+            ],
+            # The same dates are specified, but we test at the actual current time.
+            [
+                utc_now(),
+                "2019-04-30",
+                datetime_utc(2019, 4, 30, 0, 0, 0),
+                "2018-07-03",
+                datetime_utc(2018, 7, 3, 0, 0, 0),
+            ],
+            # The same dates are specified, but we test at the actual current time.
+            [
+                utc_now(),
+                "4150-04-30",
+                datetime_utc(4150, 4, 30, 0, 0, 0),
+                "4099-07-03",
+                datetime_utc(4099, 7, 3, 0, 0, 0),
+            ],
+        ],
+    )
+    def test_parse_command_line_start_not_before_until(
+        self,
+        capsys,
+        current_utc_time: datetime,
+        start_arg: str | None,
+        expected_start: datetime,
+        until_arg: str | None,
+        expected_until: datetime,
+    ):
+        start_args = ["--start", start_arg] if start_arg else []
+        until_args = ["--until", until_arg] if until_arg else []
+        cmd_args = start_args + until_args
+
+        with freeze_time(current_utc_time), pytest.raises(SystemExit) as excinfo:
+            parsed = PlaytimeEntriesEmailReportsScript.parse_command_line(
+                cmd_args=cmd_args
+            )
+        _, err = capsys.readouterr()
+        assert 2 == excinfo.value.code
+        assert re.search(r"start date \(.*\) must be before until date \(.*\).", err)


### PR DESCRIPTION
## Description

Adds `start` and `until` date range to playback time reporting script.

## Motivation and Context

Add ability to report on ad hoc date range. The default dates remain the same.

## How Has This Been Tested?

- Manual testing.
- CI tests pass for branch.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
