### PR TITLE
PP-518 Fixed the OPDS facetGroupType attribute namespace

### DIFF
--- a/core/feed/serializer/opds.py
+++ b/core/feed/serializer/opds.py
@@ -38,6 +38,7 @@ ATTRIBUTE_MAPPING = {
     "rights": f"{{{OPDSFeed.DCTERMS_NS}}}rights",
     "ProviderName": f"{{{OPDSFeed.BIBFRAME_NS}}}ProviderName",
     "facetGroup": f"{{{OPDSFeed.OPDS_NS}}}facetGroup",
+    "facetGroupType": f"{{{OPDSFeed.SIMPLIFIED_NS}}}facetGroupType",
     "activeFacet": f"{{{OPDSFeed.OPDS_NS}}}activeFacet",
     "ratingValue": f"{{{OPDSFeed.SCHEMA_NS}}}ratingValue",
 }


### PR DESCRIPTION
## Description
The feed refactor missed out on the namespace for the attribute, this adds it back.
<!--- Describe your changes -->

## Motivation and Context
The Android Apps were breaking due to the incorrectly namespaced attribute
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested the /groups feed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
