### PR TITLE
Fix for e06f965879ab MARC file deletion migration (PP-773)

### DIFF
--- a/tests/migration/test_20231206_e06f965879ab.py
+++ b/tests/migration/test_20231206_e06f965879ab.py
@@ -104,31 +104,6 @@ def test_migration_no_s3_integration(
     )
 
 
-def test_migration_bucket_url_not_found(
-    alembic_runner: MigrationContext,
-    alembic_engine: Engine,
-    create_cachedmarcfile: CreateCachedMarcFile,
-    caplog: LogCaptureFixture,
-) -> None:
-    alembic_runner.migrate_down_to(MIGRATION_ID)
-    alembic_runner.migrate_down_one()
-
-    container = container_instance()
-    mock_storage = MagicMock(spec=S3Service)
-    mock_storage.bucket = "test-bucket42"
-
-    # If we can't parse the key from the URL, the migration should fail
-    with alembic_engine.connect() as connection:
-        create_cachedmarcfile(connection, "http://s3.amazonaws.com/test-bucket/1.mrc")
-
-    with pytest.raises(RuntimeError) as excinfo, container.storage.public.override(
-        mock_storage
-    ):
-        alembic_runner.migrate_up_one()
-
-    assert "Unexpected URL format" in str(excinfo.value)
-
-
 def test_migration_bucket_url_different(
     alembic_runner: MigrationContext,
     alembic_engine: Engine,

--- a/tests/migration/test_20231206_e06f965879ab.py
+++ b/tests/migration/test_20231206_e06f965879ab.py
@@ -43,7 +43,7 @@ class CreateCachedMarcFile:
 
         return representation_id, file_id
 
-    def representation(self, connection: Connection, url: str) -> int:
+    def representation(self, connection: Connection, url: Optional[str]) -> int:
         row = connection.execute(
             "INSERT INTO representations (media_type, url) "
             "VALUES ('application/marc', %s) returning id",


### PR DESCRIPTION
## Description

`e06f965879ab` was hard to test, since it involves both the DB and S3. After the migration ran on Minotaur and Cerberus, there are a couple changes needed:

- The latest code puts the MARC file URL in `Representation.mirror_url` and `Representation.url` but older versions of the code only put the url in `Representation.url`. So older files were failing this migration because `mirror_url` is `NULL`. So its safe to just use URL for everything.
- Some records have NULL in `url` (as well as `mirror_url`). I'm not sure how this happened. But there is no way we can delete the file in this case, so it doesn't fail the migration, just outputs a log message.
- The URLs are stored URL escaped, and S3 keys are expected not to be escaped, so we have to call `unquote` on the keys.
- Don't fail the migration if we can't parse the key out of the URL. Just log what happened and move on.

## Motivation and Context

Troubleshooting failed migration on `Cerberus`.

## How Has This Been Tested?

- Tested with local DB copy, but no s3... so 🤞🏻
- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
