### PR TITLE
PP-685 Install the tzdata package 

### DIFF
--- a/docker/Dockerfile.baseimage
+++ b/docker/Dockerfile.baseimage
@@ -36,6 +36,7 @@ RUN install_clean \
       # needed for xmlsec
       libxmlsec1-dev \
       libxmlsec1-openssl \
+      tzdata \
       pkg-config && \
     curl -sSL https://install.python-poetry.org | POETRY_HOME="/opt/poetry" python3 - --yes --version $POETRY_VERSION && \
     ln -s /opt/poetry/bin/poetry /usr/local/bin/poetry && \


### PR DESCRIPTION
## Description
The tzdata package needs to be installed in the docker containers in order for the TZ env var to be respected.
This change installs the package in the base container.
<!--- Describe your changes -->

## Motivation and Context
The crontab entries are being executed at the associated UTC, rather than US/Eastern, time. This has them running 4-5 hours earlier than expected, depending on daylight savings time.
[JIRA](https://ebce-lyrasis.atlassian.net/browse/PP-685)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
The built script container had the right time and timezone when using the `date` command.
The `/var/log/cron.log` also displayed the EST times.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
