### PR TITLE
Count all eligible licenses (PP-527)

### DIFF
--- a/core/model/licensing.py
+++ b/core/model/licensing.py
@@ -148,7 +148,7 @@ class License(Base, LicenseFunctions):
 
     @property
     def is_available_for_borrowing(self) -> bool:
-        "Can this license currently be used to borrow a book?"
+        """Can this license currently be used to borrow a book?"""
         return (
             not self.is_inactive
             and self.checkouts_available is not None

--- a/tests/core/models/test_licensing.py
+++ b/tests/core/models/test_licensing.py
@@ -481,32 +481,32 @@ class TestLicense:
 
         # First, we use the time-limited license that's expiring first.
         assert time_limited_2 == licenses.pool.best_available_license()
-        time_limited_2.loan_to(licenses.db.patron())
+        time_limited_2.checkout()
 
         # When that's not available, we use the next time-limited license.
         assert licenses.time_limited == licenses.pool.best_available_license()
-        licenses.time_limited.loan_to(licenses.db.patron())
+        licenses.time_limited.checkout()
 
         # The time-and-loan-limited license also counts as time-limited for this.
         assert licenses.time_and_loan_limited == licenses.pool.best_available_license()
-        licenses.time_and_loan_limited.loan_to(licenses.db.patron())
+        licenses.time_and_loan_limited.checkout()
 
         # Next is the perpetual license.
         assert licenses.perpetual == licenses.pool.best_available_license()
-        licenses.perpetual.loan_to(licenses.db.patron())
+        licenses.perpetual.checkout()
 
         # Then the loan-limited license with the most remaining checkouts.
         assert licenses.loan_limited == licenses.pool.best_available_license()
-        licenses.loan_limited.loan_to(licenses.db.patron())
+        licenses.loan_limited.checkout()
 
         # That license allows 2 concurrent checkouts, so it's still the
         # best license until it's checked out again.
         assert licenses.loan_limited == licenses.pool.best_available_license()
-        licenses.loan_limited.loan_to(licenses.db.patron())
+        licenses.loan_limited.checkout()
 
         # There's one more loan-limited license.
         assert loan_limited_2 == licenses.pool.best_available_license()
-        loan_limited_2.loan_to(licenses.db.patron())
+        loan_limited_2.checkout()
 
         # Now all licenses are either loaned out or expired.
         assert None == licenses.pool.best_available_license()


### PR DESCRIPTION
## Description

- Don't use a license's active loans when determining its eligibility for a checkout.
- Update tests to perform checkout, so that license accounting happens.

## Motivation and Context

Because `License.checkouts_available` already accounts for active loans, we
were effectively reducing the number of concurrent loans available.

[Jira [PP-527](https://ebce-lyrasis.atlassian.net/browse/PP-527)]

## How Has This Been Tested?

- Manually tested in local development environment.
- CI tests for associated branch have passed.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-527]: https://ebce-lyrasis.atlassian.net/browse/PP-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ