### PR TITLE
Fix failure to set unlimited_access property on non-existent pool.

### DIFF
--- a/api/opds_for_distributors.py
+++ b/api/opds_for_distributors.py
@@ -357,7 +357,10 @@ class OPDSForDistributorsImporter(OPDSImporter):
         pool, work = super().update_work_for_edition(
             *args, is_open_access=False, **kwargs
         )
-        pool.unlimited_access = True
+
+        if pool:
+            pool.unlimited_access = True
+
         return pool, work
 
     @classmethod

--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -524,6 +524,12 @@ class OPDSImporter(CirculationConfigurationMixin):
                 if work:
                     works[key] = work
             except Exception as e:
+                logging.warning(
+                    f"Non-fatal exception: Failed to import item - import will continue: "
+                    f"identifier={key}; collection={self.collection.name}; "
+                    f"data_source={self.data_source}; exception={e}",
+                    stack_info=True,
+                )
                 identifier, ignore = Identifier.parse_urn(self._db, key)
                 data_source = self.data_source
                 failure = CoverageFailure(


### PR DESCRIPTION
## Description
Simply checks if the pool is not None before trying to set a property on it. 
Improves logging to show detailed failure info in logs during OPDS feed imports so that future issues will be easier to troubleshoot in the future.

One thing I'm not sure about:  does it make sense for the pool to be returned as a None from `super().update_work_for_e
dition`

<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-192

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I reran San Rafael BiblioBoard  collection locally and confirmed that all 139 failures are no longer occurring.

```
./bin/opds_for_distributors_import_monitor --collection "San Rafael BiblioBoard" --force
...
99d7-25f0535356c6: rel=alternate", "timestamp": "2023-09-22T17:57:25.570186+00:00"}
{"host": "8e97e3d1a6b0", "app": "simplified", "name": "OPDS for Distributors Import Monitor", "level": "INFO", "filename": "monitor.py", "message": "[San Rafael BiblioBoard] Items imported: 30379. Failures: 0.", "timestamp": "2023-09-22T17:57:25.652138+00:00"}
{"host": "8e97e3d1a6b0", "app": "simplified", "name": "OPDS for Distributors Import Monitor", "level": "INFO", "filename": "monitor.py", "message": "[San Rafael BiblioBoard] Ran OPDS for Distributors Import Monitor monitor in 3664.29 sec.", "timestamp": "2023-09-22T17:57:25.657573+00:00"}
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [/] I have updated the documentation accordingly.
- [] All new and existing tests passed.
