### PR TITLE
PP-490 Fixed the lcp and adobe drm tag names in the annotators

### DIFF
--- a/core/feed/acquisition.py
+++ b/core/feed/acquisition.py
@@ -74,9 +74,9 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
     def generate_feed(self, annotate: bool = True) -> None:
         """Generate the feed metadata and links.
         We assume the entries have already been annotated."""
-        self._feed.add_metadata("id", text=self.url)
-        self._feed.add_metadata("title", text=self.title)
-        self._feed.add_metadata("updated", text=strftime(utc_now()))
+        self._feed.metadata.id = self.url
+        self._feed.metadata.title = self.title
+        self._feed.metadata.updated = strftime(utc_now())
         self._feed.add_link(href=self.url, rel="self")
         if annotate:
             self.annotator.annotate_feed(self._feed)

--- a/core/feed/annotator/circulation.py
+++ b/core/feed/annotator/circulation.py
@@ -1503,7 +1503,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
                 drm_licensor = FeedEntryType.create(
                     vendor=vendor_id, clientToken=FeedEntryType(text=token)
                 )
-                cached = {"licensor": drm_licensor}
+                cached = {"drm_licensor": drm_licensor}
 
             self._adobe_id_cache[cache_key] = cached
         else:
@@ -1525,7 +1525,9 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             hashed_passphrase: LCPHashedPassphrase = (
                 lcp_credential_factory.get_hashed_passphrase(db, active_loan.patron)
             )
-            response["hashed_passphrase"] = FeedEntryType(text=hashed_passphrase.hashed)
+            response["lcp_hashed_passphrase"] = FeedEntryType(
+                text=hashed_passphrase.hashed
+            )
         except LCPError:
             # The patron's passphrase wasn't generated yet and not present in the database.
             pass
@@ -1544,7 +1546,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             ] = self.patron.authorization_identifier
 
         patron_tag = FeedEntryType.create(**patron_details)
-        feed.add_metadata("patron", patron_tag)
+        feed.metadata.patron = patron_tag
 
     def add_authentication_document_link(self, feed_obj: FeedData) -> None:
         """Create a <link> tag that points to the circulation

--- a/core/feed/annotator/loan_and_hold.py
+++ b/core/feed/annotator/loan_and_hold.py
@@ -89,8 +89,6 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
                 feed.add_link(link.href, rel=link.rel)
             if "drm_licensor" in tags:
                 feed.metadata.drm_licensor = tags["drm_licensor"]
-            if "lcp_hashed_passphrase" in tags:
-                feed.metadata.lcp_hashed_passphrase = tags["lcp_hashed_passphrase"]
 
     def annotate_work_entry(
         self, entry: WorkEntry, updated: Optional[datetime] = None

--- a/core/feed/annotator/loan_and_hold.py
+++ b/core/feed/annotator/loan_and_hold.py
@@ -87,8 +87,10 @@ class LibraryLoanAndHoldAnnotator(LibraryAnnotator):
             link = self.user_profile_management_protocol_link
             if link.href is not None:
                 feed.add_link(link.href, rel=link.rel)
-            for name, value in tags.items():
-                feed.add_metadata(name, feed_entry=value)
+            if "drm_licensor" in tags:
+                feed.metadata.drm_licensor = tags["drm_licensor"]
+            if "lcp_hashed_passphrase" in tags:
+                feed.metadata.lcp_hashed_passphrase = tags["lcp_hashed_passphrase"]
 
     def annotate_work_entry(
         self, entry: WorkEntry, updated: Optional[datetime] = None

--- a/core/feed/navigation.py
+++ b/core/feed/navigation.py
@@ -51,9 +51,9 @@ class NavigationFeed(BaseOPDSFeed):
         return feed
 
     def generate_feed(self) -> None:
-        self._feed.add_metadata("title", text=self.title)
-        self._feed.add_metadata("id", text=self.url)
-        self._feed.add_metadata("updated", text=strftime(utc_now()))
+        self._feed.metadata.title = self.title
+        self._feed.metadata.id = self.url
+        self._feed.metadata.updated = strftime(utc_now())
         self._feed.add_link(href=self.url, rel="self")
         if not self.lane.children:
             # We can't generate links to children, since this Worklist

--- a/core/feed/serializer/opds2.py
+++ b/core/feed/serializer/opds2.py
@@ -54,10 +54,10 @@ class OPDS2Serializer(SerializerInterface[Dict[str, Any]]):
     def _serialize_metadata(self, feed: FeedData) -> Dict[str, Any]:
         fmeta = feed.metadata
         metadata: Dict[str, Any] = {}
-        if title := fmeta.get("title"):
-            metadata["title"] = title.text
-        if item_count := fmeta.get("items_per_page"):
-            metadata["itemsPerPage"] = int(item_count.text or 0)
+        if fmeta.title:
+            metadata["title"] = fmeta.title
+        if fmeta.items_per_page is not None:
+            metadata["itemsPerPage"] = fmeta.items_per_page
         return metadata
 
     def serialize_opds_message(self, entry: OPDSMessage) -> Dict[str, Any]:

--- a/core/feed/types.py
+++ b/core/feed/types.py
@@ -201,6 +201,17 @@ class WorkEntry(BaseModel):
         self.license_pool = license_pool
 
 
+@dataclass
+class FeedMetadata(BaseModel):
+    title: Optional[str] = None
+    id: Optional[str] = None
+    updated: Optional[str] = None
+    items_per_page: Optional[int] = None
+    patron: Optional[FeedEntryType] = None
+    drm_licensor: Optional[FeedEntryType] = None
+    lcp_hashed_passphrase: Optional[FeedEntryType] = None
+
+
 class DataEntryTypes:
     NAVIGATION = "navigation"
 
@@ -222,7 +233,7 @@ class FeedData(BaseModel):
     facet_links: List[Link] = field(default_factory=list)
     entries: List[WorkEntry] = field(default_factory=list)
     data_entries: List[DataEntry] = field(default_factory=list)
-    metadata: Dict[str, FeedEntryType] = field(default_factory=dict)
+    metadata: FeedMetadata = field(default_factory=lambda: FeedMetadata())
     entrypoint: Optional[str] = None
 
     class Config:
@@ -230,11 +241,3 @@ class FeedData(BaseModel):
 
     def add_link(self, href: str, **kwargs: Any) -> None:
         self.links.append(Link(href=href, **kwargs))
-
-    def add_metadata(
-        self, name: str, feed_entry: Optional[FeedEntryType] = None, **kwargs: Any
-    ) -> None:
-        if not feed_entry:
-            self.metadata[name] = FeedEntryType(**kwargs)
-        else:
-            self.metadata[name] = feed_entry

--- a/tests/api/feed/test_library_annotator.py
+++ b/tests/api/feed/test_library_annotator.py
@@ -262,7 +262,7 @@ class TestLibraryAnnotator:
             pool, loan, other_delivery_mechanism
         )
         assert link is not None
-        assert link.drm_licensor == None
+        assert link.drm_licensor is None
 
         # No new Credential has been associated with the patron.
         assert old_credentials == patron.credentials

--- a/tests/api/feed/test_opds2_serializer.py
+++ b/tests/api/feed/test_opds2_serializer.py
@@ -6,6 +6,7 @@ from core.feed.types import (
     Author,
     FeedData,
     FeedEntryType,
+    FeedMetadata,
     IndirectAcquisition,
     Link,
     WorkEntry,
@@ -20,9 +21,9 @@ from core.util.opds_writer import OPDSMessage
 class TestOPDS2Serializer:
     def test_serialize_feed(self):
         feed = FeedData(
-            metadata=dict(
-                items_per_page=FeedEntryType(text="20"),
-                title=FeedEntryType(text="Title"),
+            metadata=FeedMetadata(
+                title="Title",
+                items_per_page=20,
             )
         )
         w = WorkEntry(

--- a/tests/api/feed/test_opds_acquisition_feed.py
+++ b/tests/api/feed/test_opds_acquisition_feed.py
@@ -1402,11 +1402,11 @@ class TestNavigationFeed:
 
         feed = response._feed
 
-        assert "Navigation" == feed.metadata["title"].text
+        assert "Navigation" == feed.metadata.title
         [self_link] = feed.links
         assert "http://navigation" == self_link.href
         assert "self" == self_link.rel
-        assert "http://navigation" == feed.metadata["id"].text
+        assert "http://navigation" == feed.metadata.id
         [fantasy, romance] = sorted(feed.data_entries, key=lambda x: x.title or "")
 
         assert data.fantasy.display_name == fantasy.title
@@ -1436,11 +1436,11 @@ class TestNavigationFeed:
             session, "Navigation", "http://navigation", data.fantasy, MockAnnotator()
         )
         parsed = feed._feed
-        assert "Navigation" == parsed.metadata["title"].text
+        assert "Navigation" == parsed.metadata.title
         [self_link] = parsed.links
         assert "http://navigation" == self_link.href
         assert "self" == self_link.rel
-        assert "http://navigation" == parsed.metadata["id"].text
+        assert "http://navigation" == parsed.metadata.id
         [fantasy] = parsed.data_entries
 
         assert "All " + data.fantasy.display_name == fantasy.title


### PR DESCRIPTION
## Description
Had to make feed metadata properties strict via a dataclass, since there were differences in how the drm information is consumed in the metadata vs within a link entry.
The bug was simple, the serializers expected "drm_licensor" and "lcp_hashed_passphrase" whereas the the annotators were using the more metadata friendly "licensor" and "hashed_passphrase" keys.

<!--- Describe your changes -->

## Motivation and Context
LCP hashed passphrases were not showing up in the feeds.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Did not have locally available LCP or Adobe protected data.
Unit tests were updated and tested.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
