### PR TITLE
Remove app initialization lock (PP-893)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -21,7 +21,7 @@ from api.util.profilers import (
 )
 from core.app_server import ErrorHandler
 from core.flask_sqlalchemy_session import flask_scoped_session
-from core.model import LOCK_ID_APP_INIT, SessionManager, pg_advisory_lock
+from core.model import SessionManager
 from core.service.container import Services, container_instance
 from core.util import LanguageCodes
 from core.util.cache import CachedData
@@ -113,15 +113,9 @@ def initialize_application() -> PalaceFlask:
         error_handler = ErrorHandler(app, container.config.logging.level())
         app.register_error_handler(Exception, error_handler.handle)
 
-        # TODO: Remove this lock once our settings are moved to integration settings.
-        # We need this lock, so that only one instance of the application is
-        # initialized at a time. This prevents database conflicts when multiple
-        # CM instances try to create the same configurationsettings at the same
-        # time during initialization. This should be able to go away once we
-        # move our settings off the configurationsettings system.
-        with pg_advisory_lock(app._db, LOCK_ID_APP_INIT):
-            initialize_circulation_manager(container)
-            initialize_admin(secret_key=container.config.sitewide.secret_key())
+        # Initialize the circulation manager
+        initialize_circulation_manager(container)
+        initialize_admin(secret_key=container.config.sitewide.secret_key())
     return app
 
 

--- a/core/model/__init__.py
+++ b/core/model/__init__.py
@@ -34,10 +34,6 @@ from core.model.constants import (
 # initializes or migrates the database at a time.
 LOCK_ID_DB_INIT = 1000000001
 
-# This is the lock ID used to ensure that only one circulation manager
-# initializes an application instance at a time.
-LOCK_ID_APP_INIT = 1000000002
-
 
 @contextmanager
 def pg_advisory_lock(


### PR DESCRIPTION
## Description

Now that our site settings are converted, we should be able to remove the app initialization lock.

## Motivation and Context

This should speed up our container startup. I broke this one out into its own PR in case we have to roll it back. I did some testing, but there are a lot of cases to test here and its timing dependant. If there is a problem with this we will find out soon enough once its merged though.

## How Has This Been Tested?

- Tested combinations of: 
  - startup in container
  - startup in dev mode
  - new database
  - existing database

And everything seemed to work okay.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
