### PR TITLE
Correct label for patron auth ID restriction type. (PP-877)

### DIFF
--- a/api/authentication/basic.py
+++ b/api/authentication/basic.py
@@ -191,13 +191,13 @@ class BasicAuthProviderLibrarySettings(AuthProviderLibrarySettings):
     library_identifier_restriction_type: LibraryIdentifierRestriction = FormField(
         LibraryIdentifierRestriction.NONE,
         form=ConfigurationFormItem(
-            label="Library Identifier Restriction",
+            label="Library Identifier Restriction Type",
             type=ConfigurationFormItemType.SELECT,
             description="When multiple libraries share an ILS, a person may be able to "
-            "authenticate with the ILS but not be considered a patron of "
+            "authenticate with the ILS, but not be considered a patron of "
             "<em>this</em> library. This setting contains the rule for determining "
             "whether an identifier is valid for this specific library. <p/> "
-            "If this setting it set to 'No Restriction' then the values for "
+            "If this setting is set to 'No Restriction', then the values for "
             "<em>Library Identifier Field</em> and <em>Library Identifier "
             "Restriction</em> will not be used.",
             options={


### PR DESCRIPTION
## Description

- Fixes a label, a typo, and some punctuation for the patron auth library settings.

## Motivation and Context

[Jira [PP-877](https://ebce-lyrasis.atlassian.net/browse/PP-877)]

## How Has This Been Tested?

- Manual testing in a local dev environment.
- [CI tests for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/7633340099) passed.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-877]: https://ebce-lyrasis.atlassian.net/browse/PP-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ