### PR TITLE
Revoke response respects accept header (PP-886)

### DIFF
--- a/api/controller/loan.py
+++ b/api/controller/loan.py
@@ -544,7 +544,8 @@ class LoanController(CirculationManagerController):
         work = pool.work
         annotator = self.manager.annotator(None)
         return OPDSAcquisitionFeed.entry_as_response(
-            OPDSAcquisitionFeed.single_entry(work, annotator)
+            OPDSAcquisitionFeed.single_entry(work, annotator),
+            mime_types=flask.request.accept_mimetypes,
         )
 
     def detail(self, identifier_type, identifier):

--- a/core/feed/serializer/opds2.py
+++ b/core/feed/serializer/opds2.py
@@ -33,6 +33,8 @@ MARC_CODE_TO_ROLES = {
 
 
 class OPDS2Serializer(SerializerInterface[dict[str, Any]]):
+    CONTENT_TYPE = "application/opds+json"
+
     def __init__(self) -> None:
         pass
 
@@ -210,7 +212,7 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]]):
         return result
 
     def content_type(self) -> str:
-        return "application/opds+json"
+        return self.CONTENT_TYPE
 
     @classmethod
     def to_string(cls, data: dict[str, Any]) -> str:


### PR DESCRIPTION
## Description

- `revoke` response respects Accept header.
- DRYed out some tests while adding new ones for this functionality.

## Motivation and Context

[Jira [PP-886](https://ebce-lyrasis.atlassian.net/browse/PP-886)]

## How Has This Been Tested?

- Manually tested functionality in local dev environment.
- Updated tests to explicitly cover OPDS 1 and 2 serializations.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/7718074207) for associated branch passed.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-886]: https://ebce-lyrasis.atlassian.net/browse/PP-886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ