### PR TITLE
Enforce SIP2 timeout across calls to read on the socket (PP-659)

### DIFF
--- a/api/sip/client.py
+++ b/api/sip/client.py
@@ -31,6 +31,7 @@ import re
 import socket
 import ssl
 import tempfile
+import time
 from enum import Enum
 from typing import Callable, Optional
 
@@ -891,16 +892,19 @@ class SIPClient(Constants):
 
         This method exists only to be subclassed by MockSIPClient.
         """
-        self.connection.send(data)
+        self.connection.sendall(data)
 
     def read_message(self, max_size=1024 * 1024):
         """Read a SIP2 message from the socket connection.
 
         A SIP2 message ends with a \\r character.
         """
+        start_time = time.time()
         done = False
         data = b""
         while not done:
+            if time.time() - start_time > self.TIMEOUT:
+                raise OSError("Timeout reading from socket.")
             tmp = self.connection.recv(4096)
             data = data + tmp
             if not tmp:


### PR DESCRIPTION
## Description

Enforce a timeout across multiple recv calls and fix a potential issue with our send call.

## Motivation and Context

@RishiDiwanTT here is my suggestion about how we might handle PP-659. I'm not sure it will fix the issue, but this seems like a potential way we could be taking a long time for SIP connections. Every time we call `recv` the timeout is reset, so we might be just spending a lot of time waiting in this loop for data.

I also noticed that we call [`send` ](https://docs.python.org/3/library/socket.html#socket.socket.send) to send the SIP data, which calls out in the documentation:
> Applications are responsible for checking that all data has been sent; if only some of the data was transmitted, the application needs to attempt delivery of the remaining data. 

We don't do that checking. So its possible that sometimes we are not sending a complete SIP message, which might be slowing things down with retries etc. I think we want to be calling [`sendall`](https://docs.python.org/3/library/socket.html#socket.socket.sendall) 
> Unlike [send()](https://docs.python.org/3/library/socket.html#socket.socket.send), this method continues to send data from bytes until either all data has been sent or an error occurs.

That might sort out some issues we are seeing here as well.

## How Has This Been Tested?

Running locally + tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
