### PR TITLE
Fixed an error while serializing LCP passphrases

### DIFF
--- a/core/feed/serializer/opds2.py
+++ b/core/feed/serializer/opds2.py
@@ -165,7 +165,7 @@ class OPDS2Serializer(SerializerInterface[Dict[str, Any]]):
             props["indirectAcquisition"].append(_indirect(indirect))
 
         if link.lcp_hashed_passphrase:
-            props["lcp_hashed_passphrase"] = link.lcp_hashed_passphrase
+            props["lcp_hashed_passphrase"] = link.lcp_hashed_passphrase.text
 
         if link.drm_licensor:
             props["licensor"] = {

--- a/tests/api/feed/test_opds2_serializer.py
+++ b/tests/api/feed/test_opds2_serializer.py
@@ -152,6 +152,7 @@ class TestOPDS2Serializer:
             availability_status="available",
             availability_since="2022-02-02",
             availability_until="2222-02-02",
+            lcp_hashed_passphrase=FeedEntryType(text="LCPPassphrase"),
             indirect_acquisitions=[
                 IndirectAcquisition(
                     type="indirect1",
@@ -180,6 +181,7 @@ class TestOPDS2Serializer:
                     "child": [{"type": "indirect1-1"}, {"type": "indirect1-2"}],
                 }
             ],
+            lcp_hashed_passphrase="LCPPassphrase",
         )
 
         # Test availability states


### PR DESCRIPTION
## Description
The passphrase pre-serialization is a FeedEntryType object, so should make use of the `.text`  attribute.
<!--- Describe your changes -->

## Motivation and Context
The `/loans` API was failing while trying to serialize as an OPDS2 feed.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Updated the unit tests.
Manually tested the `/loans` endpoint
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
