### PR TITLE
Make it easier to use log_elapsed_time with LoggerMixin

### DIFF
--- a/api/circulation_manager.py
+++ b/api/circulation_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import urllib.parse
 from typing import TYPE_CHECKING
 
@@ -41,7 +40,8 @@ from core.lane import Lane, WorkList
 from core.model import ConfigurationSetting, Library
 from core.model.discovery_service_registration import DiscoveryServiceRegistration
 from core.service.container import Services
-from core.util.log import elapsed_time_logging, log_elapsed_time
+from core.service.logging.configuration import LogLevel
+from core.util.log import LoggerMixin, elapsed_time_logging, log_elapsed_time
 
 if TYPE_CHECKING:
     from api.admin.controller.admin_search import AdminSearchController
@@ -90,9 +90,7 @@ if TYPE_CHECKING:
     from api.admin.controller.work_editor import WorkController as AdminWorkController
 
 
-class CirculationManager:
-    log = logging.getLogger("api.circulation_manager.CirculationManager")
-
+class CirculationManager(LoggerMixin):
     # API Controllers
     index_controller: IndexController
     opds_feeds: OPDSFeedController
@@ -188,7 +186,7 @@ class CirculationManager:
             self.load_settings()
             self.site_configuration_last_update = last_update
 
-    @log_elapsed_time(log_method=log.info, message_prefix="load_settings")
+    @log_elapsed_time(log_level=LogLevel.info, message_prefix="load_settings")
     def load_settings(self):
         """Load all necessary configuration settings and external
         integrations from the database.

--- a/core/util/log.py
+++ b/core/util/log.py
@@ -3,23 +3,49 @@ import logging
 import sys
 import time
 from contextlib import contextmanager
-from typing import Callable, Optional
+from typing import Callable, Generator, Optional, TypeVar
+
+from typing_extensions import ParamSpec
+
+from core.service.logging.configuration import LogLevel
+
+P = ParamSpec("P")
+T = TypeVar("T")
 
 
 def log_elapsed_time(
-    *, log_method: Callable, message_prefix: Optional[str] = None, skip_start=False
-):
+    *,
+    log_level: LogLevel,
+    message_prefix: Optional[str] = None,
+    skip_start: bool = False,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Decorator for logging elapsed time.
 
-    :param log_method: Callable to be used to log the message(s).
+    Must be applied to a method of a subclass of LoggerMixin or a class that has a log property
+    that is an instance of logging.Logger.
+
+    :param log_level: The log level to use for the emitted log records.
     :param message_prefix: Optional string to be prepended to the emitted log records.
     :param skip_start: Boolean indicating whether to skip the starting message.
     """
     prefix = f"{message_prefix}: " if message_prefix else ""
 
-    def outer(fn):
+    def outer(fn: Callable[P, T]) -> Callable[P, T]:
         @functools.wraps(fn)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            if (
+                len(args) > 0
+                and hasattr(args[0], "log")
+                and isinstance(args[0].log, logging.Logger)
+            ):
+                log_method = getattr(args[0].log, log_level.name)
+            elif len(args) > 0 and hasattr(args[0], "logger"):
+                log_method = getattr(args[0].logger(), log_level.name)
+            else:
+                raise RuntimeError(
+                    "Decorator must be applied to a method of a LoggerMixin or a subclass of LoggerMixin."
+                )
+
             if not skip_start:
                 log_method(f"{prefix}Starting...")
             tic = time.perf_counter()
@@ -38,8 +64,11 @@ def log_elapsed_time(
 
 @contextmanager
 def elapsed_time_logging(
-    *, log_method: Callable, message_prefix: Optional[str] = None, skip_start=False
-):
+    *,
+    log_method: Callable[[str], None],
+    message_prefix: Optional[str] = None,
+    skip_start: bool = False,
+) -> Generator[None, None, None]:
     """Context manager for logging elapsed time.
 
     :param log_method: Callable to be used to log the message(s).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ module = [
     "core.util.authentication_for_opds",
     "core.util.base64",
     "core.util.cache",
+    "core.util.log",
     "core.util.notifications",
     "core.util.problem_detail",
     "core.util.string_helpers",

--- a/tests/core/util/test_log.py
+++ b/tests/core/util/test_log.py
@@ -1,0 +1,53 @@
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+from core.service.logging.configuration import LogLevel
+from core.util.log import LoggerMixin, log_elapsed_time
+
+
+class MockClass(LoggerMixin):
+    @classmethod
+    @log_elapsed_time(log_level=LogLevel.info, message_prefix="Test")
+    def test_method(cls):
+        pass
+
+    @log_elapsed_time(
+        log_level=LogLevel.debug, message_prefix="Test 12345", skip_start=True
+    )
+    def test_method_2(self):
+        pass
+
+
+def test_log_elapsed_time_cls(caplog: LogCaptureFixture):
+    caplog.set_level(LogLevel.info.value)
+
+    MockClass.test_method()
+    assert len(caplog.records) == 2
+
+    [first, second] = caplog.records
+    assert first.name == "tests.core.util.test_log.MockClass"
+    assert first.message == "Test: Starting..."
+    assert first.levelname == LogLevel.info.value
+
+    assert second.name == "tests.core.util.test_log.MockClass"
+    assert "Test: Completed. (elapsed time:" in second.message
+    assert second.levelname == LogLevel.info.value
+
+
+def test_log_elapsed_time_instance(caplog: LogCaptureFixture):
+    caplog.set_level(LogLevel.debug.value)
+
+    MockClass().test_method_2()
+    assert len(caplog.records) == 1
+    [record] = caplog.records
+    assert record.name == "tests.core.util.test_log.MockClass"
+    assert "Test 12345: Completed. (elapsed time:" in record.message
+    assert record.levelname == LogLevel.debug.value
+
+
+def test_log_elapsed_time_invalid(caplog: LogCaptureFixture):
+    caplog.set_level(LogLevel.info.value)
+
+    with pytest.raises(RuntimeError):
+        log_elapsed_time(log_level=LogLevel.info, message_prefix="Test")(lambda: None)()
+    assert len(caplog.records) == 0


### PR DESCRIPTION
## Description

Right now the `log_elapsed_time` decorator cannot use the logger defined by `LoggerMixin` because the logging function needs to be passed into the decorator, and it is not available when the function is decorated. Modify the decorator so it is easier to use in this case.

## Motivation and Context

I'd like to switch `CirculationManager` to inherent from `LoggerMixin` but still be able to use `log_elapsed_time`.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
