### PR TITLE
Add a second run of `cache_marc_files`.

### DIFF
--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -42,7 +42,7 @@ HOME=/var/www/circulation
 0 0 * * 0 root core/bin/run -d 60 novelist_update >> /var/log/cron.log 2>&1
 
 # Generate MARC files for libraries that have a MARC exporter configured.
-0 3 * * * root core/bin/run cache_marc_files >> /var/log/cron.log 2>&1
+0 3,11 * * * root core/bin/run cache_marc_files >> /var/log/cron.log 2>&1
 
 # The remaining scripts keep the circulation manager in sync with
 # specific types of collections.


### PR DESCRIPTION
## Description

Runs `cache_marc_files` a second time, later in the day.

## Motivation and Context

Adds a second opportunity to run. The second time takes into account that we're currently running our containers on UTC, rather than US/Eastern time.

[Jira [PP-624](https://ebce-lyrasis.atlassian.net/browse/PP-624)]

## How Has This Been Tested?

- This PR does not change any code, just adds another time at which an existing script runs.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-624]: https://ebce-lyrasis.atlassian.net/browse/PP-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ