### PR TITLE
PP-745 Removed patron synchronization checks for annotations

### DIFF
--- a/api/annotations.py
+++ b/api/annotations.py
@@ -149,9 +149,6 @@ class AnnotationWriter:
 class AnnotationParser:
     @classmethod
     def parse(cls, _db, data, patron):
-        if patron.synchronize_annotations != True:
-            return PATRON_NOT_OPTED_IN_TO_ANNOTATION_SYNC
-
         try:
             data = json.loads(data)
             if "id" in data and data["id"] is None:

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -271,13 +271,6 @@ INVALID_ANALYTICS_EVENT_TYPE = pd(
     detail=_("The analytics event must be a supported type."),
 )
 
-PATRON_NOT_OPTED_IN_TO_ANNOTATION_SYNC = pd(
-    "http://librarysimplified.org/terms/problem/opt-in-required",
-    status_code=403,
-    title=_("Patron must opt in."),
-    detail=_("The patron must opt in to synchronize annotations to a server."),
-)
-
 INVALID_ANNOTATION_MOTIVATION = pd(
     "http://librarysimplified.org/terms/problem/invalid-annotation-motivation",
     status_code=400,

--- a/core/model/patron.py
+++ b/core/model/patron.py
@@ -729,9 +729,6 @@ class Annotation(Base):
         """Find or create an Annotation, but only if the patron has
         annotation sync turned on.
         """
-        if not patron.synchronize_annotations:
-            raise ValueError("Patron has opted out of synchronizing annotations.")
-
         return get_one_or_create(_db, Annotation, patron=patron, *args, **kwargs)
 
     def set_inactive(self):

--- a/tests/api/test_annotations.py
+++ b/tests/api/test_annotations.py
@@ -749,4 +749,6 @@ class TestAnnotationParser:
             data_json,
             annotation_parser_fixture.patron_value,
         )
-        assert PATRON_NOT_OPTED_IN_TO_ANNOTATION_SYNC == annotation
+
+        # We no longer respect the patron settings for sync
+        assert isinstance(annotation, Annotation)

--- a/tests/api/test_controller_profile.py
+++ b/tests/api/test_controller_profile.py
@@ -82,16 +82,7 @@ class TestProfileController:
             )
             assert request_patron.synchronize_annotations is None
 
-            # This means we can't create annotations for them.
-            pytest.raises(
-                ValueError,
-                Annotation.get_one_or_create,
-                profile_fixture.db.session,
-                patron=request_patron,
-                identifier=identifier,
-            )
-
-            # But by sending a PUT request...
+            # By sending a PUT request...
             profile_fixture.manager.profiles.protocol()
 
             # ...we can change synchronize_annotations to True.

--- a/tests/core/models/test_patron.py
+++ b/tests/core/models/test_patron.py
@@ -428,19 +428,6 @@ class TestPatron:
         db.session.commit()
         assert 0 == len(p1.annotations)
 
-        # Patron #1 can no longer use Annotation.get_one_or_create.
-        pytest.raises(
-            ValueError,
-            Annotation.get_one_or_create,
-            db.session,
-            patron=p1,
-            identifier=identifier,
-            motivation=Annotation.IDLING,
-        )
-
-        # Patron #2's annotation is unaffected.
-        assert 1 == len(p2.annotations)
-
         # But patron #2 can use Annotation.get_one_or_create.
         i2, is_new = Annotation.get_one_or_create(
             db.session,


### PR DESCRIPTION
## Description
Now the CM will record annotations regardless of patron settings
The checks were removed from the controller, and the patron data model.

There is a side-effect of the patron disabling their sync which deletes all previous annotations. Should that be removed as well?
<!--- Describe your changes -->

## Motivation and Context
The Apps should be able to sync their data regardless of Patron settings.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests were updated to reflect the changes.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
