### PR TITLE
Fix flaky quicksight test

### DIFF
--- a/api/admin/controller/quicksight.py
+++ b/api/admin/controller/quicksight.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 import boto3
 import flask
+from sqlalchemy import select
 
 from api.admin.model.quicksight import (
     QuicksightDashboardNamesResponse,
@@ -71,9 +72,11 @@ class QuickSightController(CirculationManagerController):
                 )
             )
 
-        libraries = (
-            self._db.query(Library).filter(Library.id.in_(allowed_library_ids)).all()
-        )
+        libraries = self._db.execute(
+            select(Library.name)
+            .where(Library.id.in_(allowed_library_ids))
+            .order_by(Library.name)
+        ).all()
 
         try:
             delimiter = "|"

--- a/tests/api/admin/controller/test_quicksight.py
+++ b/tests/api/admin/controller/test_quicksight.py
@@ -74,7 +74,10 @@ class TestQuicksightController:
                         "Dashboard": {"InitialDashboardId": "uuid1"}
                     },
                     SessionTags=[
-                        dict(Key="library_name", Value="|".join([default.name, library1.name]))  # type: ignore[list-item]
+                        dict(
+                            Key="library_name",
+                            Value="|".join([str(library1.name), str(default.name)]),
+                        )
                     ],
                 )
 
@@ -97,7 +100,7 @@ class TestQuicksightController:
                         "Dashboard": {"InitialDashboardId": "uuid2"}
                     },
                     SessionTags=[
-                        dict(Key="library_name", Value="|".join([library1.name]))  # type: ignore[list-item]
+                        dict(Key="library_name", Value="|".join([str(library1.name)]))
                     ],
                 )
 


### PR DESCRIPTION
## Description

Because the libraries we were getting back from the DB were not ordered, we could not rely on the order of the libraries in the tests, which was causing test failures. 

It seems desirable to have a stable sort of the libraries we pass to quicksight anyway, so I added order to the query that generates our library list. I also modified the query slightly, so it just returns the library name, instead of the whole ORM Library object, since we are only using the name.

## Motivation and Context

Test failures in CI:
https://github.com/ThePalaceProject/circulation/actions/runs/6431978534/job/17465903012#step:8:410

## How Has This Been Tested?

- Running tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
