### PR TITLE
Add per-medium breakouts to dashboard statistics inventories. (PP-728)

### DIFF
--- a/api/admin/config.py
+++ b/api/admin/config.py
@@ -17,7 +17,7 @@ class OperationalMode(str, Enum):
 class Configuration(LoggerMixin):
     APP_NAME = "Palace Collection Manager"
     PACKAGE_NAME = "@thepalaceproject/circulation-admin"
-    PACKAGE_VERSION = "1.11.0"
+    PACKAGE_VERSION = "1.12.0"
 
     STATIC_ASSETS = {
         "admin_js": "circulation-admin.js",

--- a/api/admin/dashboard_stats.py
+++ b/api/admin/dashboard_stats.py
@@ -144,15 +144,9 @@ class Statistics:
             statistics, "metered_license_stats", medium, "available"
         )
 
-        # TODO: We no longer support self-hosted books, so this should always be 0.
-        #  this value is still included in the response for backwards compatibility,
-        #  but should be removed in a future release.
-        self_hosted_titles = 0
-
         return InventoryStatistics(
             titles=metered_titles + unlimited_titles + open_access_titles,
             available_titles=loanable_titles,
-            self_hosted_titles=self_hosted_titles,
             open_access_titles=open_access_titles,
             licensed_titles=metered_titles + unlimited_titles,
             unlimited_license_titles=unlimited_titles,

--- a/api/admin/dashboard_stats.py
+++ b/api/admin/dashboard_stats.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Callable, Iterable
 
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func, select
-from sqlalchemy.sql.expression import and_, or_
+from sqlalchemy.sql.expression import and_, false, or_, true
 
 from api.admin.model.dashboard_statistics import (
     CollectionInventory,
@@ -35,16 +35,16 @@ def generate_statistics(admin: Admin, db: Session) -> StatisticsResponse:
 
 
 class Statistics:
-    METERED_LICENSE_FILTER = and_(  # type: ignore[type-var]
+    METERED_LICENSE_FILTER = and_(
         LicensePool.licenses_owned > 0,
-        LicensePool.unlimited_access == False,
-        LicensePool.open_access == False,
+        LicensePool.unlimited_access == false(),
+        LicensePool.open_access == false(),
     )
-    UNLIMITED_LICENSE_FILTER = and_(  # type: ignore[type-var]
-        LicensePool.unlimited_access == True,
-        LicensePool.open_access == False,
+    UNLIMITED_LICENSE_FILTER = and_(
+        LicensePool.unlimited_access == true(),
+        LicensePool.open_access == false(),
     )
-    OPEN_ACCESS_FILTER = LicensePool.open_access == True
+    OPEN_ACCESS_FILTER = LicensePool.open_access == true()
     AT_LEAST_ONE_LOANABLE_FILTER = or_(
         UNLIMITED_LICENSE_FILTER,
         OPEN_ACCESS_FILTER,
@@ -204,7 +204,7 @@ class Statistics:
         )
 
     def stats(self, admin: Admin) -> StatisticsResponse:
-        """Build and return a statistics response for admin's authorized libraries."""
+        """Build and return a statistics response for admin user's authorized libraries."""
 
         # Determine which libraries and collections are authorized for this user.
         authorized_libraries = self._libraries_for_admin(admin)

--- a/api/admin/model/dashboard_statistics.py
+++ b/api/admin/model/dashboard_statistics.py
@@ -54,9 +54,6 @@ class InventoryStatistics(StatisticsBaseModel):
     available_titles: NonNegativeInt = Field(
         description="Number of books available to lend."
     )
-    self_hosted_titles: NonNegativeInt = Field(
-        description="Number of books that are self-hosted."
-    )
     open_access_titles: NonNegativeInt = Field(
         description="Number of books with an Open Access license."
     )

--- a/api/admin/model/dashboard_statistics.py
+++ b/api/admin/model/dashboard_statistics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, List
+from typing import Any, Dict, List
 
 from pydantic import Field, NonNegativeInt
 
@@ -90,6 +90,9 @@ class LibraryStatistics(CustomBaseModel):
     inventory_summary: InventoryStatistics = Field(
         description="Summary of inventory statistics for this library."
     )
+    inventory_by_medium: Dict[str, InventoryStatistics] = Field(
+        description="Per-medium inventory statistics for this library."
+    )
     collection_ids: List[int] = Field(
         description="List of associated collection identifiers."
     )
@@ -102,6 +105,9 @@ class CollectionInventory(CustomBaseModel):
     name: str = Field(description="Collection name.")
     inventory: InventoryStatistics = Field(
         description="Inventory statistics for this collection."
+    )
+    inventory_by_medium: Dict[str, InventoryStatistics] = Field(
+        description="Per-medium inventory statistics for this collection."
     )
 
 
@@ -116,6 +122,9 @@ class StatisticsResponse(CustomBaseModel):
     )
     inventory_summary: InventoryStatistics = Field(
         description="Summary inventory across all included collections."
+    )
+    inventory_by_medium: Dict[str, InventoryStatistics] = Field(
+        description="Per-medium summary inventory across all included collections."
     )
     patron_summary: PatronStatistics = Field(
         description="Summary patron statistics across all libraries."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ module = [
     "api.admin.controller.library_settings",
     "api.admin.controller.patron_auth_service_self_tests",
     "api.admin.controller.patron_auth_services",
+    "api.admin.dashboard_stats",
     "api.admin.form_data",
     "api.admin.model.dashboard_statistics",
     "api.adobe_vendor_id",

--- a/tests/api/admin/test_dashboard_stats.py
+++ b/tests/api/admin/test_dashboard_stats.py
@@ -156,7 +156,6 @@ def test_stats_inventory(admin_statistics_session: AdminStatisticsSessionFixture
     for inventory_data in [library_inventory, summary_inventory]:
         assert 0 == inventory_data.titles
         assert 0 == inventory_data.available_titles
-        assert 0 == inventory_data.self_hosted_titles
         assert 0 == inventory_data.open_access_titles
         assert 0 == inventory_data.licensed_titles
         assert 0 == inventory_data.unlimited_license_titles
@@ -193,7 +192,6 @@ def test_stats_inventory(admin_statistics_session: AdminStatisticsSessionFixture
     for inventory_data in [library_inventory, summary_inventory]:
         assert 2 == inventory_data.titles
         assert 1 == inventory_data.available_titles
-        assert 0 == inventory_data.self_hosted_titles
         assert 0 == inventory_data.open_access_titles
         assert 2 == inventory_data.licensed_titles
         assert 0 == inventory_data.unlimited_license_titles
@@ -215,7 +213,6 @@ def test_stats_inventory(admin_statistics_session: AdminStatisticsSessionFixture
     summary_inventory = response.inventory_summary
     assert 2 == library_inventory.titles
     assert 1 == library_inventory.available_titles
-    assert 0 == library_inventory.self_hosted_titles
     assert 0 == library_inventory.open_access_titles
     assert 2 == library_inventory.licensed_titles
     assert 0 == library_inventory.unlimited_license_titles
@@ -225,7 +222,6 @@ def test_stats_inventory(admin_statistics_session: AdminStatisticsSessionFixture
 
     assert 3 == summary_inventory.titles
     assert 2 == summary_inventory.available_titles
-    assert 0 == summary_inventory.self_hosted_titles
     assert 0 == summary_inventory.open_access_titles
     assert 3 == summary_inventory.licensed_titles
     assert 0 == summary_inventory.unlimited_license_titles
@@ -245,7 +241,6 @@ def test_stats_inventory(admin_statistics_session: AdminStatisticsSessionFixture
     for inventory_data in [library_inventory, summary_inventory]:
         assert 2 == inventory_data.titles
         assert 1 == inventory_data.available_titles
-        assert 0 == inventory_data.self_hosted_titles
         assert 0 == inventory_data.open_access_titles
         assert 2 == inventory_data.licensed_titles
         assert 0 == inventory_data.unlimited_license_titles
@@ -265,7 +260,6 @@ def test_stats_collections(admin_statistics_session: AdminStatisticsSessionFixtu
     assert empty_inventory == InventoryStatistics(
         titles=0,
         available_titles=0,
-        self_hosted_titles=0,
         open_access_titles=0,
         licensed_titles=0,
         unlimited_license_titles=0,
@@ -287,7 +281,6 @@ def test_stats_collections(admin_statistics_session: AdminStatisticsSessionFixtu
     assert new_metered_inventory == InventoryStatistics(
         titles=2,
         available_titles=2,
-        self_hosted_titles=0,
         open_access_titles=0,
         licensed_titles=2,
         unlimited_license_titles=0,

--- a/tests/api/admin/test_dashboard_stats.py
+++ b/tests/api/admin/test_dashboard_stats.py
@@ -321,10 +321,6 @@ def test_stats_collections(admin_statistics_session: AdminStatisticsSessionFixtu
 
     response = session.get_statistics()
     library_stats_data = response.libraries_by_key.get(default_library.short_name)
-    # all_collections_by_id = {c.id: c for c in response.collections}
-    # library_collections_by_id = {
-    #     id_: all_collections_by_id[id_] for id_ in library_stats_data.collection_ids
-    # }
     assert 1 == len(response.collections)
     assert 1 == len(response.inventory_by_medium)
     assert 1 == len(library_stats_data.collection_ids)


### PR DESCRIPTION
## Description

- Add per-medium breakouts to dashboard statistics inventories.
- Add supporting tests and clean up some tests.
- Resolve some PEP-8 and mypy issues with SQLAlchemy filters.

This work requires changes to the circulation admin UI. The following work is required before this PR can be moved out of `draft` status and merged:
- [X] Change interface in `circulation-admin` and make the changes required for PP-728. 
  These changes are introduced in [circulation-admin PR 98](https://github.com/ThePalaceProject/circulation-admin/pull/98).
- [x] Release a [new version (v1.12.0)](https://github.com/ThePalaceProject/circulation-admin/releases/tag/v1.12.0) of `circulation-admin`.
- [X] Update this PR with new version of `circulation-admin`.

Note:
- Based on testing, the changes in this PR are backward compatible with recent versions of the circulation admin UI.
- The API has changed, so I am labeling as _incompatible changes_.
## Motivation and Context

Need to support additional detail by type of medium (book, audiobook, etc.).

[Jira [PP-728](https://ebce-lyrasis.atlassian.net/browse/PP-728)]

## How Has This Been Tested?

- Additional tests.
- Manual testing in local development environment.
- [CI tests for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/7081348146) pass.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-728]: https://ebce-lyrasis.atlassian.net/browse/PP-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ