### PR TITLE
Refactor tests for several of the admin controllers (PP-497)

### DIFF
--- a/tests/api/admin/controller/test_metadata_service_self_tests.py
+++ b/tests/api/admin/controller/test_metadata_service_self_tests.py
@@ -20,7 +20,9 @@ class MetadataServiceSelfTestsFixture(MetadataServicesFixture):
         super().__init__(db)
         manager = MagicMock()
         manager._db = db.session
-        self.controller = MetadataServiceSelfTestsController(manager)
+        self.controller: MetadataServiceSelfTestsController = (
+            MetadataServiceSelfTestsController(manager)
+        )
         self.db = db
 
 

--- a/tests/api/admin/controller/test_metadata_service_self_tests.py
+++ b/tests/api/admin/controller/test_metadata_service_self_tests.py
@@ -1,47 +1,84 @@
+from unittest.mock import MagicMock, create_autospec
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from flask import Response
+
+from api.admin.controller.metadata_service_self_tests import (
+    MetadataServiceSelfTestsController,
+)
 from api.admin.problem_details import *
 from api.nyt import NYTBestSellerAPI
-from core.model import ExternalIntegration, create
-from core.selftest import HasSelfTests
+from core.util.problem_detail import ProblemDetail
+from tests.api.admin.controller.test_metadata_services import MetadataServicesFixture
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.flask import FlaskAppFixture
+
+
+class MetadataServiceSelfTestsFixture(MetadataServicesFixture):
+    def __init__(self, db: DatabaseTransactionFixture):
+        super().__init__(db)
+        manager = MagicMock()
+        manager._db = db.session
+        self.controller = MetadataServiceSelfTestsController(manager)
+        self.db = db
+
+
+@pytest.fixture
+def metadata_services_fixture(
+    db: DatabaseTransactionFixture,
+) -> MetadataServiceSelfTestsFixture:
+    return MetadataServiceSelfTestsFixture(db)
 
 
 class TestMetadataServiceSelfTests:
     def test_metadata_service_self_tests_with_no_identifier(
-        self, settings_ctrl_fixture
+        self, metadata_services_fixture: MetadataServiceSelfTestsFixture
     ):
-        with settings_ctrl_fixture.request_context_with_admin("/"):
-            response = settings_ctrl_fixture.manager.admin_metadata_service_self_tests_controller.process_metadata_service_self_tests(
+        response = (
+            metadata_services_fixture.controller.process_metadata_service_self_tests(
                 None
             )
-            assert response.title == MISSING_IDENTIFIER.title
-            assert response.detail == MISSING_IDENTIFIER.detail
-            assert response.status_code == 400
+        )
+        assert isinstance(response, ProblemDetail)
+        assert response.title == MISSING_IDENTIFIER.title
+        assert response.detail == MISSING_IDENTIFIER.detail
+        assert response.status_code == 400
 
     def test_metadata_service_self_tests_with_no_metadata_service_found(
-        self, settings_ctrl_fixture
+        self,
+        metadata_services_fixture: MetadataServiceSelfTestsFixture,
+        flask_app_fixture: FlaskAppFixture,
     ):
-        with settings_ctrl_fixture.request_context_with_admin("/"):
-            response = settings_ctrl_fixture.manager.admin_metadata_service_self_tests_controller.process_metadata_service_self_tests(
+        with flask_app_fixture.test_request_context("/"):
+            response = metadata_services_fixture.controller.process_metadata_service_self_tests(
                 -1
             )
-            assert response == MISSING_SERVICE
-            assert response.status_code == 404
+        assert response == MISSING_SERVICE
+        assert response.status_code == 404
 
-    def test_metadata_service_self_tests_test_get(self, settings_ctrl_fixture):
-        old_prior_test_results = HasSelfTests.prior_test_results
-        HasSelfTests.prior_test_results = settings_ctrl_fixture.mock_prior_test_results
-        metadata_service, ignore = create(
-            settings_ctrl_fixture.ctrl.db.session,
-            ExternalIntegration,
-            protocol=ExternalIntegration.NYT,
-            goal=ExternalIntegration.METADATA_GOAL,
+    def test_metadata_service_self_tests_test_get(
+        self,
+        metadata_services_fixture: MetadataServiceSelfTestsFixture,
+        flask_app_fixture: FlaskAppFixture,
+        monkeypatch: MonkeyPatch,
+    ):
+        metadata_service = metadata_services_fixture.create_nyt_integration()
+        mock_prior_test_results = create_autospec(
+            NYTBestSellerAPI.prior_test_results, return_value={"test": "results"}
         )
+        monkeypatch.setattr(
+            NYTBestSellerAPI, "prior_test_results", mock_prior_test_results
+        )
+
         # Make sure that HasSelfTest.prior_test_results() was called and that
         # it is in the response's self tests object.
-        with settings_ctrl_fixture.request_context_with_admin("/"):
-            response = settings_ctrl_fixture.manager.admin_metadata_service_self_tests_controller.process_metadata_service_self_tests(
+        with flask_app_fixture.test_request_context("/"):
+            response_data = metadata_services_fixture.controller.process_metadata_service_self_tests(
                 metadata_service.id
             )
-            response_metadata_service = response.get("self_test_results")
+            assert isinstance(response_data, dict)
+            response_metadata_service = response_data.get("self_test_results", {})
 
             assert response_metadata_service.get("id") == metadata_service.id
             assert response_metadata_service.get("name") == metadata_service.name
@@ -50,45 +87,32 @@ class TestMetadataServiceSelfTests:
                 == NYTBestSellerAPI.NAME
             )
             assert response_metadata_service.get("goal") == metadata_service.goal
-            assert (
-                response_metadata_service.get("self_test_results")
-                == HasSelfTests.prior_test_results()
+            assert response_metadata_service.get("self_test_results") == {
+                "test": "results"
+            }
+
+    def test_metadata_service_self_tests_post(
+        self,
+        metadata_services_fixture: MetadataServiceSelfTestsFixture,
+        flask_app_fixture: FlaskAppFixture,
+        monkeypatch: MonkeyPatch,
+        db: DatabaseTransactionFixture,
+    ):
+        metadata_service = metadata_services_fixture.create_nyt_integration()
+        mock_run_self_tests = create_autospec(
+            NYTBestSellerAPI.run_self_tests, return_value=(dict(test="results"), None)
+        )
+        monkeypatch.setattr(NYTBestSellerAPI, "run_self_tests", mock_run_self_tests)
+
+        controller = metadata_services_fixture.controller
+        with flask_app_fixture.test_request_context("/", method="POST"):
+            response = controller.process_metadata_service_self_tests(
+                metadata_service.id
             )
-        HasSelfTests.prior_test_results = old_prior_test_results
-
-    def test_metadata_service_self_tests_post(self, settings_ctrl_fixture):
-        old_run_self_tests = HasSelfTests.run_self_tests
-        HasSelfTests.run_self_tests = settings_ctrl_fixture.mock_run_self_tests
-
-        metadata_service, ignore = create(
-            settings_ctrl_fixture.ctrl.db.session,
-            ExternalIntegration,
-            protocol=ExternalIntegration.NYT,
-            goal=ExternalIntegration.METADATA_GOAL,
-        )
-        m = (
-            settings_ctrl_fixture.manager.admin_metadata_service_self_tests_controller.self_tests_process_post
-        )
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            response = m(metadata_service.id)
-            assert response._status == "200 OK"
+            assert isinstance(response, Response)
+            assert response.status_code == 200
             assert "Successfully ran new self tests" == response.get_data(as_text=True)
 
-        positional, keyword = settings_ctrl_fixture.run_self_tests_called_with
-        # run_self_tests was called with positional arguments:
-        # * The database connection
-        # * The method to call to instantiate a HasSelfTests implementation
-        #   (NYTBestSellerAPI.from_config)
-        # * The database connection again (to be passed into
-        #   NYTBestSellerAPI.from_config).
-        assert (
-            settings_ctrl_fixture.ctrl.db.session,
-            NYTBestSellerAPI.from_config,
-            settings_ctrl_fixture.ctrl.db.session,
-        ) == positional
-
-        # run_self_tests was not called with any keyword arguments.
-        assert {} == keyword
-
-        # Undo the mock.
-        HasSelfTests.run_self_tests = old_run_self_tests
+        mock_run_self_tests.assert_called_once_with(
+            db.session, NYTBestSellerAPI.from_config, db.session
+        )

--- a/tests/api/admin/controller/test_metadata_services.py
+++ b/tests/api/admin/controller/test_metadata_services.py
@@ -1,13 +1,16 @@
 import json
+from unittest.mock import MagicMock
 
 import flask
 import pytest
-from werkzeug.datastructures import MultiDict
+from flask import Response
+from werkzeug.datastructures import ImmutableMultiDict
 
 from api.admin.controller.metadata_services import MetadataServicesController
 from api.admin.exceptions import AdminNotAuthorized
 from api.admin.problem_details import (
     CANNOT_CHANGE_PROTOCOL,
+    DUPLICATE_INTEGRATION,
     INCOMPLETE_CONFIGURATION,
     INTEGRATION_NAME_ALREADY_IN_USE,
     MISSING_SERVICE,
@@ -15,101 +18,137 @@ from api.admin.problem_details import (
     NO_SUCH_LIBRARY,
     UNKNOWN_PROTOCOL,
 )
-from api.novelist import NoveListAPI
-from api.nyt import NYTBestSellerAPI
-from core.model import AdminRole, ExternalIntegration, create, get_one
+from core.model import ExternalIntegration, IntegrationConfiguration, create, get_one
+from core.util.problem_detail import ProblemDetail
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.flask import FlaskAppFixture
+
+
+class MetadataServicesFixture:
+    def __init__(self, db: DatabaseTransactionFixture):
+        novelist_protocol = ExternalIntegration.NOVELIST
+        assert novelist_protocol is not None
+        self.novelist_protocol = novelist_protocol
+
+        nyt_protocol = ExternalIntegration.NYT
+        assert nyt_protocol is not None
+        self.nyt_protocol = nyt_protocol
+
+        manager = MagicMock()
+        manager._db = db.session
+        self.controller = MetadataServicesController(manager)
+        self.db = db
+
+    def create_novelist_integration(
+        self,
+        username: str = "user",
+        password: str = "pass",
+    ) -> ExternalIntegration:
+        integration = self.db.external_integration(
+            protocol=self.novelist_protocol,
+            goal=ExternalIntegration.METADATA_GOAL,
+        )
+        integration.username = username
+        integration.password = password
+        return integration
+
+    def create_nyt_integration(
+        self,
+        api_key: str = "xyz",
+    ) -> ExternalIntegration:
+        integration = self.db.external_integration(
+            protocol=self.nyt_protocol,
+            goal=ExternalIntegration.METADATA_GOAL,
+        )
+        integration.password = api_key
+        return integration
+
+
+@pytest.fixture
+def metadata_services_fixture(
+    db: DatabaseTransactionFixture,
+) -> MetadataServicesFixture:
+    return MetadataServicesFixture(db)
 
 
 class TestMetadataServices:
-    def create_service(self, name, db_session):
-        return create(
-            db_session,
-            ExternalIntegration,
-            protocol=ExternalIntegration.__dict__.get(name) or "fake",
-            goal=ExternalIntegration.METADATA_GOAL,
-        )[0]
-
     def test_process_metadata_services_dispatches_by_request_method(
-        self, settings_ctrl_fixture
+        self,
+        metadata_services_fixture: MetadataServicesFixture,
+        flask_app_fixture: FlaskAppFixture,
     ):
-        class Mock(MetadataServicesController):
-            def process_get(self):
-                return "GET"
+        controller = metadata_services_fixture.controller
 
-            def process_post(self):
-                return "POST"
-
-        controller = Mock(settings_ctrl_fixture.manager)
-        with settings_ctrl_fixture.request_context_with_admin("/"):
-            assert "GET" == controller.process_metadata_services()
-
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            assert "POST" == controller.process_metadata_services()
-
-        # This is also where permissions are checked.
-        settings_ctrl_fixture.admin.remove_role(AdminRole.SYSTEM_ADMIN)
-        settings_ctrl_fixture.ctrl.db.session.flush()
-
-        with settings_ctrl_fixture.request_context_with_admin("/"):
+        # Make sure permissions are checked.
+        with flask_app_fixture.test_request_context("/"):
             pytest.raises(AdminNotAuthorized, controller.process_metadata_services)
 
-    def test_process_get_with_no_services(self, settings_ctrl_fixture):
-        with settings_ctrl_fixture.request_context_with_admin("/"):
-            response = (
-                settings_ctrl_fixture.manager.admin_metadata_services_controller.process_get()
-            )
-            assert response.get("metadata_services") == []
-            protocols = response.get("protocols")
-            assert NoveListAPI.NAME in [p.get("label") for p in protocols]
-            assert "settings" in protocols[0]
+        # Mock out the process_get and process_post methods so we can
+        # verify that they're called.
+        controller.process_get = MagicMock()
+        controller.process_post = MagicMock()
 
-    def test_process_get_with_one_service(self, settings_ctrl_fixture):
-        novelist_service = self.create_service(
-            "NOVELIST", settings_ctrl_fixture.ctrl.db.session
-        )
-        novelist_service.username = "user"
-        novelist_service.password = "pass"
+        with flask_app_fixture.test_request_context_system_admin("/"):
+            controller.process_metadata_services()
+            controller.process_get.assert_called_once()
+            controller.process_post.assert_not_called()
 
-        controller = settings_ctrl_fixture.manager.admin_metadata_services_controller
+        controller.process_get = MagicMock()
+        controller.process_post = MagicMock()
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            controller.process_metadata_services()
+            controller.process_get.assert_not_called()
+            controller.process_post.assert_called_once()
 
-        with settings_ctrl_fixture.request_context_with_admin("/"):
-            response = controller.process_get()
-            [service] = response.get("metadata_services")
+    def test_process_get_with_no_services(
+        self, metadata_services_fixture: MetadataServicesFixture
+    ):
+        response_content = metadata_services_fixture.controller.process_get()
+        assert isinstance(response_content, dict)
+        assert response_content.get("metadata_services") == []
+        [nyt, novelist] = response_content.get("protocols", [])
 
-            assert novelist_service.id == service.get("id")
-            assert ExternalIntegration.NOVELIST == service.get("protocol")
-            assert "user" == service.get("settings").get(ExternalIntegration.USERNAME)
-            assert "pass" == service.get("settings").get(ExternalIntegration.PASSWORD)
+        assert novelist.get("name") == metadata_services_fixture.novelist_protocol
+        assert "settings" in novelist
+        assert novelist.get("sitewide") is False
 
-        novelist_service.libraries += [settings_ctrl_fixture.ctrl.db.default_library()]
-        with settings_ctrl_fixture.request_context_with_admin("/"):
-            response = controller.process_get()
-            [service] = response.get("metadata_services")
+        assert nyt.get("name") == metadata_services_fixture.nyt_protocol
+        assert "settings" in nyt
+        assert nyt.get("sitewide") is True
 
-            assert "user" == service.get("settings").get(ExternalIntegration.USERNAME)
-            [library] = service.get("libraries")
-            assert (
-                settings_ctrl_fixture.ctrl.db.default_library().short_name
-                == library.get("short_name")
-            )
+    def test_process_get_with_one_service(
+        self,
+        metadata_services_fixture: MetadataServicesFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        novelist_service = metadata_services_fixture.create_novelist_integration()
+        controller = metadata_services_fixture.controller
 
-    def test_find_protocol_class(self, settings_ctrl_fixture):
-        [nyt, novelist, fake] = [
-            self.create_service(x, settings_ctrl_fixture.ctrl.db.session)
-            for x in ["NYT", "NOVELIST", "FAKE"]
-        ]
-        m = (
-            settings_ctrl_fixture.manager.admin_metadata_services_controller.find_protocol_class
-        )
+        response_data = controller.process_get()
+        assert isinstance(response_data, dict)
+        [service] = response_data.get("metadata_services", [])
 
-        assert m(nyt)[0] == NYTBestSellerAPI
-        assert m(novelist)[0] == NoveListAPI
-        pytest.raises(NotImplementedError, m, fake)
+        assert service.get("id") == novelist_service.id
+        assert service.get("protocol") == metadata_services_fixture.novelist_protocol
+        assert service.get("settings").get("username") == "user"
+        assert service.get("settings").get("password") == "pass"
 
-    def test_metadata_services_post_errors(self, settings_ctrl_fixture):
-        controller = settings_ctrl_fixture.manager.admin_metadata_services_controller
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            flask.request.form = MultiDict(
+        novelist_service.libraries += [db.default_library()]
+        response_data = controller.process_get()
+        assert isinstance(response_data, dict)
+        [service] = response_data.get("metadata_services", [])
+
+        [library] = service.get("libraries")
+        assert library.get("short_name") == db.default_library().short_name
+
+    def test_metadata_services_post_errors(
+        self,
+        metadata_services_fixture: MetadataServicesFixture,
+        flask_app_fixture: FlaskAppFixture,
+    ):
+        controller = metadata_services_fixture.controller
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
                 [
                     ("name", "Name"),
                     ("protocol", "Unknown"),
@@ -118,204 +157,300 @@ class TestMetadataServices:
             response = controller.process_post()
             assert response == UNKNOWN_PROTOCOL
 
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            flask.request.form = MultiDict([])
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict([])
             response = controller.process_post()
+            assert isinstance(response, ProblemDetail)
             assert response == INCOMPLETE_CONFIGURATION
 
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            flask.request.form = MultiDict(
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
                 [
                     ("name", "Name"),
                 ]
             )
             response = controller.process_post()
+            assert isinstance(response, ProblemDetail)
             assert response == NO_PROTOCOL_FOR_NEW_SERVICE
 
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            flask.request.form = MultiDict(
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
                 [
                     ("name", "Name"),
                     ("id", "123"),
-                    ("protocol", ExternalIntegration.NYT),
+                    ("protocol", metadata_services_fixture.novelist_protocol),
                 ]
             )
             response = controller.process_post()
+            assert isinstance(response, ProblemDetail)
             assert response == MISSING_SERVICE
 
-        service = self.create_service("NOVELIST", settings_ctrl_fixture.ctrl.db.session)
+        service = metadata_services_fixture.create_novelist_integration()
         service.name = "name"
 
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            flask.request.form = MultiDict(
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
                 [
-                    ("name", service.name),
-                    ("protocol", ExternalIntegration.NYT),
+                    ("name", str(service.name)),
+                    ("protocol", metadata_services_fixture.nyt_protocol),
                 ]
             )
             response = controller.process_post()
+            assert isinstance(response, ProblemDetail)
             assert response == INTEGRATION_NAME_ALREADY_IN_USE
 
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            flask.request.form = MultiDict(
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
                 [
                     ("name", "Name"),
-                    ("id", service.id),
-                    ("protocol", ExternalIntegration.NYT),
+                    ("id", str(service.id)),
+                    ("protocol", metadata_services_fixture.nyt_protocol),
                 ]
             )
             response = controller.process_post()
             assert response == CANNOT_CHANGE_PROTOCOL
 
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            flask.request.form = MultiDict(
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
                 [
-                    ("id", service.id),
-                    ("protocol", ExternalIntegration.NOVELIST),
+                    ("id", str(service.id)),
+                    ("protocol", metadata_services_fixture.novelist_protocol),
                 ]
             )
             response = controller.process_post()
+            assert isinstance(response, ProblemDetail)
             assert response.uri == INCOMPLETE_CONFIGURATION.uri
 
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            flask.request.form = MultiDict(
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
                 [
                     ("name", "Name"),
-                    ("id", service.id),
-                    ("protocol", ExternalIntegration.NOVELIST),
-                    (ExternalIntegration.USERNAME, "user"),
-                    (ExternalIntegration.PASSWORD, "pass"),
+                    ("id", str(service.id)),
+                    ("protocol", str(service.protocol)),
+                    ("username", "user"),
+                    ("password", "pass"),
                     ("libraries", json.dumps([{"short_name": "not-a-library"}])),
                 ]
             )
             response = controller.process_post()
+            assert isinstance(response, ProblemDetail)
             assert response.uri == NO_SUCH_LIBRARY.uri
 
-    def test_metadata_services_post_create(self, settings_ctrl_fixture):
-        controller = settings_ctrl_fixture.manager.admin_metadata_services_controller
-        library = settings_ctrl_fixture.ctrl.db.library(
+    def test_metadata_services_post_create(
+        self,
+        metadata_services_fixture: MetadataServicesFixture,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        controller = metadata_services_fixture.controller
+        library = db.library(
             name="Library",
             short_name="L",
         )
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            flask.request.form = MultiDict(
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
                 [
                     ("name", "Name"),
-                    ("protocol", ExternalIntegration.NOVELIST),
-                    (ExternalIntegration.USERNAME, "user"),
-                    (ExternalIntegration.PASSWORD, "pass"),
+                    ("protocol", metadata_services_fixture.novelist_protocol),
+                    ("username", "user"),
+                    ("password", "pass"),
                     ("libraries", json.dumps([{"short_name": "L"}])),
                 ]
             )
             response = controller.process_post()
+            assert isinstance(response, Response)
             assert response.status_code == 201
 
-        # A new ExternalIntegration has been created based on the submitted
+        # A new IntegrationConfiguration has been created based on the submitted
         # information.
         service = get_one(
-            settings_ctrl_fixture.ctrl.db.session,
+            db.session,
             ExternalIntegration,
             goal=ExternalIntegration.METADATA_GOAL,
         )
-        assert service.id == int(response.response[0])
-        assert ExternalIntegration.NOVELIST == service.protocol
-        assert "user" == service.username
-        assert "pass" == service.password
-        assert [library] == service.libraries
+        assert service is not None
+        assert service.id == int(response.get_data(as_text=True))
+        assert service.protocol == metadata_services_fixture.novelist_protocol
+        assert service.username == "user"
+        assert service.password == "pass"
+        assert service.libraries == [library]
 
-    def test_metadata_services_post_edit(self, settings_ctrl_fixture):
-        l1 = settings_ctrl_fixture.ctrl.db.library(
+    def test_metadata_services_post_create_multiple(
+        self,
+        metadata_services_fixture: MetadataServicesFixture,
+        flask_app_fixture: FlaskAppFixture,
+    ):
+        controller = metadata_services_fixture.controller
+        metadata_services_fixture.create_novelist_integration()
+        metadata_services_fixture.create_nyt_integration()
+
+        # If we try to create a second NYT service, we'll get an error.
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "Name"),
+                    ("protocol", metadata_services_fixture.nyt_protocol),
+                    ("password", "pass"),
+                ]
+            )
+            response = controller.process_post()
+            assert isinstance(response, ProblemDetail)
+            assert response == DUPLICATE_INTEGRATION
+
+        # However we can create a second NoveList service.
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "Name"),
+                    ("protocol", metadata_services_fixture.novelist_protocol),
+                    ("username", "user"),
+                    ("password", "pass"),
+                ]
+            )
+            response = controller.process_post()
+            assert isinstance(response, Response)
+            assert response.status_code == 201
+
+    def test_metadata_services_post_edit(
+        self,
+        metadata_services_fixture: MetadataServicesFixture,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        l1 = db.library(
             name="Library 1",
             short_name="L1",
         )
-        l2 = settings_ctrl_fixture.ctrl.db.library(
+        l2 = db.library(
             name="Library 2",
             short_name="L2",
         )
-        novelist_service = self.create_service(
-            "NOVELIST", settings_ctrl_fixture.ctrl.db.session
+        novelist_service = metadata_services_fixture.create_novelist_integration(
+            username="olduser", password="oldpass"
         )
-        novelist_service.username = "olduser"
-        novelist_service.password = "oldpass"
         novelist_service.libraries = [l1]
 
-        controller = settings_ctrl_fixture.manager.admin_metadata_services_controller
-        with settings_ctrl_fixture.request_context_with_admin("/", method="POST"):
-            flask.request.form = MultiDict(
+        controller = metadata_services_fixture.controller
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
                 [
                     ("name", "Name"),
-                    ("id", novelist_service.id),
-                    ("protocol", ExternalIntegration.NOVELIST),
-                    (ExternalIntegration.USERNAME, "user"),
-                    (ExternalIntegration.PASSWORD, "pass"),
+                    ("id", str(novelist_service.id)),
+                    ("protocol", str(novelist_service.protocol)),
+                    ("username", "newuser"),
+                    ("password", "newpass"),
                     ("libraries", json.dumps([{"short_name": "L2"}])),
                 ]
             )
             response = controller.process_post()
             assert response.status_code == 200
 
-    def test_check_name_unique(self, settings_ctrl_fixture):
-        kwargs = dict(
-            protocol=ExternalIntegration.NYT, goal=ExternalIntegration.METADATA_GOAL
-        )
+        # The existing integration has been updated based on the submitted
+        # information.
+        assert novelist_service.username == "newuser"
+        assert novelist_service.password == "newpass"
+        assert novelist_service.libraries == [l2]
 
+    def test_check_name_unique(
+        self,
+        metadata_services_fixture: MetadataServicesFixture,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ):
         existing_service, ignore = create(
-            settings_ctrl_fixture.ctrl.db.session,
+            db.session,
             ExternalIntegration,
             name="existing service",
-            **kwargs
+            protocol=ExternalIntegration.NYT,
+            goal=ExternalIntegration.METADATA_GOAL,
         )
         new_service, ignore = create(
-            settings_ctrl_fixture.ctrl.db.session,
+            db.session,
             ExternalIntegration,
             name="new service",
-            **kwargs
-        )
-
-        m = (
-            settings_ctrl_fixture.manager.admin_metadata_services_controller.check_name_unique
+            protocol=ExternalIntegration.NYT,
+            goal=ExternalIntegration.METADATA_GOAL,
         )
 
         # Try to change new service so that it has the same name as existing service
         # -- this is not allowed.
-        result = m(new_service, existing_service.name)
-        assert result == INTEGRATION_NAME_ALREADY_IN_USE
+        controller = metadata_services_fixture.controller
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", existing_service.name),
+                    ("id", new_service.id),
+                    ("protocol", new_service.protocol),
+                    ("username", "user"),
+                    ("password", "pass"),
+                ]
+            )
+            response = controller.process_post()
+            assert isinstance(response, ProblemDetail)
+            assert response == INTEGRATION_NAME_ALREADY_IN_USE
 
         # Try to edit existing service without changing its name -- this is fine.
-        assert None == m(existing_service, existing_service.name)
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", existing_service.name),
+                    ("id", existing_service.id),
+                    ("protocol", new_service.protocol),
+                    ("username", "user"),
+                    ("password", "pass"),
+                ]
+            )
+            response = controller.process_post()
+            assert isinstance(response, Response)
+            assert response.status_code == 200
 
         # Changing the existing service's name is also fine.
-        assert None == m(existing_service, "new name")
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "New Name"),
+                    ("id", existing_service.id),
+                    ("protocol", new_service.protocol),
+                    ("username", "user"),
+                    ("password", "pass"),
+                ]
+            )
+            response = controller.process_post()
+            assert isinstance(response, Response)
+            assert response.status_code == 200
 
-    def test_metadata_service_delete(self, settings_ctrl_fixture):
-        l1 = settings_ctrl_fixture.ctrl.db.library(
+    def test_metadata_service_delete(
+        self,
+        metadata_services_fixture: MetadataServicesFixture,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        l1 = db.library(
             name="Library 1",
             short_name="L1",
         )
-        novelist_service = self.create_service(
-            "NOVELIST", settings_ctrl_fixture.ctrl.db.session
+        novelist_service = metadata_services_fixture.create_novelist_integration(
+            username="olduser", password="oldpass"
         )
-        novelist_service.username = "olduser"
-        novelist_service.password = "oldpass"
         novelist_service.libraries = [l1]
 
-        with settings_ctrl_fixture.request_context_with_admin("/", method="DELETE"):
-            settings_ctrl_fixture.admin.remove_role(AdminRole.SYSTEM_ADMIN)
+        controller = metadata_services_fixture.controller
+        with flask_app_fixture.test_request_context("/", method="DELETE"):
             pytest.raises(
                 AdminNotAuthorized,
-                settings_ctrl_fixture.manager.admin_metadata_services_controller.process_delete,
+                controller.process_delete,
                 novelist_service.id,
             )
 
-            settings_ctrl_fixture.admin.add_role(AdminRole.SYSTEM_ADMIN)
-            response = settings_ctrl_fixture.manager.admin_metadata_services_controller.process_delete(
-                novelist_service.id
-            )
+        with flask_app_fixture.test_request_context_system_admin("/", method="DELETE"):
+            service_id = novelist_service.id
+            assert isinstance(service_id, int)
+            response = controller.process_delete(service_id)
             assert response.status_code == 200
 
         service = get_one(
-            settings_ctrl_fixture.ctrl.db.session,
-            ExternalIntegration,
+            db.session,
+            IntegrationConfiguration,
             id=novelist_service.id,
         )
-        assert None == service
+        assert service is None

--- a/tests/api/admin/controller/test_metadata_services.py
+++ b/tests/api/admin/controller/test_metadata_services.py
@@ -378,9 +378,9 @@ class TestMetadataServices:
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
             flask.request.form = ImmutableMultiDict(
                 [
-                    ("name", existing_service.name),
-                    ("id", new_service.id),
-                    ("protocol", new_service.protocol),
+                    ("name", str(existing_service.name)),
+                    ("id", str(new_service.id)),
+                    ("protocol", str(new_service.protocol)),
                     ("username", "user"),
                     ("password", "pass"),
                 ]
@@ -393,9 +393,9 @@ class TestMetadataServices:
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
             flask.request.form = ImmutableMultiDict(
                 [
-                    ("name", existing_service.name),
-                    ("id", existing_service.id),
-                    ("protocol", new_service.protocol),
+                    ("name", str(existing_service.name)),
+                    ("id", str(existing_service.id)),
+                    ("protocol", str(new_service.protocol)),
                     ("username", "user"),
                     ("password", "pass"),
                 ]
@@ -409,8 +409,8 @@ class TestMetadataServices:
             flask.request.form = ImmutableMultiDict(
                 [
                     ("name", "New Name"),
-                    ("id", existing_service.id),
-                    ("protocol", new_service.protocol),
+                    ("id", str(existing_service.id)),
+                    ("protocol", str(new_service.protocol)),
                     ("username", "user"),
                     ("password", "pass"),
                 ]

--- a/tests/api/admin/controller/test_patron_auth.py
+++ b/tests/api/admin/controller/test_patron_auth.py
@@ -14,12 +14,10 @@ from api.admin.controller.patron_auth_services import PatronAuthServicesControll
 from api.admin.exceptions import AdminNotAuthorized
 from api.admin.problem_details import (
     CANNOT_CHANGE_PROTOCOL,
-    FAILED_TO_RUN_SELF_TESTS,
     INCOMPLETE_CONFIGURATION,
     INTEGRATION_NAME_ALREADY_IN_USE,
     INVALID_CONFIGURATION_OPTION,
     INVALID_LIBRARY_IDENTIFIER_RESTRICTION_REGULAR_EXPRESSION,
-    MISSING_IDENTIFIER,
     MISSING_SERVICE,
     MISSING_SERVICE_NAME,
     MULTIPLE_BASIC_AUTH_SERVICES,
@@ -40,7 +38,6 @@ from core.integration.goals import Goals
 from core.model import Library, get_one
 from core.model.integration import IntegrationConfiguration
 from core.problem_details import INVALID_INPUT
-from core.selftest import HasSelfTestsIntegrationConfiguration
 from core.util.problem_detail import ProblemDetail
 from tests.fixtures.flask import FlaskAppFixture
 
@@ -271,14 +268,13 @@ class TestPatronAuth:
         create_simple_auth_integration: SimpleAuthIntegrationFixture,
     ):
         auth_service, _ = create_simple_auth_integration()
-        form = ImmutableMultiDict(
-            [
-                ("id", str(auth_service.id)),
-                ("protocol", SIP2AuthenticationProvider.__module__),
-            ]
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("id", str(auth_service.id)),
+                    ("protocol", SIP2AuthenticationProvider.__module__),
+                ]
+            )
             response = controller.process_patron_auth_services()
         assert response == CANNOT_CHANGE_PROTOCOL
 
@@ -289,14 +285,13 @@ class TestPatronAuth:
         create_simple_auth_integration: SimpleAuthIntegrationFixture,
     ):
         auth_service, _ = create_simple_auth_integration()
-        form = ImmutableMultiDict(
-            [
-                ("name", str(auth_service.name)),
-                ("protocol", SIP2AuthenticationProvider.__module__),
-            ]
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", str(auth_service.name)),
+                    ("protocol", SIP2AuthenticationProvider.__module__),
+                ]
+            )
             response = controller.process_patron_auth_services()
         assert response == INTEGRATION_NAME_ALREADY_IN_USE
 
@@ -308,19 +303,18 @@ class TestPatronAuth:
         common_args: list[tuple[str, str]],
     ):
         auth_service, _ = create_millenium_auth_integration()
-        form = ImmutableMultiDict(
-            [
-                ("name", "some auth name"),
-                ("id", str(auth_service.id)),
-                ("protocol", MilleniumPatronAPI.__module__),
-                ("url", "http://url"),
-                ("authentication_mode", "Invalid mode"),
-                ("verify_certificate", "true"),
-            ]
-            + common_args
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "some auth name"),
+                    ("id", str(auth_service.id)),
+                    ("protocol", MilleniumPatronAPI.__module__),
+                    ("url", "http://url"),
+                    ("authentication_mode", "Invalid mode"),
+                    ("verify_certificate", "true"),
+                ]
+                + common_args
+            )
             response = controller.process_patron_auth_services()
         assert isinstance(response, ProblemDetail)
         assert response.uri == INVALID_CONFIGURATION_OPTION.uri
@@ -333,14 +327,13 @@ class TestPatronAuth:
         common_args: list[tuple[str, str]],
     ):
         auth_service, _ = create_simple_auth_integration()
-        form = ImmutableMultiDict(
-            [
-                ("id", str(auth_service.id)),
-                ("protocol", SimpleAuthenticationProvider.__module__),
-            ]
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("id", str(auth_service.id)),
+                    ("protocol", SimpleAuthenticationProvider.__module__),
+                ]
+            )
             response = controller.process_patron_auth_services()
         assert isinstance(response, ProblemDetail)
         assert response.uri == INCOMPLETE_CONFIGURATION.uri
@@ -351,14 +344,13 @@ class TestPatronAuth:
         flask_app_fixture: FlaskAppFixture,
         common_args: list[tuple[str, str]],
     ):
-        form = ImmutableMultiDict(
-            [
-                ("protocol", SimpleAuthenticationProvider.__module__),
-            ]
-            + common_args
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("protocol", SimpleAuthenticationProvider.__module__),
+                ]
+                + common_args
+            )
             response = controller.process_patron_auth_services()
         assert isinstance(response, ProblemDetail)
         assert response == MISSING_SERVICE_NAME
@@ -369,16 +361,15 @@ class TestPatronAuth:
         flask_app_fixture: FlaskAppFixture,
         common_args: list[tuple[str, str]],
     ):
-        form = ImmutableMultiDict(
-            [
-                ("name", "testing auth name"),
-                ("protocol", SimpleAuthenticationProvider.__module__),
-                ("libraries", json.dumps([{"short_name": "not-a-library"}])),
-            ]
-            + common_args
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "testing auth name"),
+                    ("protocol", SimpleAuthenticationProvider.__module__),
+                    ("libraries", json.dumps([{"short_name": "not-a-library"}])),
+                ]
+                + common_args
+            )
             response = controller.process_patron_auth_services()
         assert isinstance(response, ProblemDetail)
         assert response.uri == NO_SUCH_LIBRARY.uri
@@ -389,16 +380,15 @@ class TestPatronAuth:
         flask_app_fixture: FlaskAppFixture,
         common_args: list[tuple[str, str]],
     ):
-        form = ImmutableMultiDict(
-            [
-                ("name", "testing auth name"),
-                ("protocol", SimpleAuthenticationProvider.__module__),
-                ("libraries", json.dumps([{}])),
-            ]
-            + common_args
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "testing auth name"),
+                    ("protocol", SimpleAuthenticationProvider.__module__),
+                    ("libraries", json.dumps([{}])),
+                ]
+                + common_args
+            )
             response = controller.process_patron_auth_services()
         assert isinstance(response, ProblemDetail)
         assert response.uri == INVALID_INPUT.uri
@@ -413,27 +403,26 @@ class TestPatronAuth:
         common_args: list[tuple[str, str]],
     ):
         auth_service, _ = create_simple_auth_integration(default_library)
-        form = ImmutableMultiDict(
-            [
-                ("name", "testing auth name"),
-                ("protocol", SimpleAuthenticationProvider.__module__),
-                (
-                    "libraries",
-                    json.dumps(
-                        [
-                            {
-                                "short_name": default_library.short_name,
-                                "library_identifier_restriction_type": LibraryIdentifierRestriction.NONE.value,
-                                "library_identifier_field": "barcode",
-                            }
-                        ]
-                    ),
-                ),
-            ]
-            + common_args
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "testing auth name"),
+                    ("protocol", SimpleAuthenticationProvider.__module__),
+                    (
+                        "libraries",
+                        json.dumps(
+                            [
+                                {
+                                    "short_name": default_library.short_name,
+                                    "library_identifier_restriction_type": LibraryIdentifierRestriction.NONE.value,
+                                    "library_identifier_field": "barcode",
+                                }
+                            ]
+                        ),
+                    ),
+                ]
+                + common_args
+            )
             response = controller.process_patron_auth_services()
         assert isinstance(response, ProblemDetail)
         assert response.uri == MULTIPLE_BASIC_AUTH_SERVICES.uri
@@ -445,28 +434,27 @@ class TestPatronAuth:
         default_library: Library,
         common_args: list[tuple[str, str]],
     ):
-        form = ImmutableMultiDict(
-            [
-                ("name", "testing auth name"),
-                ("protocol", SimpleAuthenticationProvider.__module__),
-                (
-                    "libraries",
-                    json.dumps(
-                        [
-                            {
-                                "short_name": default_library.short_name,
-                                "library_identifier_restriction_type": LibraryIdentifierRestriction.REGEX.value,
-                                "library_identifier_field": "barcode",
-                                "library_identifier_restriction_criteria": "(invalid re",
-                            }
-                        ]
-                    ),
-                ),
-            ]
-            + common_args
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "testing auth name"),
+                    ("protocol", SimpleAuthenticationProvider.__module__),
+                    (
+                        "libraries",
+                        json.dumps(
+                            [
+                                {
+                                    "short_name": default_library.short_name,
+                                    "library_identifier_restriction_type": LibraryIdentifierRestriction.REGEX.value,
+                                    "library_identifier_field": "barcode",
+                                    "library_identifier_restriction_criteria": "(invalid re",
+                                }
+                            ]
+                        ),
+                    ),
+                ]
+                + common_args
+            )
             response = controller.process_patron_auth_services()
         assert isinstance(response, ProblemDetail)
         assert response == INVALID_LIBRARY_IDENTIFIER_RESTRICTION_REGULAR_EXPRESSION
@@ -477,14 +465,13 @@ class TestPatronAuth:
         controller: PatronAuthServicesController,
         flask_app_fixture: FlaskAppFixture,
     ):
-        form = ImmutableMultiDict(
-            [
-                ("protocol", SimpleAuthenticationProvider.__module__),
-            ]
-            + common_args
-        )
         with flask_app_fixture.test_request_context("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("protocol", SimpleAuthenticationProvider.__module__),
+                ]
+                + common_args
+            )
             pytest.raises(AdminNotAuthorized, controller.process_patron_auth_services)
 
     def test_patron_auth_services_post_create(
@@ -495,28 +482,27 @@ class TestPatronAuth:
         flask_app_fixture: FlaskAppFixture,
         db: DatabaseTransactionFixture,
     ):
-        form = ImmutableMultiDict(
-            [
-                ("name", "testing auth name"),
-                ("protocol", SimpleAuthenticationProvider.__module__),
-                (
-                    "libraries",
-                    json.dumps(
-                        [
-                            {
-                                "short_name": default_library.short_name,
-                                "library_identifier_restriction_type": LibraryIdentifierRestriction.REGEX.value,
-                                "library_identifier_field": "barcode",
-                                "library_identifier_restriction_criteria": "^1234",
-                            }
-                        ]
-                    ),
-                ),
-            ]
-            + common_args
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "testing auth name"),
+                    ("protocol", SimpleAuthenticationProvider.__module__),
+                    (
+                        "libraries",
+                        json.dumps(
+                            [
+                                {
+                                    "short_name": default_library.short_name,
+                                    "library_identifier_restriction_type": LibraryIdentifierRestriction.REGEX.value,
+                                    "library_identifier_field": "barcode",
+                                    "library_identifier_restriction_criteria": "^1234",
+                                }
+                            ]
+                        ),
+                    ),
+                ]
+                + common_args
+            )
             response = controller.process_patron_auth_services()
         assert isinstance(response, Response)
         assert response.status_code == 201
@@ -540,18 +526,17 @@ class TestPatronAuth:
             == "^1234"
         )
 
-        form = ImmutableMultiDict(
-            [
-                ("name", "testing auth 2 name"),
-                ("protocol", MilleniumPatronAPI.__module__),
-                ("url", "https://url.com"),
-                ("verify_certificate", "false"),
-                ("authentication_mode", "pin"),
-            ]
-            + common_args
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "testing auth 2 name"),
+                    ("protocol", MilleniumPatronAPI.__module__),
+                    ("url", "https://url.com"),
+                    ("verify_certificate", "false"),
+                    ("authentication_mode", "pin"),
+                ]
+                + common_args
+            )
             response = controller.process_patron_auth_services()
         assert isinstance(response, Response)
         assert response.status_code == 201
@@ -598,27 +583,26 @@ class TestPatronAuth:
             "old_password",
         )
 
-        form = ImmutableMultiDict(
-            [
-                ("id", str(auth_service.id)),
-                ("protocol", SimpleAuthenticationProvider.__module__),
-                (
-                    "libraries",
-                    json.dumps(
-                        [
-                            {
-                                "short_name": l2.short_name,
-                                "library_identifier_restriction_type": LibraryIdentifierRestriction.NONE.value,
-                                "library_identifier_field": "barcode",
-                            }
-                        ]
-                    ),
-                ),
-            ]
-            + common_args
-        )
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
-            flask.request.form = form
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("id", str(auth_service.id)),
+                    ("protocol", SimpleAuthenticationProvider.__module__),
+                    (
+                        "libraries",
+                        json.dumps(
+                            [
+                                {
+                                    "short_name": l2.short_name,
+                                    "library_identifier_restriction_type": LibraryIdentifierRestriction.NONE.value,
+                                    "library_identifier_field": "barcode",
+                                }
+                            ]
+                        ),
+                    ),
+                ]
+                + common_args
+            )
             response = controller.process_patron_auth_services()
         assert isinstance(response, Response)
         assert response.status_code == 200
@@ -675,147 +659,3 @@ class TestPatronAuth:
             id=auth_service.id,
         )
         assert service is None
-
-    def test_patron_auth_self_tests_with_no_identifier(
-        self, controller: PatronAuthServicesController
-    ):
-        response = controller.process_patron_auth_service_self_tests(None)
-        assert isinstance(response, ProblemDetail)
-        assert response.title == MISSING_IDENTIFIER.title
-        assert response.detail == MISSING_IDENTIFIER.detail
-        assert response.status_code == 400
-
-    def test_patron_auth_self_tests_with_no_auth_service_found(
-        self,
-        controller: PatronAuthServicesController,
-        flask_app_fixture: FlaskAppFixture,
-    ):
-        with flask_app_fixture.test_request_context("/"):
-            response = controller.process_patron_auth_service_self_tests(-1)
-        assert isinstance(response, ProblemDetail)
-        assert response == MISSING_SERVICE
-        assert response.status_code == 404
-
-    def test_patron_auth_self_tests_get_with_no_libraries(
-        self,
-        controller: PatronAuthServicesController,
-        flask_app_fixture: FlaskAppFixture,
-        create_simple_auth_integration: SimpleAuthIntegrationFixture,
-    ):
-        auth_service, _ = create_simple_auth_integration()
-        with flask_app_fixture.test_request_context("/"):
-            response_obj = controller.process_patron_auth_service_self_tests(
-                auth_service.id
-            )
-        assert isinstance(response_obj, Response)
-        response = response_obj.json
-        assert isinstance(response, dict)
-        results = response.get("self_test_results", {}).get("self_test_results")
-        assert results.get("disabled") is True
-        assert (
-            results.get("exception")
-            == "You must associate this service with at least one library before you can run self tests for it."
-        )
-
-    def test_patron_auth_self_tests_test_get_no_results(
-        self,
-        controller: PatronAuthServicesController,
-        flask_app_fixture: FlaskAppFixture,
-        create_simple_auth_integration: SimpleAuthIntegrationFixture,
-        default_library: Library,
-    ):
-        auth_service, _ = create_simple_auth_integration(library=default_library)
-
-        # Make sure that we return the correct response when there are no results
-        with flask_app_fixture.test_request_context("/"):
-            response_obj = controller.process_patron_auth_service_self_tests(
-                auth_service.id
-            )
-        assert isinstance(response_obj, Response)
-        response = response_obj.json
-        assert isinstance(response, dict)
-        response_auth_service = response.get("self_test_results", {})
-
-        assert response_auth_service.get("name") == auth_service.name
-        assert response_auth_service.get("protocol") == auth_service.protocol
-        assert response_auth_service.get("id") == auth_service.id
-        assert response_auth_service.get("self_test_results") == "No results yet"
-
-    def test_patron_auth_self_tests_test_get(
-        self,
-        controller: PatronAuthServicesController,
-        flask_app_fixture: FlaskAppFixture,
-        create_simple_auth_integration: SimpleAuthIntegrationFixture,
-        default_library: Library,
-    ):
-        expected_results = dict(
-            duration=0.9,
-            start="2018-08-08T16:04:05Z",
-            end="2018-08-08T16:05:05Z",
-            results=[],
-        )
-        auth_service, _ = create_simple_auth_integration(library=default_library)
-        auth_service.self_test_results = expected_results
-
-        # Make sure that HasSelfTest.prior_test_results() was called and that
-        # it is in the response's self tests object.
-        with flask_app_fixture.test_request_context("/"):
-            response_obj = controller.process_patron_auth_service_self_tests(
-                auth_service.id
-            )
-        assert isinstance(response_obj, Response)
-        response = response_obj.json
-        assert isinstance(response, dict)
-        response_auth_service = response.get("self_test_results", {})
-
-        assert response_auth_service.get("name") == auth_service.name
-        assert response_auth_service.get("protocol") == auth_service.protocol
-        assert response_auth_service.get("id") == auth_service.id
-        assert response_auth_service.get("self_test_results") == expected_results
-
-    def test_patron_auth_self_tests_post_with_no_libraries(
-        self,
-        controller: PatronAuthServicesController,
-        flask_app_fixture: FlaskAppFixture,
-        create_simple_auth_integration: SimpleAuthIntegrationFixture,
-    ):
-        auth_service, _ = create_simple_auth_integration()
-        with flask_app_fixture.test_request_context("/", method="POST"):
-            response = controller.process_patron_auth_service_self_tests(
-                auth_service.id,
-            )
-        assert isinstance(response, ProblemDetail)
-        assert response.title == FAILED_TO_RUN_SELF_TESTS.title
-        assert response.detail is not None
-        assert "Failed to run self tests" in response.detail
-        assert response.status_code == 400
-
-    def test_patron_auth_self_tests_test_post(
-        self,
-        controller: PatronAuthServicesController,
-        flask_app_fixture: FlaskAppFixture,
-        create_simple_auth_integration: SimpleAuthIntegrationFixture,
-        monkeypatch: MonkeyPatch,
-        db: DatabaseTransactionFixture,
-    ):
-        expected_results = ("value", "results")
-        mock = MagicMock(return_value=expected_results)
-        monkeypatch.setattr(
-            HasSelfTestsIntegrationConfiguration, "run_self_tests", mock
-        )
-        library = db.default_library()
-        auth_service, _ = create_simple_auth_integration(library=library)
-
-        with flask_app_fixture.test_request_context("/", method="POST"):
-            response = controller.process_patron_auth_service_self_tests(
-                auth_service.id
-            )
-        assert isinstance(response, Response)
-        assert response.status == "200 OK"
-        assert "Successfully ran new self tests" == response.get_data(as_text=True)
-
-        assert mock.call_count == 1
-        assert mock.call_args.args[0] == db.session
-        assert mock.call_args.args[1] is None
-        assert mock.call_args.args[2] == library.id
-        assert mock.call_args.args[3] == auth_service.id

--- a/tests/fixtures/flask.py
+++ b/tests/fixtures/flask.py
@@ -35,13 +35,14 @@ class FlaskAppFixture:
         self, *args: Any, admin: Admin | None = None, **kwargs: Any
     ) -> Generator[RequestContext, None, None]:
         with self.app.test_request_context(*args, **kwargs) as c:
+            self.db.session.begin_nested()
             flask.request.admin = admin  # type: ignore[attr-defined]
             yield c
 
             # Flush any changes that may have occurred during the request, then
             # expire all objects to ensure that the next request will see the
             # changes.
-            self.db.session.flush()
+            self.db.session.commit()
             self.db.session.expire_all()
 
     @contextmanager

--- a/tests/fixtures/flask.py
+++ b/tests/fixtures/flask.py
@@ -1,28 +1,58 @@
-from collections.abc import Generator
+from __future__ import annotations
 
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
+import flask
 import pytest
 from flask.ctx import RequestContext
 from flask_babel import Babel
 
 from api.util.flask import PalaceFlask
+from core.model import Admin, AdminRole, Library, get_one_or_create
+from tests.fixtures.database import DatabaseTransactionFixture
+
+
+class FlaskAppFixture:
+    def __init__(self, db: DatabaseTransactionFixture) -> None:
+        self.app = PalaceFlask(__name__)
+        self.db = db
+        Babel(self.app)
+
+    def admin_user(
+        self,
+        email: str = "admin@admin.org",
+        role: str = AdminRole.SYSTEM_ADMIN,
+        library: Library | None = None,
+    ) -> Admin:
+        admin, _ = get_one_or_create(self.db.session, Admin, email=email)
+        admin.add_role(role, library)
+        return admin
+
+    @contextmanager
+    def test_request_context(
+        self, *args: Any, admin: Admin | None = None, **kwargs: Any
+    ) -> Generator[RequestContext, None, None]:
+        with self.app.test_request_context(*args, **kwargs) as c:
+            flask.request.admin = admin  # type: ignore[attr-defined]
+            yield c
+
+            # Flush any changes that may have occurred during the request, then
+            # expire all objects to ensure that the next request will see the
+            # changes.
+            self.db.session.flush()
+            self.db.session.expire_all()
+
+    @contextmanager
+    def test_request_context_system_admin(
+        self, *args: Any, **kwargs: Any
+    ) -> Generator[RequestContext, None, None]:
+        admin = self.admin_user()
+        with self.test_request_context(*args, **kwargs, admin=admin) as c:
+            yield c
 
 
 @pytest.fixture
-def mock_app() -> PalaceFlask:
-    app = PalaceFlask(__name__)
-    Babel(app)
-    return app
-
-
-@pytest.fixture
-def get_request_context(mock_app: PalaceFlask) -> Generator[RequestContext, None, None]:
-    with mock_app.test_request_context("/") as mock_request_context:
-        yield mock_request_context
-
-
-@pytest.fixture
-def post_request_context(
-    mock_app: PalaceFlask,
-) -> Generator[RequestContext, None, None]:
-    with mock_app.test_request_context("/", method="POST") as mock_request_context:
-        yield mock_request_context
+def flask_app_fixture(db: DatabaseTransactionFixture) -> FlaskAppFixture:
+    return FlaskAppFixture(db)


### PR DESCRIPTION
## Description

This PR does some refactoring of the tests for the following controllers:
- `CollectionSelfTestsController`
- `CollectionSettingsController`
- `MetadataServicesController`
- `MetadataServiceSelfTestsController`
- `PatronAuthController`
- `PatronAuthSelfTestsController`

The test refactoring updates the tests to use a minimal new `flask_app_fixture` that lets us get a flask context without the overhead of instantiating a while `CirculationManager` instance.

This speeds up the tests and makes them a bit easier to reason about. It also breaks these tests out from the deeply nested hierarchy of fixtures we are using for admin controller tests. I'm hoping we can use this fixture to do similar work to other controller tests as we have the opportunity.

## Motivation and Context

This test refactoring was done in advance of work to refactor the controllers themselves. Since the test diffs are huge, I figured it would be helpful to land them in a separate commit.

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
