### PR TITLE
Add collection name and distributor facets to the crawlable feed (PP-775)

### DIFF
--- a/api/controller.py
+++ b/api/controller.py
@@ -1047,11 +1047,13 @@ class OPDSFeedController(CirculationManagerController):
         if isinstance(search_engine, ProblemDetail):
             return search_engine
 
-        annotator = annotator or self.manager.annotator(worklist)
-
         # A crawlable feed has only one possible set of Facets,
         # so library settings are irrelevant.
-        facets = CrawlableFacets.default(None)
+        facets = self.manager.load_facets_from_request(
+            worklist=worklist,
+            base_class=CrawlableFacets,
+        )
+        annotator = annotator or self.manager.annotator(worklist, facets=facets)
 
         return feed_class.page(
             _db=self._db,

--- a/api/lanes.py
+++ b/api/lanes.py
@@ -1361,7 +1361,15 @@ class CrawlableFacets(Facets):
 
     @classmethod
     def available_facets(cls, config, facet_group_name):
-        return [cls.SETTINGS[facet_group_name]]
+        facets = [cls.SETTINGS[facet_group_name]]
+
+        if (
+            facet_group_name == Facets.DISTRIBUTOR_FACETS_GROUP_NAME
+            or facet_group_name == Facets.COLLECTION_NAME_FACETS_GROUP_NAME
+        ) and config is not None:
+            facets.extend(config.enabled_facets(facet_group_name))
+
+        return facets
 
     @classmethod
     def default_facet(cls, config, facet_group_name):

--- a/tests/api/test_controller_crawlfeed.py
+++ b/tests/api/test_controller_crawlfeed.py
@@ -242,7 +242,7 @@ class TestCrawlableFeed:
 
         # Good pagination data -> feed_class.page() is called.
         sort_key = ["sort", "pagination", "key"]
-        with circulation_fixture.app.test_request_context(
+        with circulation_fixture.request_context_with_library(
             "/?size=23&key=%s" % json.dumps(sort_key)
         ):
             response = circulation_fixture.manager.opds_feeds._crawlable_feed(
@@ -288,7 +288,7 @@ class TestCrawlableFeed:
         # If a custom Annotator is passed in to _crawlable_feed, it's
         # propagated to the page() call.
         mock_annotator = object()
-        with circulation_fixture.app.test_request_context("/"):
+        with circulation_fixture.request_context_with_library("/"):
             response = circulation_fixture.manager.opds_feeds._crawlable_feed(
                 annotator=mock_annotator, **in_kwargs
             )
@@ -306,3 +306,11 @@ class TestCrawlableFeed:
         # There is one entry with the expected title.
         [entry] = feed["entries"]
         assert entry["title"] == work.title
+
+        # The feed has the expected facet groups.
+        facet_groups = {
+            l["facetgroup"]
+            for l in feed["feed"]["links"]
+            if l["rel"] == "http://opds-spec.org/facet"
+        }
+        assert facet_groups == {"Collection Name", "Distributor"}


### PR DESCRIPTION
## Description

Add `Collection Name` and `Distributor` facets to the `crawlable` endpoint.

## Motivation and Context

ByWater are using the crawlable endpoint for their integration, and they need this endpoint to have facets for collection name and distributor.

## How Has This Been Tested?

Local testing with minotaur DB.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
