### PR TITLE
Add patron "Basic Token" authentication feature switch. (PP-431)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ To let the application know which database to use, set the `SIMPLIFIED_PRODUCTIO
 export SIMPLIFIED_PRODUCTION_DATABASE="postgresql://palace:test@localhost:5432/circ"
 ```
 
+##### Patron `Basic Token` authentication
+
+Enables/disables patron "basic token" authentication through setting the designated environment variable to any
+(case-insensitive) value of "true"/"yes"/"on"/"1" or "false"/"no"/"off"/"0", respectively.
+If the value is the empty string or the variable is not present in the environment, it is disabled by default.
+- `SIMPLIFIED_ENABLE_BASIC_TOKEN_AUTH`
+
+```sh
+export SIMPLIFIED_ENABLE_BASIC_TOKEN_AUTH=true
+```
+
 ##### Firebase Cloud Messaging
 
 For Firebase Cloud Messaging (FCM) support (e.g., for notifications), `one` (and only one) of the following should be set:

--- a/api/authentication/basic_token.py
+++ b/api/authentication/basic_token.py
@@ -23,6 +23,8 @@ class BasicTokenAuthenticationProvider(AuthenticationProvider):
     It is a companion to the basic authentication, and has no meaning without it.
     """
 
+    FLOW_TYPE = "http://thepalaceproject.org/authtype/basic-token"
+
     def __init__(
         self,
         _db: Session,
@@ -105,7 +107,7 @@ class BasicTokenAuthenticationProvider(AuthenticationProvider):
 
     @property
     def flow_type(self) -> str:
-        return "http://thepalaceproject.org/authtype/basic-token"
+        return self.FLOW_TYPE
 
     @classmethod
     def description(cls) -> str:

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -401,7 +401,9 @@ class LibraryAuthenticator:
         ):
             raise CannotLoadConfiguration("Two basic auth providers configured")
         self.basic_auth_provider = provider
-        if self.library is not None:
+        # TODO: We can remove the configuration test once
+        #  basic token authentication is fully deployed.
+        if self.library is not None and Configuration.basic_token_auth_is_enabled():
             self.access_token_authentication_provider = (
                 BasicTokenAuthenticationProvider(
                     self._db, self.library, self.basic_auth_provider

--- a/core/util/__init__.py
+++ b/core/util/__init__.py
@@ -582,6 +582,39 @@ def chunks(lst, chunk_size, start_index=0):
         yield lst[i : i + chunk_size]
 
 
+def ansible_boolean(
+    value: Optional[str | bool],
+    label: Optional[str] = None,
+    default: Optional[bool] = None,
+) -> bool:
+    """Map Ansible "truthy" and "falsy" values to a Python boolean.
+
+    :param value: The value from which to map.
+    :param label: Optional name or label associated with the value.
+    :param default: Default result if value is empty string or None.
+    """
+    _value_label = f"Value of '{label}'" if label else "Value"
+    if default is not None and not isinstance(default, bool):
+        raise TypeError("'default' must be a boolean, when specified.")
+    if isinstance(value, bool):
+        return value
+    if value is None or value == "":
+        if default is not None:
+            return default
+        raise ValueError(
+            f"{_value_label} must be non-null and non-empty if no default is specified."
+        )
+    if not isinstance(value, str):
+        raise TypeError(f"{_value_label} must be a string or boolean.")
+
+    if value.upper() in ("TRUE", "T", "ON", "YES", "Y", "1"):
+        return True
+    if value.upper() in ("FALSE", "F", "OFF", "NO", "N", "0"):
+        return False
+
+    raise ValueError(f"{_value_label} does not map to True or False.")
+
+
 class ValuesMeta(type):
     """Metaclass to allow operators on simple constants defining classes"""
 

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -1,6 +1,7 @@
 import json
 import os
 from collections import Counter
+from contextlib import nullcontext as does_not_raise
 from unittest.mock import patch
 
 import pytest
@@ -196,3 +197,40 @@ class TestConfiguration:
             match=r"Cannot parse value of FCM credential environment variable .* as JSON.",
         ):
             Configuration.fcm_credentials()
+
+    @pytest.mark.parametrize(
+        "env_var_value, expected_result, raises_exception",
+        [
+            ["true", True, False],
+            ["True", True, False],
+            [None, False, False],
+            ["", False, False],
+            ["false", False, False],
+            ["False", False, False],
+            ["3", None, True],
+            ["X", None, True],
+        ],
+    )
+    @patch.object(os, "environ", new=dict())
+    def test_basic_token_auth_is_enabled(
+        self, env_var_value, expected_result, raises_exception
+    ):
+        env_var = Configuration.BASIC_TOKEN_AUTH_ENABLED_ENVVAR
+
+        # Simulate an unset environment variable with the `None` value.
+        if env_var_value is None:
+            del os.environ[env_var]
+        else:
+            os.environ[env_var] = env_var_value
+
+        expected_exception = (
+            pytest.raises(
+                CannotLoadConfiguration,
+                match=f"Invalid value for {env_var} environment variable.",
+            )
+            if raises_exception
+            else does_not_raise()
+        )
+
+        with expected_exception:
+            assert expected_result == Configuration.basic_token_auth_is_enabled()


### PR DESCRIPTION
## Description

Enables/disables patron "Basic Token" authentication through setting the `SIMPLIFIED_ENABLE_BASIC_TOKEN_AUTH` environment variable to any (case-insensitive) value of "true"/"yes"/"on"/"1" or "false"/"no"/"off"/"0", respectively. If the value is the empty string or the variable is not present in the environment, it is disabled by default.

## Motivation and Context

The need to selectively enable and disable the patron "basic token" authentication capability has had us adding and removing the code via commits for the past few cycles. This has meant that we were sometimes deploying to production code different than what we had tested in our development and staging environments. This change will allow us to deploy the same code and selectively turn this feature on and off via configuration.

[Jira [PP-431](https://ebce-lyrasis.atlassian.net/browse/PP-431)]

## How Has This Been Tested?

- New tests added for new functionality.
- Manual testing in local development environment.
- CA tests passed on the associated feature branch.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-431]: https://ebce-lyrasis.atlassian.net/browse/PP-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ