### PR TITLE
Make sure expired tokens give correct status / problem detail (PP-970)

### DIFF
--- a/api/authentication/access_token.py
+++ b/api/authentication/access_token.py
@@ -166,19 +166,6 @@ class PatronJWEAccessTokenProvider(LoggerMixin):
         return TokenPatronInfo(**payload)
 
     @classmethod
-    def is_access_token(cls, token: str | None) -> bool:
-        """Test if the given token is a valid JWE token"""
-        if token is None:
-            return False
-
-        try:
-            cls.decode_token(token)
-        except Exception:
-            return False
-
-        return True
-
-    @classmethod
     def delete_old_keys(cls, _db: Session) -> int:
         """Delete old keys from the DB
 

--- a/api/authentication/basic_token.py
+++ b/api/authentication/basic_token.py
@@ -14,7 +14,6 @@ from api.authentication.base import (
     AuthProviderSettings,
 )
 from api.authentication.basic import BasicAuthenticationProvider
-from api.authenticator import BearerTokenType
 from core.integration.base import LibrarySettingsType, SettingsType
 from core.model import Patron, Session, get_one
 from core.selftest import SelfTestResult
@@ -77,12 +76,7 @@ class BasicTokenAuthenticationProvider(
 
     def get_credential_from_header(self, auth: Authorization) -> str | None:
         """If we are the right type of token, then decode the password from the token"""
-        if (
-            auth
-            and auth.type.lower() == "bearer"
-            and auth.token
-            and BearerTokenType.from_token(auth.token) == BearerTokenType.JWE
-        ):
+        if auth and auth.type.lower() == "bearer" and auth.token:
             try:
                 token = PatronJWEAccessTokenProvider.decrypt_token(self._db, auth.token)
                 return token.pwd

--- a/tests/api/authentication/test_access_token.py
+++ b/tests/api/authentication/test_access_token.py
@@ -272,19 +272,6 @@ class TestJWEProvider:
             PatronJWEAccessTokenProvider.decrypt_token(db.session, token)
         assert exc.value.problem_detail == PATRON_AUTH_ACCESS_TOKEN_INVALID
 
-    def test_is_access_token(self, jwe_provider: JWEProviderFixture):
-        # Happy path
-        token = jwe_provider.generate_token()
-        assert PatronJWEAccessTokenProvider.is_access_token(token) is True
-
-        with patch.object(PatronJWEAccessTokenProvider, "decode_token") as decode:
-            # An incorrect type
-            decode.side_effect = Exception("Bang!")
-            assert PatronJWEAccessTokenProvider.is_access_token(token) is False
-
-        # The token is not the right format
-        assert PatronJWEAccessTokenProvider.is_access_token("not-a-token") is False
-
     @freeze_time()
     def test_delete_old_keys(self):
         mock_session = MagicMock()

--- a/tests/api/authentication/test_basic_token.py
+++ b/tests/api/authentication/test_basic_token.py
@@ -59,13 +59,23 @@ class TestBasicTokenAuthenticationProvider:
             db.session, patron, "passworx"
         )
 
-        pwd = provider.get_credential_from_header(
-            Authorization(auth_type="Bearer", token=token)
+        assert (
+            provider.get_credential_from_header(
+                Authorization(auth_type="Bearer", token=token)
+            )
+            == "passworx"
         )
-        assert pwd == "passworx"
 
-        pwd = provider.get_credential_from_header(Authorization(auth_type="Basic"))
-        assert pwd == None
+        assert (
+            provider.get_credential_from_header(Authorization(auth_type="Basic"))
+            is None
+        )
+        assert (
+            provider.get_credential_from_header(
+                Authorization(auth_type="Bearer", token="junk")
+            )
+            is None
+        )
 
     def test_authentication_flow_document(
         self, db: DatabaseTransactionFixture, controller_fixture: ControllerFixture


### PR DESCRIPTION
## Description

In https://github.com/ThePalaceProject/circulation/pull/1664 I made token validation a bit too strict, so expired tokens were failing validation, which meant they were then returning 400 status instead of 401. They should be returning a 401 and the token expired problem detail document.

Fixed this so the initial validation is much more lax, it just determines what type of token we are dealing with and added some tests cases for this.

## Motivation and Context

Android app was not refreshing the token when getting a 400 status, so token auth was then failing.

## How Has This Been Tested?

- Running tests locally

Once this is merged we'll roll out to minotaur and test that everything is happy in apps.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
