### PR TITLE
Fix flaky marc test

### DIFF
--- a/tests/core/test_marc.py
+++ b/tests/core/test_marc.py
@@ -770,11 +770,11 @@ class TestMARCExporter:
         assert len(records) == 2
 
         title_fields = [record.get_fields("245") for record in records]
-        titles = [fields[0].get_subfields("a")[0] for fields in title_fields]
-        assert titles == [
+        titles = {fields[0].get_subfields("a")[0] for fields in title_fields}
+        assert titles == {
             marc_exporter_fixture.w1.title,
             marc_exporter_fixture.w2.title,
-        ]
+        }
 
     def test_records_since_time(
         self,


### PR DESCRIPTION
## Description

I saw a MARC test failing in https://github.com/ThePalaceProject/circulation/pull/1570 that looked like it was just the order of the test results. This makes that order into a set, so we know the results are there, but don't care about ordering as its not defined.

## Motivation and Context

Fix flaky test.

## How Has This Been Tested?

- Running unit tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
