### PR TITLE
Some patron authenticators delegate their patron lookup. (PP-461) 

### DIFF
--- a/api/admin/controller/patron.py
+++ b/api/admin/controller/patron.py
@@ -35,13 +35,14 @@ class PatronController(CirculationManagerController, AdminPermissionsControllerM
 
         patron_data = PatronData(authorization_identifier=identifier)
         complete_patron_data = None
+        patron_lookup_providers = list(authenticator.unique_patron_lookup_providers)
 
-        if not authenticator.providers:
+        if not patron_lookup_providers:
             return NO_SUCH_PATRON.detailed(
                 _("This library has no authentication providers, so it has no patrons.")
             )
 
-        for provider in authenticator.providers:
+        for provider in patron_lookup_providers:
             complete_patron_data = provider.remote_patron_lookup(patron_data)
             if complete_patron_data:
                 return complete_patron_data

--- a/api/authentication/base.py
+++ b/api/authentication/base.py
@@ -79,6 +79,14 @@ class AuthenticationProvider(
         # it should override this value and set it to False.
         ...
 
+    @property
+    def patron_lookup_provider(self):
+        """Return the provider responsible for patron lookup.
+
+        By default, we'll put ourself forward for this task.
+        """
+        return self
+
     @abstractmethod
     def authenticated_patron(
         self, _db: Session, header: dict | str

--- a/api/authentication/basic_token.py
+++ b/api/authentication/basic_token.py
@@ -36,6 +36,10 @@ class BasicTokenAuthenticationProvider(AuthenticationProvider):
         # An access token provider is a companion authentication to the basic providers
         self.basic_provider = basic_provider
 
+    @property
+    def patron_lookup_provider(self):
+        return self.basic_provider
+
     def authenticated_patron(
         self, _db: Session, token: dict | str
     ) -> Patron | ProblemDetail | None:

--- a/tests/api/admin/controller/test_patron.py
+++ b/tests/api/admin/controller/test_patron.py
@@ -33,7 +33,7 @@ class TestPatronController:
 
         class MockAuthenticator:
             def __init__(self, providers):
-                self.providers = providers
+                self.unique_patron_lookup_providers = providers
 
         class MockAuthenticationProvider:
             def __init__(self, patron_dict):
@@ -73,7 +73,7 @@ class TestPatronController:
             )
 
         # Authenticator can't find patron with this identifier
-        authenticator.providers.append(auth_provider)
+        authenticator.unique_patron_lookup_providers.append(auth_provider)
         with patron_controller_fixture.request_context_with_library_and_admin("/"):
             flask.request.form = form
             response = m(authenticator)

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -937,6 +937,15 @@ class TestLibraryAuthenticator:
             authenticator = LibraryAuthenticator(
                 _db=db.session, library=db.default_library(), basic_auth_provider=basic
             )
+
+        token_auth_provider, basic_auth_provider = authenticator.providers
+        [patron_lookup_provider] = authenticator.unique_patron_lookup_providers
+        assert (
+            cast(BasicTokenAuthenticationProvider, token_auth_provider).basic_provider
+            == basic_auth_provider
+        )
+        assert patron_lookup_provider == basic_auth_provider
+
         patron = db.patron()
         token = AccessTokenProvider.generate_token(db.session, patron, "pass")
         auth = Authorization(auth_type="bearer", token=token)


### PR DESCRIPTION
## Description

Adds method to patron authentication providers to indicate the (possibly different) authentication provider that handles its patron lookups.

## Motivation and Context

Patron lookups for reseting Adobe IDs were failing with basic token authentication enabled because `BasicTokenAuthenticationProvider` needs to delegate patron lookups to its associated `BasicAuthenticationProvider`.

[Jira [PP-461](https://ebce-lyrasis.atlassian.net/browse/PP-461)]

## How Has This Been Tested?

- Manual testing of the failing code path in local development environment.
- Added testing for the new functionality.
- CI build passing for associate branch.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-461]: https://ebce-lyrasis.atlassian.net/browse/PP-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ