### PR TITLE
Track code coverage for scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ exclude_also = [
 [tool.coverage.run]
 branch = true
 relative_files = true
-source = ["api", "core"]
+source = ["api", "core", "scripts"]
 
 [tool.isort]
 known_first_party = ["api", "core", "customlists"]


### PR DESCRIPTION
## Description

Right now codecov is showing coverage for the `scripts.py` file, but we have it excluded from our code coverage configuration, so the code coverage isn't being properly tracked. This config change should let us track the coverage for this file.

## Motivation and Context

In #1523 I was getting a codecov failure for lines that should have been covered, I believe this is because of this configuration. I think this is going to cause our code coverage to drop, but that is just a side effect of properly tracking the coverage here. 

## How Has This Been Tested?

Running tests locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
