### PR TITLE
PP-139 Switched on OPDS2 capabilities for crawlable feeds

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1077,7 +1077,7 @@ class OPDSFeedController(CirculationManagerController):
             facets=facets,
             pagination=pagination,
             search_engine=search_engine,
-        ).as_response()
+        ).as_response(mime_types=flask.request.accept_mimetypes)
 
     def _load_search_facets(self, lane):
         entrypoints = list(flask.request.library.entrypoints)


### PR DESCRIPTION
## Description
Using the Accept header mimetypes the OPDS protocol is selected.
<!--- Describe your changes -->

## Motivation and Context
This feed provides a last_updated ordering that is required for some consumers on the OPDS2 feed.
[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-139)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested both OPDS1 and OPDS2 protocols are working for the crawlable feed.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
