### PR TITLE
Run loan notifications script only once daily.

### DIFF
--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -106,7 +106,7 @@ HOME=/var/www/circulation
 
 # Notifications
 #
-10 */2 * * * root core/bin/run loan_notifications >> /var/log/cron.log 2>&1
+10 3 * * * root core/bin/run loan_notifications >> /var/log/cron.log 2>&1
 15 */2 * * * root core/bin/run hold_notifications >> /var/log/cron.log 2>&1
 0 1 * * * root core/bin/run patron_activity_sync_notifications >> /var/log/cron.log 2>&1
 


### PR DESCRIPTION
## Description

- Reduces the run frequency of the loans notifications script to once per day.
- Runs it in the middle of the night to reduce to likelihood of narrowly missing an alert based on the time the loan was made.

## Motivation and Context

Receiving loan notifications on the app clients each time the loan notifications script runs.

[Jira [PP-669](https://ebce-lyrasis.atlassian.net/browse/PP-669)]

## How Has This Been Tested?

This PR does not change any code, just the time at which it begins executing.

## Checklist

- [X] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.


[PP-669]: https://ebce-lyrasis.atlassian.net/browse/PP-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ