### PR TITLE
Borrow single item feed response respects accept header. (PP-829)

### DIFF
--- a/api/controller/loan.py
+++ b/api/controller/loan.py
@@ -145,11 +145,12 @@ class LoanController(CirculationManagerController):
         # At this point we have either a loan or a hold. If a loan, serve
         # a feed that tells the patron how to fulfill the loan. If a hold,
         # serve a feed that talks about the hold.
-        response_kwargs = {}
-        if is_new:
-            response_kwargs["status"] = 201
-        else:
-            response_kwargs["status"] = 200
+        # We also need to drill in the Accept header, so that it eventually
+        # gets sent to core.feed.opds.BaseOPDSFeed.entry_as_response
+        response_kwargs = {
+            "status": 201 if is_new else 200,
+            "mime_types": flask.request.accept_mimetypes,
+        }
         return OPDSAcquisitionFeed.single_entry_loans_feed(
             self.circulation, loan_or_hold, **response_kwargs
         )

--- a/core/feed/opds.py
+++ b/core/feed/opds.py
@@ -84,7 +84,9 @@ class BaseOPDSFeed(FeedInterface):
             logging.getLogger().error(f"Entry data has not been generated for {entry}")
             raise ValueError(f"Entry data has not been generated")
         response = OPDSEntryResponse(
-            response=serializer.serialize_work_entry(entry.computed),
+            response=serializer.to_string(
+                serializer.serialize_work_entry(entry.computed)
+            ),
             **response_kwargs,
         )
         if isinstance(serializer, OPDS2Serializer):


### PR DESCRIPTION
## Description

- Borrow single item feed response respects accept header.

## Motivation and Context

[Jira [PP-829](https://ebce-lyrasis.atlassian.net/browse/PP-829)]

## How Has This Been Tested?

- Manually tested functionality in local dev environment.
- Updated tests to cover OPDS 2 serialization.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/7632836744) for associated branch passed.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-829]: https://ebce-lyrasis.atlassian.net/browse/PP-829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ