### PR TITLE
Make sure default audience can be selected (PP-752)

### DIFF
--- a/api/saml/configuration/model.py
+++ b/api/saml/configuration/model.py
@@ -1,8 +1,7 @@
 import html
 from datetime import datetime
-from enum import Enum
 from threading import Lock
-from typing import Any, Dict, List, Optional, Pattern, Union
+from typing import Any, Dict, List, Optional, Pattern
 
 from flask_babel import lazy_gettext as _
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
@@ -33,6 +32,7 @@ from core.exceptions import BaseError
 from core.integration.settings import (
     ConfigurationFormItem,
     ConfigurationFormItemType,
+    ConfigurationFormOptionsType,
     FormField,
     SettingsValidationError,
 )
@@ -52,9 +52,9 @@ class FederatedIdentityProviderOptions:
         """Initialize a new instance of FederatedIdentityProviderOptions class."""
         self._mutex = Lock()
         self._last_updated_at = datetime.min
-        self._options: Dict[Union[Enum, str], str] = {}
+        self._options: ConfigurationFormOptionsType = {}
 
-    def __call__(self, db: Session) -> Dict[Union[Enum, str], str]:
+    def __call__(self, db: Session) -> ConfigurationFormOptionsType:
         """Get federated identity provider options."""
         with self._mutex:
             if self._needs_refresh(db):
@@ -76,7 +76,7 @@ class FederatedIdentityProviderOptions:
         return needs_refresh
 
     @staticmethod
-    def _fetch(db: Session) -> Dict[Union[Enum, str], str]:
+    def _fetch(db: Session) -> ConfigurationFormOptionsType:
         """Fetch federated identity provider options."""
         identity_providers = (
             db.query(

--- a/core/integration/settings.py
+++ b/core/integration/settings.py
@@ -198,6 +198,8 @@ class ConfigurationFormItem:
 
     @staticmethod
     def get_form_value(value: Any) -> Any:
+        if value is None:
+            return ""
         if isinstance(value, Enum):
             return value.value
         if isinstance(value, bool):

--- a/core/integration/settings.py
+++ b/core/integration/settings.py
@@ -155,6 +155,9 @@ class ConfigurationFormItemType(Enum):
     IMAGE = "image"
 
 
+ConfigurationFormOptionsType = Mapping[Union[Enum, str, None], str]
+
+
 @dataclass(frozen=True)
 class ConfigurationFormItem:
     """
@@ -182,9 +185,9 @@ class ConfigurationFormItem:
     # When the type is SELECT, LIST, or MENU, the options are used to populate the
     # field in the admin interface. This can either be a callable that returns a
     # dictionary of options or a dictionary of options.
-    options: Callable[[Session], Dict[Enum | str, str]] | Mapping[
-        Enum | str, str
-    ] | None = None
+    options: Callable[
+        [Session], ConfigurationFormOptionsType
+    ] | ConfigurationFormOptionsType | None = None
 
     # Required is usually determined by the Pydantic model, but can be overridden
     # here, in the case where a field would not be required in the model, but is

--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -112,8 +112,6 @@ class OPDSImporterSettings(
     SAMLWAYFlessSetttings,
     FormatPrioritiesSettings,
 ):
-    _NO_DEFAULT_AUDIENCE = ""
-
     external_account_id: AnyHttpUrl = FormField(
         form=ConfigurationFormItem(
             label=_("URL"),
@@ -125,8 +123,8 @@ class OPDSImporterSettings(
         form=ConfigurationFormItem(label=_("Data source name"), required=True)
     )
 
-    default_audience: str = FormField(
-        default=_NO_DEFAULT_AUDIENCE,
+    default_audience: Optional[str] = FormField(
+        None,
         form=ConfigurationFormItem(
             label=_("Default audience"),
             description=_(
@@ -135,7 +133,7 @@ class OPDSImporterSettings(
             ),
             type=ConfigurationFormItemType.SELECT,
             options={
-                **{_NO_DEFAULT_AUDIENCE: _("No default audience")},
+                **{None: _("No default audience")},
                 **{audience: audience for audience in sorted(Classifier.AUDIENCES)},
             },
             required=False,


### PR DESCRIPTION
## Description

We were unable to select "Default Audience" in the OPDS configuration form prior to this change. It would always just report that a required value was missing.

## Motivation and Context

Fix issue submitting the OPDS configuration form.

## How Has This Been Tested?

Local testing in CM admin interface.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
