### PR TITLE
PP-466 Fix notification script failures

### DIFF
--- a/tests/core/util/test_notifications.py
+++ b/tests/core/util/test_notifications.py
@@ -30,7 +30,8 @@ def push_notf_fixture(db: DatabaseTransactionFixture) -> PushNotificationsFixtur
 class TestPushNotifications:
     def test_send_loan_notification(self, push_notf_fixture: PushNotificationsFixture):
         db = push_notf_fixture.db
-        patron = db.patron()
+        patron = db.patron(external_identifier="xyz1")
+        patron.authorization_identifier = "abc1"
 
         device_token, _ = get_one_or_create(
             db.session,
@@ -78,7 +79,9 @@ class TestPushNotifications:
 
     def test_send_activity_sync(self, push_notf_fixture: PushNotificationsFixture):
         db = push_notf_fixture.db
+        # Only patron 1 will get authorization identifiers
         patron1 = db.patron()
+        patron1.authorization_identifier = "auth1"
         patron2 = db.patron()
         patron3 = db.patron()
 
@@ -132,7 +135,6 @@ class TestPushNotifications:
                         event_type=NotificationConstants.ACTIVITY_SYNC_TYPE,
                         loans_endpoint="http://localhost/default/loans",
                         external_identifier=patron2.external_identifier,
-                        authorization_identifier=patron2.authorization_identifier,
                     ),
                 ),
                 mock.call(
@@ -141,7 +143,6 @@ class TestPushNotifications:
                         event_type=NotificationConstants.ACTIVITY_SYNC_TYPE,
                         loans_endpoint="http://localhost/default/loans",
                         external_identifier=patron2.external_identifier,
-                        authorization_identifier=patron2.authorization_identifier,
                     ),
                 ),
             ]
@@ -150,7 +151,9 @@ class TestPushNotifications:
 
     def test_holds_notification(self, push_notf_fixture: PushNotificationsFixture):
         db = push_notf_fixture.db
+        # Only patron1 will get an identifier
         patron1 = db.patron()
+        patron1.authorization_identifier = "auth1"
         patron2 = db.patron()
         DeviceToken.create(
             db.session, DeviceTokenTypes.FCM_ANDROID, "test-token-1", patron1
@@ -220,7 +223,6 @@ class TestPushNotifications:
                     event_type=NotificationConstants.HOLD_AVAILABLE_TYPE,
                     loans_endpoint=loans_api,
                     external_identifier=hold2.patron.external_identifier,
-                    authorization_identifier=hold2.patron.authorization_identifier,
                     identifier=hold2.license_pool.identifier.identifier,
                     type=hold2.license_pool.identifier.type,
                     library=hold2.patron.library.short_name,


### PR DESCRIPTION
## Description
Ensured the optional attributes of a patron are vetted before being used in a notification
<!--- Describe your changes -->

## Motivation and Context
Some attributes of a user are optional (NoneTypes), which are incompatible with the FCM notification format.
So we ensure only strings are used in the notifications.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated to test the situation
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
