### PR TITLE
Ensures that large numbers of libraries can be sent to the anonymous …

### DIFF
--- a/api/admin/controller/quicksight.py
+++ b/api/admin/controller/quicksight.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import boto3
 import flask
@@ -122,7 +123,7 @@ class QuickSightController(CirculationManagerController):
         delimiter = "|"
         max_chars_per_tag = 256
 
-        session_tags = []
+        session_tags: list[dict[Any, str]] = []
         per_tag_character_count = 0
         tag_index = 0
         tag_values = []

--- a/api/admin/controller/quicksight.py
+++ b/api/admin/controller/quicksight.py
@@ -121,23 +121,33 @@ class QuickSightController(CirculationManagerController):
             )
 
         delimiter = "|"
+        # specified by AWS's session tag limit
         max_chars_per_tag = 256
 
         session_tags: list[dict[Any, str]] = []
+
+        if len(short_names) == 0:
+            return session_tags
+
         per_tag_character_count = 0
         tag_index = 0
         tag_values = []
         for short_name in short_names:
+            # add one for the delimiter
             chars_to_be_added = len(short_name) + 1
+            # Add values as long as they will not exceed the maximum limit
             if chars_to_be_added + per_tag_character_count <= max_chars_per_tag:
                 tag_values.append(short_name)
                 per_tag_character_count += chars_to_be_added
             else:
+                # otherwise append the tag and values and start a new tag with
+                # a new list of values
                 append_to_session_tags()
                 per_tag_character_count = chars_to_be_added
                 tag_values = [short_name]
                 tag_index += 1
 
+        # append the un-appended tag and values
         append_to_session_tags()
 
         return session_tags

--- a/tests/api/admin/controller/test_quicksight.py
+++ b/tests/api/admin/controller/test_quicksight.py
@@ -1,9 +1,10 @@
 import uuid
+from typing import cast
 from unittest import mock
 
 import pytest
 
-from core.model import create
+from core.model import Library, create
 from core.model.admin import Admin, AdminRole
 from core.util.problem_detail import ProblemError
 from tests.fixtures.api_admin import AdminControllerFixture
@@ -121,7 +122,7 @@ class TestQuicksightController:
         system_admin.add_role(AdminRole.SYSTEM_ADMIN)
         default = db.default_library()
 
-        libraries = []
+        libraries: list[Library] = []
         for x in range(0, 37):
             libraries.append(db.library(short_name="TL" + str(x).zfill(4)))
 
@@ -144,7 +145,7 @@ class TestQuicksightController:
 
             random_uuid = str(uuid.uuid4())
             with quicksight_fixture.request_context_with_admin(
-                f"/?library_uuids={','.join([x.uuid for x in libraries ])}",
+                f"/?library_uuids={','.join(cast(list[str], [x.uuid for x in libraries ]))}",
                 admin=system_admin,
             ) as ctx:
                 response = ctrl.generate_quicksight_url("primary")
@@ -165,11 +166,17 @@ class TestQuicksightController:
                     SessionTags=[
                         dict(
                             Key="library_short_name_0",
-                            Value="|".join([x.short_name for x in libraries[0:36]]),
+                            Value="|".join(
+                                cast(list[str], [x.short_name for x in libraries[0:36]])
+                            ),
                         ),
                         dict(
                             Key="library_short_name_1",
-                            Value="|".join([x.short_name for x in libraries[36:37]]),
+                            Value="|".join(
+                                cast(
+                                    list[str], [x.short_name for x in libraries[36:37]]
+                                )
+                            ),
                         ),
                     ],
                 )

--- a/tests/api/admin/controller/test_quicksight.py
+++ b/tests/api/admin/controller/test_quicksight.py
@@ -77,8 +77,10 @@ class TestQuicksightController:
                     },
                     SessionTags=[
                         dict(
-                            Key="library_name",
-                            Value="|".join([str(library1.name), str(default.name)]),
+                            Key="library_short_name_0",
+                            Value="|".join(
+                                [str(library1.short_name), str(default.short_name)]
+                            ),
                         )
                     ],
                 )
@@ -102,7 +104,73 @@ class TestQuicksightController:
                         "Dashboard": {"InitialDashboardId": "uuid2"}
                     },
                     SessionTags=[
-                        dict(Key="library_name", Value="|".join([str(library1.name)]))
+                        dict(
+                            Key="library_short_name_0",
+                            Value="|".join([str(library1.short_name)]),
+                        )
+                    ],
+                )
+
+    def test_generate_quicksight_url_with_a_large_number_of_libraries(
+        self, quicksight_fixture: QuickSightControllerFixture
+    ):
+        ctrl = quicksight_fixture.manager.admin_quicksight_controller
+        db = quicksight_fixture.ctrl.db
+
+        system_admin, _ = create(db.session, Admin, email="admin@email.com")
+        system_admin.add_role(AdminRole.SYSTEM_ADMIN)
+        default = db.default_library()
+
+        libraries = []
+        for x in range(0, 37):
+            libraries.append(db.library(short_name="TL" + str(x).zfill(4)))
+
+        with mock.patch(
+            "api.admin.controller.quicksight.boto3"
+        ) as mock_boto, mock.patch(
+            "api.admin.controller.quicksight.Configuration.quicksight_authorized_arns"
+        ) as mock_qs_arns:
+            arns = dict(
+                primary=[
+                    "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid1",
+                    "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid2",
+                ],
+            )
+            mock_qs_arns.return_value = arns
+            generate_method: mock.MagicMock = (
+                mock_boto.client().generate_embed_url_for_anonymous_user
+            )
+            generate_method.return_value = {"Status": 201, "EmbedUrl": "https://embed"}
+
+            random_uuid = str(uuid.uuid4())
+            with quicksight_fixture.request_context_with_admin(
+                f"/?library_uuids={','.join([x.uuid for x in libraries ])}",
+                admin=system_admin,
+            ) as ctx:
+                response = ctrl.generate_quicksight_url("primary")
+
+                # Assert the right client was created, with a region
+                assert mock_boto.client.call_args == mock.call(
+                    "quicksight", region_name="us-west-1"
+                )
+                # Assert the reqest and response formats
+                assert response["embedUrl"] == "https://embed"
+                assert generate_method.call_args == mock.call(
+                    AwsAccountId="aws-account-id",
+                    Namespace="default",
+                    AuthorizedResourceArns=arns["primary"],
+                    ExperienceConfiguration={
+                        "Dashboard": {"InitialDashboardId": "uuid1"}
+                    },
+                    SessionTags=[
+                        dict(
+                            Key="library_short_name_0",
+                            Value="|".join([x.short_name for x in libraries[0:36]]),
+                        ),
+                        dict(
+                            Key="library_short_name_1",
+                            Value="|".join([x.short_name for x in libraries[36:37]]),
+                        ),
                     ],
                 )
 


### PR DESCRIPTION
…quicksight url generator.

Two changes were required here:  

1) Since Quicksight limits the number of characters for a session tag value to 256,  it's better to use the library short_name since it is more compact.  
2) In case the number of libraries for a CM is large ( more than 30 or 40 ),  the PR ensures that we use auxiliary session tags (per AWS recommendations) that are mapped to the short_name fied.

## Description

<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-793
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
1) Modified the unit tests
2) Add a new unit test to cover the large list of libraries scenario.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
