### PR TITLE
Faster migration to add the should_track_playtime column 

### DIFF
--- a/alembic/versions/20231124_6af9160a578e_licensepools_time_tracking_flag.py
+++ b/alembic/versions/20231124_6af9160a578e_licensepools_time_tracking_flag.py
@@ -19,11 +19,15 @@ depends_on = None
 def upgrade() -> None:
     op.add_column(
         "licensepools",
-        sa.Column("should_track_playtime", sa.Boolean(), nullable=True, default=False),
+        sa.Column(
+            "should_track_playtime",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.false(),
+            default=False,
+        ),
     )
-    session = op.get_bind()
-    session.execute("UPDATE licensepools SET should_track_playtime=false")
-    op.alter_column("licensepools", "should_track_playtime", nullable=False)
+    op.alter_column("licensepools", "should_track_playtime", server_default=None)
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Description

Update the `20231124_6af9160a578e_licensepools_time_tracking_flag.py` migration to run faster. The end result of the migration is the same, so places where this migration has already been run don't need to be updated, but it might be worth applying this change before rolling out to production, so the migrations don't take so long.

We may want to apply this as a hotfix before PP-804.

## Motivation and Context

While working on #1590 and #1591 yesterday, I noticed that running the `20231124_6af9160a578e_licensepools_time_tracking_flag.py` migration was very slow for me locally. Taking 5 minutes or more to complete.

```
EXPLAIN ANALYZE UPDATE licensepools SET should_track_playtime=false;
                                                            QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------
 Update on licensepools  (cost=0.00..195445.12 rows=8718712 width=185) (actual time=526615.635..526615.639 rows=0 loops=1)
   ->  Seq Scan on licensepools  (cost=0.00..195445.12 rows=8718712 width=185) (actual time=17.832..2094.770 rows=2760547 loops=1)
 Planning Time: 11.259 ms
 JIT:
   Functions: 2
   Options: Inlining false, Optimization false, Expressions true, Deforming true
   Timing: Generation 0.487 ms, Inlining 0.000 ms, Optimization 1.007 ms, Emission 16.444 ms, Total 17.938 ms
 Execution Time: 526841.444 ms
(8 rows)
``` 

It isn't a huge deal, since the migrations are only run once, but since we have some downtime while migrations are run, it would be better if it didn't take so long to update.

## How Has This Been Tested?

Tested locally with CT and NJ DB. Running this migration went from 5-6min to less then a second in both cases.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
