### PR TITLE
Handle `null` medium in dashboard stats. (PP-728)

### DIFF
--- a/api/admin/dashboard_stats.py
+++ b/api/admin/dashboard_stats.py
@@ -196,7 +196,10 @@ class Statistics:
         """Return a CollectionInventory for the given collection."""
 
         statistics = self._run_collection_stats_queries(collection)
-        inventory_by_medium = statistics.inventories_by_medium()
+        # Ensure that the key is a string, even if the medium is null.
+        inventory_by_medium = {
+            str(m): inv for m, inv in statistics.inventories_by_medium().items()
+        }
         summary_inventory = sum(
             inventory_by_medium.values(), InventoryStatistics.zeroed()
         )


### PR DESCRIPTION
## Description

- Ensure medium key of `inventory_by_medium` is a string, even if the medium is "None".

## Motivation and Context

1. Null medium type cause internal server error and
2. We always want a string for this key.

[Jira [PP-728](https://ebce-lyrasis.atlassian.net/browse/PP-728)]

## How Has This Been Tested?

- Updated test case to cover an edition with a `null` medium.
- [CI passes](https://github.com/ThePalaceProject/circulation/actions/runs/7171865761) for associated feature branch.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-728]: https://ebce-lyrasis.atlassian.net/browse/PP-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ