### PR TITLE
Accept POST requests to the /patrons/me/token endpoint (PP-464)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -395,7 +395,7 @@ def delete_patron_devices():
     return app.manager.patron_devices.delete_patron_device()
 
 
-@library_dir_route("/patrons/me/token", methods=["GET"])
+@library_dir_route("/patrons/me/token", methods=["POST"])
 @api_spec.validate(resp=SpecResponse(HTTP_200=PatronAuthAccessToken), tags=["patron"])
 @has_library
 @requires_auth


### PR DESCRIPTION
## Description

Accept POST requests to the /patrons/me/token endpoint.

## Motivation and Context

Discussion on Notion here: https://www.notion.so/Create-plan-for-token-based-authentication-61bbd66923b94b38bccfa838546b6ad8?d=7ff681b5d2134f8682cf68f9e991669a&pvs=4#4ef3b7831e4f482daa4f380bb716d362

Looks like this was accidentally made to accept GET requests, when it should be accepting POST requests.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
