### PR TITLE
Fix for `previous months` helper function. (PP-

### DIFF
--- a/core/util/datetime_helpers.py
+++ b/core/util/datetime_helpers.py
@@ -64,19 +64,19 @@ def strptime_utc(date_string, format):
 
 
 def previous_months(number_of_months: int) -> Tuple[datetime.date, datetime.date]:
-    """Calculate date interval for matching the previous designate number of months.
+    """Calculate date boundaries for matching the specified previous number of months.
 
     :param number_of_months: The number of months in the interval.
-    :returns: A date interval consisting of a 2-tuple of `start` and `until`
-        dates, such that matching dates are on the half-closed/half-open
-        interval [start, until) (i.e., start <= match < until).
-        - `start` date: designates the first date of the period. Only dates/datetimes
-        greater than or equal to this date should match.
-        - `until` date: designates the date just beyond the end of the period. Only
-        dates/datetimes less than `until` should match.
+    :returns: Date interval boundaries, consisting of a 2-tuple of
+        `start` and `until` dates.
 
-    Start will be the first day of the designated month.
-    Until will be the first day of the current month.
+    These boundaries should be used such that matching dates are on the
+    half-closed/half-open interval `[start, until)` (i.e., start <= match < until).
+    Only dates/datetimes greater than or equal to `start` and less than
+    (NOT less than or equal to) `until` should be considered as matching.
+
+    `start` will be the first day of the designated month.
+    `until` will be the first day of the current month.
     """
     now = utc_now()
     start = now - relativedelta(months=number_of_months)

--- a/core/util/datetime_helpers.py
+++ b/core/util/datetime_helpers.py
@@ -1,8 +1,8 @@
 import datetime
-import math
 from typing import Optional, Tuple
 
 import pytz
+from dateutil.relativedelta import relativedelta
 
 # datetime helpers
 # As part of the python 3 conversion, the datetime object went through a
@@ -63,12 +63,23 @@ def strptime_utc(date_string, format):
     return to_utc(datetime.datetime.strptime(date_string, format))
 
 
-def previous_months(number_of_months) -> Tuple[datetime.date, datetime.date]:
+def previous_months(number_of_months: int) -> Tuple[datetime.date, datetime.date]:
+    """Calculate date interval for matching the previous designate number of months.
+
+    :param number_of_months: The number of months in the interval.
+    :returns: A date interval consisting of a 2-tuple of `start` and `until`
+        dates, such that matching dates are on the half-closed/half-open
+        interval [start, until) (i.e., start <= match < until).
+        - `start` date: designates the first date of the period. Only dates/datetimes
+        greater than or equal to this date should match.
+        - `until` date: designates the date just beyond the end of the period. Only
+        dates/datetimes less than `until` should match.
+
+    Start will be the first day of the designated month.
+    Until will be the first day of the current month.
+    """
     now = utc_now()
-    # Start from the first of number_of_months ago, where 0=12
-    expected_year = now.year - math.floor(number_of_months / 12)
-    expected_month = ((now.month - number_of_months) % 12) or 12
-    start = now.replace(year=expected_year, month=expected_month, day=1)
-    # Until the first of this month
+    start = now - relativedelta(months=number_of_months)
+    start = start.replace(day=1)
     until = now.replace(day=1)
     return start.date(), until.date()

--- a/tests/core/util/test_datetime_helpers.py
+++ b/tests/core/util/test_datetime_helpers.py
@@ -154,3 +154,137 @@ class TestPreviousMonths:
             actual_start, actual_until = previous_months(number_of_months=months)
             assert actual_start == start
             assert actual_until == until
+
+    @pytest.mark.parametrize(
+        "current_datetime, start, until, months",
+        [
+            (
+                datetime_utc(2000, 1, 15),
+                datetime.date(1999, 12, 1),
+                datetime.date(2000, 1, 1),
+                1,
+            ),
+            (
+                datetime_utc(2000, 1, 15),
+                datetime.date(1999, 11, 1),
+                datetime.date(2000, 1, 1),
+                2,
+            ),
+            (
+                datetime_utc(2000, 1, 15),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 1, 1),
+                3,
+            ),
+            (
+                datetime_utc(2000, 2, 15),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 2, 1),
+                4,
+            ),
+            (
+                datetime_utc(2000, 3, 31),
+                datetime.date(2000, 2, 1),
+                datetime.date(2000, 3, 1),
+                1,
+            ),
+            (
+                datetime_utc(2000, 3, 31),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 3, 1),
+                5,
+            ),
+            (
+                datetime_utc(2000, 4, 15),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 4, 1),
+                6,
+            ),
+            (
+                datetime_utc(2000, 5, 15),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 5, 1),
+                7,
+            ),
+            (
+                datetime_utc(2000, 6, 15),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 6, 1),
+                8,
+            ),
+            (
+                datetime_utc(2000, 7, 15),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 7, 1),
+                9,
+            ),
+            (
+                datetime_utc(2000, 8, 15),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 8, 1),
+                10,
+            ),
+            (
+                datetime_utc(2000, 9, 15),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 9, 1),
+                11,
+            ),
+            (
+                datetime_utc(2000, 10, 15),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 10, 1),
+                12,
+            ),
+            (
+                datetime_utc(2000, 11, 15),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 11, 1),
+                13,
+            ),
+            (
+                datetime_utc(2000, 12, 15),
+                datetime.date(1999, 10, 1),
+                datetime.date(2000, 12, 1),
+                14,
+            ),
+            (
+                datetime_utc(2000, 12, 15),
+                datetime.date(2000, 6, 1),
+                datetime.date(2000, 12, 1),
+                6,
+            ),
+            (
+                datetime_utc(2000, 12, 15),
+                datetime.date(2000, 6, 1),
+                datetime.date(2000, 12, 1),
+                6,
+            ),
+            (
+                datetime_utc(2000, 12, 15),
+                datetime.date(1999, 6, 1),
+                datetime.date(2000, 12, 1),
+                18,
+            ),
+            (
+                datetime_utc(2000, 12, 15),
+                datetime.date(1990, 6, 1),
+                datetime.date(2000, 12, 1),
+                126,
+            ),
+            (
+                datetime_utc(2000, 12, 15),
+                datetime.date(1999, 12, 1),
+                datetime.date(2000, 12, 1),
+                12,
+            ),
+        ],
+    )
+    def test_boundaries_at_different_current_times(
+        self, current_datetime, start, until, months
+    ):
+        with patch("core.util.datetime_helpers.utc_now") as mock_utc_now:
+            mock_utc_now.return_value = current_datetime
+            actual_start, actual_until = previous_months(number_of_months=months)
+            assert actual_start == start
+            assert actual_until == until

--- a/tests/core/util/test_datetime_helpers.py
+++ b/tests/core/util/test_datetime_helpers.py
@@ -156,7 +156,7 @@ class TestPreviousMonths:
             assert actual_until == until
 
     @pytest.mark.parametrize(
-        "current_datetime, start, until, months",
+        "current_datetime, expected_start, expected_until, months",
         [
             (
                 datetime_utc(2000, 1, 15),
@@ -281,10 +281,13 @@ class TestPreviousMonths:
         ],
     )
     def test_boundaries_at_different_current_times(
-        self, current_datetime, start, until, months
+        self, current_datetime, expected_start, expected_until, months
     ):
         with patch("core.util.datetime_helpers.utc_now") as mock_utc_now:
             mock_utc_now.return_value = current_datetime
-            actual_start, actual_until = previous_months(number_of_months=months)
-            assert actual_start == start
-            assert actual_until == until
+            computed_start, computed_until = previous_months(number_of_months=months)
+            assert computed_start == expected_start
+            assert computed_until == expected_until
+            # Both dates should be the 1st of the month.
+            assert 1 == computed_start.day
+            assert 1 == computed_until.day

--- a/tests/core/util/test_datetime_helpers.py
+++ b/tests/core/util/test_datetime_helpers.py
@@ -138,24 +138,6 @@ class TestToUTC:
 
 class TestPreviousMonths:
     @pytest.mark.parametrize(
-        "start,until,months",
-        [
-            (datetime.date(2000, 6, 1), datetime.date(2000, 12, 1), 6),
-            (datetime.date(1999, 6, 1), datetime.date(2000, 12, 1), 18),
-            (datetime.date(1990, 6, 1), datetime.date(2000, 12, 1), 126),
-            (datetime.date(1999, 12, 1), datetime.date(2000, 12, 1), 12),
-        ],
-    )
-    def test_boundaries(self, start, until, months):
-        with patch("core.util.datetime_helpers.utc_now") as mock_utc_now:
-            mock_utc_now.return_value = datetime.datetime(
-                2000, 12, 15, 0, 0, 0, 0, tzinfo=pytz.UTC
-            )
-            actual_start, actual_until = previous_months(number_of_months=months)
-            assert actual_start == start
-            assert actual_until == until
-
-    @pytest.mark.parametrize(
         "current_datetime, expected_start, expected_until, months",
         [
             (


### PR DESCRIPTION
## Description

- Fixes `previous_months` function to deliver valid and correct interval boundaries, regardless of the current date when run.
- Adds new test cases that simulate a variety of run dates.

## Motivation and Context

`previous_months` could return the wrong year in some cases.

[Jira [PP-460](https://ebce-lyrasis.atlassian.net/browse/PP-460)]

## How Has This Been Tested?

- Manually tested in local development environment.
- Retained all previous tests while adding new ones.
- [CI test/build passed](https://github.com/ThePalaceProject/circulation/actions/runs/6209915567) for the associated feature branch.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.


[PP-460]: https://ebce-lyrasis.atlassian.net/browse/PP-460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ