### PR TITLE
Ensure that drm_licensor (FeedEntryType) is serialized properly.

### DIFF
--- a/core/feed/serializer/opds2.py
+++ b/core/feed/serializer/opds2.py
@@ -171,7 +171,9 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]]):
 
         if link.drm_licensor:
             props["licensor"] = {
-                "clientToken": getattr(link.drm_licensor, "clientToken"),
+                "clientToken": getattr(
+                    getattr(link.drm_licensor, "clientToken"), "text"
+                ),
                 "vendor": getattr(link.drm_licensor, "vendor"),
             }
 

--- a/tests/api/feed/test_opds2_serializer.py
+++ b/tests/api/feed/test_opds2_serializer.py
@@ -146,6 +146,11 @@ class TestOPDS2Serializer:
         assert metadata["narrator"] == dict(name="narrator2")
 
     def test__serialize_acquisition_link(self):
+        drm_licensor = FeedEntryType()
+        drm_licensor.add_attributes(
+            {"vendor": "vendor_name", "clientToken": FeedEntryType(text="token_value")}
+        )
+
         serializer = OPDS2Serializer()
         acquisition = Acquisition(
             href="http://acquisition",
@@ -164,6 +169,7 @@ class TestOPDS2Serializer:
                     ],
                 ),
             ],
+            drm_licensor=drm_licensor,
         )
 
         result = serializer._serialize_acquisition_link(acquisition)
@@ -184,6 +190,7 @@ class TestOPDS2Serializer:
                 }
             ],
             lcp_hashed_passphrase="LCPPassphrase",
+            licensor={"clientToken": "token_value", "vendor": "vendor_name"},
         )
 
         # Test availability states


### PR DESCRIPTION
## Description

Prior to this change, the drm_licensor attribute (which is a FeedEntryType) of the AcquisitionLink wasn't being serialized properly because the clientToken field of the drm_licensor (which is a FeedEntryType) is not a string but a nested FeedEntryType.  

The fix ensures that the clientToke value is extracted getting the text "text" property of the FeedEntryType.
## Motivation and Context
 https://ebce-lyrasis.atlassian.net/browse/PP-830

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests updated.  
Tested manually in my local instance.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
