### PR TITLE
Fix logging for monitors (PP-570)

### DIFF
--- a/core/monitor.py
+++ b/core/monitor.py
@@ -32,6 +32,7 @@ from core.model import (
     get_one_or_create,
 )
 from core.model.configuration import ConfigurationSetting
+from core.service.container import container_instance
 from core.util.datetime_helpers import utc_now
 
 if TYPE_CHECKING:
@@ -113,6 +114,10 @@ class Monitor:
         self.collection_id = None
         if collection:
             self.collection_id = collection.id
+
+        # Make sure that logging is configured.
+        self.services = container_instance()
+        self.services.init_resources()
 
     @property
     def log(self):

--- a/tests/core/test_monitor.py
+++ b/tests/core/test_monitor.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -52,6 +53,7 @@ from core.monitor import (
     WorkReaper,
     WorkSweepMonitor,
 )
+from core.service import container
 from core.util.datetime_helpers import datetime_utc, utc_now
 from tests.core.mock import (
     AlwaysSuccessfulCoverageProvider,
@@ -268,6 +270,14 @@ class TestMonitor:
         assert isinstance(t1.start, datetime.datetime)
         assert isinstance(t2.start, datetime.datetime)
         assert t2.start > t1.start
+
+    def test_init_configures_logging(self, db: DatabaseTransactionFixture):
+        mock_services = MagicMock()
+        container._container_instance = mock_services
+        collection = db.collection()
+        MockMonitor(db.session, collection)
+        mock_services.init_resources.assert_called_once()
+        container._container_instance = None
 
 
 class TestCollectionMonitor:


### PR DESCRIPTION
## Description

This makes sure that we initialize logging before running monitors.

## Motivation and Context

While testing the notification scripts today, I noticed that I wasn't seeing any logging from monitors.

## How Has This Been Tested?

- Tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
