### PR TITLE
Loan notification once, three days before expiration. (PP-927)

### DIFF
--- a/core/scripts.py
+++ b/core/scripts.py
@@ -2587,8 +2587,8 @@ class LoanNotificationsScript(Script):
     """Notifications must be sent to Patrons based on when their current loans
     are expiring"""
 
-    # Days before on which to send out a notification
-    LOAN_EXPIRATION_DAYS = [3]
+    # List of days before expiration on which we will send out notifications.
+    DEFAULT_LOAN_EXPIRATION_DAYS = [3]
     BATCH_SIZE = 100
 
     def __init__(
@@ -2597,9 +2597,13 @@ class LoanNotificationsScript(Script):
         services: Services | None = None,
         notifications: PushNotifications | None = None,
         *args,
+        loan_expiration_days: list[int] | None = None,
         **kwargs,
     ):
         super().__init__(_db, services, *args, **kwargs)
+        self.loan_expiration_days = (
+            loan_expiration_days or self.DEFAULT_LOAN_EXPIRATION_DAYS
+        )
         self.notifications = notifications or PushNotifications(
             self.services.config.sitewide.base_url()
         )
@@ -2657,7 +2661,7 @@ class LoanNotificationsScript(Script):
             self.log.warning(f"Loan: {loan.id} has no end date, skipping")
             return
         delta: datetime.timedelta = loan.end - now
-        if delta.days in self.LOAN_EXPIRATION_DAYS:
+        if delta.days in self.loan_expiration_days:
             self.log.info(
                 f"Patron {patron.authorization_identifier} has an expiring loan on ({loan.license_pool.identifier.urn})"
             )

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -2588,7 +2588,7 @@ class LoanNotificationsScript(Script):
     are expiring"""
 
     # Days before on which to send out a notification
-    LOAN_EXPIRATION_DAYS = [5, 1]
+    LOAN_EXPIRATION_DAYS = [3]
     BATCH_SIZE = 100
 
     def __init__(

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -2429,6 +2429,23 @@ class TestLoanNotificationsScript:
                 db.session, services=services_fixture.services
             )
         assert script.BATCH_SIZE == 100
+        assert (
+            script.loan_expiration_days
+            == LoanNotificationsScript.DEFAULT_LOAN_EXPIRATION_DAYS
+        )
+        assert script.notifications == mock_notifications.return_value
+        mock_notifications.assert_called_once_with("http://test-circulation-manager")
+
+        with patch(
+            "core.scripts.PushNotifications", autospec=True
+        ) as mock_notifications:
+            script = LoanNotificationsScript(
+                db.session,
+                services=services_fixture.services,
+                loan_expiration_days=[-2, 0, 220],
+            )
+        assert script.BATCH_SIZE == 100
+        assert script.loan_expiration_days == [-2, 0, 220]
         assert script.notifications == mock_notifications.return_value
         mock_notifications.assert_called_once_with("http://test-circulation-manager")
 


### PR DESCRIPTION
## Description

- Change loan notifications to be delivered once, three days before expiration.
- Add test to ensure that all notifications for a given loan are sent on the expected day(s).
- Setup tests such that the list of notification days can eventually be moved to configuration.

## Motivation and Context

[Jira [PP-927](https://ebce-lyrasis.atlassian.net/jira/software/c/projects/PP/boards/4?assignee=712020:9878b21d-a456-49ab-9c67-b41eb1c0dacf&selectedIssue=PP-927)]

## How Has This Been Tested?

- This needs to be tested in the QA environment.
- Added new test, as mentioned above.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/7894640338) passed for associated branch.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-927]: https://ebce-lyrasis.atlassian.net/browse/PP-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ