### PR TITLE
Bump pre-commit linters to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.2
+    rev: v3.14.0
     hooks:
       - id: pyupgrade
         args:
@@ -25,7 +25,7 @@ repos:
           - --keep-runtime-typing
 
   - repo: https://github.com/myint/autoflake
-    rev: v2.1.1
+    rev: v2.2.1
     hooks:
       - id: autoflake
         args:
@@ -34,7 +34,7 @@ repos:
           - --ignore-init-module-imports
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.9.1
     hooks:
       - id: black
         name: Run black
@@ -46,20 +46,20 @@ repos:
         name: Run isort
 
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.22.0
+    rev: 0.27.0
     hooks:
       - id: check-github-workflows
       - id: check-github-actions
 
   - repo: https://github.com/pappasam/toml-sort
-    rev: v0.23.0
+    rev: v0.23.1
     hooks:
       - id: toml-sort
         args: []
         files: pyproject.toml
 
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.9
+    rev: v0.9.13.4
     hooks:
       - id: pymarkdown
         args:

--- a/api/admin/announcement_list_validator.py
+++ b/api/admin/announcement_list_validator.py
@@ -12,7 +12,6 @@ from core.util.problem_detail import ProblemError
 
 
 class AnnouncementListValidator:
-
     DATE_FORMAT = "%Y-%m-%d"
 
     def __init__(

--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -15,7 +15,6 @@ class OperationalMode(str, Enum):
 
 
 class Configuration:
-
     APP_NAME = "Palace Collection Manager"
     PACKAGE_NAME = "@thepalaceproject/circulation-admin"
     PACKAGE_VERSION = "1.10.0"

--- a/api/admin/controller/individual_admin_settings.py
+++ b/api/admin/controller/individual_admin_settings.py
@@ -74,7 +74,6 @@ class IndividualAdminSettingsController(SettingsController):
             roles = []
             show_admin = True
             for role in admin.roles:
-
                 # System admin sees all
                 if highest_role.role == AdminRole.SYSTEM_ADMIN:
                     append_role(roles, role)
@@ -318,7 +317,8 @@ class IndividualAdminSettingsController(SettingsController):
 
     def handle_roles(self, admin, roles, settingUp):
         """Compare the admin's existing set of roles against the roles submitted in the form, and,
-        unless there's a problem with the roles or the permissions, modify the admin's roles accordingly"""
+        unless there's a problem with the roles or the permissions, modify the admin's roles accordingly
+        """
 
         # User = person submitting the form; admin = person who the form is about
 

--- a/api/admin/controller/sitewide_settings.py
+++ b/api/admin/controller/sitewide_settings.py
@@ -52,7 +52,6 @@ class SitewideConfigurationSettingsController(SettingsController):
         return Response(str(_("Deleted")), 200)
 
     def validate_form_fields(self, setting, fields):
-
         MISSING_FIELD_MESSAGES = dict(
             key=MISSING_SITEWIDE_SETTING_KEY, value=MISSING_SITEWIDE_SETTING_VALUE
         )

--- a/api/admin/controller/work_editor.py
+++ b/api/admin/controller/work_editor.py
@@ -34,7 +34,6 @@ from .base import AdminPermissionsControllerMixin
 
 
 class WorkController(CirculationManagerController, AdminPermissionsControllerMixin):
-
     STAFF_WEIGHT = 1000
 
     def details(self, identifier_type, identifier):

--- a/api/admin/opds.py
+++ b/api/admin/opds.py
@@ -14,7 +14,6 @@ class AdminAnnotator(LibraryAnnotator):
     def annotate_work_entry(
         self, work, active_license_pool, edition, identifier, feed, entry
     ):
-
         super().annotate_work_entry(
             work, active_license_pool, edition, identifier, feed, entry
         )

--- a/api/admin/password_admin_authentication_provider.py
+++ b/api/admin/password_admin_authentication_provider.py
@@ -22,7 +22,6 @@ from .templates import (
 
 
 class PasswordAdminAuthenticationProvider(AdminAuthenticationProvider):
-
     NAME = "Password Auth"
 
     SIGN_IN_TEMPLATE = sign_in_template.format(

--- a/api/annotations.py
+++ b/api/annotations.py
@@ -37,7 +37,6 @@ jsonld.set_document_loader(load_document)
 
 
 class AnnotationWriter:
-
     CONTENT_TYPE = 'application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"'
 
     JSONLD_CONTEXT = "http://www.w3.org/ns/anno.jsonld"

--- a/api/axis.py
+++ b/api/axis.py
@@ -138,7 +138,6 @@ class Axis360API(
     Axis360APIConstants,
     HasLibraryIntegrationConfiguration,
 ):
-
     NAME = ExternalIntegration.AXIS_360
 
     SET_DELIVERY_MECHANISM_AT = BaseCirculationAPI.BORROW_STEP

--- a/api/base_controller.py
+++ b/api/base_controller.py
@@ -79,7 +79,6 @@ class BaseCirculationManagerController:
         return patron
 
     def authenticated_patron(self, authorization_header: Authorization):
-
         """Look up the patron authenticated by the given authorization header.
 
         The header could contain a barcode and pin or a token for an

--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -98,7 +98,6 @@ class BibliothecaSettings(BaseSettings):
 
 
 class BibliothecaLibrarySettings(BaseCirculationLoanSettings):
-
     dont_display_reserves: Optional[str] = FormField(
         form=ConfigurationFormItem(
             label=_("Show/Hide Titles with No Available Loans"),

--- a/api/config.py
+++ b/api/config.py
@@ -16,7 +16,6 @@ from core.util import MoneyUtility
 
 
 class Configuration(CoreConfiguration):
-
     DEFAULT_OPDS_FORMAT = "simple_opds_entry"
 
     # The list of patron web urls allowed to access this CM

--- a/api/custom_index.py
+++ b/api/custom_index.py
@@ -82,7 +82,6 @@ class CustomIndexView:
 
 
 class COPPAGate(CustomIndexView):
-
     PROTOCOL = "COPPA Age Gate"
 
     URI = "http://librarysimplified.org/terms/restrictions/coppa"

--- a/api/custom_patron_catalog.py
+++ b/api/custom_patron_catalog.py
@@ -153,7 +153,6 @@ CustomPatronCatalog.register(CustomRootLane)
 
 
 class COPPAGate(CustomPatronCatalog):
-
     PROTOCOL = "COPPA Age Gate"
 
     AUTHENTICATION_TYPE = "http://librarysimplified.org/terms/authentication/gate/coppa"

--- a/api/google_analytics_provider.py
+++ b/api/google_analytics_provider.py
@@ -13,7 +13,6 @@ from .config import CannotLoadConfiguration
 
 
 class GoogleAnalyticsProvider:
-
     NAME = _("Google Analytics")
     DESCRIPTION = _("How to Configure a Google Analytics Integration")
     INSTRUCTIONS = _(
@@ -86,7 +85,6 @@ class GoogleAnalyticsProvider:
             )
 
     def collect_event(self, library, license_pool, event_type, time, **kwargs):
-
         # Explicitly destroy any neighborhood information -- we don't
         # want to send this to third-party sources.
         kwargs.pop("neighborhood", None)

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1377,13 +1377,11 @@ class CrawlableFacets(Facets):
 
 
 class CrawlableLane(DynamicLane):
-
     # By default, crawlable feeds are cached for 12 hours.
     MAX_CACHE_AGE = 12 * 60 * 60
 
 
 class CrawlableCollectionBasedLane(CrawlableLane):
-
     # Since these collections may be shared collections, for which
     # recent information is very important, these feeds are only
     # cached for 2 hours.
@@ -1393,7 +1391,6 @@ class CrawlableCollectionBasedLane(CrawlableLane):
     COLLECTION_ROUTE = "crawlable_collection_feed"
 
     def initialize(self, library_or_collections):
-
         self.collection_feed = False
 
         if isinstance(library_or_collections, Library):

--- a/api/local_analytics_exporter.py
+++ b/api/local_analytics_exporter.py
@@ -22,7 +22,6 @@ class LocalAnalyticsExporter:
     """Export large numbers of analytics events in CSV format."""
 
     def export(self, _db, start, end, locations=None, library=None):
-
         # Get the results from the database.
         query = self.analytics_query(start, end, locations, library)
         results = _db.execute(query)

--- a/api/novelist.py
+++ b/api/novelist.py
@@ -38,7 +38,6 @@ from core.util.http import HTTP
 
 
 class NoveListAPI:
-
     PROTOCOL = ExternalIntegration.NOVELIST
     NAME = _("Novelist API")
 

--- a/api/nyt.py
+++ b/api/nyt.py
@@ -24,7 +24,6 @@ from .config import CannotLoadConfiguration, IntegrationException
 
 
 class NYTAPI:
-
     DATE_FORMAT = "%Y-%m-%d"
 
     # NYT best-seller lists are associated with dates, but fields like
@@ -60,7 +59,6 @@ class NYTAPI:
 
 
 class NYTBestSellerAPI(NYTAPI, HasSelfTests):
-
     PROTOCOL = ExternalIntegration.NYT
     GOAL = ExternalIntegration.METADATA_GOAL
     NAME = _("NYT Best Seller API")

--- a/api/saml/wayfless.py
+++ b/api/saml/wayfless.py
@@ -76,7 +76,6 @@ class SAMLWAYFlessAcquisitionLinkProcessor(
     def fulfill(
         self, patron, pin, licensepool, delivery_mechanism, fulfillment: FulfillmentInfo
     ) -> FulfillmentInfo:
-
         self._logger.debug(
             f"WAYFless acquisition link template: {self._wayfless_url_template}"
         )

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -223,7 +223,6 @@ class Constants:
 
 
 class SIPClient(Constants):
-
     log = client_logger
 
     # Maximum retries of a SIP message before failing.

--- a/api/web_publication_manifest.py
+++ b/api/web_publication_manifest.py
@@ -36,7 +36,6 @@ class SpineItem:
 
 
 class FindawayManifest(AudiobookManifest):
-
     # This URI prefix makes it clear when we are using a term coined
     # by Findaway in a JSON-LD document.
     FINDAWAY_EXTENSION_CONTEXT = (

--- a/core/classifier/__init__.py
+++ b/core/classifier/__init__.py
@@ -383,7 +383,6 @@ class GradeLevelClassifier(Classifier):
 
     @classmethod
     def target_age(cls, identifier, name, require_explicit_grade_marker=False):
-
         if (identifier and "education" in identifier) or (name and "education" in name):
             # This is a book about teaching, e.g. fifth grade.
             return cls.range_tuple(None, None)
@@ -498,7 +497,6 @@ class AgeClassifier(Classifier):
 
     @classmethod
     def audience(cls, identifier, name, require_explicit_age_marker=False):
-
         target_age = cls.target_age(identifier, name, require_explicit_age_marker)
         return cls.default_audience_for_target_age(target_age)
 

--- a/core/classifier/age.py
+++ b/core/classifier/age.py
@@ -75,7 +75,6 @@ class GradeLevelClassifier(Classifier):
 
     @classmethod
     def target_age(cls, identifier, name, require_explicit_grade_marker=False):
-
         if (identifier and "education" in identifier) or (name and "education" in name):
             # This is a book about teaching, e.g. fifth grade.
             return cls.range_tuple(None, None)

--- a/core/classifier/ddc.py
+++ b/core/classifier/ddc.py
@@ -8,7 +8,6 @@ resource_dir = os.path.join(base_dir, "..", "resources")
 
 
 class DeweyDecimalClassifier(Classifier):
-
     NAMES = json.load(open(os.path.join(resource_dir, "dewey_1000.json")))
 
     # Add some other values commonly found in MARC records.

--- a/core/classifier/gutenberg.py
+++ b/core/classifier/gutenberg.py
@@ -2,7 +2,6 @@ from . import *
 
 
 class GutenbergBookshelfClassifier(Classifier):
-
     # Any classification that includes the string "Fiction" will be
     # counted as fiction. This is just the leftovers.
     FICTION = {

--- a/core/classifier/lcc.py
+++ b/core/classifier/lcc.py
@@ -2,7 +2,6 @@ from . import *
 
 
 class LCCClassifier(Classifier):
-
     TOP_LEVEL = re.compile("^([A-Z]{1,2})")
     FICTION = {"PN", "PQ", "PR", "PS", "PT", "PZ"}
     JUVENILE = {"PZ"}

--- a/core/classifier/overdrive.py
+++ b/core/classifier/overdrive.py
@@ -2,7 +2,6 @@ from . import *
 
 
 class OverdriveClassifier(Classifier):
-
     # These genres are only used to describe video titles.
     VIDEO_GENRES = [
         "Action",

--- a/core/classifier/simplified.py
+++ b/core/classifier/simplified.py
@@ -4,7 +4,6 @@ from . import *
 
 
 class SimplifiedGenreClassifier(Classifier):
-
     NONE = NO_VALUE
 
     @classmethod

--- a/core/config.py
+++ b/core/config.py
@@ -27,13 +27,11 @@ class CannotLoadConfiguration(IntegrationException):
 
 
 class ConfigurationConstants:
-
     TRUE = "true"
     FALSE = "false"
 
 
 class Configuration(ConfigurationConstants):
-
     log = logging.getLogger("Configuration file loader")
 
     # Environment variables that contain URLs to the database

--- a/core/coverage.py
+++ b/core/coverage.py
@@ -1277,7 +1277,7 @@ class CollectionCoverageProvider(IdentifierCoverageProvider):
 
         if license_pool:
             if not license_pool.work or not license_pool.work.presentation_ready:
-                for (v, default) in (("exclude_search", self.EXCLUDE_SEARCH_INDEX),):
+                for v, default in (("exclude_search", self.EXCLUDE_SEARCH_INDEX),):
                     if not v in calculate_work_kwargs:
                         calculate_work_kwargs[v] = default
 

--- a/core/equivalents_coverage.py
+++ b/core/equivalents_coverage.py
@@ -103,7 +103,6 @@ class EquivalentIdentifiersCoverageProvider(BaseCoverageProvider):
 
         recursive_equivs = []
         for link_id, parent_id in chained_identifiers:
-
             # First time around we MUST delete any chains formed from this identifier before
             if parent_id not in completed_identifiers:
                 delete_stmt = delete(RecursiveEquivalencyCache).where(

--- a/core/facets.py
+++ b/core/facets.py
@@ -2,7 +2,6 @@ from flask_babel import lazy_gettext as _
 
 
 class FacetConstants:
-
     # A special constant, basically an additional rel, indicating that
     # an OPDS facet group represents different entry points into a
     # WorkList.
@@ -154,7 +153,6 @@ class FacetConfig(FacetConstants):
 
     @classmethod
     def from_library(cls, library):
-
         enabled_facets = dict()
         for group in list(FacetConstants.DEFAULT_ENABLED_FACETS.keys()):
             enabled_facets[group] = library.enabled_facets(group)

--- a/core/metadata_layer.py
+++ b/core/metadata_layer.py
@@ -556,7 +556,6 @@ class LicenseData(LicenseFunctions):
 
 
 class TimestampData:
-
     CLEAR_VALUE = Timestamp.CLEAR_VALUE
 
     def __init__(
@@ -1998,7 +1997,7 @@ class CSVMetadataImporter:
                         primary_identifier = identifier
 
         subjects = []
-        for (field_name, (subject_type, weight)) in list(self.subject_fields.items()):
+        for field_name, (subject_type, weight) in list(self.subject_fields.items()):
             values = self.list_field(row, field_name)
             for value in values:
                 subjects.append(

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -344,7 +344,6 @@ def json_serializer(*args, **kwargs) -> str:
 
 
 class SessionManager:
-
     # A function that calculates recursively equivalent identifiers
     # is also defined in SQL.
     RECURSIVE_EQUIVALENTS_FUNCTION = "recursive_equivalents.sql"

--- a/core/model/admin.py
+++ b/core/model/admin.py
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
 
 
 class Admin(Base, HasSessionCache):
-
     __tablename__ = "admins"
 
     id = Column(Integer, primary_key=True)
@@ -158,6 +157,7 @@ class Admin(Base, HasSessionCache):
         # First check if the admin is a manager of _all_ libraries.
         if self.is_sitewide_library_manager():
             return True
+
         # If not, they could still be a manager of _this_ library.
         def lookup_hook():
             return (
@@ -186,6 +186,7 @@ class Admin(Base, HasSessionCache):
         # Check if the admin is a librarian for _all_ libraries.
         if self.is_sitewide_librarian():
             return True
+
         # If not, they might be a librarian of _this_ library.
         def lookup_hook():
             return (
@@ -272,7 +273,6 @@ class Admin(Base, HasSessionCache):
 
 
 class AdminRole(Base, HasSessionCache):
-
     __tablename__ = "adminroles"
 
     id = Column(Integer, primary_key=True)

--- a/core/model/cachedfeed.py
+++ b/core/model/cachedfeed.py
@@ -35,7 +35,6 @@ CachedFeedKeys = namedtuple(
 
 
 class CachedFeed(Base):
-
     __tablename__ = "cachedfeeds"
     id = Column(Integer, primary_key=True)
 

--- a/core/model/configuration.py
+++ b/core/model/configuration.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
 
 
 class ExternalIntegrationLink(Base):
-
     __tablename__ = "externalintegrationslinks"
 
     NO_MIRROR_INTEGRATION = "NO_MIRROR"
@@ -298,7 +297,6 @@ class ExternalIntegration(Base):
 
     @classmethod
     def lookup(cls, _db, protocol, goal, library=None):
-
         integrations = _db.query(cls).filter(cls.protocol == protocol, cls.goal == goal)
 
         if library:
@@ -647,7 +645,6 @@ class ConfigurationSetting(Base, HasSessionCache):
 
     @hybrid_property
     def value(self):
-
         """What's the current value of this configuration setting?
         If not present, the value may be inherited from some other
         ConfigurationSetting.

--- a/core/model/customlist.py
+++ b/core/model/customlist.py
@@ -359,7 +359,6 @@ customlist_sharedlibrary: Table = Table(
 
 
 class CustomListEntry(Base):
-
     __tablename__ = "customlistentries"
     id = Column(Integer, primary_key=True)
     list_id = Column(Integer, ForeignKey("customlists.id"), index=True)

--- a/core/model/datasource.py
+++ b/core/model/datasource.py
@@ -291,7 +291,6 @@ class DataSource(Base, HasSessionCache, DataSourceConstants):
             (cls.ENKI, True, False, IdentifierConstants.ENKI_ID, None),
             (cls.PROQUEST, True, False, IdentifierConstants.PROQUEST_ID, None),
         ):
-
             obj = DataSource.lookup(
                 _db,
                 name,

--- a/core/model/identifier.py
+++ b/core/model/identifier.py
@@ -431,7 +431,6 @@ class Identifier(Base, IdentifierConstants):
 
     @classmethod
     def type_and_identifier_for_urn(cls, identifier_string: str) -> tuple[str, str]:
-
         for parser in Identifier.PARSERS:
             result = parser.parse(identifier_string)
             if result:

--- a/core/model/licensing.py
+++ b/core/model/licensing.py
@@ -1773,7 +1773,6 @@ class DeliveryMechanism(Base, HasSessionCache):
         return (self.content_type, self.drm_scheme)
 
     def __repr__(self):
-
         if self.default_client_can_fulfill:
             fulfillable = "fulfillable"
         else:

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -60,7 +60,6 @@ class LoanAndHoldMixin:
 
 
 class Patron(Base):
-
     __tablename__ = "patrons"
     id = Column(Integer, primary_key=True)
 

--- a/core/model/resource.py
+++ b/core/model/resource.py
@@ -281,7 +281,6 @@ class Resource(Base):
 
     @classmethod
     def best_covers_among(cls, resources):
-
         """Choose the best covers from a list of Resources."""
         champions = []
         champion_key = None

--- a/core/model/work.py
+++ b/core/model/work.py
@@ -476,7 +476,6 @@ class Work(Base):
                 )
                 for needs_merge in list(licensepools_for_work.keys()):
                     if needs_merge != work:
-
                         # Make sure that Work we're about to merge has
                         # nothing but LicensePools whose permanent
                         # work ID matches the permanent work ID of the

--- a/core/opds2.py
+++ b/core/opds2.py
@@ -232,6 +232,7 @@ class AcquisitonFeedOPDS2(OPDS2Feed):
         max_age: Optional[int] = None,
     ):
         """The publication feed, cached"""
+
         # do some caching magic
         # then do the publication
         def refresh():

--- a/core/opensearch.py
+++ b/core/opensearch.py
@@ -11,7 +11,6 @@ class OpenSearchDocument:
 
     @classmethod
     def search_info(cls, lane):
-
         d = dict(name="Search")
         tags = []
 

--- a/core/python_expression_dsl/util.py
+++ b/core/python_expression_dsl/util.py
@@ -57,7 +57,6 @@ def _parse_number(tokens: ParseResults) -> Number:
 def _parse_unary_expression(
     expression_type: Type[UE], tokens: ParseResults
 ) -> Optional[UE]:
-
     """Transform the token into an unary expression.
 
     :param tokens: ParseResults objects

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -362,8 +362,8 @@ class RunThreadedCollectionCoverageProviderScript(Script):
 
         for collection in collections:
             provider = self.provider_class(collection, **self.provider_kwargs)
-            with (
-                pool or DatabasePool(self.worker_size, self.session_factory)
+            with pool or DatabasePool(
+                self.worker_size, self.session_factory
             ) as job_queue:
                 query_size, batch_size = self.get_query_and_batch_sizes(provider)
                 # Without a commit, the query to count which items need
@@ -798,7 +798,6 @@ class RunCoverageProviderScript(IdentifierInputScript):
     def __init__(
         self, provider, _db=None, cmd_args=None, *provider_args, **provider_kwargs
     ):
-
         super().__init__(_db)
         parsed_args = self.parse_command_line(self._db, cmd_args)
         if parsed_args.identifier_type:
@@ -1581,7 +1580,6 @@ class AddClassificationScript(IdentifierInputScript):
 
 
 class WorkProcessingScript(IdentifierInputScript):
-
     name = "Work processing script"
 
     def __init__(
@@ -1812,7 +1810,6 @@ class ReclassifyWorksForUncheckedSubjectsScript(WorkClassificationScript):
         the ordering of the rows follows all the joined tables"""
 
         for subject in self._unchecked_subjects():
-
             last_work: Optional[Work] = None  # Last work object of the previous page
             # IDs of the last work, for paging
             work_id, license_id, iden_id, classn_id = (
@@ -2114,7 +2111,6 @@ class CheckContributorNamesInDB(IdentifierInputScript):
         return query.order_by(Edition.id)
 
     def do_run(self, batch_size=10):
-
         self.query = self.make_query(
             self._db,
             self.parsed_args.identifier_type,
@@ -2846,7 +2842,8 @@ class CustomListUpdateEntriesScript(CustomListSweeperScript):
 
     def _update_list_with_new_entries(self, custom_list: CustomList):
         """Run a search on a custom list, assuming we have auto_update_enabled with a valid query
-        Only json type queries are supported right now, without any support for additional facets"""
+        Only json type queries are supported right now, without any support for additional facets
+        """
 
         start_page = 1
         json_query = None
@@ -2902,7 +2899,6 @@ class DeleteInvisibleLanesScript(LibraryInputScript):
     """Delete lanes that are flagged as invisible"""
 
     def process_library(self, library):
-
         try:
             for lane in self._db.query(Lane).filter(Lane.library_id == library.id):
                 if not lane.visible:

--- a/core/search/service.py
+++ b/core/search/service.py
@@ -69,7 +69,8 @@ class SearchServiceFailedDocument:
 
 class SearchService(ABC):
     """The interface we need from services like Opensearch. Essentially, it provides the operations we want with
-    sensible types, rather than the untyped pile of JSON the actual search client provides."""
+    sensible types, rather than the untyped pile of JSON the actual search client provides.
+    """
 
     @abstractmethod
     def read_pointer_name(self) -> str:

--- a/core/service/container.py
+++ b/core/service/container.py
@@ -9,7 +9,6 @@ from core.service.storage.container import Storage
 
 
 class Services(DeclarativeContainer):
-
     config = providers.Configuration()
 
     storage = Container(

--- a/core/util/__init__.py
+++ b/core/util/__init__.py
@@ -232,7 +232,6 @@ class MetadataSimilarity:
 
 
 class TitleProcessor:
-
     title_stopwords = ["The ", "A ", "An "]
 
     @classmethod
@@ -264,7 +263,6 @@ class TitleProcessor:
 
 
 class Bigrams:
-
     all_letters = re.compile("^[a-z]+$")
 
     def __init__(self, bigrams):
@@ -523,7 +521,6 @@ english_bigrams.proportional = Counter(english_bigram_frequencies)
 
 
 class MoneyUtility:
-
     DEFAULT_CURRENCY = "USD"
 
     @classmethod

--- a/core/util/cache.py
+++ b/core/util/cache.py
@@ -70,7 +70,8 @@ class CachedData:
     Cache data using the CachedData.cache instance
     This must be initialized somewhere in the vicinity of its usage with CacheData.initialize(_db)
     While writing methods to cache, always lock the body to the _db is used and updated in a threadsafe manner
-    Always expunge objects before returning the data, to avoid stale/cross-thread session usage"""
+    Always expunge objects before returning the data, to avoid stale/cross-thread session usage
+    """
 
     # Instance of itself
     cache: Optional[CachedData] = None

--- a/core/util/flask_util.py
+++ b/core/util/flask_util.py
@@ -152,7 +152,6 @@ class OPDSFeedResponse(Response):
         max_age=None,
         private=None,
     ):
-
         mimetype = mimetype or OPDSFeed.ACQUISITION_FEED_TYPE
         status = status or 200
         if max_age is None:

--- a/core/util/opds_writer.py
+++ b/core/util/opds_writer.py
@@ -20,7 +20,6 @@ class ElementMaker(builder.ElementMaker):
 
 
 class AtomFeed:
-
     ATOM_TYPE = "application/atom+xml"
 
     ATOM_LIKE_TYPES = [ATOM_TYPE, "application/xml"]
@@ -174,7 +173,6 @@ class AtomFeed:
 
 
 class OPDSFeed(AtomFeed):
-
     ACQUISITION_FEED_TYPE = (
         AtomFeed.ATOM_TYPE + ";profile=opds-catalog;kind=acquisition"
     )

--- a/scripts.py
+++ b/scripts.py
@@ -150,7 +150,6 @@ class FillInAuthorScript(MetadataCalculationScript):
 
 
 class CacheRepresentationPerLane(TimestampScript, LaneSweeperScript):
-
     name = "Cache one representation per lane"
 
     @classmethod
@@ -496,7 +495,6 @@ class CacheFacetListsPerLane(CacheRepresentationPerLane):
 
 
 class CacheOPDSGroupFeedPerLane(CacheRepresentationPerLane):
-
     name = "Cache OPDS grouped feed for each lane"
 
     def should_process_lane(self, lane):
@@ -1119,7 +1117,6 @@ class DisappearingBookReportScript(Script):
 
 
 class NYTBestSellerListsScript(TimestampScript):
-
     name = "Update New York Times best-seller lists"
 
     def __init__(self, include_history=False):
@@ -1132,7 +1129,6 @@ class NYTBestSellerListsScript(TimestampScript):
         # For every best-seller list...
         names = self.api.list_of_lists()
         for l in sorted(names["results"], key=lambda x: x["list_name_encoded"]):
-
             name = l["list_name_encoded"]
             self.log.info("Handling list %s" % name)
             best = self.api.best_seller_list(l)

--- a/tests/api/discovery/test_opds_registration.py
+++ b/tests/api/discovery/test_opds_registration.py
@@ -570,7 +570,6 @@ class TestOpdsRegistrationService:
     def test__send_registration_request(
         self, remote_registry_fixture: RemoteRegistryFixture, requests_mock: Mocker
     ):
-
         # If everything goes well, the return value of do_post is
         # passed through.
         url = "http://url.com"

--- a/tests/api/mockapi/overdrive.py
+++ b/tests/api/mockapi/overdrive.py
@@ -123,7 +123,6 @@ class MockOverdriveResponse:
 
 
 class MockOverdriveAPI(MockOverdriveCoreAPI, OverdriveAPI):
-
     library_data = '{"id":1810,"name":"My Public Library (MA)","type":"Library","collectionToken":"1a09d9203","links":{"self":{"href":"http://api.overdrive.com/v1/libraries/1810","type":"application/vnd.overdrive.api+json"},"products":{"href":"http://api.overdrive.com/v1/collections/1a09d9203/products","type":"application/vnd.overdrive.api+json"},"dlrHomepage":{"href":"http://ebooks.nypl.org","type":"text/html"}},"formats":[{"id":"audiobook-wma","name":"OverDrive WMA Audiobook"},{"id":"ebook-pdf-adobe","name":"Adobe PDF eBook"},{"id":"ebook-mediado","name":"MediaDo eBook"},{"id":"ebook-epub-adobe","name":"Adobe EPUB eBook"},{"id":"ebook-kindle","name":"Kindle Book"},{"id":"audiobook-mp3","name":"OverDrive MP3 Audiobook"},{"id":"ebook-pdf-open","name":"Open PDF eBook"},{"id":"ebook-overdrive","name":"OverDrive Read"},{"id":"video-streaming","name":"Streaming Video"},{"id":"ebook-epub-open","name":"Open EPUB eBook"}]}'
 
     token_data = '{"access_token":"foo","token_type":"bearer","expires_in":3600,"scope":"LIB META AVAIL SRCH"}'

--- a/tests/api/sip/test_authentication_provider.py
+++ b/tests/api/sip/test_authentication_provider.py
@@ -121,7 +121,6 @@ def create_provider(
 
 
 class TestSIP2AuthenticationProvider:
-
     # We feed sample data into the MockSIPClient, even though it adds
     # an extra step of indirection, because it lets us use as a
     # starting point the actual (albeit redacted) SIP2 messages we

--- a/tests/api/test_adobe_vendor_id.py
+++ b/tests/api/test_adobe_vendor_id.py
@@ -382,7 +382,6 @@ class TestAuthdataUtility:
         assert "lib|0|1234|IQlGTjZ:J0VzNTI;WCEjKVoqX1M@" == token
 
     def test_decode_two_part_short_client_token_uses_adobe_base64_encoding(self):
-
         # The base64 encoding of this signature has a plus sign in it.
         signature = "LbU}66%\\-4zt>R>_)\n2Q"
         encoded_signature = AuthdataUtility.adobe_base64_encode(signature)

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -1322,7 +1322,6 @@ class TestLibraryAuthenticator:
 
 
 class TestBasicAuthenticationProvider:
-
     credentials = dict(username="user", password="")
 
     def test_authenticated_patron_passes_on_none(

--- a/tests/api/test_axis.py
+++ b/tests/api/test_axis.py
@@ -74,7 +74,6 @@ if TYPE_CHECKING:
 
 
 class Axis360Fixture:
-
     # Sample bibliographic and availability data you can use in a test
     # without having to parse it from an XML file.
     BIBLIOGRAPHIC_DATA = Metadata(
@@ -595,7 +594,10 @@ class TestAxis360API:
 
         # If there is a LicensePool but it has no owned licenses,
         # it's already been reaped, so nothing happens.
-        edition, pool, = axis360.db.edition(
+        (
+            edition,
+            pool,
+        ) = axis360.db.edition(
             data_source_name=DataSource.AXIS_360,
             identifier_type=id1.type,
             identifier_id=id1.identifier,
@@ -607,7 +609,10 @@ class TestAxis360API:
         # collection from the collection associated with this
         # Axis360API object, so it's not affected.
         collection2 = axis360.db.collection()
-        edition2, pool2, = axis360.db.edition(
+        (
+            edition2,
+            pool2,
+        ) = axis360.db.edition(
             data_source_name=DataSource.AXIS_360,
             identifier_type=id1.type,
             identifier_id=id1.identifier,

--- a/tests/api/test_bibliotheca.py
+++ b/tests/api/test_bibliotheca.py
@@ -875,7 +875,6 @@ class TestCheckoutResponseParser:
 
 
 class TestErrorParser:
-
     BIBLIOTHECA_ERROR_RESPONSE_BODY_TEMPLATE = (
         '<Error xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
         "<Code>Gen-001</Code><Message>"
@@ -1048,7 +1047,6 @@ class TestErrorParser:
 
 
 class TestBibliothecaEventParser:
-
     # Sample event feed to test out the parser.
     TWO_EVENTS = """<LibraryEventBatch xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <PublishId>1b0d6667-a10e-424a-9f73-fb6f6d41308e</PublishId>
@@ -2017,7 +2015,6 @@ class TestBibliographicCoverageProvider(TestBibliothecaAPI):
         assert True == pool.work.presentation_ready
 
     def test_internal_formats(self):
-
         m = ItemListParser.internal_formats
 
         def _check_format(input, expect_medium, expect_format, expect_drm):

--- a/tests/api/test_circulationapi.py
+++ b/tests/api/test_circulationapi.py
@@ -1441,7 +1441,6 @@ class TestCirculationAPI:
     def test_sync_bookshelf_applies_locked_delivery_mechanism_to_loan(
         self, circulation_api: CirculationAPIFixture
     ):
-
         # By the time we hear about the patron's loan, they've already
         # locked in an oddball delivery mechanism.
         mechanism = DeliveryMechanismInfo(
@@ -1473,7 +1472,6 @@ class TestCirculationAPI:
     def test_sync_bookshelf_respects_last_loan_activity_sync(
         self, circulation_api: CirculationAPIFixture
     ):
-
         # We believe we have up-to-date loan activity for this patron.
         now = utc_now()
         circulation_api.patron.last_loan_activity_sync = now

--- a/tests/api/test_controller_base.py
+++ b/tests/api/test_controller_base.py
@@ -32,7 +32,6 @@ from tests.fixtures.library import LibraryFixture
 
 class TestBaseController:
     def test_unscoped_session(self, circulation_fixture: CirculationControllerFixture):
-
         """Compare to TestScopedSession.test_scoped_session to see
         how database sessions will be handled in production.
         """
@@ -200,7 +199,6 @@ class TestBaseController:
     def test_handle_conditional_request(
         self, circulation_fixture: CirculationControllerFixture
     ):
-
         # First, test success: the client provides If-Modified-Since
         # and it is _not_ earlier than the 'last modified' date known by
         # the server.

--- a/tests/api/test_controller_scopedsession.py
+++ b/tests/api/test_controller_scopedsession.py
@@ -22,7 +22,8 @@ from tests.fixtures.api_controller import (
 class ScopedHolder:
     """A scoped holder used to store some state in the test. This is necessary because
     we want to do some unusual things with scoped sessions, and don't necessary have access
-    to a database transaction fixture in all of the various methods that will be called."""
+    to a database transaction fixture in all of the various methods that will be called.
+    """
 
     def __init__(self):
         self.identifiers = 0

--- a/tests/api/test_firstbook2.py
+++ b/tests/api/test_firstbook2.py
@@ -26,7 +26,6 @@ class MockFirstBookResponse:
 
 
 class MockFirstBookAuthenticationAPI(FirstBookAuthenticationAPI):
-
     SUCCESS = '"Valid Code Pin Pair"'
     FAILURE = '{"code":404,"message":"Access Code Pin Pair not found"}'
 

--- a/tests/api/test_millenium_patron.py
+++ b/tests/api/test_millenium_patron.py
@@ -28,7 +28,6 @@ class MockResponse:
 
 
 class MockAPI(MilleniumPatronAPI):
-
     queue: List[Any]
     requests_made: List[Any]
 

--- a/tests/api/test_novelist.py
+++ b/tests/api/test_novelist.py
@@ -15,7 +15,6 @@ from ..fixtures.database import DatabaseTransactionFixture
 
 
 class NoveListFixture:
-
     db: DatabaseTransactionFixture
     files: NoveListFilesFixture
     integration: ExternalIntegration

--- a/tests/api/test_nyt.py
+++ b/tests/api/test_nyt.py
@@ -240,7 +240,6 @@ class TestNYTBestSellerList:
 
 
 class TestNYTBestSellerListTitle:
-
     one_list_title = json.loads(
         r"""{"list_name":"Combined Print and E-Book Fiction","display_name":"Combined Print & E-Book Fiction","bestsellers_date":"2015-01-17","published_date":"2015-02-01","rank":1,"rank_last_week":0,"weeks_on_list":1,"asterisk":0,"dagger":0,"amazon_product_url":"http:\/\/www.amazon.com\/The-Girl-Train-A-Novel-ebook\/dp\/B00L9B7IKE?tag=thenewyorktim-20","isbns":[{"isbn10":"1594633665","isbn13":"9781594633669"},{"isbn10":"0698185390","isbn13":"9780698185395"}],"book_details":[{"title":"THE GIRL ON THE TRAIN","description":"A psychological thriller set in London is full of complications and betrayals.","contributor":"by Paula Hawkins","author":"Paula Hawkins","contributor_note":"","price":0,"age_group":"","publisher":"Riverhead","isbns":[{"isbn10":"1594633665","isbn13":"9781594633669"},{"isbn10":"0698185390","isbn13":"9780698185395"}],"primary_isbn13":"9780698185395","primary_isbn10":"0698185390"}],"reviews":[{"book_review_link":"","first_chapter_link":"","sunday_review_link":"","article_chapter_link":""}]}"""
     )

--- a/tests/api/test_odilo.py
+++ b/tests/api/test_odilo.py
@@ -369,7 +369,6 @@ class TestOdiloCirculationAPI:
         odilo.api.log.info("Test resource not found on remote ok!")
 
     def test_make_absolute_url(self, odilo: OdiloFixture):
-
         # A relative URL is made absolute using the API's base URL.
         relative = "/relative-url"
         absolute = odilo.api._make_absolute_url(relative)

--- a/tests/api/test_odl.py
+++ b/tests/api/test_odl.py
@@ -1854,7 +1854,6 @@ class TestODLImporter:
 
         # First import the license when it is not expired
         with freeze_time(license_expiry - datetime.timedelta(days=1)):
-
             # Import the test feed.
             (
                 imported_editions,
@@ -1881,7 +1880,6 @@ class TestODLImporter:
 
         # Reimport the license when it is expired
         with freeze_time(license_expiry + datetime.timedelta(days=1)):
-
             # Import the test feed.
             (
                 imported_editions,

--- a/tests/api/test_opds_for_distributors.py
+++ b/tests/api/test_opds_for_distributors.py
@@ -131,7 +131,7 @@ class TestOPDSForDistributorsAPI:
         # BEARER_TOKEN access control scheme, then X is a supported
         # media type for an OPDS For Distributors collection.
         supported = opds_dist_api_fixture.api.SUPPORTED_MEDIA_TYPES
-        for (format, drm) in DeliveryMechanism.default_client_can_fulfill_lookup:
+        for format, drm in DeliveryMechanism.default_client_can_fulfill_lookup:
             if drm == (DeliveryMechanism.BEARER_TOKEN) and format is not None:
                 assert format in supported
 
@@ -624,7 +624,6 @@ class TestOPDSForDistributorsImporter:
     def test__add_format_data(
         self, opds_dist_api_fixture: OPDSForDistributorsAPIFixture
     ):
-
         # Mock SUPPORTED_MEDIA_TYPES for purposes of test.
         api = OPDSForDistributorsAPI
         old_value = api.SUPPORTED_MEDIA_TYPES

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -5,14 +5,12 @@ from tests.fixtures.api_routes import RouteTestFixture
 
 
 class TestAppConfiguration:
-
     # Test the configuration of the real Flask app.
     def test_configuration(self):
         assert False == routes.app.url_map.merge_slashes
 
 
 class TestIndex:
-
     CONTROLLER_NAME = "index_controller"
 
     @pytest.fixture(scope="function")
@@ -30,7 +28,6 @@ class TestIndex:
 
 
 class TestOPDSFeed:
-
     CONTROLLER_NAME = "opds_feeds"
 
     @pytest.fixture(scope="function")
@@ -117,7 +114,6 @@ class TestMARCRecord:
 
 
 class TestProfileController:
-
     CONTROLLER_NAME = "profiles"
 
     @pytest.fixture(scope="function")
@@ -134,7 +130,6 @@ class TestProfileController:
 
 
 class TestLoansController:
-
     CONTROLLER_NAME = "loans"
 
     @pytest.fixture(scope="function")
@@ -221,7 +216,6 @@ class TestLoansController:
 
 
 class TestAnnotationsController:
-
     CONTROLLER_NAME = "annotations"
 
     @pytest.fixture(scope="function")
@@ -254,7 +248,6 @@ class TestAnnotationsController:
 
 
 class TestURNLookupController:
-
     CONTROLLER_NAME = "urn_lookup"
 
     @pytest.fixture(scope="function")
@@ -268,7 +261,6 @@ class TestURNLookupController:
 
 
 class TestWorkController:
-
     CONTROLLER_NAME = "work_controller"
 
     @pytest.fixture(scope="function")
@@ -395,7 +387,6 @@ class TestApplicationVersionController:
 
 
 class TestHealthCheck:
-
     # This code isn't in a controller, and it doesn't really do anything,
     # so we check that it returns a specific result.
     def test_health_check(self, route_test: RouteTestFixture):

--- a/tests/api/test_selftest.py
+++ b/tests/api/test_selftest.py
@@ -271,7 +271,6 @@ class TestRunSelfTestsScript:
         assert ["result 1", "result 2"] == script.processed
 
     def test_process_result(self, db: DatabaseTransactionFixture):
-
         # Test a successful test that returned a result.
         success = SelfTestResult("i succeeded")
         success.success = True

--- a/tests/core/classifiers/test_classifier.py
+++ b/tests/core/classifiers/test_classifier.py
@@ -34,7 +34,6 @@ GenreData.populate(globals(), genres, fiction_genres, nonfiction_genres)
 
 class TestLowercased:
     def test_constructor(self):
-
         l = Lowercased("A string")
 
         # A string is lowercased.
@@ -65,7 +64,6 @@ class TestGenreData:
 
 class TestClassifier:
     def test_default_target_age_for_audience(self):
-
         assert (None, None) == Classifier.default_target_age_for_audience(
             Classifier.AUDIENCE_CHILDREN
         )

--- a/tests/core/classifiers/test_ddc.py
+++ b/tests/core/classifiers/test_ddc.py
@@ -14,7 +14,6 @@ class TestDewey:
         assert None == DDC.name_for("Fic")
 
     def test_audience(self):
-
         child = Classifier.AUDIENCE_CHILDREN
         adult = Classifier.AUDIENCE_ADULT
         young_adult = Classifier.AUDIENCE_YOUNG_ADULT

--- a/tests/core/classifiers/test_lcc.py
+++ b/tests/core/classifiers/test_lcc.py
@@ -4,7 +4,6 @@ from core.classifier.lcc import LCCClassifier as LCC
 
 class TestLCC:
     def test_name_for(self):
-
         child = Classifier.AUDIENCE_CHILDREN
         adult = Classifier.AUDIENCE_ADULT
 

--- a/tests/core/models/test_circulationevent.py
+++ b/tests/core/models/test_circulationevent.py
@@ -78,7 +78,6 @@ class TestCirculationEvent:
         return event, was_new
 
     def test_new_title(self, db: DatabaseTransactionFixture):
-
         # Here's a new title.
         collection = db.collection()
         data = self._event_data(

--- a/tests/core/models/test_contributor.py
+++ b/tests/core/models/test_contributor.py
@@ -140,7 +140,6 @@ class TestContributor:
         assert d == out_display
 
     def test_default_names(self, db: DatabaseTransactionFixture):
-
         # Pass in a default display name and it will always be used.
         self._names(
             "Jones, Bob", "Jones", "Sally Smith", default_display_name="Sally Smith"

--- a/tests/core/models/test_edition.py
+++ b/tests/core/models/test_edition.py
@@ -150,7 +150,6 @@ class TestEdition:
         )
 
     def test_sort_by_priority(self, db: DatabaseTransactionFixture):
-
         # Make editions created by the license source, the metadata
         # wrangler, and library staff.
         admin = db.edition(
@@ -184,7 +183,6 @@ class TestEdition:
         assert ids(expect) == ids(actual)
 
     def test_equivalent_identifiers(self, db: DatabaseTransactionFixture):
-
         edition = db.edition()
         identifier = db.identifier()
         session = db.session
@@ -203,7 +201,6 @@ class TestEdition:
         )
 
     def test_recursive_edition_equivalence(self, db: DatabaseTransactionFixture):
-
         # Here's a Edition for a Project Gutenberg text.
         gutenberg, gutenberg_pool = db.edition(
             data_source_name=DataSource.GUTENBERG,

--- a/tests/core/models/test_hassessioncache.py
+++ b/tests/core/models/test_hassessioncache.py
@@ -83,7 +83,6 @@ class TestHasSessionCache:
     def test_by_cache_key_miss_triggers_cache_miss_hook(
         self, mock_db, mock_class, mock
     ):
-
         db = mock_db()
         cache_miss_hook = MagicMock(side_effect=lambda: (mock, True))
         created, is_new = mock_class.by_cache_key(db, mock.cache_key(), cache_miss_hook)

--- a/tests/core/models/test_patron.py
+++ b/tests/core/models/test_patron.py
@@ -112,7 +112,6 @@ class TestHold:
         assert work == hold.work
 
     def test_until(self, db: DatabaseTransactionFixture):
-
         one_day = datetime.timedelta(days=1)
         two_days = datetime.timedelta(days=2)
 

--- a/tests/core/models/test_resource.py
+++ b/tests/core/models/test_resource.py
@@ -57,7 +57,6 @@ class TestHyperlink:
 
 class TestResource:
     def test_as_delivery_mechanism_for(self, db: DatabaseTransactionFixture):
-
         # Calling as_delivery_mechanism_for on a Resource that is used
         # to deliver a specific LicensePool returns the appropriate
         # LicensePoolDeliveryMechanism.
@@ -447,7 +446,6 @@ class TestRepresentation:
         assert "" == m("no/such-media-type")
 
     def test_default_filename(self, db: DatabaseTransactionFixture):
-
         # Here's a common sort of URL.
         url = "http://example.com/foo/bar/baz.txt"
         representation, ignore = db.representation(url)
@@ -498,7 +496,6 @@ class TestRepresentation:
         assert "cover.png" == filename
 
     def test_cautious_http_get(self):
-
         h = DummyHTTPClient()
         h.queue_response(200, content="yay")
 

--- a/tests/core/service/storage/test_s3.py
+++ b/tests/core/service/storage/test_s3.py
@@ -302,9 +302,9 @@ class S3ServiceIntegrationFixture:
 
 
 @pytest.fixture
-def s3_service_integration_fixture() -> Generator[
-    S3ServiceIntegrationFixture, None, None
-]:
+def s3_service_integration_fixture() -> (
+    Generator[S3ServiceIntegrationFixture, None, None]
+):
     fixture = S3ServiceIntegrationFixture()
     yield fixture
     fixture.close()

--- a/tests/core/test_coverage.py
+++ b/tests/core/test_coverage.py
@@ -684,6 +684,7 @@ class TestIdentifierCoverageProvider:
         """Test various acceptable and unacceptable values for the class
         variable INPUT_IDENTIFIER_TYPES.
         """
+
         # It's okay to set INPUT_IDENTIFIER_TYPES to None it means you
         # will cover any and all identifier types.
         class Base(IdentifierCoverageProvider):

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -328,7 +328,6 @@ class TestFacetsWithEntryPoint:
         assert [] == m(None)
 
     def test_modify_search_filter(self):
-
         # When an entry point is selected, search filters are modified so
         # that they only find works that fit that entry point.
         filter = Filter()
@@ -949,7 +948,6 @@ class TestFacets:
             ),
             (Facets.AVAILABLE_NOT_NOW, [not_available]),
         ]:
-
             facets = Facets(db.default_library(), None, availability, None, None, None)
             modified = facets.modify_database_query(db.session, qu)
             assert (availability, sorted(x.title for x in modified)) == (
@@ -2307,7 +2305,6 @@ class TestWorkList:
         # Verify that the Facets object passed into groups() is
         # propagated to the methods called by groups().
         class MockWorkList(WorkList):
-
             overview_facets_called_with = None
 
             def works(self, _db, pagination, facets):
@@ -4576,7 +4573,6 @@ class TestWorkListGroupsEndToEnd:
         # the WorkList.
 
         class MockWorkList:
-
             display_name = "Mock"
             visible = True
             priority = 2

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -696,7 +696,6 @@ class TestMetadata:
         assert edition.series_position == metadata.series_position
 
     def test_update(self, db: DatabaseTransactionFixture):
-
         # Tests that Metadata.update correctly prefers new fields to old, unless
         # new fields aren't defined.
 
@@ -841,7 +840,6 @@ class TestMetadata:
         assert_registered(full=False)
 
     def test_apply_identifier_equivalency(self, db: DatabaseTransactionFixture):
-
         # Set up an Edition.
         edition, pool = db.edition(with_license_pool=True)
 
@@ -893,7 +891,6 @@ class TestMetadata:
         assert equivalency.output.identifier == "def"
 
     def test_apply_no_value(self, db: DatabaseTransactionFixture):
-
         edition_old, pool = db.edition(with_license_pool=True)
 
         metadata = Metadata(
@@ -1152,7 +1149,6 @@ class TestCirculationData:
 
 class TestTimestampData:
     def test_constructor(self):
-
         # By default, all fields are set to None
         d = TimestampData()
         for i in (
@@ -1235,7 +1231,6 @@ class TestTimestampData:
             assert i == None
 
     def test_finalize_full(self, db: DatabaseTransactionFixture):
-
         # You can call finalize() with a complete set of arguments.
         d = TimestampData()
         d.finalize(

--- a/tests/core/test_monitor.py
+++ b/tests/core/test_monitor.py
@@ -63,7 +63,6 @@ from tests.fixtures.time import Time
 
 
 class MockMonitor(Monitor):
-
     SERVICE_NAME = "Dummy monitor for test"
 
     def __init__(self, _db, collection=None):

--- a/tests/core/test_opds_import.py
+++ b/tests/core/test_opds_import.py
@@ -2188,6 +2188,7 @@ class TestOPDSImportMonitor:
         feed = data.content_server_mini_feed
 
         http = DummyHTTPClient()
+
         # If there's new data, follow_one_link extracts the next links.
         def follow():
             return monitor.follow_one_link("http://url", do_get=http.do_get)

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -2112,7 +2112,6 @@ class TestRebuildSearchIndexScript:
 
 
 class TestSearchIndexCoverageRemover:
-
     SERVICE_NAME = "Search Index Coverage Remover"
 
     def test_do_run(self, db: DatabaseTransactionFixture):

--- a/tests/core/test_selftest.py
+++ b/tests/core/test_selftest.py
@@ -19,7 +19,6 @@ from tests.fixtures.database import DatabaseTransactionFixture
 
 
 class TestSelfTestResult:
-
     now = utc_now()
     future = now + datetime.timedelta(seconds=5)
 
@@ -228,6 +227,7 @@ class TestHasSelfTests:
 
     def test_run_test_success(self):
         o = MockSelfTest()
+
         # This self-test method will succeed.
         def successful_test(arg, kwarg):
             return arg, kwarg
@@ -240,6 +240,7 @@ class TestHasSelfTests:
 
     def test_run_test_failure(self):
         o = MockSelfTest()
+
         # This self-test method will fail.
         def unsuccessful_test(arg, kwarg):
             raise IntegrationException(arg, kwarg)

--- a/tests/core/test_summary_evaluator.py
+++ b/tests/core/test_summary_evaluator.py
@@ -30,7 +30,6 @@ class TestSummaryEvaluator:
         assert s2 == self._best(s1, s2)
 
     def test_noun_phrase_coverage_is_important(self):
-
         s1 = "The story of Alice and the White Rabbit."
         s2 = "The story of Alice and the Mock Turtle."
         s3 = "Alice meets the Mock Turtle and the White Rabbit."

--- a/tests/core/util/test_opds_writer.py
+++ b/tests/core/util/test_opds_writer.py
@@ -9,7 +9,6 @@ from core.util.opds_writer import AtomFeed, OPDSMessage
 
 class TestOPDSMessage:
     def test_equality(self):
-
         a = OPDSMessage("urn", 200, "message")
         assert a == a
         assert a != None

--- a/tests/core/util/test_util.py
+++ b/tests/core/util/test_util.py
@@ -39,7 +39,6 @@ class TestMetadataSimilarity:
         assert 1 == MetadataSimilarity.title_similarity("foo bar.", "FOO BAR")
 
     def test_histogram_distance(self):
-
         # These two sets of titles generate exactly the same histogram.
         # Their distance is 0.
         a1 = ["The First Title", "The Second Title"]
@@ -422,7 +421,6 @@ class TestFastQueryCount:
 
 class TestSlugify:
     def test_slugify(self):
-
         # text are slugified.
         assert "hey-im-a-feed" == slugify("Hey! I'm a feed!!")
         assert "you-and-me-n-every_feed" == slugify("You & Me n Every_Feed")

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -972,9 +972,9 @@ class TemporaryDirectoryConfigurationFixture:
 
 
 @pytest.fixture(scope="function")
-def temporary_directory_configuration() -> Iterable[
-    TemporaryDirectoryConfigurationFixture
-]:
+def temporary_directory_configuration() -> (
+    Iterable[TemporaryDirectoryConfigurationFixture]
+):
     fix = TemporaryDirectoryConfigurationFixture.create()
     yield fix
     fix.close()

--- a/tests/migration/test_20230531_0af587ff8595.py
+++ b/tests/migration/test_20230531_0af587ff8595.py
@@ -101,7 +101,6 @@ def test_key_rename(
     create_config_setting: CreateConfigSetting,
     create_collection: CreateCollection,
 ) -> None:
-
     alembic_runner.migrate_down_to("a9ed3f76d649")
     with alembic_engine.connect() as connection:
         integration_id = create_external_integration(


### PR DESCRIPTION
## Description

Changes in this PR are entirely automated. They are the result of running: 
```
pre-commit autoupdate
pre-commit run -a
```

This bumps up the version of all our pre-commit linters to the latest, then re-runs the linters to catch any changes. Almost (maybe all?) of the changes are from black. It looks like there have been a few minor formatting changes there, but they seem benign, so it seems worth updating.

## Motivation and Context

Nice to keep our pre-commit config reasonably up to date.

## How Has This Been Tested?

- Running tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
