### PR TITLE
Allow pyinstrument to profile our test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,22 @@ module under the hood to do the profiling.
 
 This profiler uses [PyInstrument](https://pyinstrument.readthedocs.io/en/latest/) to profile the code.
 
+#### Profiling tests suite
+
+PyInstrument can be used to profile the test suite, as well as the main application code.
+
+To profile the core test suite, run the following command:
+
+```sh
+pyinstrument -m pytest --no-cov tests/core/
+```
+
+To profile the API test suite, run the following command:
+
+```sh
+pyinstrument -m pytest --no-cov tests/api/
+```
+
 #### Environment Variables
 
 - `PALACE_PYINSTRUMENT`: Profiling will the enabled if this variable is set. The saved profile data will be available at

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,3 +1,4 @@
+from freezegun.config import configure as fg_configure
 from pytest import register_assert_rewrite
 
 register_assert_rewrite("tests.fixtures.database")
@@ -39,3 +40,8 @@ pytest_plugins = [
     "tests.fixtures.tls_server",
     "tests.fixtures.vendor_id",
 ]
+
+# Make sure if we are using pyinstrument to profile tests, that
+# freezegun doesn't interfere with it.
+# See: https://github.com/spulec/freezegun#ignore-packages
+fg_configure(extend_ignore_list=["pyinstrument"])

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,3 +1,5 @@
+from freezegun.config import configure as fg_configure
+
 pytest_plugins = [
     "tests.fixtures.announcements",
     "tests.fixtures.csv_files",
@@ -13,3 +15,8 @@ pytest_plugins = [
     "tests.fixtures.time",
     "tests.fixtures.tls_server",
 ]
+
+# Make sure if we are using pyinstrument to profile tests, that
+# freezegun doesn't interfere with it.
+# See: https://github.com/spulec/freezegun#ignore-packages
+fg_configure(extend_ignore_list=["pyinstrument"])


### PR DESCRIPTION
## Description

- Add a note to the README about how we can use `pyinstrument` to profile tests.
- Make sure that `freezetime` is configured to ignore `pyinstrument`, so it doesn't throw off the profiling.

## Motivation and Context

Added this because some changes I made in PP-93 slowed down test runs significantly, and I needed to do some profiling to figure out what was going on there. Figured it would be good to have some documentation about how to do this.

## How Has This Been Tested?

- Running tests locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
