### PR TITLE
CI check making sure DB migrations keep database in sync

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -110,6 +110,34 @@ jobs:
           files: ./coverage.xml
           flags: migration
 
+  docker-test-migrations:
+    name: Docker migration test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    # We want to run on external PRs, but not on our own internal PRs as they'll be run
+    # by the push to the branch. This prevents duplicated runs on internal PRs.
+    # Some discussion of this here:
+    # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable network offload
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Test migrations
+        run: ./docker/ci/test_migrations.sh
+
   docker-image-build:
     name: Docker build
     runs-on: ubuntu-latest

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -331,7 +331,7 @@ jobs:
   docker-image-push:
     name: Push circ-${{ matrix.image }}
     runs-on: ubuntu-latest
-    needs: [test, test-migrations, docker-image-build, docker-image-test]
+    needs: [test, test-migrations, docker-test-migrations, docker-image-build, docker-image-test]
     permissions:
       contents: read
       packages: write

--- a/alembic/versions/20231101_2d72d6876c52_remove_collection_external_integration.py
+++ b/alembic/versions/20231101_2d72d6876c52_remove_collection_external_integration.py
@@ -241,7 +241,7 @@ def downgrade() -> None:
         "ix_collections_external_integration_id",
         "collections",
         ["external_integration_id"],
-        unique=False,
+        unique=True,
     )
 
     op.create_foreign_key(
@@ -305,5 +305,5 @@ def downgrade() -> None:
 
     op.drop_column("integration_configurations", "context")
 
-    op.create_index("ix_collections_name", "collections", ["name"], unique=False)
+    op.create_index("ix_collections_name", "collections", ["name"], unique=True)
     op.alter_column("collections", "name", existing_type=sa.VARCHAR(), nullable=False)

--- a/docker/ci/test_migrations.sh
+++ b/docker/ci/test_migrations.sh
@@ -24,6 +24,37 @@ run_in_container()
   compose_cmd run --build --rm webapp /bin/bash -c "source env/bin/activate && $*"
 }
 
+cleanup() {
+  compose_cmd down
+  git checkout -q "${current_branch}"
+}
+
+run_migrations() {
+  ALEMBIC_CMD=$1
+  run_in_container "alembic ${ALEMBIC_CMD}"
+  exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    echo "ERROR: Running database migrations failed."
+    cleanup
+    exit $exit_code
+  fi
+  echo ""
+}
+
+check_db() {
+  DETAILED_ERROR=$1
+  run_in_container "alembic check"
+  exit_code=$?
+  if [[ $exit_code -eq 0 ]]; then
+    echo "SUCCESS: Database is in sync."
+    echo ""
+  else
+    echo "ERROR: Database is out of sync! ${DETAILED_ERROR}"
+    cleanup
+    exit $exit_code
+  fi
+}
+
 if ! git diff --quiet; then
   echo "ERROR: You have uncommitted changes. These changes will be lost if you run this script."
   echo "  Please commit or stash your changes and try again."
@@ -49,7 +80,7 @@ echo "Current branch: ${current_branch}"
 # Find the first migration file
 first_migration_id=$(run_in_container alembic history -r'base:base+1' -v | head -n 1 | cut -d ' ' -f2)
 if [[ -z $first_migration_id ]]; then
-  echo "ERROR: Could not find first migration."
+  echo "ERROR: Could not find first migration id."
   exit 1
 fi
 
@@ -64,37 +95,40 @@ echo ""
 
 # Find the git commit where the first migration file was added
 first_migration_commit=$(git log --follow --format=%H --reverse "${first_migration_file}" | head -n 1)
+if [[ -z $first_migration_commit ]]; then
+  echo "ERROR: Could not find first migration commit hash."
+  exit 1
+fi
 
 echo "Starting containers and initializing database at commit ${first_migration_commit}"
 git checkout -q "${first_migration_commit}"
 compose_cmd down
 compose_cmd up -d pg
 run_in_container "./bin/util/initialize_instance"
+initialize_exit_code=$?
+if [[ $initialize_exit_code -ne 0 ]]; then
+  echo "ERROR: Failed to initialize instance."
+  cleanup
+  exit $initialize_exit_code
+fi
 echo ""
 
 # Migrate up to the current commit and check if the database is in sync
+echo "Testing upgrade migrations on branch ${current_branch}"
 git checkout -q "${current_branch}"
-echo "Running database migrations on branch ${current_branch}"
-run_in_container "alembic upgrade head"
-exit_code=$?
-if [[ $exit_code -ne 0 ]]; then
-  echo "ERROR: Database migration failed."
-  exit $exit_code
-fi
-echo ""
+run_migrations "upgrade head"
+check_db "A new migration is required or a up migration is broken."
 
-echo "Checking database status"
-run_in_container "alembic check"
-exit_code=$?
-echo ""
+# Migrate down to the first migration and check if the database is in sync
+echo "Testing downgrade migrations"
+run_migrations "downgrade ${first_migration_id}"
+git checkout -q "${first_migration_commit}"
+check_db "A down migration is broken."
 
-if [[ $exit_code -eq 0 ]]; then
-  echo "SUCCESS: Database is in sync."
-else
-  echo "ERROR: Database is out of sync. A new migration is required."
-fi
+# Migrate back up once more to make sure that the database is still in sync
+echo "Testing upgrade migrations a second time"
+git checkout -q "${current_branch}"
+run_migrations "upgrade head"
+check_db "A up migration is likely broken."
 
-# Stop containers
-compose_cmd down
-
-exit $exit_code
+cleanup

--- a/docker/ci/test_migrations.sh
+++ b/docker/ci/test_migrations.sh
@@ -13,10 +13,9 @@
 # then a new migration is required. We then repeat this process with our down
 # migrations to make sure that the down migrations stay in sync as well.
 #
-# This test cannot be added to the normal migration test suite since it requires
-# manipulating the git history and checking out older versions of the codebase.
-#
-# All of the commands in this script are run inside a docker-compose environment.
+# Note: This test cannot be added to the normal migration test suite since it requires
+# manipulating the git history and checking out older versions of the codebase. All of
+# the commands in this script are run inside a docker-compose environment.
 #
 # [1] https://alembic.sqlalchemy.org/en/latest/autogenerate.html#running-alembic-check-to-test-for-new-upgrade-operations
 

--- a/docker/ci/test_migrations.sh
+++ b/docker/ci/test_migrations.sh
@@ -3,17 +3,22 @@
 # This script makes sure that our database migrations bring the database up to date
 # so that the resulting database is the same as if we had initialized a new instance.
 #
-# This is done by checking out the an older version of our codebase. The commit when
-# the first migration was added and initializing a new instance. Then we check out
-# the current version of our codebase and run the migrations. If the database is in
-# sync, then the migrations are up to date. If the database is out of sync, then
-# a new migration is required. We then repeat this process with our down migrations
-# to make sure that the down migrations stay in sync as well.
+# This is done by (1) checking out an older version of our codebase at the commit on
+# which the first migration was added and then (2) initializing a new instance. Then
+# we check out the current version of our codebase and run our migrations.
 #
-# This test is cannot be added to the normal migration test suite since it requires
+# After the migrations are complete we use `alembic check` [1] to make sure that the
+# database model matches the migrated database. If the model matches, then the database
+# database is in sync and the migrations are up to date. If the database doesn't match
+# then a new migration is required. We then repeat this process with our down
+# migrations to make sure that the down migrations stay in sync as well.
+#
+# This test cannot be added to the normal migration test suite since it requires
 # manipulating the git history and checking out older versions of the codebase.
 #
 # All of the commands in this script are run inside a docker-compose environment.
+#
+# [1] https://alembic.sqlalchemy.org/en/latest/autogenerate.html#running-alembic-check-to-test-for-new-upgrade-operations
 
 
 compose_cmd() {

--- a/docker/ci/test_migrations.sh
+++ b/docker/ci/test_migrations.sh
@@ -7,7 +7,8 @@
 # the first migration was added and initializing a new instance. Then we check out
 # the current version of our codebase and run the migrations. If the database is in
 # sync, then the migrations are up to date. If the database is out of sync, then
-# a new migration is required.
+# a new migration is required. We then repeat this process with our down migrations
+# to make sure that the down migrations stay in sync as well.
 #
 # This test is cannot be added to the normal migration test suite since it requires
 # manipulating the git history and checking out older versions of the codebase.

--- a/docker/ci/test_migrations.sh
+++ b/docker/ci/test_migrations.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# This script makes sure that our database migrations bring the database up to date
+# so that the resulting database is the same as if we had initialized a new instance.
+#
+# This is done by checking out the an older version of our codebase. The commit when
+# the first migration was added and initializing a new instance. Then we check out
+# the current version of our codebase and run the migrations. If the database is in
+# sync, then the migrations are up to date. If the database is out of sync, then
+# a new migration is required.
+#
+# This test is cannot be added to the normal migration test suite since it requires
+# manipulating the git history and checking out older versions of the codebase.
+#
+# All of the commands in this script are run inside a docker-compose environment.
+
+
+compose_cmd() {
+  docker --log-level ERROR compose --progress quiet "$@"
+}
+
+run_in_container()
+{
+  compose_cmd run --build --rm webapp /bin/bash -c "source env/bin/activate && $*"
+}
+
+if ! git diff --quiet; then
+  echo "ERROR: You have uncommitted changes. These changes will be lost if you run this script."
+  echo "  Please commit or stash your changes and try again."
+  exit 1
+fi
+
+# Find the currently checked out branch
+current_branch=$(git symbolic-ref -q --short HEAD)
+current_branch_exit_code=$?
+
+# If we are not on a branch, then we are in a detached HEAD state, so
+# we use the commit hash instead. This happens in CI when being run
+# against a PR instead of a branch.
+# See: https://stackoverflow.com/questions/69935511/how-do-i-save-the-current-head-so-i-can-check-it-back-out-in-the-same-way-later
+if [[ $current_branch_exit_code -ne 0 ]]; then
+  current_branch=$(git rev-parse HEAD)
+  echo "WARNING: You are in a detached HEAD state. This is normal when running in CI."
+  echo "  The current commit hash will be used instead of a branch name."
+fi
+
+echo "Current branch: ${current_branch}"
+
+# Find the first migration file
+first_migration_id=$(run_in_container alembic history -r'base:base+1' -v | head -n 1 | cut -d ' ' -f2)
+if [[ -z $first_migration_id ]]; then
+  echo "ERROR: Could not find first migration."
+  exit 1
+fi
+
+first_migration_file=$(find alembic/versions -name "*${first_migration_id}*.py")
+if [[ -z $first_migration_file ]]; then
+  echo "ERROR: Could not find first migration file."
+  exit 1
+fi
+
+echo "First migration file: ${first_migration_file}"
+echo ""
+
+# Find the git commit where the first migration file was added
+first_migration_commit=$(git log --follow --format=%H --reverse "${first_migration_file}" | head -n 1)
+
+echo "Starting containers and initializing database at commit ${first_migration_commit}"
+git checkout -q "${first_migration_commit}"
+compose_cmd down
+compose_cmd up -d pg
+run_in_container "./bin/util/initialize_instance"
+echo ""
+
+# Migrate up to the current commit and check if the database is in sync
+git checkout -q "${current_branch}"
+echo "Running database migrations on branch ${current_branch}"
+run_in_container "alembic upgrade head"
+exit_code=$?
+if [[ $exit_code -ne 0 ]]; then
+  echo "ERROR: Database migration failed."
+  exit $exit_code
+fi
+echo ""
+
+echo "Checking database status"
+run_in_container "alembic check"
+exit_code=$?
+echo ""
+
+if [[ $exit_code -eq 0 ]]; then
+  echo "SUCCESS: Database is in sync."
+else
+  echo "ERROR: Database is out of sync. A new migration is required."
+fi
+
+# Stop containers
+compose_cmd down
+
+exit $exit_code


### PR DESCRIPTION
## Description

Previously our tests could not check that when upgrading / downgrading the database, we ended up in the expected state because you need older versions of the code to do this operation. This automates the process and adds it to CI, so that we can be more confident that upgraded databases match the state of newly initialized databases.

## Motivation and Context

This ended up as a bit of a side quest when I noticed while working with production DBs for https://github.com/ThePalaceProject/circulation/pull/1590 and https://github.com/ThePalaceProject/circulation/pull/1591 that one of our down migrations wasn't matching. 

That migration is fixed in this PR, and when that commit is left out, this PR catches the error.

## How Has This Been Tested?

Running CI, and it caught a DB downgrade error in our codebase already.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
