### PR TITLE
Fully type hint `core/util/xmlparser.py` (PP-500)

### DIFF
--- a/api/bibliotheca.py
+++ b/api/bibliotheca.py
@@ -9,13 +9,14 @@ import logging
 import re
 import time
 import urllib.parse
+from abc import ABC
 from datetime import datetime, timedelta
-from io import BytesIO, StringIO
-from typing import Dict
+from io import BytesIO
+from typing import Dict, Generator, List, Tuple, Type, TypeVar, Union
 
 import dateutil.parser
 from flask_babel import lazy_gettext as _
-from lxml import etree
+from lxml.etree import _Element
 from pymarc import parse_xml_to_array
 
 from api.circulation import (
@@ -75,7 +76,7 @@ from core.scripts import RunCollectionMonitorScript
 from core.util.datetime_helpers import datetime_utc, strptime_utc, to_utc, utc_now
 from core.util.http import HTTP
 from core.util.string_helpers import base64
-from core.util.xmlparser import XMLParser
+from core.util.xmlparser import XMLParser, XMLProcessor
 
 
 class BibliothecaSettings(BaseSettings):
@@ -293,7 +294,7 @@ class BibliothecaAPI(
         )
         response = self.request(url)
         if response.status_code != 200:
-            raise ErrorParser().process_all(response.content)
+            raise ErrorParser().process_first(response.content)
         yield from parse_xml_to_array(BytesIO(response.content))
 
     def bibliographic_lookup_request(self, identifiers):
@@ -324,7 +325,7 @@ class BibliothecaAPI(
             identifier_strings.append(i)
 
         data = self.bibliographic_lookup_request(identifier_strings)
-        return [metadata for metadata in self.item_list_parser.parse(data)]
+        return [metadata for metadata in self.item_list_parser.process_all(data)]
 
     def _request_with_timeout(self, method, url, *args, **kwargs):
         """This will be overridden in MockBibliothecaAPI."""
@@ -441,7 +442,7 @@ class BibliothecaAPI(
             start_date = None
         else:
             # Error condition.
-            error = ErrorParser().process_all(response.content)
+            error = ErrorParser().process_first(response.content)
             if isinstance(error, AlreadyCheckedOut):
                 # It's already checked out. No problem.
                 pass
@@ -449,7 +450,7 @@ class BibliothecaAPI(
                 raise error
 
         # At this point we know we have a loan.
-        loan_expires = CheckoutResponseParser().process_all(response.content)
+        loan_expires = CheckoutResponseParser().process_first(response.content)
         loan = LoanInfo(
             licensepool.collection,
             DataSource.BIBLIOTHECA,
@@ -544,7 +545,7 @@ class BibliothecaAPI(
             response_content = response.content.decode("utf-8")
         if response.status_code in (200, 201):
             start_date = utc_now()
-            end_date = HoldResponseParser().process_all(response_content)
+            end_date = HoldResponseParser().process_first(response_content)
             return HoldInfo(
                 licensepool.collection,
                 DataSource.BIBLIOTHECA,
@@ -557,7 +558,7 @@ class BibliothecaAPI(
         else:
             if not response_content:
                 raise CannotHold()
-            error = ErrorParser().process_all(response_content)
+            error = ErrorParser().process_first(response_content)
             if isinstance(error, Exception):
                 raise error
             else:
@@ -643,16 +644,15 @@ class DummyBibliothecaAPIResponse:
         self.content = content
 
 
-class ItemListParser(XMLParser):
+class ItemListParser(XMLProcessor[Metadata]):
     DATE_FORMAT = "%Y-%m-%d"
     YEAR_FORMAT = "%Y"
 
-    NAMESPACES: Dict[str, str] = {}
-
     unescape_entity_references = html.unescape
 
-    def parse(self, xml):
-        yield from self.process_all(xml, "//Item")
+    @property
+    def xpath_expression(self) -> str:
+        return "//Item"
 
     parenthetical = re.compile(r" \([^)]+\)$")
 
@@ -664,8 +664,10 @@ class ItemListParser(XMLParser):
     }
 
     @classmethod
-    def contributors_from_string(cls, string, role=Contributor.AUTHOR_ROLE):
-        contributors = []
+    def contributors_from_string(
+        cls, string: Optional[str], role: str = Contributor.AUTHOR_ROLE
+    ) -> List[ContributorData]:
+        contributors: List[ContributorData] = []
         if not string:
             return contributors
 
@@ -682,8 +684,8 @@ class ItemListParser(XMLParser):
         return contributors
 
     @classmethod
-    def parse_genre_string(self, s):
-        genres = []
+    def parse_genre_string(self, s: Optional[str]) -> List[SubjectData]:
+        genres: List[SubjectData] = []
         if not s:
             return genres
         for i in s.split(","):
@@ -705,16 +707,14 @@ class ItemListParser(XMLParser):
             )
         return genres
 
-    def process_one(self, tag, namespaces):
+    def process_one(
+        self, tag: _Element, namespaces: Optional[Dict[str, str]]
+    ) -> Metadata:
         """Turn an <item> tag into a Metadata and an encompassed CirculationData
         objects, and return the Metadata."""
 
         def value(bibliotheca_key):
             return self.text_of_optional_subtag(tag, bibliotheca_key)
-
-        links = dict()
-        identifiers = dict()
-        subjects = []
 
         primary_identifier = IdentifierData(Identifier.BIBLIOTHECA_ID, value("ItemId"))
 
@@ -868,10 +868,14 @@ class ItemListParser(XMLParser):
         return medium, [format]
 
 
-class BibliothecaParser(XMLParser):
+T = TypeVar("T")
+
+
+class BibliothecaParser(XMLProcessor[T], ABC):
     INPUT_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
-    def parse_date(self, value):
+    @classmethod
+    def parse_date(cls, value):
         """Parse the string Bibliotheca sends as a date.
 
         Usually this is a string in INPUT_TIME_FORMAT, but it might be None.
@@ -880,7 +884,7 @@ class BibliothecaParser(XMLParser):
             value = None
         else:
             try:
-                value = strptime_utc(value, self.INPUT_TIME_FORMAT)
+                value = strptime_utc(value, cls.INPUT_TIME_FORMAT)
             except ValueError as e:
                 logging.error(
                     'Unable to parse Bibliotheca date: "%s"', value, exc_info=e
@@ -912,7 +916,7 @@ class WorkflowException(BibliothecaException):
         )
 
 
-class ErrorParser(BibliothecaParser):
+class ErrorParser(BibliothecaParser[Exception]):
     """Turn an error document from the Bibliotheca web service into a CheckoutException"""
 
     wrong_status = re.compile(
@@ -928,23 +932,31 @@ class ErrorParser(BibliothecaParser):
         "The patron has no eBooks checked out": NotCheckedOut,
     }
 
-    def process_all(self, string):
+    @property
+    def xpath_expression(self) -> str:
+        return "//Error"
+
+    def process_first(self, string: str | bytes) -> Exception:
         try:
-            for i in super().process_all(string, "//Error"):
-                return i
+            return_val = super().process_first(string)
         except Exception as e:
             # The server sent us an error with an incorrect or
             # nonstandard syntax.
             return RemoteInitiatedServerError(string, BibliothecaAPI.SERVICE_NAME)
 
-        # We were not able to interpret the result as an error.
-        # The most likely cause is that the Bibliotheca app server is down.
-        return RemoteInitiatedServerError(
-            "Unknown error",
-            BibliothecaAPI.SERVICE_NAME,
-        )
+        if return_val is None:
+            # We were not able to interpret the result as an error.
+            # The most likely cause is that the Bibliotheca app server is down.
+            return RemoteInitiatedServerError(
+                "Unknown error",
+                BibliothecaAPI.SERVICE_NAME,
+            )
 
-    def process_one(self, error_tag, namespaces):
+        return return_val
+
+    def process_one(
+        self, error_tag: _Element, namespaces: Optional[Dict[str, str]]
+    ) -> Exception:
         message = self.text_of_optional_subtag(error_tag, "Message")
         if not message:
             return RemoteInitiatedServerError(
@@ -1007,7 +1019,7 @@ class ErrorParser(BibliothecaParser):
         return BibliothecaException(message)
 
 
-class PatronCirculationParser(BibliothecaParser):
+class PatronCirculationParser(XMLParser):
 
     """Parse Bibliotheca's patron circulation status document into a list of
     LoanInfo and HoldInfo objects.
@@ -1015,39 +1027,45 @@ class PatronCirculationParser(BibliothecaParser):
 
     id_type = Identifier.BIBLIOTHECA_ID
 
-    def __init__(self, collection, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, collection: Collection) -> None:
         self.collection = collection
 
-    def process_all(self, string):
-        parser = etree.XMLParser()
-        # If the data is an HTTP response, it is a bytestring and
-        # must be converted before it is parsed.
-        if isinstance(string, bytes):
-            string = string.decode("utf-8")
-        root = etree.parse(StringIO(string), parser)
-        sup = super()
-        loans = sup.process_all(root, "//Checkouts/Item", handler=self.process_one_loan)
-        holds = sup.process_all(root, "//Holds/Item", handler=self.process_one_hold)
-        reserves = sup.process_all(
-            root, "//Reserves/Item", handler=self.process_one_reserve
+    def process_all(
+        self, string: bytes | str
+    ) -> itertools.chain[Union[LoanInfo, HoldInfo]]:
+        xml = self._load_xml(string)
+        loans = self._process_all(
+            xml, "//Checkouts/Item", namespaces={}, handler=self.process_one_loan
         )
+        holds = self._process_all(
+            xml, "//Holds/Item", namespaces={}, handler=self.process_one_hold
+        )
+        reserves = self._process_all(
+            xml, "//Reserves/Item", namespaces={}, handler=self.process_one_reserve
+        )
+        return itertools.chain(loans, holds, reserves)
 
-        everything = itertools.chain(loans, holds, reserves)
-        return [x for x in everything if x]
-
-    def process_one_loan(self, tag, namespaces):
+    def process_one_loan(
+        self, tag: _Element, namespaces: Dict[str, str]
+    ) -> Optional[LoanInfo]:
         return self.process_one(tag, namespaces, LoanInfo)
 
-    def process_one_hold(self, tag, namespaces):
+    def process_one_hold(
+        self, tag: _Element, namespaces: Dict[str, str]
+    ) -> Optional[HoldInfo]:
         return self.process_one(tag, namespaces, HoldInfo)
 
-    def process_one_reserve(self, tag, namespaces):
+    def process_one_reserve(
+        self, tag: _Element, namespaces: Dict[str, str]
+    ) -> Optional[HoldInfo]:
         hold_info = self.process_one(tag, namespaces, HoldInfo)
-        hold_info.hold_position = 0
+        if hold_info is not None:
+            hold_info.hold_position = 0
         return hold_info
 
-    def process_one(self, tag, namespaces, source_class):
+    def process_one(
+        self, tag: _Element, namespaces: Dict[str, str], source_class: Type[T]
+    ) -> Optional[T]:
         if not tag.xpath("ItemId"):
             # This happens for events associated with books
             # no longer in our collection.
@@ -1077,23 +1095,20 @@ class PatronCirculationParser(BibliothecaParser):
         return source_class(*a)
 
 
-class DateResponseParser(BibliothecaParser):
+class DateResponseParser(BibliothecaParser[Optional[datetime]], ABC):
     """Extract a date from a response."""
 
     RESULT_TAG_NAME: Optional[str] = None
     DATE_TAG_NAME: Optional[str] = None
 
-    def process_all(self, string):
-        parser = etree.XMLParser()
-        # If the data is an HTTP response, it is a bytestring and
-        # must be converted before it is parsed.
-        if isinstance(string, bytes):
-            string = string.decode("utf-8")
-        root = etree.parse(StringIO(string), parser)
-        m = root.xpath(f"/{self.RESULT_TAG_NAME}/{self.DATE_TAG_NAME}")
-        if not m:
-            return None
-        due_date = m[0].text
+    @property
+    def xpath_expression(self) -> str:
+        return f"/{self.RESULT_TAG_NAME}/{self.DATE_TAG_NAME}"
+
+    def process_one(
+        self, tag: _Element, namespaces: Optional[Dict[str, str]]
+    ) -> Optional[datetime]:
+        due_date = tag.text
         if not due_date:
             return None
         return strptime_utc(due_date, EventParser.INPUT_TIME_FORMAT)
@@ -1103,16 +1118,18 @@ class CheckoutResponseParser(DateResponseParser):
 
     """Extract due date from a checkout response."""
 
-    RESULT_TAG_NAME = "CheckoutResult"
-    DATE_TAG_NAME = "DueDateInUTC"
+    @property
+    def xpath_expression(self) -> str:
+        return f"/CheckoutResult/DueDateInUTC"
 
 
 class HoldResponseParser(DateResponseParser):
 
     """Extract availability date from a hold response."""
 
-    RESULT_TAG_NAME = "PlaceHoldResult"
-    DATE_TAG_NAME = "AvailabilityDateInUTC"
+    @property
+    def xpath_expression(self) -> str:
+        return f"/PlaceHoldResult/AvailabilityDateInUTC"
 
 
 class EventParser(BibliothecaParser):
@@ -1133,9 +1150,17 @@ class EventParser(BibliothecaParser):
         "REMOVED": CirculationEvent.DISTRIBUTOR_LICENSE_REMOVE,
     }
 
-    def process_all(self, string, no_events_error=False):
+    @property
+    def xpath_expression(self) -> str:
+        return "//CloudLibraryEvent"
+
+    def process_all(
+        self, string: bytes | str, no_events_error=False
+    ) -> Generator[
+        Tuple[str, str, Optional[str], datetime, Optional[datetime], str], None, None
+    ]:
         has_events = False
-        for i in super().process_all(string, "//CloudLibraryEvent"):
+        for i in super().process_all(string):
             yield i
             has_events = True
 
@@ -1154,7 +1179,9 @@ class EventParser(BibliothecaParser):
                 BibliothecaAPI.SERVICE_NAME,
             )
 
-    def process_one(self, tag, namespaces):
+    def process_one(
+        self, tag: _Element, namespaces: Optional[Dict[str, str]]
+    ) -> Tuple[str, str, Optional[str], datetime, Optional[datetime], str]:
         isbn = self.text_of_subtag(tag, "ISBN")
         bibliotheca_id = self.text_of_subtag(tag, "ItemId")
         patron_id = self.text_of_optional_subtag(tag, "PatronId")

--- a/api/millenium_patron.py
+++ b/api/millenium_patron.py
@@ -27,7 +27,6 @@ from core.model import Patron
 from core.util import MoneyUtility
 from core.util.datetime_helpers import datetime_utc, utc_now
 from core.util.http import HTTP
-from core.util.xmlparser import XMLParser
 
 
 class NeighborhoodMode(Enum):
@@ -167,7 +166,7 @@ class MilleniumPatronLibrarySettings(BasicAuthProviderLibrarySettings):
     )
 
 
-class MilleniumPatronAPI(BasicAuthenticationProvider, XMLParser):
+class MilleniumPatronAPI(BasicAuthenticationProvider):
     @classmethod
     def label(cls) -> str:
         return "Millenium"

--- a/core/util/xmlparser.py
+++ b/core/util/xmlparser.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from io import BytesIO
-from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    Generator,
+    Generic,
+    List,
+    Optional,
+    TypeVar,
+)
 
 from lxml import etree
 
 if TYPE_CHECKING:
-    from lxml.etree import Element
-
+    from lxml.etree import _Element, _ElementTree
 
 T = TypeVar("T")
 
@@ -20,17 +29,17 @@ class XMLParser:
 
     @classmethod
     def _xpath(
-        cls, tag: Element, expression: str, namespaces: Optional[Dict[str, str]] = None
-    ) -> List[Element]:
+        cls, tag: _Element, expression: str, namespaces: Optional[Dict[str, str]] = None
+    ) -> List[_Element]:
         if not namespaces:
             namespaces = cls.NAMESPACES
         """Wrapper to do a namespaced XPath expression."""
-        return tag.xpath(expression, namespaces=namespaces)
+        return tag.xpath(expression, namespaces=namespaces)  # type: ignore[no-any-return]
 
     @classmethod
     def _xpath1(
-        cls, tag: Element, expression: str, namespaces: Optional[Dict[str, str]] = None
-    ) -> Optional[Element]:
+        cls, tag: _Element, expression: str, namespaces: Optional[Dict[str, str]] = None
+    ) -> Optional[_Element]:
         """Wrapper to do a namespaced XPath expression."""
         values = cls._xpath(tag, expression, namespaces=namespaces)
         if not values:
@@ -45,7 +54,7 @@ class XMLParser:
         )
 
     def text_of_optional_subtag(
-        self, tag: Element, name: str, namespaces: Optional[Dict[str, str]] = None
+        self, tag: _Element, name: str, namespaces: Optional[Dict[str, str]] = None
     ) -> Optional[str]:
         tag = self._xpath1(tag, name, namespaces=namespaces)
         if tag is None or tag.text is None:
@@ -54,28 +63,31 @@ class XMLParser:
             return str(tag.text)
 
     def text_of_subtag(
-        self, tag: Element, name: str, namespaces: Optional[Dict[str, str]] = None
+        self, tag: _Element, name: str, namespaces: Optional[Dict[str, str]] = None
     ) -> str:
         return str(tag.xpath(name, namespaces=namespaces)[0].text)
 
     def int_of_subtag(
-        self, tag: Element, name: str, namespaces: Optional[Dict[str, str]] = None
+        self, tag: _Element, name: str, namespaces: Optional[Dict[str, str]] = None
     ) -> int:
         return int(self.text_of_subtag(tag, name, namespaces=namespaces))
 
     def int_of_optional_subtag(
-        self, tag: Element, name: str, namespaces: Optional[Dict[str, str]] = None
+        self, tag: _Element, name: str, namespaces: Optional[Dict[str, str]] = None
     ) -> Optional[int]:
         v = self.text_of_optional_subtag(tag, name, namespaces=namespaces)
         if not v:
             return None
         return int(v)
 
-    def process_all(self, xml, xpath, namespaces=None, handler=None, parser=None):
-        if not parser:
-            parser = etree.XMLParser(recover=True)
-        if not handler:
-            handler = self.process_one
+    @staticmethod
+    def _load_xml(
+        xml: str | bytes | _ElementTree,
+    ) -> _ElementTree:
+        """
+        Load an XML document from string or bytes and handle the case where
+        the document has already been parsed.
+        """
         if isinstance(xml, str):
             xml = xml.encode("utf8")
 
@@ -85,14 +97,77 @@ class XMLParser:
             # encounters the null character. Remove that character
             # immediately and XMLParser will handle the rest.
             xml = xml.replace(b"\x00", b"")
-            root = etree.parse(BytesIO(xml), parser)
-        else:
-            root = xml
+            parser = etree.XMLParser(recover=True)
+            return etree.parse(BytesIO(xml), parser)
 
-        for i in root.xpath(xpath, namespaces=namespaces):
+        else:
+            return xml
+
+    @staticmethod
+    def _process_all(
+        xml: _ElementTree,
+        xpath_expression: str,
+        namespaces: Dict[str, str],
+        handler: Callable[[_Element, Dict[str, str]], Optional[T]],
+    ) -> Generator[T, None, None]:
+        """
+        Process all elements matching the given XPath expression. Calling
+        the given handler function on each element and yielding the result
+        if it is not None.
+        """
+        for i in xml.xpath(xpath_expression, namespaces=namespaces):
             data = handler(i, namespaces)
             if data is not None:
                 yield data
 
-    def process_one(self, tag, namespaces):
+
+class XMLProcessor(XMLParser, Generic[T], ABC):
+    """
+    A class that simplifies making a class that processes XML documents.
+    It loads the XML document, runs an XPath expression to find all matching
+    elements, and calls the process_one function on each element.
+    """
+
+    def process_all(
+        self,
+        xml: str | bytes | _ElementTree,
+    ) -> Generator[T, None, None]:
+        """
+        Process all elements matching the given XPath expression. Calling
+        process_one on each element and yielding the result if it is not None.
+        """
+        root = self._load_xml(xml)
+        return self._process_all(
+            root, self.xpath_expression, self.NAMESPACES, self.process_one
+        )
+
+    def process_first(
+        self,
+        xml: str | bytes | _ElementTree,
+    ) -> Optional[T]:
+        """
+        Process the first element matching the given XPath expression. Calling
+        process_one on the element and returning None if no elements match or
+        if process_one returns None.
+        """
+        for i in self.process_all(xml):
+            return i
         return None
+
+    @property
+    @abstractmethod
+    def xpath_expression(self) -> str:
+        """
+        The xpath expression to use to find elements to process.
+        """
+        ...
+
+    @abstractmethod
+    def process_one(
+        self, tag: _Element, namespaces: Optional[Dict[str, str]]
+    ) -> Optional[T]:
+        """
+        Process one element and return the result. Return None if the element
+        should be ignored.
+        """
+        ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ module = [
     "core.util.authentication_for_opds",
     "core.util.cache",
     "core.util.problem_detail",
+    "core.util.xmlparser",
     "tests.fixtures.authenticator",
     "tests.migration.*",
 ]

--- a/tests/core/util/test_xml_parser.py
+++ b/tests/core/util/test_xml_parser.py
@@ -1,52 +1,91 @@
-from core.util.xmlparser import XMLParser
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from lxml.etree import _Element
+
+from core.util.xmlparser import XMLProcessor
 
 
-class MockParser(XMLParser):
+class MockProcessor(XMLProcessor[_Element]):
     """A mock XMLParser that just returns every tag it hears about."""
 
-    def process_one(self, tag, namespaces):
+    def __init__(self, xpath_expression: str) -> None:
+        self._xpath_expression = xpath_expression
+
+    @property
+    def xpath_expression(self) -> str:
+        return self._xpath_expression
+
+    def process_one(
+        self, tag: _Element, namespaces: Optional[Dict[str, str]]
+    ) -> _Element:
         return tag
 
 
-class TestXMLParser:
-    def test_process_all(self):
+class TestXMLProcessor:
+    def test_process_all(self) -> None:
         # Verify that process_all can handle either XML markup
         # or an already-parsed tag object.
         data = "<atag>This is a tag.</atag>"
 
         # Try it with markup.
-        parser = MockParser()
-        [tag] = parser.process_all(data, "/*")
+        parser = MockProcessor("/*")
+        [tag] = parser.process_all(data)
         assert "atag" == tag.tag
         assert "This is a tag." == tag.text
 
         # Try it with a tag.
-        [tag2] = parser.process_all(tag, "/*")
+        [tag2] = parser.process_all(tag)
         assert tag == tag2
 
-    def test_process_all_with_xpath(self):
+    def test_process_all_with_xpath(self) -> None:
         # Verify that process_all processes only tags that
         # match the given XPath expression.
         data = "<parent><a>First</a><b>Second</b><a>Third</a></parent><a>Fourth</a>"
 
-        parser = MockParser()
+        parser = MockProcessor("/parent/a")
 
         # Only process the <a> tags beneath the <parent> tag.
-        [tag1, tag3] = parser.process_all(data, "/parent/a")
+        [tag1, tag3] = parser.process_all(data)
         assert "First" == tag1.text
         assert "Third" == tag3.text
 
-    def test_invalid_characters_are_stripped(self):
+    def test_invalid_characters_are_stripped(self) -> None:
         data = b'<?xml version="1.0" encoding="utf-8"><tag>I enjoy invalid characters, such as \x00\x01 and \x1F. But I also like \xe2\x80\x9csmart quotes\xe2\x80\x9d.</tag>'
-        parser = MockParser()
-        [tag] = parser.process_all(data, "/tag")
+        parser = MockProcessor("/tag")
+        [tag] = parser.process_all(data)
         assert (
             "I enjoy invalid characters, such as  and . But I also like “smart quotes”."
             == tag.text
         )
 
-    def test_invalid_entities_are_stripped(self):
+    def test_invalid_entities_are_stripped(self) -> None:
         data = '<?xml version="1.0" encoding="utf-8"><tag>I enjoy invalid entities, such as &#x00;&#x01; and &#x1F;</tag>'
-        parser = MockParser()
-        [tag] = parser.process_all(data, "/tag")
+        parser = MockProcessor("/tag")
+        [tag] = parser.process_all(data)
         assert "I enjoy invalid entities, such as  and " == tag.text
+
+    def test_process_first_result(self) -> None:
+        # Verify that process_all processes only tags that
+        # match the given XPath expression.
+        data = "<parent><a>First</a><b>Second</b><a>Third</a></parent><a>Fourth</a>"
+
+        parser = MockProcessor("/parent/a")
+
+        # Only process the <a> tags beneath the <parent> tag.
+        tag1_first_call = parser.process_first(data)
+        assert tag1_first_call is not None
+        assert "First" == tag1_first_call.text
+
+        # Calling process first again will return the same tag
+        tag1_second_call = parser.process_first(data)
+        assert tag1_second_call is not None
+        assert "First" == tag1_second_call.text
+
+        # But a different tag instance
+        assert tag1_first_call is not tag1_second_call
+
+        # If no tag is found, process_first returns None
+        parser = MockProcessor("/parent/c")
+        assert parser.process_first(data) is None


### PR DESCRIPTION
## Description

Fully type hint `core/util/xmlparser.py`. Went down a bit of a rabbit hole 🐰 trying to type annotate the circulation API code and ended up type annotating the `core/util/xmlparser.py` class.

## Motivation and Context

As part of PP-500. I'm adding some type annotations to the `CirculationAPI` classes. Since both axis and bibliotecha use `xmlparser.py`, it seemed like we needed to annotate it. Turned out to be more work then I expected 😅 

## How Has This Been Tested?

- Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
