### PR TITLE
Refactor controller tests to use flask_app_fixture (PP-893)

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -30,7 +30,6 @@ def setup_admin_controllers(manager: CirculationManager):
     from api.admin.controller.patron import PatronController
     from api.admin.controller.patron_auth_services import PatronAuthServicesController
     from api.admin.controller.reset_password import ResetPasswordController
-    from api.admin.controller.settings import SettingsController
     from api.admin.controller.sign_in import SignInController
     from api.admin.controller.sitewide_settings import (
         SitewideConfigurationSettingsController,
@@ -48,7 +47,6 @@ def setup_admin_controllers(manager: CirculationManager):
     manager.admin_custom_lists_controller = CustomListsController(manager)
     manager.admin_lanes_controller = LanesController(manager)
     manager.admin_dashboard_controller = DashboardController(manager)
-    manager.admin_settings_controller = SettingsController(manager)
     manager.admin_patron_controller = PatronController(manager)
     manager.admin_discovery_services_controller = DiscoveryServicesController(manager)
     manager.admin_discovery_service_library_registrations_controller = (

--- a/api/circulation_manager.py
+++ b/api/circulation_manager.py
@@ -64,7 +64,6 @@ if TYPE_CHECKING:
     from api.admin.controller.patron_auth_services import PatronAuthServicesController
     from api.admin.controller.quicksight import QuickSightController
     from api.admin.controller.reset_password import ResetPasswordController
-    from api.admin.controller.settings import SettingsController
     from api.admin.controller.sign_in import SignInController
     from api.admin.controller.sitewide_settings import (
         SitewideConfigurationSettingsController,
@@ -100,7 +99,6 @@ class CirculationManager(LoggerMixin):
     admin_custom_lists_controller: CustomListsController
     admin_lanes_controller: LanesController
     admin_dashboard_controller: DashboardController
-    admin_settings_controller: SettingsController
     admin_patron_controller: PatronController
     admin_discovery_services_controller: DiscoveryServicesController
     admin_discovery_service_library_registrations_controller: DiscoveryServiceLibraryRegistrationsController

--- a/tests/api/admin/controller/test_base.py
+++ b/tests/api/admin/controller/test_base.py
@@ -1,59 +1,83 @@
 import pytest
 
+from api.admin.controller.base import AdminPermissionsControllerMixin
 from api.admin.exceptions import AdminNotAuthorized
 from core.model import AdminRole
-from tests.fixtures.api_admin import AdminControllerFixture
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.flask import FlaskAppFixture
+
+
+@pytest.fixture()
+def controller() -> AdminPermissionsControllerMixin:
+    return AdminPermissionsControllerMixin()
 
 
 class TestAdminPermissionsControllerMixin:
-    def test_require_system_admin(self, admin_ctrl_fixture: AdminControllerFixture):
-        with admin_ctrl_fixture.request_context_with_admin("/admin"):
+    def test_require_system_admin(
+        self,
+        controller: AdminPermissionsControllerMixin,
+        flask_app_fixture: FlaskAppFixture,
+    ):
+        with flask_app_fixture.test_request_context("/admin"):
             pytest.raises(
                 AdminNotAuthorized,
-                admin_ctrl_fixture.manager.admin_work_controller.require_system_admin,
+                controller.require_system_admin,
             )
 
-            admin_ctrl_fixture.admin.add_role(AdminRole.SYSTEM_ADMIN)
-            admin_ctrl_fixture.manager.admin_work_controller.require_system_admin()
+        with flask_app_fixture.test_request_context_system_admin("/admin"):
+            controller.require_system_admin()
 
     def test_require_sitewide_library_manager(
-        self, admin_ctrl_fixture: AdminControllerFixture
+        self,
+        controller: AdminPermissionsControllerMixin,
+        flask_app_fixture: FlaskAppFixture,
     ):
-        with admin_ctrl_fixture.request_context_with_admin("/admin"):
+        with flask_app_fixture.test_request_context("/admin"):
             pytest.raises(
                 AdminNotAuthorized,
-                admin_ctrl_fixture.manager.admin_work_controller.require_sitewide_library_manager,
+                controller.require_sitewide_library_manager,
             )
 
-            admin_ctrl_fixture.admin.add_role(AdminRole.SITEWIDE_LIBRARY_MANAGER)
-            admin_ctrl_fixture.manager.admin_work_controller.require_sitewide_library_manager()
+        library_manager = flask_app_fixture.admin_user(
+            role=AdminRole.SITEWIDE_LIBRARY_MANAGER
+        )
+        with flask_app_fixture.test_request_context("/admin", admin=library_manager):
+            controller.require_sitewide_library_manager()
 
-    def test_require_library_manager(self, admin_ctrl_fixture: AdminControllerFixture):
-        with admin_ctrl_fixture.request_context_with_admin("/admin"):
+    def test_require_library_manager(
+        self,
+        controller: AdminPermissionsControllerMixin,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        with flask_app_fixture.test_request_context("/admin"):
             pytest.raises(
                 AdminNotAuthorized,
-                admin_ctrl_fixture.manager.admin_work_controller.require_library_manager,
-                admin_ctrl_fixture.ctrl.db.default_library(),
+                controller.require_library_manager,
+                db.default_library(),
             )
 
-            admin_ctrl_fixture.admin.add_role(
-                AdminRole.LIBRARY_MANAGER, admin_ctrl_fixture.ctrl.db.default_library()
-            )
-            admin_ctrl_fixture.manager.admin_work_controller.require_library_manager(
-                admin_ctrl_fixture.ctrl.db.default_library()
-            )
+        library_manager = flask_app_fixture.admin_user(
+            role=AdminRole.LIBRARY_MANAGER, library=db.default_library()
+        )
+        with flask_app_fixture.test_request_context("/admin", admin=library_manager):
+            controller.require_library_manager(db.default_library())
 
-    def test_require_librarian(self, admin_ctrl_fixture: AdminControllerFixture):
-        with admin_ctrl_fixture.request_context_with_admin("/admin"):
+    def test_require_librarian(
+        self,
+        controller: AdminPermissionsControllerMixin,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        with flask_app_fixture.test_request_context("/admin"):
             pytest.raises(
                 AdminNotAuthorized,
-                admin_ctrl_fixture.manager.admin_work_controller.require_librarian,
-                admin_ctrl_fixture.ctrl.db.default_library(),
+                controller.require_librarian,
+                db.default_library(),
             )
 
-            admin_ctrl_fixture.admin.add_role(
-                AdminRole.LIBRARIAN, admin_ctrl_fixture.ctrl.db.default_library()
-            )
-            admin_ctrl_fixture.manager.admin_work_controller.require_librarian(
-                admin_ctrl_fixture.ctrl.db.default_library()
-            )
+        librarian = flask_app_fixture.admin_user(
+            role=AdminRole.LIBRARIAN, library=db.default_library()
+        )
+        with flask_app_fixture.test_request_context("/admin", admin=librarian):
+            controller.require_librarian(db.default_library())

--- a/tests/api/admin/controller/test_settings.py
+++ b/tests/api/admin/controller/test_settings.py
@@ -71,9 +71,7 @@ class TestSettingsController:
         self, settings_ctrl_fixture: SettingsControllerFixture
     ):
         """Test the _get_integration_info helper method."""
-        m = (
-            settings_ctrl_fixture.manager.admin_settings_controller._get_integration_info
-        )
+        m = settings_ctrl_fixture.controller._get_integration_info
 
         # Test the case where there are integrations in the database
         # with the given goal, but none of them match the
@@ -87,7 +85,7 @@ class TestSettingsController:
     def test_create_integration(self, settings_ctrl_fixture: SettingsControllerFixture):
         """Test the _create_integration helper method."""
 
-        m = settings_ctrl_fixture.manager.admin_settings_controller._create_integration
+        m = settings_ctrl_fixture.controller._create_integration
 
         protocol_definitions = [
             dict(name="allow many"),
@@ -131,7 +129,7 @@ class TestSettingsController:
     def test_check_url_unique(self, settings_ctrl_fixture: SettingsControllerFixture):
         # Verify our ability to catch duplicate integrations for a
         # given URL.
-        m = settings_ctrl_fixture.manager.admin_settings_controller.check_url_unique
+        m = settings_ctrl_fixture.controller.check_url_unique
 
         # Here's an ExternalIntegration.
         original = settings_ctrl_fixture.ctrl.db.external_integration(
@@ -215,9 +213,7 @@ class TestSettingsController:
     def test__get_protocol_class(
         self, settings_ctrl_fixture: SettingsControllerFixture
     ):
-        _get_protocol_class = (
-            settings_ctrl_fixture.manager.admin_settings_controller._get_settings_class
-        )
+        _get_protocol_class = settings_ctrl_fixture.controller._get_settings_class
         registry = IntegrationRegistry[Any](Goals.LICENSE_GOAL)
 
         class P1Settings(BaseSettings):
@@ -261,7 +257,7 @@ class TestSettingsController:
         db = settings_ctrl_fixture.ctrl.db
         config = db.default_collection().integration_configuration
         _set_configuration_library = (
-            settings_ctrl_fixture.manager.admin_settings_controller._set_configuration_library
+            settings_ctrl_fixture.controller._set_configuration_library
         )
         library = db.library(short_name="short-name")
 

--- a/tests/fixtures/api_admin.py
+++ b/tests/fixtures/api_admin.py
@@ -1,9 +1,11 @@
 from contextlib import contextmanager
+from unittest.mock import MagicMock
 
 import flask
 import pytest
 
 from api.admin.controller import setup_admin_controllers
+from api.admin.controller.settings import SettingsController
 from api.app import initialize_admin
 from api.circulation_manager import CirculationManager
 from api.config import Configuration
@@ -99,6 +101,10 @@ class SettingsControllerFixture(AdminControllerFixture):
 
         # Make the admin a system admin so they can do everything by default.
         self.admin.add_role(AdminRole.SYSTEM_ADMIN)
+
+        mock_manager = MagicMock()
+        mock_manager._db = self.ctrl.db.session
+        self.controller = SettingsController(mock_manager)
 
     def do_request(self, url, *args, **kwargs):
         """Mock HTTP get/post method to replace HTTP.get_with_timeout or post_with_timeout."""

--- a/tests/fixtures/flask.py
+++ b/tests/fixtures/flask.py
@@ -8,6 +8,7 @@ import flask
 import pytest
 from flask.ctx import RequestContext
 from flask_babel import Babel
+from werkzeug.datastructures import ImmutableMultiDict
 
 from api.util.flask import PalaceFlask
 from core.model import Admin, AdminRole, Library, get_one_or_create
@@ -37,6 +38,8 @@ class FlaskAppFixture:
         with self.app.test_request_context(*args, **kwargs) as c:
             self.db.session.begin_nested()
             flask.request.admin = admin  # type: ignore[attr-defined]
+            flask.request.form = ImmutableMultiDict()
+            flask.request.files = ImmutableMultiDict()
             yield c
 
             # Flush any changes that may have occurred during the request, then

--- a/tests/fixtures/flask.py
+++ b/tests/fixtures/flask.py
@@ -33,10 +33,15 @@ class FlaskAppFixture:
 
     @contextmanager
     def test_request_context(
-        self, *args: Any, admin: Admin | None = None, **kwargs: Any
+        self,
+        *args: Any,
+        admin: Admin | None = None,
+        library: Library | None = None,
+        **kwargs: Any,
     ) -> Generator[RequestContext, None, None]:
         with self.app.test_request_context(*args, **kwargs) as c:
             self.db.session.begin_nested()
+            flask.request.library = library  # type: ignore[attr-defined]
             flask.request.admin = admin  # type: ignore[attr-defined]
             flask.request.form = ImmutableMultiDict()
             flask.request.files = ImmutableMultiDict()


### PR DESCRIPTION
## Description

Refactor tests to use the new flask_app_fixture defined in https://github.com/ThePalaceProject/circulation/pull/1632. Remove a couple uses of the `SettingsController` class.

This cleanup was done in anticipation of the removal of the ExternalIntegration, ConfigurationSettings and SettingsController classes in a future PR.

## Motivation and Context

Cleanup for PP-4 now that almost everything has been converted to use integration settings.

## How Has This Been Tested?

Running tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
