### PR TITLE
Fix overdrive advantage collection parent reporting (PP-806)

### DIFF
--- a/api/admin/controller/collection_settings.py
+++ b/api/admin/controller/collection_settings.py
@@ -43,8 +43,11 @@ class CollectionSettingsController(
         if service_info:
             # Add 'marked_for_deletion' to the service info
             service_info["marked_for_deletion"] = service.collection.marked_for_deletion
-
-            service_info["parent_id"] = service.collection.parent_id
+            service_info["parent_id"] = (
+                service.collection.parent.integration_configuration_id
+                if service.collection.parent
+                else None
+            )
             service_info["settings"]["export_marc_records"] = str(
                 service.collection.export_marc_records
             ).lower()

--- a/tests/api/admin/controller/test_collections.py
+++ b/tests/api/admin/controller/test_collections.py
@@ -132,7 +132,7 @@ class TestCollectionSettings:
                 "overdrive_client_secret"
             ] == settings2.get("overdrive_client_secret")
 
-            assert c2.id == coll3.get("parent_id")
+            assert c2.integration_configuration.id == coll3.get("parent_id")
 
             coll3_libraries = coll3.get("libraries")
             assert 2 == len(coll3_libraries)


### PR DESCRIPTION
## Description

The changes in https://github.com/ThePalaceProject/circulation/pull/1494 make it so the ID that the admin UI works with for collections is the ID of the integration, not the ID of the collection. We had a bit of a mixup, where the ID of the collection was still being reported as the ID for the parent collection. 

This should fix that issue, so the admin UI reports the correct collection. 

## Motivation and Context

In the Collection Managers, previously configured OverDrive Advantage accounts are showing “None” for Parent or an incorrect parent account. Changing the Parent account to the correct account then saving does not actually save – the save appears to work after clicking the Submit button; however, after navigating away and back to the collection the Parent account reverts to None or to the incorrect parent account it had. 

See JIRA: https://ebce-lyrasis.atlassian.net/browse/PP-806

This probably points to a bit more refactoring we should do, so we actually store on the CM side the parents integration ID, instead of collection ID, but I didn't want to make that large a change as part of this bugfix. I'm going to make a separate ticket for that.

## How Has This Been Tested?

Tested with CT and CA DBs.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
