### PR TITLE
Allow ODL feeds to have open access titles (PP-847)

### DIFF
--- a/api/odl2.py
+++ b/api/odl2.py
@@ -284,13 +284,14 @@ class ODL2Importer(BaseODLImporter[ODL2Settings], OPDS2Importer):
                             )
                         )
 
-        metadata.circulation.licenses = licenses
-        metadata.circulation.licenses_owned = None
-        metadata.circulation.licenses_available = None
-        metadata.circulation.licenses_reserved = None
-        metadata.circulation.patrons_in_hold_queue = None
-        metadata.circulation.formats.extend(formats)
-        metadata.medium = medium
+        if len(licenses) != 0:
+            metadata.circulation.licenses = licenses
+            metadata.circulation.licenses_owned = None
+            metadata.circulation.licenses_available = None
+            metadata.circulation.licenses_reserved = None
+            metadata.circulation.patrons_in_hold_queue = None
+            metadata.circulation.formats.extend(formats)
+            metadata.medium = medium
 
         return metadata
 

--- a/api/odl2.py
+++ b/api/odl2.py
@@ -284,6 +284,8 @@ class ODL2Importer(BaseODLImporter[ODL2Settings], OPDS2Importer):
                             )
                         )
 
+        # If we don't have any licenses, then this title is an open-access title.
+        # So we don't change the circulation data.
         if len(licenses) != 0:
             metadata.circulation.licenses = licenses
             metadata.circulation.licenses_owned = None

--- a/tests/api/files/odl2/oa-title.json
+++ b/tests/api/files/odl2/oa-title.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {
+    "title": "Feedbooks"
+  },
+  "links": [
+    {
+      "type": "application/opds+json",
+      "rel": "self",
+      "href": "https://market.feedbooks.com/api/libraries/harvest.json"
+    }
+  ],
+  "publications": [
+    {
+      "metadata": {
+        "@type": "http://schema.org/Book",
+        "title": "Maria: or, The Wrongs of Woman",
+        "language": "en",
+        "modified": "2024-01-17T14:34:03+01:00",
+        "published": "1798-01-01T00:00:00+00:09",
+        "identifier": "https://www.feedbooks.com/book/7256",
+        "schema:encodingFormat": "application/epub+zip",
+        "presentation": {
+          "layout": "reflowable"
+        },
+        "author": [
+          {
+            "name": "Mary Wollstonecraft",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/publicdomain/browse/recent.json?author_id=1315&lang=en"
+              }
+            ]
+          }
+        ],
+        "publisher": {
+          "name": "Feedbooks",
+          "links": [
+            {
+              "type": "application/opds+json",
+              "href": "https://market.feedbooks.com/publicdomain/browse/recent.json?lang=en&publisher=Feedbooks"
+            }
+          ]
+        },
+        "description": "Wollstonecraft's philosophical and gothic novel revolves around the story of a woman imprisoned in an insane asylum by her husband. It focuses on the societal rather than the individual \"wrongs of woman\" and criticizes what Wollstonecraft viewed as the patriarchal institution of marriage in eighteenth-century Britain and the legal system that protected it. [Source: Wikipedia]",
+        "subject": [
+          {
+            "code": "FBFIC000000",
+            "name": "Fiction",
+            "scheme": "http://www.feedbooks.com/categories",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/publicdomain/browse/top.json?cat=FBFIC000000&lang=en"
+              }
+            ]
+          },
+          {
+            "code": "FBFIC019000",
+            "name": "Literary",
+            "scheme": "http://www.feedbooks.com/categories",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/publicdomain/browse/top.json?cat=FBFIC019000&lang=en"
+              }
+            ]
+          },
+          {
+            "code": "READ0000",
+            "scheme": "http://schema.org/Audience",
+            "name": "Adult",
+            "links": [
+              {
+                "type": "application/opds+json",
+                "href": "https://market.feedbooks.com/publicdomain/browse/top.json?age=READ0000&lang=en"
+              }
+            ]
+          }
+        ]
+      },
+      "images": [
+        {
+          "href": "https://covers.feedbooks.net/book/7256.jpg?size=large&t=1549045914",
+          "type": "image/jpeg",
+          "width": 260,
+          "height": 420
+        },
+        {
+          "href": "https://covers.feedbooks.net/book/7256.jpg?t=1549045914",
+          "type": "image/jpeg",
+          "width": 100,
+          "height": 180
+        }
+      ],
+      "links": [
+        {
+          "rel": "http://opds-spec.org/acquisition/open-access",
+          "href": "https://license.feedbooks.net/loan/open_content",
+          "type": "application/epub+zip"
+        },
+        {
+          "rel": "self",
+          "href": "https://market.feedbooks.com/book/7256.json",
+          "type": "application/opds-publication+json",
+          "properties": {
+            "authenticate": {
+              "href": "https://market.feedbooks.com/user/authentication",
+              "type": "application/opds-authentication+json"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/api/test_odl2.py
+++ b/tests/api/test_odl2.py
@@ -41,7 +41,7 @@ class TestODL2Importer:
     def _get_delivery_mechanism_by_drm_scheme_and_content_type(
         delivery_mechanisms: list[LicensePoolDeliveryMechanism],
         content_type: str,
-        drm_scheme: str,
+        drm_scheme: str | None,
     ) -> DeliveryMechanism | None:
         """Find a license pool in the list by its identifier.
 
@@ -326,6 +326,51 @@ class TestODL2Importer:
             )
         )
         assert lcp_delivery_mechanism is not None
+
+    @freeze_time("2016-01-01T00:00:00+00:00")
+    def test_import_open_access(
+        self,
+        odl2_importer: ODL2Importer,
+        odl_mock_get: MockGet,
+        api_odl2_files_fixture: ODL2APIFilesFixture,
+    ) -> None:
+        """
+        Ensure that ODL2Importer2 correctly processes and imports a feed with an
+        open access book.
+        """
+        feed = api_odl2_files_fixture.sample_text("oa-title.json")
+        imported_editions, pools, works, failures = odl2_importer.import_from_feed(feed)
+
+        # Make sure we imported one edition and it is an audiobook
+        assert isinstance(imported_editions, list)
+        assert 1 == len(imported_editions)
+
+        [edition] = imported_editions
+        assert isinstance(edition, Edition)
+        assert (
+            edition.primary_identifier.identifier
+            == "https://www.feedbooks.com/book/7256"
+        )
+        assert edition.primary_identifier.type == "URI"
+        assert edition.medium == EditionConstants.BOOK_MEDIUM
+
+        # Make sure that license pools have correct configuration
+        assert isinstance(pools, list)
+        assert 1 == len(pools)
+
+        [license_pool] = pools
+        assert license_pool.open_access is True
+
+        assert 1 == len(license_pool.delivery_mechanisms)
+
+        oa_ebook_delivery_mechanism = (
+            self._get_delivery_mechanism_by_drm_scheme_and_content_type(
+                license_pool.delivery_mechanisms,
+                MediaTypes.EPUB_MEDIA_TYPE,
+                None,
+            )
+        )
+        assert oa_ebook_delivery_mechanism is not None
 
 
 class TestODL2API:

--- a/tests/api/test_odl2.py
+++ b/tests/api/test_odl2.py
@@ -331,7 +331,6 @@ class TestODL2Importer:
     def test_import_open_access(
         self,
         odl2_importer: ODL2Importer,
-        odl_mock_get: MockGet,
         api_odl2_files_fixture: ODL2APIFilesFixture,
     ) -> None:
         """
@@ -341,7 +340,6 @@ class TestODL2Importer:
         feed = api_odl2_files_fixture.sample_text("oa-title.json")
         imported_editions, pools, works, failures = odl2_importer.import_from_feed(feed)
 
-        # Make sure we imported one edition and it is an audiobook
         assert isinstance(imported_editions, list)
         assert 1 == len(imported_editions)
 


### PR DESCRIPTION
## Description

Add some code to the ODL API to handle the case where a ODL title is open access.

## Motivation and Context

See: PP-847

## How Has This Been Tested?

Tested locally, importing feed, checking out title, viewing loans feed and returning title.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
