### PR TITLE
PP-617 Added the device registration link to the patron profile document

### DIFF
--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -78,7 +78,7 @@ class CirculationPatronProfileStorage(PatronProfileStorage):
             )
             links.append(annotations_link)
 
-            doc["links"] = links
+            doc["links"].extend(links)
 
         if drm:
             doc["drm"] = drm

--- a/core/model/constants.py
+++ b/core/model/constants.py
@@ -239,6 +239,7 @@ class LinkRelations:
     BORROW = "http://opds-spec.org/acquisition/borrow"
 
     TIME_TRACKING = "http://palaceproject.io/terms/timeTracking"
+    DEVICE_REGISTRATION = "http://palaceproject.io/terms/deviceRegistration"
 
     CIRCULATION_ALLOWED = [
         OPEN_ACCESS_DOWNLOAD,

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm.session import Session
 
 from core.classifier import Classifier
 from core.model import Base, get_one_or_create, numericrange_to_tuple
+from core.model.constants import LinkRelations
 from core.model.credential import Credential
 from core.model.hybrid import hybrid_property
 from core.user_profile import ProfileStorage
@@ -770,6 +771,17 @@ class PatronProfileStorage(ProfileStorage):
             )
         settings = {self.SYNCHRONIZE_ANNOTATIONS: patron.synchronize_annotations}
         doc[self.SETTINGS_KEY] = settings
+        doc["links"] = [
+            dict(
+                rel=LinkRelations.DEVICE_REGISTRATION,
+                type="application/json",
+                href=self.url_for(
+                    "put_patron_devices",
+                    library_short_name=self.patron.library.short_name,
+                    _external=True,
+                ),
+            )
+        ]
         return doc
 
     def update(self, settable, full):

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -52,6 +52,7 @@ from core.integration.goals import Goals
 from core.integration.registry import IntegrationRegistry
 from core.mock_analytics_provider import MockAnalyticsProvider
 from core.model import CirculationEvent, ConfigurationSetting, Library, Patron
+from core.model.constants import LinkRelations
 from core.model.integration import (
     IntegrationConfiguration,
     IntegrationLibraryConfiguration,
@@ -458,7 +459,7 @@ class TestCirculationPatronProfileStorage:
         assert "drm:vendor" not in doc
         assert "drm:clientToken" not in doc
         assert "drm:scheme" not in doc
-        assert "links" not in doc
+        assert len(doc["links"]) == 1
 
         # Now there's authdata configured, and the DRM fields are populated with
         # the vendor ID and a short client token
@@ -474,13 +475,14 @@ class TestCirculationPatronProfileStorage:
         assert (
             adobe["drm:scheme"] == "http://librarysimplified.org/terms/drm/scheme/ACS"
         )
-        [annotations_link] = doc["links"]
+        [devices_link, annotations_link] = doc["links"]
         assert annotations_link["rel"] == "http://www.w3.org/ns/oa#annotationService"
         assert (
             annotations_link["href"]
             == "http://host/annotations?library_short_name=default"
         )
         assert annotations_link["type"] == AnnotationWriter.CONTENT_TYPE
+        assert devices_link["rel"] == LinkRelations.DEVICE_REGISTRATION
 
 
 class TestAuthenticator:


### PR DESCRIPTION
## Description
Hard coded the device registrations url into the patron profile document
Example Document
```json
{
  "simplified:authorization_identifier": "01230000000041",
  "settings": {
    "simplified:synchronize_annotations": null
  },
  "links": [
    {
      "rel": "http://palaceproject.io/terms/deviceRegistration",
      "type": "application/json",
      "href": "http://localhost:6500/localtest/patrons/me/devices/"
    }
  ]
}
```
<!--- Describe your changes -->

## Motivation and Context
The endpoint for push notification token registration is currently has to be known by the apps. Instead we should include this link in the patron profile document, so its discoverable by the apps.
[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-617)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested the patron profile document.
Updated the unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
