### PR TITLE
Modify app initialization to speed up loading (PP-893)

### DIFF
--- a/api/lanes.py
+++ b/api/lanes.py
@@ -17,7 +17,7 @@ from core.model import Contributor, DataSource, Edition, Library, Session, creat
 from core.util import LanguageCodes
 
 
-def load_lanes(_db, library):
+def load_lanes(_db, library, collection_ids):
     """Return a WorkList that reflects the current lane structure of the
     Library.
 
@@ -30,7 +30,9 @@ def load_lanes(_db, library):
     Otherwise, a WorkList containing the visible top-level lanes is
     returned.
     """
-    top_level = WorkList.top_level_for_library(_db, library)
+    top_level = WorkList.top_level_for_library(
+        _db, library, collection_ids=collection_ids
+    )
 
     # It's likely this WorkList will be used across sessions, so
     # expunge any data model objects from the database session.

--- a/core/lane.py
+++ b/core/lane.py
@@ -1338,7 +1338,7 @@ class WorkList:
         return self.MAX_CACHE_AGE
 
     @classmethod
-    def top_level_for_library(self, _db, library):
+    def top_level_for_library(self, _db, library, collection_ids=None):
         """Create a WorkList representing this library's collection
         as a whole.
 
@@ -1377,6 +1377,7 @@ class WorkList:
             children=top_level_lanes,
             media=Edition.FULFILLABLE_MEDIA,
             entrypoints=library.entrypoints,
+            collection_ids=collection_ids,
         )
         return wl
 
@@ -1397,6 +1398,7 @@ class WorkList:
         fiction=None,
         license_datasource=None,
         target_age=None,
+        collection_ids=None,
     ):
         """Initialize with basic data.
 
@@ -1455,12 +1457,13 @@ class WorkList:
 
         """
         self.library_id = None
-        self.collection_ids = None
+        self.collection_ids = collection_ids
         if library:
             self.library_id = library.id
-            self.collection_ids = [
-                collection.id for collection in library.all_collections
-            ]
+            if self.collection_ids is None:
+                self.collection_ids = [
+                    collection.id for collection in library.collection_ids
+                ]
         self.display_name = display_name
         if genres:
             self.genre_ids = [x.id for x in genres]

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Query, Session, defer
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
+from api.integration.registry.license_providers import LicenseProvidersRegistry
 from core.config import Configuration, ConfigurationConstants
 from core.coverage import CollectionCoverageProviderJob, CoverageProviderProgress
 from core.external_search import ExternalSearchIndex, Filter
@@ -916,11 +917,9 @@ class RunSelfTestsScript(LibraryInputScript):
         self.out = output
 
     def do_run(self, *args, **kwargs):
-        from api.circulation import CirculationAPI
-
         parsed = self.parse_command_line(self._db, *args, **kwargs)
         for library in parsed.libraries:
-            api_map = dict(CirculationAPI(self._db, library).registry)
+            api_map = LicenseProvidersRegistry()
             self.out.write("Testing %s\n" % library.name)
             for collection in library.collections:
                 try:

--- a/tests/api/controller/test_loan.py
+++ b/tests/api/controller/test_loan.py
@@ -1021,14 +1021,7 @@ class TestLoanController:
             library=loan_fixture.db.default_library(),
             headers=dict(Authorization=loan_fixture.valid_auth),
         ):
-            loan_fixture.manager.circulation_apis[
-                loan_fixture.db.default_library().id
-            ] = CirculationAPI(
-                loan_fixture.db.session, loan_fixture.db.default_library()
-            )
-            controller.circulation.api_for_collection[
-                loan_fixture.db.default_collection().id
-            ] = api
+            controller.circulation.api_for_license_pool = MagicMock(return_value=api)
             assert isinstance(pool.id, int)
             response = controller.fulfill(pool.id, lpdm.delivery_mechanism.id)
 
@@ -1058,9 +1051,7 @@ class TestLoanController:
             library=loan_fixture.db.default_library(),
             headers=dict(Authorization=loan_fixture.valid_auth),
         ):
-            controller.circulation.api_for_collection[
-                loan_fixture.db.default_collection().id
-            ] = api
+            controller.circulation.api_for_license_pool = MagicMock(return_value=api)
             response = controller.fulfill(pool.id, lpdm.delivery_mechanism.id)
 
         assert isinstance(response, wkResponse)

--- a/tests/api/mockapi/circulation.py
+++ b/tests/api/mockapi/circulation.py
@@ -1,18 +1,21 @@
 from abc import ABC
 from collections import defaultdict
+from collections.abc import Mapping
 
 from sqlalchemy.orm import Session
 
 from api.circulation import (
     BaseCirculationAPI,
     CirculationAPI,
+    CirculationApiType,
     HoldInfo,
     LoanInfo,
     PatronActivityCirculationAPI,
 )
 from api.circulation_manager import CirculationManager
+from core.analytics import Analytics
 from core.integration.settings import BaseSettings
-from core.model import DataSource, Hold, Loan
+from core.model import DataSource, Hold, Library, Loan
 from core.service.container import Services
 
 
@@ -174,6 +177,13 @@ class MockCirculationManager(CirculationManager):
     def __init__(self, db: Session, services: Services):
         super().__init__(db, services)
 
-    def setup_circulation(self, library, analytics):
-        """Set up the Circulation object."""
-        return MockCirculationAPI(self._db, library, analytics=analytics)
+    def setup_circulation_api(
+        self,
+        db: Session,
+        library: Library,
+        library_collection_apis: Mapping[int | None, CirculationApiType],
+        analytics: Analytics | None = None,
+    ) -> MockCirculationAPI:
+        return MockCirculationAPI(
+            db, library, library_collection_apis, analytics=analytics
+        )

--- a/tests/api/test_bibliotheca.py
+++ b/tests/api/test_bibliotheca.py
@@ -42,8 +42,6 @@ from api.circulation_exceptions import (
 )
 from api.web_publication_manifest import FindawayManifest
 from core.analytics import Analytics
-from core.integration.goals import Goals
-from core.integration.registry import IntegrationRegistry
 from core.metadata_layer import ReplacementPolicy, TimestampData
 from core.mock_analytics_provider import MockAnalyticsProvider
 from core.model import (
@@ -470,15 +468,10 @@ class TestBibliothecaAPI:
         circulation = CirculationAPI(
             db.session,
             db.default_library(),
-            registry=IntegrationRegistry(
-                Goals.LICENSE_GOAL,
-                {bibliotheca_fixture.collection.protocol: MockBibliothecaAPI},
-            ),
+            {bibliotheca_fixture.collection.id: bibliotheca_fixture.api},
         )
 
-        api = circulation.api_for_collection[bibliotheca_fixture.collection.id]
-        assert isinstance(api, MockBibliothecaAPI)
-        api.queue_response(
+        bibliotheca_fixture.api.queue_response(
             200, content=bibliotheca_fixture.files.sample_data("checkouts.xml")
         )
         circulation.sync_bookshelf(patron, "dummy pin")

--- a/tests/api/test_selftest.py
+++ b/tests/api/test_selftest.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from api.authentication.basic import BasicAuthenticationProvider
-from api.circulation import CirculationAPI
+from api.integration.registry.license_providers import LicenseProvidersRegistry
 from api.selftest import HasCollectionSelfTests, HasPatronSelfTests, SelfTestResult
 from core.exceptions import IntegrationException
 from core.model import Patron
@@ -193,11 +193,8 @@ class TestRunSelfTestsScript:
         [(collection, api_map)] = script.tested
         assert [collection] == library1.collections
 
-        # The API lookup map passed into test_collection() is based on
-        # CirculationAPI's default API map.
-        registry = CirculationAPI(db.session, db.default_library()).registry
-        for k, v in registry:
-            assert api_map[k] == v
+        # The API lookup map passed into test_collection() is a LicenseProvidersRegistry.
+        assert isinstance(api_map, LicenseProvidersRegistry)
 
         # If test_collection raises an exception, the exception is recorded,
         # and we move on.

--- a/tests/core/test_opds2_import.py
+++ b/tests/core/test_opds2_import.py
@@ -532,7 +532,15 @@ class TestOpds2Api:
 
         work = works[0]
 
-        api = CirculationAPI(db.session, opds2_importer_fixture.library)
+        api = CirculationAPI(
+            db.session,
+            opds2_importer_fixture.library,
+            {
+                opds2_importer_fixture.collection.id: OPDS2API(
+                    db.session, opds2_importer_fixture.collection
+                )
+            },
+        )
         patron = db.patron()
 
         # Borrow the book from the library

--- a/tests/core/test_opds_import.py
+++ b/tests/core/test_opds_import.py
@@ -1467,7 +1467,13 @@ class TestOPDSImporter:
             pool = pools[0]
             pool.loan_to(patron)
 
-            return CirculationAPI(session, library), patron, pool
+            return (
+                CirculationAPI(
+                    session, library, {collection.id: OPDSAPI(session, collection)}
+                ),
+                patron,
+                pool,
+            )
 
         yield _wayfless_circulation_api
 


### PR DESCRIPTION
## Description

This PR updates the app initialization to make sure we are not repeating work:
- Get the collections for each of our libraries from the DB once
- Create API classes for these collections in a single place instead of creating a API class for every library, collection pair.
- Pass these API classes to where they are needed, since the API classes themselves are library agnostic.
- And all the test changes needed to cope with this change in initialization.

## Motivation and Context

As part of cleaning up the old configuration settings, I did some testing to see how our app initialization was doing without having to do so many queries to load configuration settings. This showed that we were still slow on big CM instances to do a settings reload. Doing a bit of profiling, the big thing that is left causing problems is creating a collection API for each library a collection is used in.

I think there is more that can be done here, but it will require more changes to our initialization, and this gave a pretty solid performance boost given the fairly small changes.

## How Has This Been Tested?

Tested locally, with DB data from the CT and CA CM instances. 

These changes make a settings reload on CT go from ~8s to ~2s and CA go from ~16s to ~2s on my machine. 

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
