### PR TITLE
Relax pre-sharing validation on list entries with no associated work.

### DIFF
--- a/core/query/customlist.py
+++ b/core/query/customlist.py
@@ -74,7 +74,7 @@ class CustomListQueries(LoggerMixin):
 
         if missing_work_id_count > 0:
             log.warning(
-                f"This list contains {missing_work_id_count}  {'entries' if missing_work_id_count > 1 else 'entry'} "
+                f"This list contains {missing_work_id_count} {'entries' if missing_work_id_count > 1 else 'entry'} "
                 f"without an associated work. "
             )
         customlist.shared_locally_with_libraries.append(library)

--- a/tests/api/admin/controller/test_custom_lists.py
+++ b/tests/api/admin/controller/test_custom_lists.py
@@ -986,6 +986,26 @@ class TestCustomListsController:
         assert response["failures"] == 2
         assert response["successes"] == 0
 
+    def test_share_locally_with_entry_with_missing_work(
+        self, admin_librarian_fixture: AdminLibrarianFixture
+    ):
+        s = self._setup_share_locally(admin_librarian_fixture)
+        s.collection1.libraries.append(s.shared_with)
+
+        w = admin_librarian_fixture.ctrl.db.work(collection=s.collection1)
+        entry, ignore = s.list.add_entry(w)
+
+        entry.work = None
+        entry.work_id = None
+
+        assert entry.edition is not None
+
+        response = self._share_locally(
+            s.list, s.primary_library, admin_librarian_fixture
+        )
+        assert response["failures"] == 1  # The default library
+        assert response["successes"] == 1
+
     def test_share_locally_get(self, admin_librarian_fixture: AdminLibrarianFixture):
         """Does the GET method fetch shared lists"""
         s = self._setup_share_locally(admin_librarian_fixture)


### PR DESCRIPTION
## Description

This update simply skips validation on entries without associated works before sharing a list with a library.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-708
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
