### PR TITLE
Add PALACE_REPORTING_NAME env variable to time report subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ a storage service, you can set the following environment variables:
         - `{key}`: The key of the file.
         - `{region}`: The region of the storage service.
 
+#### Reporting
+
+- `PALACE_REPORTING_NAME`: (Optional) A name used to identify the CM instance associated with generated reports.
+- `SIMPLIFIED_REPORTING_EMAIL`: (Required) Email address of recipient of reports.
+
 #### Logging
 
 The application uses the [Python logging](https://docs.python.org/3/library/logging.html) module for logging. Optionally

--- a/core/config.py
+++ b/core/config.py
@@ -61,8 +61,8 @@ class Configuration(ConfigurationConstants):
     # Environment variable for temporary reporting email
     REPORTING_EMAIL_ENVIRONMENT_VARIABLE = "SIMPLIFIED_REPORTING_EMAIL"
 
-    # Environment variable for collection manager name
-    CM_NAME_ENVIRONMENT_VARIABLE = "PALACE_CM_NAME"
+    # Environment variable for used to distinguish one CM environment from another in reports
+    REPORTING_NAME_ENVIRONMENT_VARIABLE = "PALACE_REPORTING_NAME"
 
     # ConfigurationSetting key for the base url of the app.
     BASE_URL_KEY = "base_url"

--- a/core/config.py
+++ b/core/config.py
@@ -61,6 +61,9 @@ class Configuration(ConfigurationConstants):
     # Environment variable for temporary reporting email
     REPORTING_EMAIL_ENVIRONMENT_VARIABLE = "SIMPLIFIED_REPORTING_EMAIL"
 
+    # Environment variable for collection manager name
+    CM_NAME_ENVIRONMENT_VARIABLE = "PALACE_CM_NAME"
+
     # ConfigurationSetting key for the base url of the app.
     BASE_URL_KEY = "base_url"
 

--- a/core/jobs/playtime_entries.py
+++ b/core/jobs/playtime_entries.py
@@ -127,9 +127,10 @@ class PlaytimeEntriesEmailReportsScript(Script):
         formatted_start_date = start.strftime(self.REPORT_DATE_FORMAT)
         formatted_until_date = until.strftime(self.REPORT_DATE_FORMAT)
         report_date_label = f"{formatted_start_date} - {formatted_until_date}"
-        email_subject = (
-            f"Playtime Summaries {formatted_start_date} - {formatted_until_date}"
-        )
+
+        cm_name = os.environ.get(Configuration.CM_NAME_ENVIRONMENT_VARIABLE)
+
+        email_subject = f"{cm_name}: Playtime Summaries {formatted_start_date} - {formatted_until_date}"
         attachment_extension = "csv"
         attachment_name = f"playtime-summary-{formatted_start_date}-{formatted_until_date}.{attachment_extension}"
 

--- a/core/jobs/playtime_entries.py
+++ b/core/jobs/playtime_entries.py
@@ -128,9 +128,14 @@ class PlaytimeEntriesEmailReportsScript(Script):
         formatted_until_date = until.strftime(self.REPORT_DATE_FORMAT)
         report_date_label = f"{formatted_start_date} - {formatted_until_date}"
 
-        cm_name = os.environ.get(Configuration.CM_NAME_ENVIRONMENT_VARIABLE)
+        reporting_name = os.environ.get(
+            Configuration.REPORTING_NAME_ENVIRONMENT_VARIABLE, ""
+        )
 
-        email_subject = f"{cm_name}: Playtime Summaries {formatted_start_date} - {formatted_until_date}"
+        if len(reporting_name) > 0:
+            reporting_name += ": "
+
+        email_subject = f"{reporting_name}Playtime Summaries {formatted_start_date} - {formatted_until_date}"
         attachment_extension = "csv"
         attachment_name = f"playtime-summary-{formatted_start_date}-{formatted_until_date}.{attachment_extension}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ x-cm-env-variables: &cm-env-variables
   PALACE_STORAGE_PUBLIC_ACCESS_BUCKET: "public"
   PALACE_STORAGE_ANALYTICS_BUCKET: "analytics"
   PALACE_STORAGE_URL_TEMPLATE: "http://localhost:9000/{bucket}/{key}"
+  PALACE_CM_NAME: "TEST CM"
 
 services:
   # example docker compose configuration for testing and development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ x-cm-env-variables: &cm-env-variables
   PALACE_STORAGE_PUBLIC_ACCESS_BUCKET: "public"
   PALACE_STORAGE_ANALYTICS_BUCKET: "analytics"
   PALACE_STORAGE_URL_TEMPLATE: "http://localhost:9000/{bucket}/{key}"
-  PALACE_CM_NAME: "TEST CM"
+  PALACE_REPORTING_NAME: "TEST CM"
 
 services:
   # example docker compose configuration for testing and development

--- a/tests/core/jobs/test_playtime_entries.py
+++ b/tests/core/jobs/test_playtime_entries.py
@@ -247,7 +247,7 @@ class TestPlaytimeEntriesEmailReportsScript:
         # collection2 library2
         playtime(db.session, identifier, collection2, library2, date3m(3), 300)
 
-        cm_name = "test-cm"
+        reporting_name = "test-cm"
 
         # Horrible unbracketted syntax for python 3.8
         with patch("core.jobs.playtime_entries.csv.writer") as writer, patch(
@@ -256,7 +256,7 @@ class TestPlaytimeEntriesEmailReportsScript:
             "core.jobs.playtime_entries.os.environ",
             new={
                 Configuration.REPORTING_EMAIL_ENVIRONMENT_VARIABLE: "reporting@test.email",
-                Configuration.CM_NAME_ENVIRONMENT_VARIABLE: cm_name,
+                Configuration.REPORTING_NAME_ENVIRONMENT_VARIABLE: reporting_name,
             },
         ):
             PlaytimeEntriesEmailReportsScript(db.session).run()
@@ -293,7 +293,7 @@ class TestPlaytimeEntriesEmailReportsScript:
 
         assert email.send_email.call_count == 1
         assert email.send_email.call_args == call(
-            f"{cm_name}: Playtime Summaries {cutoff} - {until}",
+            f"{reporting_name}: Playtime Summaries {cutoff} - {until}",
             receivers=["reporting@test.email"],
             text="",
             attachments={

--- a/tests/core/jobs/test_playtime_entries.py
+++ b/tests/core/jobs/test_playtime_entries.py
@@ -247,13 +247,16 @@ class TestPlaytimeEntriesEmailReportsScript:
         # collection2 library2
         playtime(db.session, identifier, collection2, library2, date3m(3), 300)
 
+        cm_name = "test-cm"
+
         # Horrible unbracketted syntax for python 3.8
         with patch("core.jobs.playtime_entries.csv.writer") as writer, patch(
             "core.jobs.playtime_entries.EmailManager"
         ) as email, patch(
             "core.jobs.playtime_entries.os.environ",
             new={
-                Configuration.REPORTING_EMAIL_ENVIRONMENT_VARIABLE: "reporting@test.email"
+                Configuration.REPORTING_EMAIL_ENVIRONMENT_VARIABLE: "reporting@test.email",
+                Configuration.CM_NAME_ENVIRONMENT_VARIABLE: cm_name,
             },
         ):
             PlaytimeEntriesEmailReportsScript(db.session).run()
@@ -290,7 +293,7 @@ class TestPlaytimeEntriesEmailReportsScript:
 
         assert email.send_email.call_count == 1
         assert email.send_email.call_args == call(
-            f"Playtime Summaries {cutoff} - {until}",
+            f"{cm_name}: Playtime Summaries {cutoff} - {until}",
             receivers=["reporting@test.email"],
             text="",
             attachments={


### PR DESCRIPTION
…ime tracking report email.
## Description
Pulls the PALACE_CM_NAME env variable into the subject of the audio time tracking report email.
<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-539
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
