### PR TITLE
Add `.csv` extension to playback time report attachment filename. (PP-478)

### DIFF
--- a/core/jobs/playtime_entries.py
+++ b/core/jobs/playtime_entries.py
@@ -130,13 +130,14 @@ class PlaytimeEntriesEmailReportsScript(Script):
         email_subject = (
             f"Playtime Summaries {formatted_start_date} - {formatted_until_date}"
         )
-        attachment_name = (
-            f"playtime-summary-{formatted_start_date}-{formatted_until_date}"
-        )
+        attachment_extension = "csv"
+        attachment_name = f"playtime-summary-{formatted_start_date}-{formatted_until_date}.{attachment_extension}"
 
         # Write to a temporary file so we don't overflow the memory
         with TemporaryFile(
-            "w+", prefix=f"playtimereport{formatted_until_date}", suffix="csv"
+            "w+",
+            prefix=f"playtimereport{formatted_until_date}",
+            suffix=attachment_extension,
         ) as temp:
             # Write the data as a CSV
             writer = csv.writer(temp)

--- a/tests/core/jobs/test_playtime_entries.py
+++ b/tests/core/jobs/test_playtime_entries.py
@@ -294,7 +294,7 @@ class TestPlaytimeEntriesEmailReportsScript:
             receivers=["reporting@test.email"],
             text="",
             attachments={
-                f"playtime-summary-{cutoff}-{until}": ""
+                f"playtime-summary-{cutoff}-{until}.csv": ""
             },  # Mock objects do not write data
         )
 


### PR DESCRIPTION
## Description

- Adds `.csv` extension to the name of the audiobook playback time report.

## Motivation and Context

The audiobook playback time report files are in CSV format, but the email attachment name did not include the .csv extension, so the files would not automatically launch in the OS-configured CSV application when they are opened.

[Jira [PP-478](https://ebce-lyrasis.atlassian.net/browse/PP-478)]

## How Has This Been Tested?

- Manually tested functionality in local development environment.
- Modified one test to account for the extension.
- CI test/build passed for associated branch.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-478]: https://ebce-lyrasis.atlassian.net/browse/PP-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ