### PR TITLE
Fixes lane saving bug

### DIFF
--- a/api/admin/controller/custom_lists.py
+++ b/api/admin/controller/custom_lists.py
@@ -290,7 +290,7 @@ class CustomListsController(
 
             # If this list was used to populate any lanes, those lanes need to have their counts updated.
             for lane in Lane.affected_by_customlist(list):
-                lane.update_size(self._db, self.search_engine)
+                lane.update_size(self._db, search_engine=self.search_engine)
 
         new_collections = []
         for collection_id in collections:
@@ -399,7 +399,7 @@ class CustomListsController(
             # Update the size for any lanes affected by this
             # CustomList which _weren't_ deleted.
             for lane in surviving_lanes:
-                lane.update_size(self._db, self.search_engine)
+                lane.update_size(self._db, search_engine=self.search_engine)
             return Response(str(_("Deleted")), 200)
 
         return None

--- a/api/admin/controller/lanes.py
+++ b/api/admin/controller/lanes.py
@@ -160,7 +160,7 @@ class LanesController(CirculationManagerController, AdminPermissionsControllerMi
             for list in lane.customlists:
                 if list.id not in custom_list_ids:
                     lane.customlists.remove(list)
-            lane.update_size(self._db, self.search_engine)
+            lane.update_size(self._db, search_engine=self.search_engine)
 
             if is_new:
                 return Response(str(lane.id), 201)

--- a/core/lane.py
+++ b/core/lane.py
@@ -2929,10 +2929,7 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
             return True
         return False
 
-    @inject
-    def update_size(
-        self, _db, search_engine: ExternalSearchIndex = Provide["search.index"]
-    ):
+    def update_size(self, _db, search_engine: ExternalSearchIndex):
         """Update the stored estimate of the number of Works in this Lane."""
         library = self.get_library(_db)
 


### PR DESCRIPTION
## Description
This PR resolves the bug that was manifesting as a failure to save lanes.

I'm not entirely why not passing the search_engine argument without a key causes the following error:
```
{"host": "eb21d6c68737", "name": "core.app_server.ErrorHandler", "level": "ERROR", "filename": "app_server.py", "message": "Exception in web app: Lane.update_size() got multiple values for argument 'search_engine'", "timestamp": "2024-02-20T23:43:55.588382+00:00", "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py\", line 870, in full_dispatch_request\n    rv = self.dispatch_request()\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py\", line 855, in dispatch_request\n    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]\n  File \"/var/www/circulation/api/routes.py\", line 115, in decorated\n    return f(*args, **kwargs)\n  File \"/var/www/circulation/api/admin/routes.py\", line 93, in decorated\n    v = f(*args, **kwargs)\n  File \"/var/www/circulation/api/admin/routes.py\", line 64, in decorated\n    return f(*args, **kwargs)\n  File \"/var/www/circulation/api/admin/routes.py\", line 82, in decorated\n    return f(*args, **kwargs)\n  File \"/var/www/circulation/api/admin/routes.py\", line 658, in lanes\n    return app.manager.admin_lanes_controller.lanes()\n  File \"/var/www/circulation/api/admin/controller/lanes.py\", line 163, in lanes\n    lane.update_size(self._db, self.search_engine)\n  File \"src/dependency_injector/_cwiring.pyx\", line 28, in dependency_injector._cwiring._get_sync_patched._patched\nTypeError: Lane.update_size() got multiple values for argument 'search_engine'"}

``` 
When I debugged it, there was only one value being passed.  I'm guessing it has something to do with the @Inject tag trying to inject the available search_engine in addition to the explicit `self.search_engine`.  

I noticed that removing the self.seach_engine argument altogether also solved the problem which makes sense because it is injecting the available search_engine in the context. Presumably the injected search_engine instance is the same instance being passed in explicitly.   The unit tests pass because the search_engine is explicitly using the keyword.  I'm not seeing it being passed implicitly via injection anywhere else in the code. 

For the sake of completeness, I also went ahead and updated other references to `Lane.update_size` where the search_engine wasn't being passed with the keyword.

@jonathangreen :  do you have any insight into what we should be doing here? Should rely on the injection or is it better to be explicit?

<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-986
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested on a local instance.  Unit tests still pass.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
