### PR TITLE
Library short name being saved into library settings (PP-754)

### DIFF
--- a/alembic/versions/20231122_e4b120a8d1d5_remove_short_name_from_library_settings.py
+++ b/alembic/versions/20231122_e4b120a8d1d5_remove_short_name_from_library_settings.py
@@ -22,6 +22,7 @@ log = migration_logger(revision)
 def upgrade() -> None:
     conn = op.get_bind()
 
+    # Find all the library configurations that have a short_name key in their settings.
     rows = conn.execute(
         "select parent_id, library_id, settings from integration_library_configurations where settings ? 'short_name'"
     ).all()

--- a/alembic/versions/20231122_e4b120a8d1d5_remove_short_name_from_library_settings.py
+++ b/alembic/versions/20231122_e4b120a8d1d5_remove_short_name_from_library_settings.py
@@ -1,0 +1,46 @@
+"""Remove short_name from library settings.
+
+Revision ID: e4b120a8d1d5
+Revises: 2d72d6876c52
+Create Date: 2023-11-22 16:28:55.759169+00:00
+
+"""
+from alembic import op
+from core.migration.util import migration_logger
+from core.model import json_serializer
+
+# revision identifiers, used by Alembic.
+revision = "e4b120a8d1d5"
+down_revision = "2d72d6876c52"
+branch_labels = None
+depends_on = None
+
+
+log = migration_logger(revision)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    rows = conn.execute(
+        "select parent_id, library_id, settings from integration_library_configurations where settings ? 'short_name'"
+    ).all()
+
+    for row in rows:
+        settings = row.settings.copy()
+        short_name = settings.get("short_name")
+        del settings["short_name"]
+        log.info(
+            f"Removing short_name {short_name} from library configuration "
+            f"(parent:{row.parent_id}/library:{row.library_id}) {settings}"
+        )
+        settings_json = json_serializer(settings)
+        conn.execute(
+            "update integration_library_configurations set settings = (%s) where parent_id = (%s) and library_id = (%s)",
+            (settings_json, row.parent_id, row.library_id),
+        )
+
+
+def downgrade() -> None:
+    # No need to do anything here. The key was never used.
+    pass

--- a/api/admin/controller/integration_settings.py
+++ b/api/admin/controller/integration_settings.py
@@ -235,7 +235,26 @@ class IntegrationSettingsController(ABC, Generic[T], LoggerMixin):
     ) -> ChangedLibrariesTuple:
         """
         Return a tuple of lists of libraries that have had their library settings
-        added, updated, or removed.
+        added, updated, or removed. No action is taken to add, update, or remove
+        the settings, this function just parses the submitted data and returns
+        the lists of libraries that need to be processed.
+
+        :param service: The IntegrationConfiguration that the library settings should be
+            associated with.
+        :param libraries_data: A JSON string containing a list of dictionaries.
+            Each dictionary has a 'short_name' key that identifies which
+            library the settings are for, and then the rest of the dictionary is the
+            settings for that library.
+
+        :return: A named tuple with three lists of libraries:
+            - new: A list of UpdatedLibrarySettingsTuple named tuples that contains the
+                IntegrationLibraryConfiguration and settings for each library with newly
+                added settings.
+            - updated: A list of UpdatedLibrarySettingsTuple named tuples that contains the
+                IntegrationLibraryConfiguration and settings for each library that had its
+                settings updated.
+            - removed: A list of IntegrationLibraryConfiguration objects for libraries that
+                had their settings removed.
         """
         libraries = json.loads(libraries_data)
         existing_library_settings = {
@@ -244,6 +263,9 @@ class IntegrationSettingsController(ABC, Generic[T], LoggerMixin):
 
         submitted_library_settings = {}
         for library in libraries:
+            # Each library settings dictionary should have a 'short_name' key that identifies
+            # which library the settings are for. This key is removed from the dictionary as
+            # only the settings should be stored in the database.
             short_name = library.get("short_name")
             if short_name is None:
                 self.log.error(

--- a/api/admin/controller/integration_settings.py
+++ b/api/admin/controller/integration_settings.py
@@ -241,7 +241,21 @@ class IntegrationSettingsController(ABC, Generic[T], LoggerMixin):
         existing_library_settings = {
             c.library.short_name: c for c in service.library_configurations
         }
-        submitted_library_settings = {l.get("short_name"): l for l in libraries}
+
+        submitted_library_settings = {}
+        for library in libraries:
+            short_name = library.get("short_name")
+            if short_name is None:
+                self.log.error(
+                    f"Library settings missing short_name. Settings: {library}."
+                )
+                raise ProblemError(
+                    INVALID_INPUT.detailed(
+                        "Invalid library settings, missing short_name."
+                    )
+                )
+            del library["short_name"]
+            submitted_library_settings[short_name] = library
 
         removed = [
             existing_library_settings[library]


### PR DESCRIPTION
## Description

The library `short_name` is being saved into the library settings when it shouldn't be.

## Motivation and Context

This isn't causing any issues, but it likely slowing down our loading process, and causing unnecessary noise in the logs, so its good to clean up.

## How Has This Been Tested?

Running unit tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
