### PR TITLE
Default work quality for featurability score. (PP-915)

### DIFF
--- a/tests/core/test_external_search.py
+++ b/tests/core/test_external_search.py
@@ -2058,7 +2058,6 @@ class TestFeaturedFacets:
             search_engine=fixture.external_search_index,
             debug=True,
         )
-        print(only_availability_matters)
         assert 6 == len(only_availability_matters)
         last_two = only_availability_matters[-2:]
         assert data.hq_not_available in last_two


### PR DESCRIPTION
## Description

This modifies the [Painless](https://www.elastic.co/guide/en/elasticsearch/painless/6.8/painless-lang-spec.html) script that we use to calculate the "featurability" score for a work to avoid an exception when the quality score for a work is missing.

## Motivation and Context

Avoid an exception when the quality score for a work is missing. 

[Jira [PP-915](https://ebce-lyrasis.atlassian.net/browse/PP-915)]

## How Has This Been Tested?

- Manual local testing demonstrating (1) failures without the change and (2) success with it.
- Updated tests to include works with missing `quality`.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/7800675895) passed for branch.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-915]: https://ebce-lyrasis.atlassian.net/browse/PP-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ