### PR TITLE
Don't pre-load our configuration settings table cache anymore (PP-893)

### DIFF
--- a/api/circulation_manager.py
+++ b/api/circulation_manager.py
@@ -188,7 +188,6 @@ class CirculationManager(LoggerMixin):
         ):
             # Populate caches
             Library.cache_warm(self._db, lambda: libraries)
-            ConfigurationSetting.cache_warm(self._db)
 
         self.auth = Authenticator(self._db, libraries, self.analytics)
 


### PR DESCRIPTION
## Description

Now that we aren't using ConfigurationSettings anywhere. We don't need to populate the cache for them on configuration loads.

## Motivation and Context

Removing the remaining Config settings pieces.

## How Has This Been Tested?

Tested locally.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
