### PR TITLE
Add ISBN, when available, to playback time reports. (PP-572)

### DIFF
--- a/core/jobs/playtime_entries.py
+++ b/core/jobs/playtime_entries.py
@@ -254,7 +254,7 @@ class PlaytimeEntriesEmailReportsScript(Script):
         if identifier is None:
             return default_value
 
-        if _is_usable_isbn_identifier(identifier):
+        if identifier.type == Identifier.ISBN:
             return cast(str, identifier.identifier)
 
         # If our identifier is not an ISBN itself, we'll use our Recursive Equivalency
@@ -270,24 +270,7 @@ class PlaytimeEntriesEmailReportsScript(Script):
         )
 
         isbn = next(
-            map(
-                lambda id_: id_.identifier,
-                filter(
-                    lambda id_: _is_usable_isbn_identifier(id_), equivalent_identifiers
-                ),
-            ),
+            map(lambda id_: id_.identifier, equivalent_identifiers),
             None,
         )
         return isbn or default_value
-
-
-def _is_usable_isbn_identifier(id_: Identifier) -> bool:
-    """Is this a useful ISBN identifier?
-
-    :param identifier: The identifier to check.
-    """
-    return (
-        id_.type == Identifier.ISBN
-        and id_.identifier is not None
-        and id_.identifier != ""
-    )

--- a/core/jobs/playtime_entries.py
+++ b/core/jobs/playtime_entries.py
@@ -176,9 +176,15 @@ class PlaytimeEntriesEmailReportsScript(Script):
                 edition: Optional[Edition] = None
                 identifier: Optional[Identifier] = None
                 if identifier_id:
-                    identifier = get_one(self._db, Identifier, id=identifier_id)
                     edition = get_one(
                         self._db, Edition, primary_identifier_id=identifier_id
+                    )
+                    # Use the identifier from the edition where available.
+                    # Otherwise, we'll have to look it up.
+                    identifier = (
+                        edition.primary_identifier
+                        if edition
+                        else get_one(self._db, Identifier, id=identifier_id)
                     )
                 isbn = self._isbn_for_identifier(identifier)
                 title = edition and edition.title

--- a/core/jobs/playtime_entries.py
+++ b/core/jobs/playtime_entries.py
@@ -6,7 +6,7 @@ import os
 from collections import defaultdict
 from datetime import datetime, timedelta
 from tempfile import TemporaryFile
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import dateutil.parser
 import pytz
@@ -15,6 +15,7 @@ from sqlalchemy.sql.functions import sum
 from core.config import Configuration
 from core.model import get_one
 from core.model.edition import Edition
+from core.model.identifier import Identifier
 from core.model.time_tracking import PlaytimeEntry, PlaytimeSummary
 from core.util.datetime_helpers import previous_months, utc_now
 from core.util.email import EmailManager
@@ -154,7 +155,15 @@ class PlaytimeEntriesEmailReportsScript(Script):
             # Write the data as a CSV
             writer = csv.writer(temp)
             writer.writerow(
-                ["date", "urn", "collection", "library", "title", "total seconds"]
+                [
+                    "date",
+                    "urn",
+                    "isbn",
+                    "collection",
+                    "library",
+                    "title",
+                    "total seconds",
+                ]
             )
 
             for (
@@ -164,15 +173,19 @@ class PlaytimeEntriesEmailReportsScript(Script):
                 identifier_id,
                 total,
             ) in self._fetch_report_records(start=start, until=until):
-                edition = None
+                edition: Optional[Edition] = None
+                identifier: Optional[Identifier] = None
                 if identifier_id:
+                    identifier = get_one(self._db, Identifier, id=identifier_id)
                     edition = get_one(
                         self._db, Edition, primary_identifier_id=identifier_id
                     )
+                isbn = self._isbn_for_identifier(identifier)
                 title = edition and edition.title
                 row = (
                     report_date_label,
                     urn,
+                    isbn,
                     collection_name,
                     library_name,
                     title,
@@ -218,3 +231,52 @@ class PlaytimeEntriesEmailReportsScript(Script):
                 PlaytimeSummary.identifier_id,
             )
         )
+
+    @staticmethod
+    def _isbn_for_identifier(
+        identifier: Optional[Identifier],
+        /,
+        *,
+        default_value: str = "",
+        default_match_strength=-1,
+    ) -> str:
+        """Find the strongest ISBN match for the given identifier.
+
+        :param identifier: The identifier to match.
+        :param default_value: The default value to return if the identifier is missing or a match is not found.
+        :param default_match_strength: The default strength for an equivalent, if none is present.
+        """
+        if identifier is None:
+            return default_value
+
+        isbn = (
+            identifier.identifier
+            if _is_usable_isbn_identifier(identifier)
+            else next(
+                map(
+                    lambda equivalency: equivalency.output.identifier,
+                    sorted(
+                        filter(
+                            lambda equivalency: _is_usable_isbn_identifier(
+                                equivalency.output
+                            ),
+                            identifier.equivalencies,
+                        ),
+                        key=lambda equivalency: equivalency.strength
+                        or default_match_strength,
+                        reverse=True,
+                    ),
+                ),
+                None,
+            )
+        )
+        return isbn or default_value
+
+
+def _is_usable_isbn_identifier(id_: Identifier) -> bool:
+    """Is this a useful ISBN identifier?"""
+    return (
+        id_.type == Identifier.ISBN
+        and id_.identifier is not None
+        and id_.identifier != ""
+    )

--- a/tests/core/jobs/test_playtime_entries.py
+++ b/tests/core/jobs/test_playtime_entries.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timedelta
-from typing import List
+from typing import List, Optional
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -17,7 +17,7 @@ from core.jobs.playtime_entries import (
 )
 from core.model import create
 from core.model.collection import Collection
-from core.model.identifier import Identifier
+from core.model.identifier import Equivalency, Identifier
 from core.model.library import Library
 from core.model.time_tracking import PlaytimeEntry, PlaytimeSummary
 from core.util.datetime_helpers import datetime_utc, previous_months, utc_now
@@ -229,6 +229,26 @@ class TestPlaytimeEntriesEmailReportsScript:
         collection2 = db.collection()
         library2 = db.library()
 
+        isbn_ids: dict[str, Identifier] = {
+            "i1": db.identifier(
+                identifier_type=Identifier.ISBN, foreign_id="080442957X"
+            ),
+            "i2": db.identifier(
+                identifier_type=Identifier.ISBN, foreign_id="9788175257665"
+            ),
+        }
+        identifier.equivalencies = [
+            Equivalency(
+                input_id=identifier.id, output_id=isbn_ids["i1"].id, strength=0.5
+            ),
+            Equivalency(
+                input_id=isbn_ids["i1"].id, output_id=isbn_ids["i2"].id, strength=1
+            ),
+        ]
+        db.session.flush()
+        strongest_isbn = isbn_ids["i2"].identifier
+        no_isbn = ""
+
         playtime(db.session, identifier, collection, library, date3m(3), 1)
         playtime(db.session, identifier, collection, library, date3m(31), 2)
         playtime(
@@ -249,7 +269,7 @@ class TestPlaytimeEntriesEmailReportsScript:
 
         reporting_name = "test cm"
 
-        # Horrible unbracketted syntax for python 3.8
+        # Horrible unbracketed syntax for python 3.8
         with patch("core.jobs.playtime_entries.csv.writer") as writer, patch(
             "core.jobs.playtime_entries.EmailManager"
         ) as email, patch(
@@ -271,18 +291,65 @@ class TestPlaytimeEntriesEmailReportsScript:
         call_args = writer().writerow.call_args_list
         assert call_args == [
             call(
-                ["date", "urn", "collection", "library", "title", "total seconds"]
+                [
+                    "date",
+                    "urn",
+                    "isbn",
+                    "collection",
+                    "library",
+                    "title",
+                    "total seconds",
+                ]
             ),  # Header
-            call((column1, identifier.urn, collection2.name, library2.name, None, 300)),
-            call((column1, identifier.urn, collection2.name, library.name, None, 100)),
-            call((column1, identifier.urn, collection.name, library2.name, None, 200)),
             call(
-                (column1, identifier.urn, collection.name, library.name, None, 3)
+                (
+                    column1,
+                    identifier.urn,
+                    strongest_isbn,
+                    collection2.name,
+                    library2.name,
+                    None,
+                    300,
+                )
+            ),
+            call(
+                (
+                    column1,
+                    identifier.urn,
+                    strongest_isbn,
+                    collection2.name,
+                    library.name,
+                    None,
+                    100,
+                )
+            ),
+            call(
+                (
+                    column1,
+                    identifier.urn,
+                    strongest_isbn,
+                    collection.name,
+                    library2.name,
+                    None,
+                    200,
+                )
+            ),
+            call(
+                (
+                    column1,
+                    identifier.urn,
+                    strongest_isbn,
+                    collection.name,
+                    library.name,
+                    None,
+                    3,
+                )
             ),  # Identifier without edition
             call(
                 (
                     column1,
                     identifier2.urn,
+                    no_isbn,
                     collection.name,
                     library.name,
                     edition.title,
@@ -305,7 +372,7 @@ class TestPlaytimeEntriesEmailReportsScript:
         identifier = db.identifier()
         collection = db.default_collection()
         library = db.default_library()
-        entry = playtime(db.session, identifier, collection, library, date3m(20), 1)
+        _ = playtime(db.session, identifier, collection, library, date3m(20), 1)
 
         with patch("core.jobs.playtime_entries.os.environ", new={}):
             script = PlaytimeEntriesEmailReportsScript(db.session)
@@ -314,7 +381,112 @@ class TestPlaytimeEntriesEmailReportsScript:
 
             assert script._log.error.call_count == 1
             assert script._log.warning.call_count == 1
-            assert "date,urn,collection," in script._log.warning.call_args[0][0]
+            assert "date,urn,isbn,collection," in script._log.warning.call_args[0][0]
+
+    @pytest.mark.parametrize(
+        "id_key, equivalents, default_value, default_match_strength, expected_isbn",
+        [
+            # If the identifier is an ISBN, we will not use an equivalency.
+            [
+                "i1",
+                (("g1", "g2", 1), ("g2", "i1", 1), ("g1", "i2", 0.5)),
+                "",
+                -1,
+                "080442957X",
+            ],
+            [
+                "i2",
+                (("g1", "g2", 1), ("g2", "i1", 0.5), ("g1", "i2", 1)),
+                "",
+                -1,
+                "9788175257665",
+            ],
+            ["i1", (("i1", "i2", 200),), "", -1, "080442957X"],
+            ["i2", (("i2", "i1", 200),), "", -1, "9788175257665"],
+            # If identifier is not an ISBN, but has an equivalency that is, use the strongest match.
+            [
+                "g2",
+                (("g1", "g2", 1), ("g2", "i1", 1), ("g1", "i2", 0.5)),
+                "",
+                -1,
+                "080442957X",
+            ],
+            [
+                "g2",
+                (("g1", "g2", 1), ("g2", "i1", 0.5), ("g1", "i2", 1)),
+                "",
+                -1,
+                "9788175257665",
+            ],
+            [
+                "g2",
+                (("g1", "g2", 1), ("g2", "i1", 0.5), ("g1", "i2", None)),
+                "",
+                -1,
+                "080442957X",
+            ],
+            [
+                "g2",
+                (("g1", "g2", 1), ("g2", "i1", 0.5), ("g1", "i2", None)),
+                "",
+                1,
+                "9788175257665",
+            ],
+            [
+                "g2",
+                (("g1", "g2", 1), ("g2", "i1", -2), ("g1", "i2", None)),
+                "",
+                -1,
+                "9788175257665",
+            ],
+            # If we don't find an equivalent ISBN identifier, then we'll use the default.
+            ["g2", (), "default value", -1, "default value"],
+            ["g1", (("g1", "g2", 1),), "default value", -1, "default value"],
+            # If identifier is None, expect default value.
+            [None, (), "default value", -1, "default value"],
+        ],
+    )
+    def test__isbn_for_identifier(
+        self,
+        db: DatabaseTransactionFixture,
+        id_key: str | None,
+        equivalents: tuple[tuple[str, str, Optional[int | float]]],
+        default_value: str,
+        default_match_strength: Optional[int | float],
+        expected_isbn: str,
+    ):
+        ids: dict[str, Identifier] = {
+            "i1": db.identifier(
+                identifier_type=Identifier.ISBN, foreign_id="080442957X"
+            ),
+            "i2": db.identifier(
+                identifier_type=Identifier.ISBN, foreign_id="9788175257665"
+            ),
+            "g1": db.identifier(identifier_type=Identifier.GUTENBERG_ID),
+            "g2": db.identifier(identifier_type=Identifier.GUTENBERG_ID),
+        }
+        equivalencies = [
+            Equivalency(
+                input_id=ids[equivalent[0]].id,
+                output_id=ids[equivalent[1]].id,
+                strength=equivalent[2],
+            )
+            for equivalent in equivalents
+        ]
+
+        test_identifier: Optional[Identifier] = (
+            ids[id_key] if id_key is not None else None
+        )
+        if test_identifier is not None:
+            test_identifier.equivalencies = equivalencies
+            db.session.flush()
+
+        result = PlaytimeEntriesEmailReportsScript._isbn_for_identifier(
+            test_identifier,
+            default_value=default_value,
+            default_match_strength=default_match_strength,
+        )
+        assert result == expected_isbn
 
     @pytest.mark.parametrize(
         "current_utc_time, start_arg, expected_start, until_arg, expected_until",

--- a/tests/core/jobs/test_playtime_entries.py
+++ b/tests/core/jobs/test_playtime_entries.py
@@ -384,75 +384,49 @@ class TestPlaytimeEntriesEmailReportsScript:
             assert "date,urn,isbn,collection," in script._log.warning.call_args[0][0]
 
     @pytest.mark.parametrize(
-        "id_key, equivalents, default_value, default_match_strength, expected_isbn",
+        "id_key, equivalents, default_value, expected_isbn",
         [
             # If the identifier is an ISBN, we will not use an equivalency.
             [
                 "i1",
                 (("g1", "g2", 1), ("g2", "i1", 1), ("g1", "i2", 0.5)),
                 "",
-                -1,
                 "080442957X",
             ],
             [
                 "i2",
                 (("g1", "g2", 1), ("g2", "i1", 0.5), ("g1", "i2", 1)),
                 "",
-                -1,
                 "9788175257665",
             ],
-            ["i1", (("i1", "i2", 200),), "", -1, "080442957X"],
-            ["i2", (("i2", "i1", 200),), "", -1, "9788175257665"],
+            ["i1", (("i1", "i2", 200),), "", "080442957X"],
+            ["i2", (("i2", "i1", 200),), "", "9788175257665"],
             # If identifier is not an ISBN, but has an equivalency that is, use the strongest match.
             [
                 "g2",
                 (("g1", "g2", 1), ("g2", "i1", 1), ("g1", "i2", 0.5)),
                 "",
-                -1,
                 "080442957X",
             ],
             [
                 "g2",
                 (("g1", "g2", 1), ("g2", "i1", 0.5), ("g1", "i2", 1)),
                 "",
-                -1,
-                "9788175257665",
-            ],
-            [
-                "g2",
-                (("g1", "g2", 1), ("g2", "i1", 0.5), ("g1", "i2", None)),
-                "",
-                -1,
-                "080442957X",
-            ],
-            [
-                "g2",
-                (("g1", "g2", 1), ("g2", "i1", 0.5), ("g1", "i2", None)),
-                "",
-                1,
-                "9788175257665",
-            ],
-            [
-                "g2",
-                (("g1", "g2", 1), ("g2", "i1", -2), ("g1", "i2", None)),
-                "",
-                -1,
                 "9788175257665",
             ],
             # If we don't find an equivalent ISBN identifier, then we'll use the default.
-            ["g2", (), "default value", -1, "default value"],
-            ["g1", (("g1", "g2", 1),), "default value", -1, "default value"],
+            ["g2", (), "default value", "default value"],
+            ["g1", (("g1", "g2", 1),), "default value", "default value"],
             # If identifier is None, expect default value.
-            [None, (), "default value", -1, "default value"],
+            [None, (), "default value", "default value"],
         ],
     )
     def test__isbn_for_identifier(
         self,
         db: DatabaseTransactionFixture,
         id_key: str | None,
-        equivalents: tuple[tuple[str, str, Optional[int | float]]],
+        equivalents: tuple[tuple[str, str, int | float]],
         default_value: str,
-        default_match_strength: Optional[int | float],
         expected_isbn: str,
     ):
         ids: dict[str, Identifier] = {
@@ -484,7 +458,6 @@ class TestPlaytimeEntriesEmailReportsScript:
         result = PlaytimeEntriesEmailReportsScript._isbn_for_identifier(
             test_identifier,
             default_value=default_value,
-            default_match_strength=default_match_strength,
         )
         assert result == expected_isbn
 


### PR DESCRIPTION
## Description

- Adds an ISBN column to the audiobook playbook time reports.
- Attempts to find the best equivalent ISBN identifier, if the book identifier is not an ISBN.

## Motivation and Context

[Jira [PP-572](https://ebce-lyrasis.atlassian.net/browse/PP-572)]

## How Has This Been Tested?

- New tests for report output and ISBN identifier matching.
- Manual testing in local development environment, including verify report delivery.
- CI tests for the associated branch passed.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-572]: https://ebce-lyrasis.atlassian.net/browse/PP-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ