### PR TITLE
Suppress works on a per library basis (PP-939)

### DIFF
--- a/alembic/versions/20240216_9d2dccb0d6ff_ability_to_suppress_works_per_library.py
+++ b/alembic/versions/20240216_9d2dccb0d6ff_ability_to_suppress_works_per_library.py
@@ -1,0 +1,31 @@
+"""Ability to suppress works per library
+
+Revision ID: 9d2dccb0d6ff
+Revises: 1c9f519415b5
+Create Date: 2024-02-16 17:08:52.146860+00:00
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9d2dccb0d6ff"
+down_revision = "1c9f519415b5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "work_library_suppressions",
+        sa.Column("work_id", sa.Integer(), nullable=False),
+        sa.Column("library_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["library_id"], ["libraries.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["work_id"], ["works.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("work_id", "library_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("work_library_suppressions")

--- a/bin/configuration/suppress_work_for_library
+++ b/bin/configuration/suppress_work_for_library
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import os
+import sys
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import SuppressWorkForLibraryScript
+
+SuppressWorkForLibraryScript().run()

--- a/core/external_search.py
+++ b/core/external_search.py
@@ -1575,6 +1575,7 @@ class Filter(SearchBase):
             allow_holds=allow_holds,
             license_datasource=license_datasource_id,
             lane_building=True,
+            library=library,
         )
 
     def __init__(
@@ -1723,6 +1724,9 @@ class Filter(SearchBase):
 
         self.lane_building = kwargs.pop("lane_building", False)
 
+        library = kwargs.pop("library", None)
+        self.library_id = library.id if library else None
+
         # At this point there should be no keyword arguments -- you can't pass
         # whatever you want into this method.
         if kwargs:
@@ -1846,6 +1850,11 @@ class Filter(SearchBase):
 
         if self.author is not None:
             nested_filters["contributors"].append(self.author_filter)
+
+        if self.library_id:
+            f = chain(
+                f, Bool(must_not=[Terms(**{"suppressed_for": [self.library_id]})])
+            )
 
         if self.media:
             f = chain(f, Terms(medium=scrub_list(self.media)))

--- a/core/lane.py
+++ b/core/lane.py
@@ -2387,9 +2387,16 @@ class DatabaseBackedWorkList(WorkList):
         Note that this assumes the query has an active join against
         LicensePool.
         """
-        return Collection.restrict_to_ready_deliverable_works(
+        query = Collection.restrict_to_ready_deliverable_works(
             query, show_suppressed=show_suppressed, collection_ids=self.collection_ids
         )
+
+        if not show_suppressed and self.library_id is not None:
+            query = query.filter(
+                not_(Work.suppressed_for.contains(self.get_library(_db)))
+            )
+
+        return query
 
     def bibliographic_filter_clauses(self, _db, qu):
         """Create a SQLAlchemy filter that excludes books whose bibliographic

--- a/core/model/listeners.py
+++ b/core/model/listeners.py
@@ -105,6 +105,13 @@ def licensepool_removed_from_work(target, value, initiator):
         target.external_index_needs_updating()
 
 
+@event.listens_for(Work.suppressed_for, "append")
+@event.listens_for(Work.suppressed_for, "remove")
+def work_suppressed_for_library(target, value, initiator):
+    if target:
+        target.external_index_needs_updating()
+
+
 @Listener.before_flush(LicensePool, ListenerState.deleted)
 def licensepool_deleted(session: Session, instance: LicensePool) -> None:
     """A LicensePool is deleted only when its collection is deleted.

--- a/core/scripts.py
+++ b/core/scripts.py
@@ -2668,6 +2668,96 @@ class LoanNotificationsScript(Script):
             self.notifications.send_loan_expiry_message(loan, delta.days, tokens)
 
 
+class SuppressWorkForLibraryScript(Script):
+    """Suppress works from a library by identifier"""
+
+    BY_DATABASE_ID = "Database ID"
+
+    @classmethod
+    def arg_parser(cls, _db: Session | None) -> argparse.ArgumentParser:  # type: ignore[override]
+        parser = argparse.ArgumentParser()
+        if _db is None:
+            raise ValueError("No database session provided.")
+        library_name_list = sorted(str(l.short_name) for l in _db.query(Library))
+        library_names = '"' + '", "'.join(library_name_list) + '"'
+        parser.add_argument(
+            "-l",
+            "--library",
+            help="Short name of the library. Libraries on this system: %s."
+            % library_names,
+            required=True,
+            metavar="SHORT_NAME",
+        )
+        parser.add_argument(
+            "-t",
+            "--identifier-type",
+            help="Identifier type (default: ISBN). "
+            f'To name identifiers by their database ID, use --identifier-type="{cls.BY_DATABASE_ID}".',
+            default="ISBN",
+        )
+        parser.add_argument(
+            "-i",
+            "--identifier",
+            help="The identifier to suppress.",
+            required=True,
+        )
+        return parser
+
+    @classmethod
+    def parse_command_line(
+        cls, _db: Session | None = None, cmd_args: list[str] | None = None
+    ):
+        parser = cls.arg_parser(_db)
+        return parser.parse_known_args(cmd_args)[0]
+
+    def load_library(self, library_short_name: str) -> Library:
+        library_short_name = library_short_name.strip()
+        library = self._db.scalars(
+            select(Library).where(Library.short_name == library_short_name)
+        ).one_or_none()
+        if not library:
+            raise ValueError(f"Unknown library: {library_short_name}")
+        return library
+
+    def load_identifier(self, identifier_type: str, identifier: str) -> Identifier:
+        query = select(Identifier)
+        identifier_type = identifier_type.strip()
+        identifier = identifier.strip()
+        if identifier_type == self.BY_DATABASE_ID:
+            query = query.where(Identifier.id == int(identifier))
+        else:
+            query = query.where(Identifier.type == identifier_type).where(
+                Identifier.identifier == identifier
+            )
+
+        identifier_obj = self._db.scalars(query).unique().one_or_none()
+        if not identifier_obj:
+            raise ValueError(f"Unknown identifier: {identifier_type}/{identifier}")
+
+        return identifier_obj
+
+    def do_run(self, cmd_args: list[str] | None = None) -> None:
+        parsed = self.parse_command_line(self._db, cmd_args=cmd_args)
+
+        library = self.load_library(parsed.library)
+        identifier = self.load_identifier(parsed.identifier_type, parsed.identifier)
+
+        self.suppress_work(library, identifier)
+
+    def suppress_work(self, library: Library, identifier: Identifier) -> None:
+        work = identifier.work
+        if not work:
+            self.log.warning(f"No work found for {identifier}")
+            return
+
+        work.suppressed_for.append(library)
+        self.log.info(
+            f"Suppressed {identifier.type}/{identifier.identifier} (work id: {work.id}) for {library.short_name}."
+        )
+
+        self._db.commit()
+
+
 class MockStdin:
     """Mock a list of identifiers passed in on standard input."""
 

--- a/tests/core/models/test_listeners.py
+++ b/tests/core/models/test_listeners.py
@@ -216,3 +216,22 @@ class TestListeners:
             == work.coverage_records[0].operation
         )
         assert WorkCoverageRecord.REGISTERED == work.coverage_records[0].status
+
+    def test_work_suppressed_for_library(self, db: DatabaseTransactionFixture):
+        work = db.work(with_license_pool=True)
+        library = db.library()
+
+        # Clear out any WorkCoverageRecords created as the work was initialized.
+        work.coverage_records = []
+
+        # Act
+        work.suppressed_for.append(library)
+
+        # Assert
+        assert 1 == len(work.coverage_records)
+        assert work.id == work.coverage_records[0].work_id
+        assert (
+            WorkCoverageRecord.UPDATE_SEARCH_INDEX_OPERATION
+            == work.coverage_records[0].operation
+        )
+        assert WorkCoverageRecord.REGISTERED == work.coverage_records[0].status

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -4645,25 +4645,25 @@ class TestWorkListGroupsEndToEnd:
         db.default_collection().libraries += [decoy_library, another_library]
 
         # Add a couple suppressed works, to make sure they don't show up in the results.
-        suppressed_work1 = db.work(
+        globally_suppressed_work = db.work(
             title="Suppressed LP",
             fiction=True,
             genre="Literary Fiction",
             with_license_pool=True,
         )
-        suppressed_work1.quality = 0.95
-        for license_pool in suppressed_work1.license_pools:
+        globally_suppressed_work.quality = 0.95
+        for license_pool in globally_suppressed_work.license_pools:
             license_pool.suppressed = True
 
         # This work is only suppressed for a specific library.
-        suppressed_work2 = db.work(
+        library_suppressed_work = db.work(
             title="Suppressed 2",
             fiction=True,
             genre="Literary Fiction",
             with_license_pool=True,
         )
-        suppressed_work2.quality = 0.95
-        suppressed_work2.suppressed_for = [fixture.library, decoy_library]
+        library_suppressed_work.quality = 0.95
+        library_suppressed_work.suppressed_for = [fixture.library, decoy_library]
 
         fixture.populate_search_index()
 
@@ -4673,38 +4673,38 @@ class TestWorkListGroupsEndToEnd:
             from_db = fixture.work_ids_from_db(lane)
 
             # The suppressed work is not included in the results.
-            assert suppressed_work1.id not in from_search
-            assert suppressed_work1.id not in from_db
-            assert suppressed_work2.id not in from_search
-            assert suppressed_work2.id not in from_db
+            assert globally_suppressed_work.id not in from_search
+            assert globally_suppressed_work.id not in from_db
+            assert library_suppressed_work.id not in from_search
+            assert library_suppressed_work.id not in from_db
 
         # Test the decoy libraries lane as well
         decoy_library_lane = db.lane("Fiction", fiction=True, library=decoy_library)
         from_search = fixture.work_ids_from_search(decoy_library_lane)
         from_db = fixture.work_ids_from_db(decoy_library_lane)
-        assert suppressed_work1.id not in from_search
-        assert suppressed_work1.id not in from_db
-        assert suppressed_work2.id not in from_search
-        assert suppressed_work2.id not in from_db
+        assert globally_suppressed_work.id not in from_search
+        assert globally_suppressed_work.id not in from_db
+        assert library_suppressed_work.id not in from_search
+        assert library_suppressed_work.id not in from_db
 
         # Test a lane for a different library, this time the globally suppressed work should
         # still be absent, but the work suppressed for the other library should be present.
         another_library_lane = db.lane("Fiction", fiction=True, library=another_library)
         from_search = fixture.work_ids_from_search(another_library_lane)
         from_db = fixture.work_ids_from_db(another_library_lane)
-        assert suppressed_work1.id not in from_search
-        assert suppressed_work1.id not in from_db
-        assert suppressed_work2.id in from_search
-        assert suppressed_work2.id in from_db
+        assert globally_suppressed_work.id not in from_search
+        assert globally_suppressed_work.id not in from_db
+        assert library_suppressed_work.id in from_search
+        assert library_suppressed_work.id in from_db
 
         # Make sure that the suppressed works are handled correctly when searching in a lane as well
-        assert suppressed_work2 in another_library_lane.search(
+        assert library_suppressed_work in another_library_lane.search(
             db.session, "suppressed", index
         )
-        assert suppressed_work2 not in lane_data.fiction.search(
+        assert library_suppressed_work not in lane_data.fiction.search(
             db.session, "suppressed", index
         )
-        assert suppressed_work2 not in decoy_library_lane.search(
+        assert library_suppressed_work not in decoy_library_lane.search(
             db.session, "suppressed", index
         )
 

--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -4627,6 +4627,87 @@ class TestWorkListGroupsEndToEnd:
             from_db = fixture.work_ids_from_db(lane)
             assert from_search == from_db
 
+    def test_works_and_works_from_database_with_suppressed(
+        self,
+        work_list_groups_end_to_end_fixture: WorkListGroupsEndToEndFixture,
+    ):
+        db = work_list_groups_end_to_end_fixture.db
+        fixture = work_list_groups_end_to_end_fixture
+        index = fixture.external_search_fixture.external_search_index
+
+        # Create a bunch of lanes and works.
+        data = fixture.populate_works()
+        lane_data = fixture.create_lanes(data)
+
+        decoy_library = db.library()
+        another_library = db.library()
+
+        db.default_collection().libraries += [decoy_library, another_library]
+
+        # Add a couple suppressed works, to make sure they don't show up in the results.
+        suppressed_work1 = db.work(
+            title="Suppressed LP",
+            fiction=True,
+            genre="Literary Fiction",
+            with_license_pool=True,
+        )
+        suppressed_work1.quality = 0.95
+        for license_pool in suppressed_work1.license_pools:
+            license_pool.suppressed = True
+
+        # This work is only suppressed for a specific library.
+        suppressed_work2 = db.work(
+            title="Suppressed 2",
+            fiction=True,
+            genre="Literary Fiction",
+            with_license_pool=True,
+        )
+        suppressed_work2.quality = 0.95
+        suppressed_work2.suppressed_for = [fixture.library, decoy_library]
+
+        fixture.populate_search_index()
+
+        for lane_name in fields(lane_data):
+            lane = getattr(lane_data, lane_name.name)
+            from_search = fixture.work_ids_from_search(lane)
+            from_db = fixture.work_ids_from_db(lane)
+
+            # The suppressed work is not included in the results.
+            assert suppressed_work1.id not in from_search
+            assert suppressed_work1.id not in from_db
+            assert suppressed_work2.id not in from_search
+            assert suppressed_work2.id not in from_db
+
+        # Test the decoy libraries lane as well
+        decoy_library_lane = db.lane("Fiction", fiction=True, library=decoy_library)
+        from_search = fixture.work_ids_from_search(decoy_library_lane)
+        from_db = fixture.work_ids_from_db(decoy_library_lane)
+        assert suppressed_work1.id not in from_search
+        assert suppressed_work1.id not in from_db
+        assert suppressed_work2.id not in from_search
+        assert suppressed_work2.id not in from_db
+
+        # Test a lane for a different library, this time the globally suppressed work should
+        # still be absent, but the work suppressed for the other library should be present.
+        another_library_lane = db.lane("Fiction", fiction=True, library=another_library)
+        from_search = fixture.work_ids_from_search(another_library_lane)
+        from_db = fixture.work_ids_from_db(another_library_lane)
+        assert suppressed_work1.id not in from_search
+        assert suppressed_work1.id not in from_db
+        assert suppressed_work2.id in from_search
+        assert suppressed_work2.id in from_db
+
+        # Make sure that the suppressed works are handled correctly when searching in a lane as well
+        assert suppressed_work2 in another_library_lane.search(
+            db.session, "suppressed", index
+        )
+        assert suppressed_work2 not in lane_data.fiction.search(
+            db.session, "suppressed", index
+        )
+        assert suppressed_work2 not in decoy_library_lane.search(
+            db.session, "suppressed", index
+        )
+
 
 class RandomSeedFixture:
     def __init__(self):

--- a/tests/core/test_scripts.py
+++ b/tests/core/test_scripts.py
@@ -74,6 +74,7 @@ from core.scripts import (
     ShowIntegrationsScript,
     ShowLanesScript,
     ShowLibrariesScript,
+    SuppressWorkForLibraryScript,
     TimestampScript,
     UpdateCustomListSizeScript,
     UpdateLaneSizeScript,
@@ -2457,6 +2458,100 @@ class TestLoanNotificationsScript:
         assert "Missing required environment variable: PALACE_BASE_URL" in str(
             excinfo.value
         )
+
+
+class TestSuppressWorkForLibraryScript:
+    @pytest.mark.parametrize(
+        "cmd_args",
+        [
+            "",
+            "--library test",
+            "--library test  --identifier-type test",
+            "--identifier-type test",
+            "--identifier test",
+        ],
+    )
+    def test_parse_command_line_error(
+        self, db: DatabaseTransactionFixture, capsys, cmd_args: str
+    ):
+        with pytest.raises(SystemExit):
+            SuppressWorkForLibraryScript.parse_command_line(
+                db.session, cmd_args.split(" ")
+            )
+
+        assert "error: the following arguments are required" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        "cmd_args",
+        [
+            "--library test1 --identifier-type test2 --identifier test3",
+            "-l test1 -t test2 -i test3",
+        ],
+    )
+    def test_parse_command_line(self, db: DatabaseTransactionFixture, cmd_args: str):
+        parsed = SuppressWorkForLibraryScript.parse_command_line(
+            db.session, cmd_args.split(" ")
+        )
+        assert parsed.library == "test1"
+        assert parsed.identifier_type == "test2"
+        assert parsed.identifier == "test3"
+
+    def test_load_library(self, db: DatabaseTransactionFixture):
+        test_library = db.library(short_name="test")
+
+        script = SuppressWorkForLibraryScript(db.session)
+        loaded_library = script.load_library("test")
+        assert loaded_library == test_library
+
+        with pytest.raises(ValueError):
+            script.load_library("test2")
+
+    def test_load_identifier(self, db: DatabaseTransactionFixture):
+        test_identifier = db.identifier()
+
+        script = SuppressWorkForLibraryScript(db.session)
+        loaded_identifier = script.load_identifier(
+            str(test_identifier.type), str(test_identifier.identifier)
+        )
+        assert loaded_identifier == test_identifier
+
+        loaded_identifier = script.load_identifier(
+            script.BY_DATABASE_ID, str(test_identifier.id)
+        )
+        assert loaded_identifier == test_identifier
+
+        with pytest.raises(ValueError):
+            script.load_identifier("test", "test")
+
+    def test_do_run(self, db: DatabaseTransactionFixture):
+        test_library = db.library(short_name="test")
+        test_identifier = db.identifier()
+
+        script = SuppressWorkForLibraryScript(db.session)
+        suppress_work_mock = create_autospec(script.suppress_work)
+        script.suppress_work = suppress_work_mock
+        args = [
+            "--library",
+            test_library.short_name,
+            "--identifier-type",
+            test_identifier.type,
+            "--identifier",
+            test_identifier.identifier,
+        ]
+        script.do_run(args)
+
+        suppress_work_mock.assert_called_once_with(test_library, test_identifier)
+
+    def test_suppress_work(self, db: DatabaseTransactionFixture):
+        test_library = db.library(short_name="test")
+        work = db.work(with_license_pool=True)
+
+        assert work.suppressed_for == []
+
+        script = SuppressWorkForLibraryScript(db.session)
+        script.suppress_work(test_library, work.presentation_edition.primary_identifier)
+
+        assert work.suppressed_for == [test_library]
 
 
 class TestWorkConsolidationScript:


### PR DESCRIPTION
## Description

A prototype for review to suppress works on a per-library basis. 

This PR adds a new many to many relationship between the `works` and `libraries` table, that is used to capture which works are suppressed for what libraries. This data is added to the search index and is added to the default queries used to build lanes.

## Motivation and Context

This will allow libraries with shared collections to hide titles they do not want to appear in their local catalog. 

This would need to be done manually via a script for now. There is no way to do it via the admin interface. But if we are happy with the approach here, we can add admin UI support via a follow up PR.

## How Has This Been Tested?

Tested with CM running locally, and with the newly added tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
