### PR TITLE
Update how we load settings from database

### DIFF
--- a/core/integration/base.py
+++ b/core/integration/base.py
@@ -26,9 +26,9 @@ def integration_settings_load(
     """
     Load the settings object for an integration from the database.
 
-    These settings ARE NOT validated when loaded from the database. It is assumed that
-    the settings have already been validated when they were saved to the database. This
-    speeds up the loading of the settings from the database.
+    The settings are validated when loaded from the database, this is done rather
+    than using construct() because there are some types that need to get type converted
+    when round tripping from the database (such as enum) and construct() doesn't do that.
 
     :param settings_cls: The settings class that the settings should be loaded into.
     :param integration: The integration to load the settings from. This should be a
@@ -37,7 +37,7 @@ def integration_settings_load(
     :return: An instance of the settings class loaded with the settings from the database.
     """
     settings_dict = integration.settings_dict
-    return settings_cls.construct(**settings_dict)
+    return settings_cls(**settings_dict)
 
 
 def integration_settings_update(

--- a/tests/api/admin/controller/test_library_registrations.py
+++ b/tests/api/admin/controller/test_library_registrations.py
@@ -37,7 +37,7 @@ class TestLibraryRegistration:
 
         # Here's a discovery service.
         discovery_service = create_integration_configuration.discovery_service(
-            url="http://service-url/"
+            url="http://service-url.com/"
         )
 
         # We successfully registered this library with the service.
@@ -89,7 +89,7 @@ class TestLibraryRegistration:
         # registration link.
         root_catalog = dict(links=[dict(href="http://register-here/", rel="register")])
         requests_mock.get(
-            "http://service-url/",
+            "http://service-url.com/",
             json=root_catalog,
             headers={"Content-Type": OpdsRegistrationService.OPDS_2_TYPE},
         )
@@ -137,7 +137,7 @@ class TestLibraryRegistration:
             # happened.  The target of the first request is the URL to
             # the discovery service's main catalog. The second request
             # is to the "register" link found in that catalog.
-            assert ["service-url", "register-here"] == [
+            assert ["service-url.com", "register-here"] == [
                 r.hostname for r in requests_mock.request_history
             ]
 
@@ -174,7 +174,7 @@ class TestLibraryRegistration:
             # there will be no second request.
             requests_mock.reset()
             requests_mock.get(
-                "http://service-url/",
+                "http://service-url.com/",
                 json=REMOTE_INTEGRATION_FAILED.response[0],
                 status_code=502,
             )
@@ -239,7 +239,7 @@ class TestLibraryRegistration:
 
         # Create an IntegrationConfiguration to avoid that problem in future tests.
         discovery_service = create_integration_configuration.discovery_service(
-            url="http://register-here/"
+            url="http://register-here.com/"
         )
 
         # We might not get a library short name.

--- a/tests/api/test_circulationapi.py
+++ b/tests/api/test_circulationapi.py
@@ -886,10 +886,15 @@ class TestCirculationAPI:
 
     def test_fulfill_errors(self, circulation_api: CirculationAPIFixture):
         # Here's an open-access title.
+        collection = circulation_api.db.collection(
+            protocol=ExternalIntegration.OPDS_IMPORT, data_source_name="OPDS"
+        )
         circulation_api.pool.open_access = True
+        circulation_api.pool.collection = collection
+
         circulation_api.circulation.remotes[
             circulation_api.pool.data_source.name
-        ] = OPDSAPI(circulation_api.db.session, circulation_api.collection)
+        ] = OPDSAPI(circulation_api.db.session, collection)
 
         # The patron has the title on loan.
         circulation_api.pool.loan_to(circulation_api.patron)

--- a/tests/api/test_controller_multilib.py
+++ b/tests/api/test_controller_multilib.py
@@ -1,4 +1,5 @@
 from core.model import Collection, ExternalIntegration, get_one_or_create
+from core.opds_import import OPDSAPI
 from tests.fixtures.api_controller import (
     CirculationControllerFixture,
     ControllerFixtureSetupOverrides,
@@ -21,7 +22,13 @@ class TestMultipleLibraries:
                 name=f"{controller_fixture.db.fresh_str()} (for multi-library test)",
             )
             collection.create_external_integration(ExternalIntegration.OPDS_IMPORT)
-            collection.create_integration_configuration(ExternalIntegration.OPDS_IMPORT)
+            integration = collection.create_integration_configuration(
+                ExternalIntegration.OPDS_IMPORT
+            )
+            settings = OPDSAPI.settings_class()(
+                external_account_id="http://url.com", data_source="OPDS"
+            )
+            OPDSAPI.settings_update(integration, settings)
             library.collections.append(collection)
             return collection
 

--- a/tests/api/test_controller_scopedsession.py
+++ b/tests/api/test_controller_scopedsession.py
@@ -13,6 +13,7 @@ from core.model import (
     Library,
     create,
 )
+from core.opds_import import OPDSAPI
 from tests.fixtures.api_controller import (
     ControllerFixture,
     ControllerFixtureSetupOverrides,
@@ -60,7 +61,13 @@ class ScopedHolder:
             name=self.fresh_id() + " (collection for scoped session)",
         )
         collection.create_external_integration(ExternalIntegration.OPDS_IMPORT)
-        collection.create_integration_configuration(ExternalIntegration.OPDS_IMPORT)
+        integration = collection.create_integration_configuration(
+            ExternalIntegration.OPDS_IMPORT
+        )
+        settings = OPDSAPI.settings_class()(
+            external_account_id="http://url.com", data_source="OPDS"
+        )
+        OPDSAPI.settings_update(integration, settings)
         library.collections.append(collection)
         return collection
 

--- a/tests/api/test_controller_work.py
+++ b/tests/api/test_controller_work.py
@@ -844,6 +844,7 @@ class TestWorkController:
         assert result == NOT_FOUND_ON_REMOTE
 
     def test_series(self, work_fixture: WorkFixture):
+        work_fixture.collection.data_source = None
         # Test the ability of the series() method to generate an OPDS
         # feed representing all the books in a given series, subject
         # to an optional language and audience restriction.

--- a/tests/api/test_controller_work.py
+++ b/tests/api/test_controller_work.py
@@ -71,6 +71,7 @@ def work_fixture(db: DatabaseTransactionFixture):
 class TestWorkController:
     def test_contributor(self, work_fixture: WorkFixture):
         m = work_fixture.manager.work_controller.contributor
+        work_fixture.collection.data_source = None
 
         # Find a real Contributor put in the system through the setup
         # process.

--- a/tests/api/test_lanes.py
+++ b/tests/api/test_lanes.py
@@ -1163,7 +1163,7 @@ class TestJackpotWorkList:
         ] = available_now
 
         assert (
-            "License source {[Unknown]} - Medium {Book} - Collection name {%s}"
+            "License source {OPDS} - Medium {Book} - Collection name {%s}"
             % db.default_collection().name
             == default_ebooks.display_name
         )
@@ -1171,7 +1171,7 @@ class TestJackpotWorkList:
         assert [Edition.BOOK_MEDIUM] == default_ebooks.media
 
         assert (
-            "License source {[Unknown]} - Medium {Audio} - Collection name {%s}"
+            "License source {OPDS} - Medium {Audio} - Collection name {%s}"
             % db.default_collection().name
             == default_audio.display_name
         )

--- a/tests/core/models/test_configuration.py
+++ b/tests/core/models/test_configuration.py
@@ -528,7 +528,8 @@ class TestExternalIntegration:
             external_account_id="http://url.com/feed", data_source="New Data Source"
         )
         OPDSAPI.settings_update(opds_collection.integration_configuration, settings)
-        assert opds_collection.data_source.name == "New Data Source"
+        assert isinstance(opds_collection.data_source, DataSource)
+        assert opds_collection.data_source.name == "New Data Source"  # type: ignore[unreachable]
 
     def test_set_key_value_pair(
         self, example_externalintegration_fixture: ExampleExternalIntegrationFixture

--- a/tests/core/models/test_library.py
+++ b/tests/core/models/test_library.py
@@ -1,7 +1,6 @@
 import pytest
 from Crypto.PublicKey.RSA import RsaKey, import_key
 
-from core.configuration.library import LibrarySettings
 from core.model.configuration import ConfigurationSetting
 from core.model.library import Library
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -235,16 +234,6 @@ username='someuser'
         library.settings_dict = []
         with pytest.raises(ValueError):
             library.settings
-
-        # We don't validate settings when loaded from the database, since
-        # we assume they were validated when they were set.
-        library.settings_dict = {}
-        settings = library.settings
-
-        # This would normally not be possible, because website is
-        # a required property.
-        assert isinstance(settings, LibrarySettings)
-        assert not hasattr(settings, "website")
 
         # Test with a properly formatted settings dict.
         library2 = db.library()

--- a/tests/core/test_opds2_import.py
+++ b/tests/core/test_opds2_import.py
@@ -465,7 +465,7 @@ class Opds2ApiFixture:
     def __init__(self, db: DatabaseTransactionFixture, mock_http: MagicMock):
         self.patron = db.patron()
         self.collection: Collection = db.collection(
-            protocol=ExternalIntegration.OPDS2_IMPORT
+            protocol=ExternalIntegration.OPDS2_IMPORT, data_source_name="test"
         )
         self.integration = self.collection.create_external_integration(
             ExternalIntegration.OPDS2_IMPORT

--- a/tests/core/test_opds_import.py
+++ b/tests/core/test_opds_import.py
@@ -1368,6 +1368,9 @@ class TestOPDSImporter:
 
     def test_assert_importable_content(self, db: DatabaseTransactionFixture):
         session = db.session
+        collection = db.collection(
+            protocol=ExternalIntegration.OPDS_IMPORT, data_source_name="OPDS"
+        )
 
         class Mock(OPDSImporter):
             """An importer that may or may not be able to find
@@ -1403,7 +1406,7 @@ class TestOPDSImporter:
         do_get = MagicMock()
 
         # Here, there are no links at all.
-        importer = NoLinks(session, db.default_collection(), do_get)
+        importer = NoLinks(session, collection, do_get)
         with pytest.raises(IntegrationException) as excinfo:
             importer.assert_importable_content("feed", "url")
         assert "No open-access links were found in the OPDS feed." in str(excinfo.value)
@@ -1430,7 +1433,7 @@ class TestOPDSImporter:
                 ),
             ]
 
-        bad_links_importer = BadLinks(session, db.default_collection(), do_get)
+        bad_links_importer = BadLinks(session, collection, do_get)
         with pytest.raises(IntegrationException) as excinfo:
             bad_links_importer.assert_importable_content(
                 "feed", "url", max_get_attempts=2
@@ -1467,7 +1470,7 @@ class TestOPDSImporter:
                     return False
                 return "this is a book"
 
-        good_link_importer = GoodLink(session, db.default_collection(), do_get)
+        good_link_importer = GoodLink(session, collection, do_get)
         result = good_link_importer.assert_importable_content(
             "feed", "url", max_get_attempts=5
         )
@@ -2303,7 +2306,9 @@ class OPDSAPIFixture:
     def __init__(self, db: DatabaseTransactionFixture):
         self.db = db
         self.session = db.session
-        self.collection = db.collection(protocol=OPDSAPI.label())
+        self.collection = db.collection(
+            protocol=OPDSAPI.label(), data_source_name="OPDS"
+        )
         self.api = OPDSAPI(self.session, self.collection)
 
         self.mock_patron = MagicMock()

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -166,17 +166,12 @@ class DatabaseTransactionFixture:
     def _make_default_library(self) -> Library:
         """Ensure that the default library exists in the given database."""
         library = self.library("default", "default")
-        collection, ignore = get_one_or_create(
-            self._session, Collection, name="Default Collection"
+        collection = self.collection(
+            "Default Collection",
+            protocol=ExternalIntegration.OPDS_IMPORT,
+            data_source_name="OPDS",
         )
-        integration = collection.create_external_integration(
-            ExternalIntegration.OPDS_IMPORT
-        )
-        integration.goal = ExternalIntegration.LICENSE_GOAL
-        config = collection.create_integration_configuration(
-            ExternalIntegration.OPDS_IMPORT
-        )
-        config.for_library(library.id, create=True)
+        collection.integration_configuration.for_library(library.id, create=True)
         if collection not in library.collections:
             library.collections.append(collection)
         return library


### PR DESCRIPTION
## Description

Load our settings from the database with full validation, rather then short-cutting that using the `construct()` method.

## Motivation and Context

@dbernstein noted in https://github.com/ThePalaceProject/circulation/pull/1495 that we had a problem in our sip2 integration where settings were not being loaded with the proper enum types from the database. This turned out to be a more pervasive problem then just for that integration, and necessitated this fix.

## How Has This Been Tested?

Tested with the SIP2 code where this problem was first noted and ran unit tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
