### PR TITLE
No retries for web application based requests

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -28,6 +28,7 @@ from core.model import (
 from core.service.container import Services, container_instance
 from core.util import LanguageCodes
 from core.util.cache import CachedData
+from core.util.http import HTTP
 from scripts import InstanceInitializationScript
 
 
@@ -103,6 +104,7 @@ from api.admin import routes as admin_routes  # noqa
 
 
 def initialize_application() -> PalaceFlask:
+    HTTP.set_quick_failure_settings()
     with app.app_context(), flask_babel.force_locale("en"):
         initialize_database()
 

--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -1,0 +1,12 @@
+from api.app import initialize_application
+from core.util.http import HTTP
+from tests.fixtures.database import DatabaseTransactionFixture
+
+
+def test_initialize_application_http(db: DatabaseTransactionFixture):
+    # Use the db transaction fixture so that we don't use the production settings by mistake
+    assert HTTP.DEFAULT_REQUEST_RETRIES == 5
+    # Initialize the app, which will set the HTTP configuration
+    initialize_application()
+    # Now we have 0 retry logic
+    assert HTTP.DEFAULT_REQUEST_RETRIES == 0


### PR DESCRIPTION
Remove retries for any request that are within the context of the web application.
This is to ensure we do not hang web requests due to issues with third party APIs.
Also add a log for request times.
## Description

<!--- Describe your changes -->

## Motivation and Context
Having retry logic for outgoing requests during an incoming web request is a hindrance, and should be removed.
[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-586)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested the retry failures within the /loans requests, and script based retries with the axis_monitor.
Added a unit test for the web application reduced retries.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
