### PR TITLE
PP-505 Switched the _cluster API body to the AWS supported flat format

### DIFF
--- a/core/search/service.py
+++ b/core/search/service.py
@@ -168,8 +168,9 @@ class SearchServiceOpensearch1(SearchService):
         self._indexes_created: List[str] = []
 
         # Documents are not allowed to automatically create indexes.
+        # AWS OpenSearch only accepts the "flat" format
         self._client.cluster.put_settings(
-            body={"persistent": {"action": {"auto_create_index": "false"}}}
+            body={"persistent": {"action.auto_create_index": "false"}}
         )
 
     def indexes_created(self) -> List[str]:


### PR DESCRIPTION
## Description
AWS does not support the nested API format.
Reference: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-operations.html#version_api_notes
<!--- Describe your changes -->

## Motivation and Context
Minotaur could not connect to the cluster since the opening API request was failing.
[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-505)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested that the format works on an OpenSearch docker container, could not test with an actual Managed OpenSearch deployment due to "restrictive policies" on publicly accessible opensearch domains.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
