### PR TITLE
Bugfix make sure patron profile doesn't authenticate twice (PP-701)

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -2203,18 +2203,15 @@ class WorkController(CirculationManagerController):
 class ProfileController(CirculationManagerController):
     """Implement the User Profile Management Protocol."""
 
-    @property
-    def _controller(self):
+    def _controller(self, patron):
         """Instantiate a CoreProfileController that actually does the work."""
-        # TODO: Probably better to use request_patron and check for
-        # None here.
-        patron = self.authenticated_patron_from_request()
         storage = CirculationPatronProfileStorage(patron, flask.url_for)
         return CoreProfileController(storage)
 
     def protocol(self):
         """Handle a UPMP request."""
-        controller = self._controller
+        patron = flask.request.patron
+        controller = self._controller(patron)
         if flask.request.method == "GET":
             result = controller.get()
         else:

--- a/tests/api/test_controller_profile.py
+++ b/tests/api/test_controller_profile.py
@@ -98,11 +98,11 @@ class TestProfileController:
             assert request_patron.synchronize_annotations is True
 
             # The other patron is unaffected.
-            assert profile_fixture.other_patron.synchronize_annotations is False
+            assert profile_fixture.other_patron.synchronize_annotations is False  # type: ignore[unreachable]
 
         # Now we can create an annotation for the patron who enabled
         # annotation sync.
-        annotation = Annotation.get_one_or_create(
+        Annotation.get_one_or_create(  # type: ignore[unreachable]
             profile_fixture.db.session, patron=request_patron, identifier=identifier
         )
         assert 1 == len(request_patron.annotations)

--- a/tests/api/test_controller_profile.py
+++ b/tests/api/test_controller_profile.py
@@ -44,7 +44,9 @@ class TestProfileController:
             "/", method="GET", headers=profile_fixture.auth
         ):
             assert isinstance(
-                profile_fixture.manager.profiles._controller.storage,
+                profile_fixture.manager.profiles._controller(
+                    profile_fixture.other_patron
+                ).storage,
                 CirculationPatronProfileStorage,
             )
 
@@ -59,7 +61,7 @@ class TestProfileController:
             assert "200 OK" == response.status
             data = json.loads(response.get_data(as_text=True))
             settings = data["settings"]
-            assert True == settings[ProfileStorage.SYNCHRONIZE_ANNOTATIONS]
+            assert settings[ProfileStorage.SYNCHRONIZE_ANNOTATIONS] is True
 
     def test_put(self, profile_fixture: ProfileFixture):
         """Verify that a patron can modify their own profile."""
@@ -78,7 +80,7 @@ class TestProfileController:
             request_patron = (
                 profile_fixture.controller.authenticated_patron_from_request()
             )
-            assert None == request_patron.synchronize_annotations
+            assert request_patron.synchronize_annotations is None
 
             # This means we can't create annotations for them.
             pytest.raises(
@@ -90,13 +92,13 @@ class TestProfileController:
             )
 
             # But by sending a PUT request...
-            response = profile_fixture.manager.profiles.protocol()
+            profile_fixture.manager.profiles.protocol()
 
             # ...we can change synchronize_annotations to True.
-            assert True == request_patron.synchronize_annotations
+            assert request_patron.synchronize_annotations is True
 
             # The other patron is unaffected.
-            assert False == profile_fixture.other_patron.synchronize_annotations
+            assert profile_fixture.other_patron.synchronize_annotations is False
 
         # Now we can create an annotation for the patron who enabled
         # annotation sync.
@@ -115,11 +117,12 @@ class TestProfileController:
             content_type=ProfileController.MEDIA_TYPE,
             data=json.dumps(payload),
         ):
-            response = profile_fixture.manager.profiles.protocol()
+            profile_fixture.controller.authenticated_patron_from_request()
+            profile_fixture.manager.profiles.protocol()
 
             # ...the annotation goes away.
             profile_fixture.db.session.commit()
-            assert False == request_patron.synchronize_annotations
+            assert request_patron.synchronize_annotations == False
             assert 0 == len(request_patron.annotations)
 
     def test_problemdetail_on_error(self, profile_fixture: ProfileFixture):
@@ -132,6 +135,7 @@ class TestProfileController:
             headers=profile_fixture.auth,
             content_type="text/plain",
         ):
+            profile_fixture.controller.authenticated_patron_from_request()
             response = profile_fixture.manager.profiles.protocol()
             assert isinstance(response, ProblemDetail)
             assert 415 == response.status_code

--- a/tests/api/test_controller_profile.py
+++ b/tests/api/test_controller_profile.py
@@ -122,7 +122,7 @@ class TestProfileController:
 
             # ...the annotation goes away.
             profile_fixture.db.session.commit()
-            assert request_patron.synchronize_annotations == False
+            assert request_patron.synchronize_annotations is False
             assert 0 == len(request_patron.annotations)
 
     def test_problemdetail_on_error(self, profile_fixture: ProfileFixture):


### PR DESCRIPTION
## Description

Make sure requests to `patrons/me` only call out to the remote authentication service once.

https://github.com/ThePalaceProject/circulation/blob/7c2d0eeba9c3e0aee1589be41233ed868b39f402/api/routes.py#L321-L327

In `routes.py` the patron profile controller has the `requires_auth` decorator, which does the ILS auth, and puts the patron on the request. If there is no patron, then an error is returned and the route function is never called. This is what was causing the first auth request. 

Inside `app.manager.profiles.protocol()` we were making another call to `authenticated_patron_from_request` which was causing a second authentication request. Instead of doing this, we just use the patron object returned by the first call from the request.

## Motivation and Context

While testing the fix for PP-659, I noticed that requests for the `patrons/me` endpoint authenticate twice, which isn’t ideal. It increases load on our partner ILS, and its the slowest action we take, so this was making loading the patron profile document slower then it needed to be. 

## How Has This Been Tested?

Tested locally with a authentication provider to make sure that I no longer see duplicated requests to the remote auth service.

I don't think we need an additional test here since this test already makes sure that the `requires_auth` decorator is called and the patron is set on for calls to `patrons/me` https://github.com/ThePalaceProject/circulation/blob/7c2d0eeba9c3e0aee1589be41233ed868b39f402/tests/api/test_routes.py#L116-L129

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
