### PR TITLE
Refactor IntegrationSettingsController

### DIFF
--- a/api/admin/controller/patron_auth_services.py
+++ b/api/admin/controller/patron_auth_services.py
@@ -62,30 +62,8 @@ class PatronAuthServicesController(
     def process_post(self) -> Union[Response, ProblemDetail]:
         try:
             form_data = flask.request.form
-            protocol = form_data.get("protocol", None, str)
-            id = form_data.get("id", None, int)
-            name = form_data.get("name", None, str)
-            libraries_data = form_data.get("libraries", None, str)
-
-            if protocol is None and id is None:
-                raise ProblemError(NO_PROTOCOL_FOR_NEW_SERVICE)
-
-            if protocol is None or protocol not in self.registry:
-                self.log.warning(
-                    f"Unknown patron authentication service protocol: {protocol}"
-                )
-                raise ProblemError(UNKNOWN_PROTOCOL)
-
-            if id is not None:
-                # Find an existing service to edit
-                auth_service = self.get_existing_service(id, name, protocol)
-                response_code = 200
-            else:
-                # Create a new service
-                if name is None:
-                    raise ProblemError(MISSING_PATRON_AUTH_NAME)
-                auth_service = self.create_new_service(name, protocol)
-                response_code = 201
+            libraries_data = self.get_libraries_data(form_data)
+            auth_service, protocol, response_code = self.get_service(form_data)
 
             # Update settings
             impl_cls = self.registry[protocol]

--- a/api/admin/problem_details.py
+++ b/api/admin/problem_details.py
@@ -154,13 +154,6 @@ MISSING_COLLECTION = pd(
     detail=_("The specified collection does not exist."),
 )
 
-MISSING_COLLECTION_NAME = pd(
-    "http://librarysimplified.org/terms/problem/missing-collection-name",
-    status_code=400,
-    title=_("Missing collection name."),
-    detail=_("You must identify the collection by its name."),
-)
-
 MISSING_ANALYTICS_NAME = pd(
     "http://librarysimplified.org/terms/problem/missing-analytics-name",
     status_code=400,
@@ -200,11 +193,11 @@ CANNOT_CHANGE_PROTOCOL = pd(
     detail=_("A protocol can't be changed once it has been set."),
 )
 
-MISSING_PATRON_AUTH_NAME = pd(
-    "http://librarysimplified.org/terms/problem/missing-patron-auth-name",
+MISSING_SERVICE_NAME = pd(
+    "http://librarysimplified.org/terms/problem/missing-service-name",
     status_code=400,
-    title=_("Missing patron auth service name."),
-    detail=_("You must identify the patron auth service by its name."),
+    title=_("Missing service name."),
+    detail=_("You must identify the service by its name."),
 )
 
 PROTOCOL_DOES_NOT_SUPPORT_PARENTS = pd(

--- a/tests/api/admin/controller/test_collections.py
+++ b/tests/api/admin/controller/test_collections.py
@@ -12,9 +12,9 @@ from api.admin.problem_details import (
     CANNOT_DELETE_COLLECTION_WITH_CHILDREN,
     INCOMPLETE_CONFIGURATION,
     INTEGRATION_NAME_ALREADY_IN_USE,
-    MISSING_COLLECTION_NAME,
     MISSING_PARENT,
     MISSING_SERVICE,
+    MISSING_SERVICE_NAME,
     NO_PROTOCOL_FOR_NEW_SERVICE,
     NO_SUCH_LIBRARY,
     PROTOCOL_DOES_NOT_SUPPORT_PARENTS,
@@ -164,7 +164,7 @@ class TestCollectionSettings:
         [
             pytest.param(
                 {"protocol": "Overdrive"},
-                MISSING_COLLECTION_NAME,
+                MISSING_SERVICE_NAME,
                 False,
                 id="missing_name",
             ),

--- a/tests/api/admin/controller/test_patron_auth.py
+++ b/tests/api/admin/controller/test_patron_auth.py
@@ -17,8 +17,8 @@ from api.admin.problem_details import (
     INTEGRATION_NAME_ALREADY_IN_USE,
     INVALID_CONFIGURATION_OPTION,
     INVALID_LIBRARY_IDENTIFIER_RESTRICTION_REGULAR_EXPRESSION,
-    MISSING_PATRON_AUTH_NAME,
     MISSING_SERVICE,
+    MISSING_SERVICE_NAME,
     MULTIPLE_BASIC_AUTH_SERVICES,
     NO_PROTOCOL_FOR_NEW_SERVICE,
     NO_SUCH_LIBRARY,
@@ -366,7 +366,7 @@ class TestPatronAuth:
         )
         response = post_response(form)
         assert isinstance(response, ProblemDetail)
-        assert response.uri == MISSING_PATRON_AUTH_NAME.uri
+        assert response == MISSING_SERVICE_NAME
 
     def test_patron_auth_services_post_no_such_library(
         self,


### PR DESCRIPTION
## Description

Refactor `IntegrationSettingsController`, to reduce the amount of copy / paste needed to implement the `process_post` method in subclasses.

## Motivation and Context

This was originally part of https://github.com/ThePalaceProject/circulation/pull/1523 but the code review requested that it be broken out into its own PR.

## How Has This Been Tested?

Running tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
