### PR TITLE
Use codecov flags (PP-499)

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,8 +8,6 @@ coverage:
 comment:
   # Only comment when coverage changes
   require_changes: true
-  # Require all builds to finish before comment is posted
-  layout: "reach, diff, flags, files"
 
 flag_management:
   default_rules: # the rules that will be followed for any flag added, generally

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,4 +9,14 @@ comment:
   # Only comment when coverage changes
   require_changes: true
   # Require all builds to finish before comment is posted
-  after_n_builds: 8
+  layout: "reach, diff, flags, files"
+
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+        threshold: 0.2%
+      - type: patch
+        target: auto

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
+          flags: ${{ matrix.module }}
 
   test-migrations:
     name: Migration Tests
@@ -107,6 +108,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
+          flags: migration
 
   docker-image-build:
     name: Docker build


### PR DESCRIPTION
## Description

Try running codecov with [flags](https://docs.codecov.com/docs/flags) enabled. 

## Motivation and Context

This should hopefully stop codecov from failing our CI as much because it won't think that coverage has dropped until all the CI reports have been submitted. 

Jira: PP-499

## How Has This Been Tested?

- Running codecov on this PR

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
