### PR TITLE
Disable codecov per flag status

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -12,9 +12,4 @@ comment:
 flag_management:
   default_rules: # the rules that will be followed for any flag added, generally
     carryforward: true
-    statuses:
-      - type: project
-        target: auto
-        threshold: 0.2%
-      - type: patch
-        target: auto
+    statuses: []


### PR DESCRIPTION
## Description

See if we can disable per-flag status updates, since they are causing PRs to fail.

## Motivation and Context

Trying to get a reasonable codecov config.

## How Has This Been Tested?

Running codecov in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
