### PR TITLE
PP-463 Empty author tag fix

### DIFF
--- a/core/feed/annotator/base.py
+++ b/core/feed/annotator/base.py
@@ -95,7 +95,7 @@ class ToFeedEntry:
         name = contributor.display_name or contributor.sort_name
         name_key = name and name.lower()
         if not name_key or name_key in state[marc_role]:
-            # Either there is not valid name present or
+            # Either there is no valid name present or
             # we've already credited this person with this
             # MARC role. Returning a tag would be redundant.
             return None

--- a/core/feed/annotator/base.py
+++ b/core/feed/annotator/base.py
@@ -95,7 +95,8 @@ class ToFeedEntry:
         name = contributor.display_name or contributor.sort_name
         name_key = name and name.lower()
         if not name_key or name_key in state[marc_role]:
-            # We've already credited this person with this
+            # Either there is not valid name present or
+            # we've already credited this person with this
             # MARC role. Returning a tag would be redundant.
             return None
 

--- a/core/feed/annotator/base.py
+++ b/core/feed/annotator/base.py
@@ -93,8 +93,8 @@ class ToFeedEntry:
             return None
 
         name = contributor.display_name or contributor.sort_name
-        name_key = name.lower()
-        if name_key in state[marc_role]:
+        name_key = name and name.lower()
+        if not name_key or name_key in state[marc_role]:
             # We've already credited this person with this
             # MARC role. Returning a tag would be redundant.
             return None
@@ -108,7 +108,6 @@ class ToFeedEntry:
         # Record the fact that we credited this person with this role,
         # so that we don't do it again on a subsequent call.
         state[marc_role].add(name_key)
-
         return current_role, entry
 
     @classmethod

--- a/core/feed/serializer/opds.py
+++ b/core/feed/serializer/opds.py
@@ -221,7 +221,9 @@ class OPDS1Serializer(SerializerInterface[etree._Element], OPDSFeed):
             entry.append(rating_tag)
 
         for author in feed_entry.authors:
-            entry.append(self._serialize_author_tag("author", author))
+            # Author must at a minimum have a name
+            if author.name:
+                entry.append(self._serialize_author_tag("author", author))
         for contributor in feed_entry.contributors:
             entry.append(self._serialize_author_tag("contributor", contributor))
 

--- a/tests/api/feed/test_annotators.py
+++ b/tests/api/feed/test_annotators.py
@@ -155,6 +155,27 @@ class TestAnnotators:
         actual = [(x["term"], x["label"], x["ratingValue"]) for x in appeal_tags]
         assert set(expect) == set(actual)
 
+    def test_authors(self, annotators_fixture: TestAnnotatorsFixture):
+        db = annotators_fixture.db
+        edition = db.edition()
+        [c_orig] = list(edition.contributors)
+
+        c1 = edition.add_contributor("c1", Contributor.AUTHOR_ROLE, _sort_name="c1")
+        # No name contributor
+        c_none = edition.add_contributor("c2", Contributor.AUTHOR_ROLE)
+        c_none.display_name = ""
+        c_none._sort_name = ""
+
+        authors = Annotator.authors(edition)
+        # The default, c1 and c_none
+        assert len(edition.contributions) == 3
+        # Only default and c1 are used in the feed, because c_none has no name
+        assert len(authors["authors"]) == 2
+        assert set(map(lambda x: x.name, authors["authors"])) == {
+            c1.sort_name,
+            c_orig.sort_name,
+        }
+
     def test_detailed_author(self, annotators_fixture: TestAnnotatorsFixture):
         data, db, session = (
             annotators_fixture,


### PR DESCRIPTION
## Description
Author tags could wind up empty in an OPDS feed if no name was present, this protects against such an eventuality.

<!--- Describe your changes -->

## Motivation and Context
Minotaur has entries that demonstrate the problem, causing the Android App to crash
[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-463)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated for this change
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
