### PR TITLE
Display warning when MARC exporter has no collections configured (PP-59)

### DIFF
--- a/api/controller_marc.py
+++ b/api/controller_marc.py
@@ -140,7 +140,15 @@ class MARCRecordController:
         marc_files = self.get_files(session, library)
 
         if len(marc_files) == 0:
-            return "<p>" + "MARC files aren't ready to download yet." + "</p>"
+            # Are there any collections configured to export MARC records?
+            if any(c.export_marc_records for c in library.collections):
+                return "<p>" + "MARC files aren't ready to download yet." + "</p>"
+            else:
+                return (
+                    "<p>"
+                    + "No collections are configured to export MARC records."
+                    + "</p>"
+                )
 
         body = ""
         for collection_name, files in marc_files.items():

--- a/tests/api/test_controller_marc.py
+++ b/tests/api/test_controller_marc.py
@@ -254,6 +254,16 @@ class TestMARCRecordController:
             in html
         )
 
+    def test_download_page_with_exporter_but_no_collection(
+        self, marc_record_controller_fixture: MARCRecordControllerFixture
+    ):
+        marc_record_controller_fixture.integration()
+        marc_record_controller_fixture.collection.export_marc_records = False
+
+        response = marc_record_controller_fixture.controller.download_page()
+        html = marc_record_controller_fixture.get_response_html(response)
+        assert "No collections are configured to export MARC records" in html
+
     def test_download_page_with_exporter_but_no_files(
         self, marc_record_controller_fixture: MARCRecordControllerFixture
     ):


### PR DESCRIPTION
## Description

Adds a warning when viewing the MARC records page, when the MARC exporter is configured, but no collections have MARC export enabled.

## Motivation and Context

I was testing the new MARC export functionality this morning on Minotaur and noticed that the message "MARC files aren't ready to download yet" isn't really accurate in this situation, since nothing is configured to export.

## How Has This Been Tested?

- Running tests
- Local testing in admin UI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
