### PR TITLE
PP-576 Added the LCP ns to the hashed passphrase

### DIFF
--- a/core/feed/serializer/opds.py
+++ b/core/feed/serializer/opds.py
@@ -28,6 +28,7 @@ TAG_MAPPING = {
     "licensor": f"{{{OPDSFeed.DRM_NS}}}licensor",
     "patron": f"{{{OPDSFeed.SIMPLIFIED_NS}}}patron",
     "series": f"{{{OPDSFeed.SCHEMA_NS}}}series",
+    "hashed_passphrase": f"{{{OPDSFeed.LCP_NS}}}hashed_passphrase",
 }
 
 ATTRIBUTE_MAPPING = {

--- a/tests/api/feed/test_opds_serializer.py
+++ b/tests/api/feed/test_opds_serializer.py
@@ -116,7 +116,10 @@ class TestOPDSSerializer:
                 f"{{{OPDSFeed.OPDS_NS}}}availability",
                 lambda child: child.get("status") == "available",
             ),
-            ("hashed_passphrase", lambda child: child.text == "passphrase"),
+            (
+                f"{{{OPDSFeed.LCP_NS}}}hashed_passphrase",
+                lambda child: child.text == "passphrase",
+            ),
             (
                 f"{{{OPDSFeed.DRM_NS}}}licensor",
                 lambda child: child.get(f"{{{OPDSFeed.DRM_NS}}}vendor") == "vendor"


### PR DESCRIPTION
## Description
The serializer was made aware of the namespace requirements.
<!--- Describe your changes -->

## Motivation and Context
The lcp_hashed_passphrase was added back to the AcquisitionFeed in a related ticket, but we discovered that the lcp namespace is missing, which is causing the Android app to fail to detect the passphrase.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested the tag via the /loans feed.
Updated the unit test to match expectations.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
