### PR TITLE
Upgrade to Ubuntu 22.04 and Python 3.10 (PP-506)

### DIFF
--- a/docker/Dockerfile.baseimage
+++ b/docker/Dockerfile.baseimage
@@ -11,14 +11,14 @@
 #
 # Main repo for this image is here:
 # https://github.com/phusion/baseimage-docker
-FROM phusion/baseimage:focal-1.2.0 As baseimage
+FROM phusion/baseimage:jammy-1.0.1 As baseimage
 
 # Make sure base system is up to date
 RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends -o Dpkg::Options::="--force-confold" && \
     /bd_build/cleanup.sh
 
-ARG POETRY_VERSION=1.5.1
+ARG POETRY_VERSION=1.6.1
 
 # Install required packages including python, pip, compiliers and libraries needed
 # to build the python wheels we need and poetry.
@@ -61,7 +61,7 @@ COPY --chown=simplified:simplified poetry.lock pyproject.toml /var/www/circulati
 # to work from which speeds up the final image build.
 RUN python3 -m venv env && \
     SIMPLIFIED_ENVIRONMENT=/var/www/circulation/environment.sh && \
-    echo "if [[ -f $SIMPLIFIED_ENVIRONMENT ]]; then source $SIMPLIFIED_ENVIRONMENT; fi" >> env/bin/activate && \
+    echo "if [ -f $SIMPLIFIED_ENVIRONMENT ]; then source $SIMPLIFIED_ENVIRONMENT; fi" >> env/bin/activate && \
     . env/bin/activate && \
     pip install --upgrade pip && \
     poetry install --only main,pg --sync && \

--- a/docker/ci/test_webapp.sh
+++ b/docker/ci/test_webapp.sh
@@ -17,7 +17,7 @@ check_service_status "$container" /etc/service/nginx
 check_service_status "$container" /etc/service/uwsgi
 
 # Wait for UWSGI to be ready to accept connections.
-timeout 120s grep -q 'WSGI app .* ready in [0-9]* seconds' <(docker logs "$container" -f 2>&1)
+timeout 240s grep -q 'WSGI app .* ready in [0-9]* seconds' <(docker logs "$container" -f 2>&1)
 
 # Make sure the web server is running.
 healthcheck=$(docker exec "$container" curl --write-out "%{http_code}" --silent --output /dev/null http://localhost/healthcheck.html)


### PR DESCRIPTION
## Description

Update the base image that we use to Ubuntu 22.04. This will let us deploy using Python 3.10. Opening the way for us to drop support for Python 3.8 and 3.9.

## Motivation and Context

Right now the CM runs on Python 3.8. We should upgrade to a newer Python version, so that we can eventually drop Python 3.8. Python 3.8 will be unsupported by 14 Oct 2024, but I’d like to move off it it long before then.

## How Has This Been Tested?

- Tests in CI
- Built image and ran it locally, everything seemed okay

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
