### PR TITLE
Remove SettingsController from IndividualAdminSettingsController (PP-893)

### DIFF
--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -65,7 +65,7 @@ def setup_admin_controllers(manager: CirculationManager):
     )
     manager.admin_library_settings_controller = LibrarySettingsController(manager)
     manager.admin_individual_admin_settings_controller = (
-        IndividualAdminSettingsController(manager)
+        IndividualAdminSettingsController(manager._db)
     )
     manager.admin_catalog_services_controller = CatalogServicesController(manager)
     manager.admin_announcement_service = AnnouncementSettings(manager)


### PR DESCRIPTION
## Description

Remove `SettingsController` usage from the `IndividualAdminSettingsController`, since it largely doesn't use it anyway. The biggest thing is used is validate formats for the email validation. Since the rest of our email validation is done by Pydantic now, switch this over to use Pydantic as well.

## Motivation and Context

Trying to get to the place where we can remove all the old settings code including `SettingsController`.

## How Has This Been Tested?

-Testing in Admin UI locally
-Running unit tests

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
