### PR TITLE
Use LoggerMixin

### DIFF
--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from enum import Enum
 from typing import Optional
@@ -7,6 +6,7 @@ from urllib.parse import urljoin
 from requests import RequestException
 
 from core.util.http import HTTP, RequestNetworkException
+from core.util.log import LoggerMixin
 
 
 class OperationalMode(str, Enum):
@@ -14,7 +14,7 @@ class OperationalMode(str, Enum):
     development = "development"
 
 
-class Configuration:
+class Configuration(LoggerMixin):
     APP_NAME = "Palace Collection Manager"
     PACKAGE_NAME = "@thepalaceproject/circulation-admin"
     PACKAGE_VERSION = "1.10.0"
@@ -61,10 +61,6 @@ class Configuration:
             if os.path.isdir(cls.package_development_directory())
             else OperationalMode.production
         )
-
-    @classmethod
-    def logger(cls) -> logging.Logger:
-        return logging.getLogger(f"{cls.__module__}.{cls.__name__}")
 
     @classmethod
     def package_name(cls) -> str:

--- a/api/admin/controller/integration_settings.py
+++ b/api/admin/controller/integration_settings.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Generic, List, NamedTuple, Optional, Type, TypeVar
 
@@ -28,6 +27,7 @@ from core.model import (
 )
 from core.problem_details import INTERNAL_SERVER_ERROR, INVALID_INPUT
 from core.util.cache import memoize
+from core.util.log import LoggerMixin
 from core.util.problem_detail import ProblemError
 
 T = TypeVar("T", bound=HasIntegrationConfiguration)
@@ -44,7 +44,7 @@ class ChangedLibrariesTuple(NamedTuple):
     removed: List[IntegrationLibraryConfiguration]
 
 
-class IntegrationSettingsController(ABC, Generic[T]):
+class IntegrationSettingsController(ABC, Generic[T], LoggerMixin):
     def __init__(
         self,
         manager: CirculationManager,
@@ -52,7 +52,6 @@ class IntegrationSettingsController(ABC, Generic[T]):
     ):
         self._db = manager._db
         self.registry = registry or self.default_registry()
-        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
 
     @abstractmethod
     def default_registry(self) -> IntegrationRegistry[T]:

--- a/api/authentication/base.py
+++ b/api/authentication/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from abc import ABC, abstractmethod
 
 from money import Money
@@ -16,6 +15,7 @@ from core.model.integration import IntegrationConfiguration
 from core.selftest import HasSelfTestsIntegrationConfiguration
 from core.util.authentication_for_opds import OPDSAuthenticationFlow
 from core.util.datetime_helpers import utc_now
+from core.util.log import LoggerMixin
 from core.util.problem_detail import ProblemDetail
 
 
@@ -31,6 +31,7 @@ class AuthenticationProvider(
     OPDSAuthenticationFlow,
     HasLibraryIntegrationConfiguration,
     HasSelfTestsIntegrationConfiguration,
+    LoggerMixin,
     ABC,
 ):
     """Handle a specific patron authentication scheme."""
@@ -46,10 +47,6 @@ class AuthenticationProvider(
         self.library_id = library_id
         self.integration_id = integration_id
         self.analytics = analytics
-
-    @classmethod
-    def logger(cls) -> logging.Logger:
-        return logging.getLogger(f"{cls.__module__}.{cls.__name__}")
 
     def library(self, _db: Session) -> Library | None:
         return Library.by_id(_db, self.library_id)

--- a/api/authentication/basic.py
+++ b/api/authentication/basic.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import re
 from abc import ABC, abstractmethod
 from enum import Enum
@@ -277,8 +276,6 @@ class BasicAuthenticationProvider(AuthenticationProvider, ABC):
         super().__init__(
             library_id, integration_id, settings, library_settings, analytics
         )
-
-        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
 
         self.identifier_re = settings.identifier_regular_expression
         self.password_re = settings.password_regular_expression

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -33,7 +33,7 @@ from core.opds import OPDSFeed
 from core.user_profile import ProfileController
 from core.util.authentication_for_opds import AuthenticationForOPDSDocument
 from core.util.http import RemoteIntegrationException
-from core.util.log import elapsed_time_logging
+from core.util.log import LoggerMixin, elapsed_time_logging
 from core.util.problem_detail import ProblemDetail, ProblemError
 
 if sys.version_info >= (3, 11):
@@ -82,16 +82,13 @@ class CirculationPatronProfileStorage(PatronProfileStorage):
         return doc
 
 
-class Authenticator:
+class Authenticator(LoggerMixin):
     """Route requests to the appropriate LibraryAuthenticator."""
 
     def __init__(
         self, _db, libraries: Iterable[Library], analytics: Analytics | None = None
     ):
         # Create authenticators
-        self.log = logging.getLogger(
-            f"{self.__class__.__module__}.{self.__class__.__name__}"
-        )
         self.library_authenticators: dict[str, LibraryAuthenticator] = {}
         self.populate_authenticators(_db, libraries, analytics)
 
@@ -145,7 +142,7 @@ class Authenticator:
         return self.invoke_authenticator_method("decode_bearer_token", *args, **kwargs)
 
 
-class LibraryAuthenticator:
+class LibraryAuthenticator(LoggerMixin):
     """Use the registered AuthenticationProviders to turn incoming
     credentials into Patron objects.
     """
@@ -263,8 +260,6 @@ class LibraryAuthenticator:
         )
         if basic_auth_provider:
             self.register_basic_auth_provider(basic_auth_provider)
-
-        self.log = logging.getLogger("Authenticator")
 
         if saml_providers:
             for provider in saml_providers:

--- a/api/opds2.py
+++ b/api/opds2.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from flask import url_for
@@ -17,6 +16,7 @@ from core.model.resource import Hyperlink
 from core.opds2 import OPDS2Annotator
 from core.problem_details import INVALID_CREDENTIALS
 from core.util.http import HTTP
+from core.util.log import LoggerMixin
 from core.util.problem_detail import ProblemDetail
 
 if TYPE_CHECKING:
@@ -85,7 +85,9 @@ class OPDS2NavigationsAnnotator(OPDS2Annotator):
         ]
 
 
-class TokenAuthenticationFulfillmentProcessor(CirculationFulfillmentPostProcessor):
+class TokenAuthenticationFulfillmentProcessor(
+    CirculationFulfillmentPostProcessor, LoggerMixin
+):
     """In case a feed has a token auth endpoint and the content_link requires an authentication token
     Then we must fetch the required authentication token from the token_auth endpoint and
     expand the templated url with the received token.
@@ -93,10 +95,6 @@ class TokenAuthenticationFulfillmentProcessor(CirculationFulfillmentPostProcesso
 
     def __init__(self, collection) -> None:
         pass
-
-    @classmethod
-    def logger(cls) -> logging.Logger:
-        return logging.getLogger(f"{cls.__module__}.{cls.__name__}")
 
     def fulfill(
         self,

--- a/api/saml/configuration/model.py
+++ b/api/saml/configuration/model.py
@@ -1,5 +1,4 @@
 import html
-import logging
 from datetime import datetime
 from enum import Enum
 from threading import Lock
@@ -39,6 +38,7 @@ from core.integration.settings import (
 )
 from core.python_expression_dsl.evaluator import DSLEvaluationVisitor, DSLEvaluator
 from core.python_expression_dsl.parser import DSLParser
+from core.util.log import LoggerMixin
 
 
 class SAMLConfigurationError(BaseError):
@@ -92,7 +92,7 @@ class FederatedIdentityProviderOptions:
         return {entity_id: label for entity_id, label in identity_providers}
 
 
-class SAMLWebSSOAuthSettings(AuthProviderSettings):
+class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
     """SAML Web SSO Authentication settings"""
 
     service_provider_xml_metadata: str = FormField(
@@ -275,10 +275,6 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings):
         ),
         alias="debug",
     )
-
-    @classmethod
-    def logger(cls):
-        return logging.getLogger(f"{cls.__module__}.{cls.__name__}")
 
     @classmethod
     def validate_xml_metadata(cls, v: str, metadata_type: str):

--- a/api/selftest.py
+++ b/api/selftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from abc import ABC
 from typing import Generator, Iterable, Optional, Tuple, Union
 
@@ -131,10 +130,6 @@ class HasCollectionSelfTests(HasSelfTestsIntegrationConfiguration, HasPatronSelf
 
     def integration(self, _db: Session) -> IntegrationConfiguration | None:
         return self.collection.integration_configuration
-
-    @classmethod
-    def logger(cls) -> logging.Logger:
-        return logging.Logger(cls.__name__)
 
     def _no_delivery_mechanisms_test(self):
         # Find works in the tested collection that have no delivery

--- a/core/app_server.py
+++ b/core/app_server.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import gzip
-import logging
 import sys
 import traceback
 from functools import wraps
@@ -22,6 +21,7 @@ from core.lane import Facets, Pagination
 from core.model import Identifier
 from core.problem_details import *
 from core.service.logging.configuration import LogLevel
+from core.util.log import LoggerMixin
 from core.util.opds_writer import OPDSMessage
 from core.util.problem_detail import ProblemDetail
 
@@ -169,7 +169,7 @@ def compressible(f):
     return compressor
 
 
-class ErrorHandler:
+class ErrorHandler(LoggerMixin):
     def __init__(self, app: PalaceFlask, log_level: LogLevel):
         """Constructor.
 
@@ -178,7 +178,6 @@ class ErrorHandler:
         """
         self.app = app
         self.debug = log_level == LogLevel.debug
-        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
 
     def handle(self, exception: Exception) -> Response | HTTPException:
         """Something very bad has happened. Notify the client."""

--- a/core/integration/settings.py
+++ b/core/integration/settings.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
@@ -29,6 +28,7 @@ from api.admin.problem_details import (
     INCOMPLETE_CONFIGURATION,
     INVALID_CONFIGURATION_OPTION,
 )
+from core.util.log import LoggerMixin
 from core.util.problem_detail import ProblemDetail, ProblemError
 
 if TYPE_CHECKING:
@@ -244,7 +244,7 @@ class ConfigurationFormItem:
         return self.weight, form_entry
 
 
-class BaseSettings(BaseModel):
+class BaseSettings(BaseModel, LoggerMixin):
     """
     Base class for all our database backed pydantic settings classes
 
@@ -308,11 +308,6 @@ class BaseSettings(BaseModel):
         # but we generally will populate the module using the field name
         # not the alias.
         allow_population_by_field_name = True
-
-    @classmethod
-    def logger(cls) -> logging.Logger:
-        """Get the logger for this class"""
-        return logging.getLogger(f"{cls.__module__}.{cls.__name__}")
 
     @classmethod
     def configuration_form(cls, db: Session) -> List[Dict[str, Any]]:

--- a/core/selftest.py
+++ b/core/selftest.py
@@ -27,6 +27,7 @@ from core.model import Collection, ExternalIntegration
 from core.model.integration import IntegrationConfiguration
 from core.util.datetime_helpers import utc_now
 from core.util.http import IntegrationException
+from core.util.log import LoggerMixin
 from core.util.opds_writer import AtomFeed
 
 if sys.version_info >= (3, 10):
@@ -371,7 +372,7 @@ class HasSelfTests(BaseHasSelfTests, ABC):
         return None
 
 
-class HasSelfTestsIntegrationConfiguration(BaseHasSelfTests, ABC):
+class HasSelfTestsIntegrationConfiguration(BaseHasSelfTests, LoggerMixin, ABC):
     # Typing specific
     collection: Any
 
@@ -423,9 +424,4 @@ class HasSelfTestsIntegrationConfiguration(BaseHasSelfTests, ABC):
 
     @abstractmethod
     def integration(self, _db: Session) -> Optional[IntegrationConfiguration]:
-        ...
-
-    @classmethod
-    @abstractmethod
-    def logger(cls) -> logging.Logger:
         ...

--- a/core/service/storage/s3.py
+++ b/core/service/storage/s3.py
@@ -12,6 +12,7 @@ from urllib.parse import quote
 from botocore.exceptions import BotoCoreError, ClientError
 
 from core.config import CannotLoadConfiguration
+from core.util.log import LoggerMixin
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -29,7 +30,7 @@ class MultipartS3UploadPart:
     PartNumber: int
 
 
-class MultipartS3ContextManager:
+class MultipartS3ContextManager(LoggerMixin):
     def __init__(
         self,
         client: S3Client,
@@ -43,7 +44,6 @@ class MultipartS3ContextManager:
         self.bucket = bucket
         self.part_number = 1
         self.parts: List[MultipartS3UploadPart] = []
-        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
         self.media_type = media_type
         self.upload: Optional[CreateMultipartUploadOutputTypeDef] = None
         self.upload_id: Optional[str] = None
@@ -137,7 +137,7 @@ class MultipartS3ContextManager:
         return self._exception
 
 
-class S3Service:
+class S3Service(LoggerMixin):
     def __init__(
         self,
         client: S3Client,
@@ -149,7 +149,6 @@ class S3Service:
         self.region = region
         self.bucket = bucket
         self.url_template = url_template
-        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__name__}")
 
         # Validate the URL template.
         formatter = Formatter()

--- a/core/util/log.py
+++ b/core/util/log.py
@@ -62,5 +62,10 @@ class LoggerMixin:
     """Mixin that adds a standardized logger"""
 
     @classmethod
-    def logger(cls):
+    @functools.cache
+    def logger(cls) -> logging.Logger:
         return logging.getLogger(f"{cls.__module__}.{cls.__name__}")
+
+    @property
+    def log(self) -> logging.Logger:
+        return self.logger()

--- a/core/util/log.py
+++ b/core/util/log.py
@@ -67,13 +67,23 @@ else:
 
 
 class LoggerMixin:
-    """Mixin that adds a standardized logger"""
+    """Mixin that adds a logger with a standardized name"""
 
     @classmethod
     @cache_decorator
     def logger(cls) -> logging.Logger:
+        """
+        Returns a logger named after the module and name of the class.
+
+        This is cached so that we don't create a new logger every time
+        it is called.
+        """
         return logging.getLogger(f"{cls.__module__}.{cls.__name__}")
 
     @property
     def log(self) -> logging.Logger:
+        """
+        A convenience property that returns the logger for the class,
+        so it is easier to access the logger from an instance.
+        """
         return self.logger()

--- a/core/util/log.py
+++ b/core/util/log.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import sys
 import time
 from contextlib import contextmanager
 from typing import Callable, Optional
@@ -58,11 +59,18 @@ def elapsed_time_logging(
         log_method(f"{prefix}Completed. (elapsed time: {elapsed_time:0.4f} seconds)")
 
 
+# Once we drop python 3.8 this can go away
+if sys.version_info >= (3, 9):
+    cache_decorator = functools.cache
+else:
+    cache_decorator = functools.lru_cache
+
+
 class LoggerMixin:
     """Mixin that adds a standardized logger"""
 
     @classmethod
-    @functools.cache
+    @cache_decorator
     def logger(cls) -> logging.Logger:
         return logging.getLogger(f"{cls.__module__}.{cls.__name__}")
 


### PR DESCRIPTION
## Description

This adds caching to the LoggerMixin class and add a property to make it easier to access from class instances and uses the LoggerMixin to replace a number of places we were calling logging.getLogger.

## Motivation and Context

Reduce the number of duplicate calls to `logging.getLogger`, since we have a mixin class for it.

## How Has This Been Tested?

Running tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
