### PR TITLE
Fix missing required argument for update_lane_size script (PP-524)

### DIFF
--- a/core/scripts.py
+++ b/core/scripts.py
@@ -2645,7 +2645,7 @@ class ListCollectionMetadataIdentifiersScript(CollectionInputScript):
 
 
 class UpdateLaneSizeScript(LaneSweeperScript):
-    def __init__(self, _db, *args, **kwargs):
+    def __init__(self, _db=None, *args, **kwargs):
         super().__init__(_db, *args, **kwargs)
         search = kwargs.get("search_index_client", None)
         self._search: ExternalSearchIndex = search or ExternalSearchIndex(self._db)


### PR DESCRIPTION
## Description

Add default  of `None` to `_db` arg for the `update_lane_size` script.

## Motivation and Context

Working on another issue I noticed that running the update_lane_size script fails with:
```
Traceback (most recent call last):
  File "bin/update_lane_size", line 11, in <module>
    UpdateLaneSizeScript().run()
TypeError: __init__() missing 1 required positional argument: '_db'
```

This appears to have come in as part of #1268.

## How Has This Been Tested?

Ran script locally.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
