### PR TITLE
Adds new type of dialect for SIP2 servers that require spaces instead…

### DIFF
--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -120,7 +120,7 @@ class SIP2Settings(BasicAuthProviderSettings):
             options={
                 Sip2Dialect.GENERIC_ILS: "Generic ILS",
                 Sip2Dialect.AG_VERSO: "Auto-Graphics VERSO",
-                Sip2Dialect.TZ_SPACES: "TZ Spaces",
+                Sip2Dialect.FOLIO: "Folio",
             },
             required=True,
         ),

--- a/api/sip/__init__.py
+++ b/api/sip/__init__.py
@@ -120,6 +120,7 @@ class SIP2Settings(BasicAuthProviderSettings):
             options={
                 Sip2Dialect.GENERIC_ILS: "Generic ILS",
                 Sip2Dialect.AG_VERSO: "Auto-Graphics VERSO",
+                Sip2Dialect.TZ_SPACES: "TZ Spaces",
             },
             required=True,
         ),

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -345,7 +345,11 @@ class SIPClient(Constants):
             # We're implicitly logged in.
             self.must_log_in = False
         self.login_password = login_password
-        self.dialect_config = dialect.config
+
+        if isinstance(dialect, str):
+            self.dialect_config = Dialect(dialect).config
+        else:
+            self.dialect_config = dialect.config
 
     def login(self):
         """Log in to the SIP server if required."""
@@ -372,7 +376,7 @@ class SIPClient(Constants):
 
     def end_session(self, *args, **kwargs):
         """Send end session message."""
-        if self.dialect_config.sendEndSession:
+        if self.dialect_config.send_end_session:
             return self.make_request(
                 self.end_session_message,
                 self.end_session_response_parser,
@@ -554,6 +558,7 @@ class SIPClient(Constants):
         patron password: AD, variable length, optional
         """
         code = "35"
+
         timestamp = self.now()
 
         message = (
@@ -842,8 +847,10 @@ class SIPClient(Constants):
 
     def now(self):
         """Return the current time, formatted as SIP expects it."""
+        tz_spaces = self.dialect_config.tz_spaces
         now = utc_now()
-        return datetime.datetime.strftime(now, "%Y%m%d0000%H%M%S")
+        zzzz = " " * 4 if tz_spaces else "0" * 4
+        return datetime.datetime.strftime(now, f"%Y%m%d{zzzz}%H%M%S")
 
     def summary(
         self,

--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -345,11 +345,7 @@ class SIPClient(Constants):
             # We're implicitly logged in.
             self.must_log_in = False
         self.login_password = login_password
-
-        if isinstance(dialect, str):
-            self.dialect_config = Dialect(dialect).config
-        else:
-            self.dialect_config = dialect.config
+        self.dialect_config = dialect.config
 
     def login(self):
         """Log in to the SIP server if required."""
@@ -558,7 +554,6 @@ class SIPClient(Constants):
         patron password: AD, variable length, optional
         """
         code = "35"
-
         timestamp = self.now()
 
         message = (

--- a/api/sip/dialect.py
+++ b/api/sip/dialect.py
@@ -6,19 +6,23 @@ from enum import Enum
 class DialectConfig:
     """Describe a SIP2 dialect_config."""
 
-    sendEndSession: bool
+    send_end_session: bool
+    tz_spaces: bool
 
 
 class Dialect(Enum):
     GENERIC_ILS = "GenericILS"
     AG_VERSO = "AutoGraphicsVerso"
+    TZ_SPACES = "TZSpaces"
 
     @property
     def config(self) -> DialectConfig:
         """Return the configuration for this dialect."""
         if self == Dialect.GENERIC_ILS:
-            return DialectConfig(sendEndSession=True)
+            return DialectConfig(send_end_session=True, tz_spaces=False)
         elif self == Dialect.AG_VERSO:
-            return DialectConfig(sendEndSession=False)
+            return DialectConfig(send_end_session=False, tz_spaces=False)
+        elif self == Dialect.TZ_SPACES:
+            return DialectConfig(send_end_session=True, tz_spaces=True)
         else:
             raise NotImplementedError(f"Unknown dialect: {self}")

--- a/api/sip/dialect.py
+++ b/api/sip/dialect.py
@@ -13,7 +13,7 @@ class DialectConfig:
 class Dialect(Enum):
     GENERIC_ILS = "GenericILS"
     AG_VERSO = "AutoGraphicsVerso"
-    TZ_SPACES = "TZSpaces"
+    FOLIO = "TZSpaces"
 
     @property
     def config(self) -> DialectConfig:
@@ -22,7 +22,7 @@ class Dialect(Enum):
             return DialectConfig(send_end_session=True, tz_spaces=False)
         elif self == Dialect.AG_VERSO:
             return DialectConfig(send_end_session=False, tz_spaces=False)
-        elif self == Dialect.TZ_SPACES:
+        elif self == Dialect.FOLIO:
             return DialectConfig(send_end_session=True, tz_spaces=True)
         else:
             raise NotImplementedError(f"Unknown dialect: {self}")

--- a/tests/api/sip/test_client.py
+++ b/tests/api/sip/test_client.py
@@ -714,6 +714,7 @@ class TestClientDialects:
             (Dialect.GENERIC_ILS, 1, 1),
             # AG VERSO ILS shouldn't end_session message
             (Dialect.AG_VERSO, 0, 0),
+            (Dialect.TZ_SPACES, 1, 1),
         ],
     )
     def test_dialect(


### PR DESCRIPTION
… of zeros in the time zone segment of the date time values sent via the SIP2 protocol.

## Description


## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-546
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Manually test in addition to the unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
