### PR TITLE
Fix parameters for enki call (PP-620)

### DIFF
--- a/api/enki.py
+++ b/api/enki.py
@@ -217,7 +217,7 @@ class EnkiAPI(
         headers = dict(extra_headers) if extra_headers else {}
         try:
             response = self._request(
-                method, url, headers=headers, data=data, params=params, **kwargs
+                url, method, headers=headers, data=data, params=params, **kwargs
             )
         except RequestTimedOut as e:
             if not retry_on_timeout:

--- a/tests/api/mockapi/enki.py
+++ b/tests/api/mockapi/enki.py
@@ -40,7 +40,7 @@ class MockEnkiAPI(EnkiAPI):
     def queue_response(self, status_code, headers={}, content=None):
         self.responses.insert(0, MockRequestsResponse(status_code, headers, content))
 
-    def _request(self, method, url, headers, data, params, **kwargs):
+    def _request(self, url, method, headers, data, params, **kwargs):
         """Override EnkiAPI._request to pull responses from a
         queue instead of making real HTTP requests
         """


### PR DESCRIPTION
## Description

Looks like I broke the enki API in this PR: https://github.com/ThePalaceProject/circulation/pull/1463 😅 

## Motivation and Context

Seeing this traceback occurring in our server logs:
```
Traceback (most recent call last):  File "/var/www/circulation/core/util/http.py", line 273, in _request_with_timeout    response = session.request(*args, **kwargs)  File "/var/www/circulation/env/lib/python3.8/site-packages/requests/sessions.py", line 575, in request    prep = self.prepare_request(req)  File "/var/www/circulation/env/lib/python3.8/site-packages/requests/sessions.py", line 486, in prepare_request    p.prepare(  File "/var/www/circulation/env/lib/python3.8/site-packages/requests/models.py", line 368, in prepare    self.prepare_url(url, params)  File "/var/www/circulation/env/lib/python3.8/site-packages/requests/models.py", line 439, in prepare_url    raise MissingSchema(requests.exceptions.MissingSchema: Invalid URL 'get': No scheme supplied. Perhaps you meant https://get?During handling of the above exception, another exception occurred:Traceback (most recent call last):  File "/var/www/circulation/env/lib/python3.8/site-packages/flask/app.py", line 867, in full_dispatch_request    rv = self.dispatch_request()  File "/var/www/circulation/env/lib/python3.8/site-packages/flask/app.py", line 852, in dispatch_request    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  File "/var/www/circulation/api/routes.py", line 115, in decorated    return f(*args, **kwargs)  File "/var/www/circulation/api/routes.py", line 88, in wrapped_function    resp = make_response(f(*args, **kwargs))  File "/var/www/circulation/api/routes.py", line 44, in decorated    return f(*args, **kwargs)  File "/var/www/circulation/core/app_server.py", line 106, in decorated    v = f(*args, **kwargs)  File "/var/www/circulation/api/routes.py", line 418, in borrow    return app.manager.loans.borrow(identifier_type, identifier, mechanism_id)  File "/var/www/circulation/api/controller.py", line 1441, in borrow    loan_or_hold, is_new = self._borrow(patron, credential, pool, mechanism)  File "/var/www/circulation/api/controller.py", line 1476, in _borrow    loan, hold, is_new = self.circulation.borrow(  File "/var/www/circulation/api/circulation.py", line 1137, in borrow    loan_info = api.checkout(  File "/var/www/circulation/api/enki.py", line 392, in checkout    response = self.loan_request(  File "/var/www/circulation/api/enki.py", line 446, in loan_request    response = self.request(url, method="get", params=args)  File "/var/www/circulation/api/enki.py", line 211, in request    response = self._request(  File "/var/www/circulation/api/enki.py", line 249, in _request    return HTTP.request_with_timeout(  File "/var/www/circulation/core/util/http.py", line 191, in request_with_timeout    return cls._request_with_timeout(  File "/var/www/circulation/core/util/http.py", line 292, in _request_with_timeout    raise RequestNetworkException(url, e)core.util.http.RequestNetworkException: Network error contacting get: Invalid URL 'get': No scheme supplied.
```

## How Has This Been Tested?

Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
