### PR TITLE
Hold notifiations now include a short title and a body with details (PP-753)

### DIFF
--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -195,9 +195,11 @@ class PushNotifications(LoggerMixin):
             loans_api = f"{url}/{hold.patron.library.short_name}/loans"
             work: Work = hold.work
             identifier: Identifier = hold.license_pool.identifier
-            title = f'Your hold on "{work.title}" is available!'
+            title = "Your hold is available!"
+            body = f'Your hold on "{work.title}" is available!'
             data = dict(
                 title=title,
+                body=body,
                 event_type=NotificationConstants.HOLD_AVAILABLE_TYPE,
                 loans_endpoint=loans_api,
                 identifier=identifier.identifier,
@@ -209,7 +211,9 @@ class PushNotifications(LoggerMixin):
             if hold.patron.authorization_identifier:
                 data["authorization_identifier"] = hold.patron.authorization_identifier
 
-            resp = cls.send_messages(tokens, messaging.Notification(title=title), data)
+            resp = cls.send_messages(
+                tokens, messaging.Notification(title=title, body=body), data
+            )
             if len(resp) > 0:
                 # Atleast one notification succeeded
                 hold.patron_last_notified = utc_now().date()


### PR DESCRIPTION
## Description

Use a short title, so the title text doesn't get cut off on iOS, and add a body with a longer description of the hold that is available. This will let users on iOS expand the notification to see the body text.

I also modified the tests a bit, as they were not testing what `title` and `body` args were given to the `Notification` class before. 

## Motivation and Context

Bug report from A1QA that the text of the hold notification is cutoff on iOS. See PP-753.

## How Has This Been Tested?

- Running unit tests

This one is hard to test fully. We will need to do a full end to end test in the development environment to make sure this one is working as expected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
