### PR TITLE
Refactor circulation exceptions (PP-991)

### DIFF
--- a/api/admin/exceptions.py
+++ b/api/admin/exceptions.py
@@ -1,19 +1,14 @@
-from typing import Any
-
 from api.admin.problem_details import ADMIN_NOT_AUTHORIZED
-from core.util.problem_detail import ProblemDetail
+from core.util.problem_detail import BaseProblemDetailException, ProblemDetail
 
 
-class AdminNotAuthorized(Exception):
-    status_code = 403
+class AdminNotAuthorized(BaseProblemDetailException):
+    def __init__(self, message: str | None = None) -> None:
+        self.message = message
+        super().__init__(message)
 
-    def __init__(self, *args: Any) -> None:
-        self.message = None
-        if len(args) > 0:
-            self.message = args[0]
-        super().__init__(*args)
-
-    def as_problem_detail_document(self, debug=False) -> ProblemDetail:
+    @property
+    def problem_detail(self) -> ProblemDetail:
         return (
             ADMIN_NOT_AUTHORIZED.detailed(self.message)
             if self.message

--- a/api/admin/routes.py
+++ b/api/admin/routes.py
@@ -23,8 +23,8 @@ from api.controller.static_file import StaticFileController
 from api.routes import allows_library, has_library, library_route
 from core.app_server import ensure_pydantic_after_problem_detail, returns_problem_detail
 from core.util.problem_detail import (
+    BaseProblemDetailException,
     ProblemDetail,
-    ProblemDetailException,
     ProblemDetailModel,
 )
 
@@ -95,8 +95,8 @@ def returns_json_or_response_or_problem_detail(f):
     def decorated(*args, **kwargs):
         try:
             v = f(*args, **kwargs)
-        except ProblemDetailException as ex:
-            # A ProblemError is the same as a ProblemDetail
+        except BaseProblemDetailException as ex:
+            # A ProblemDetailException just needs to be converted to a ProblemDetail.
             v = ex.problem_detail
         if isinstance(v, ProblemDetail):
             return v.response

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -16,7 +16,25 @@ from flask_babel import lazy_gettext as _
 from pydantic import PositiveInt
 from sqlalchemy.orm import Query
 
-from api.circulation_exceptions import *
+from api.circulation_exceptions import (
+    AlreadyCheckedOut,
+    AlreadyOnHold,
+    CannotFulfill,
+    CannotRenew,
+    CannotReturn,
+    CurrentlyAvailable,
+    DeliveryMechanismConflict,
+    DeliveryMechanismError,
+    DeliveryMechanismMissing,
+    NoAcceptableFormat,
+    NoActiveLoan,
+    NoAvailableCopies,
+    NoLicenses,
+    NotCheckedOut,
+    NotOnHold,
+    PatronHoldLimitReached,
+    PatronLoanLimitReached,
+)
 from api.util.patron import PatronUtility
 from core.analytics import Analytics
 from core.integration.base import HasLibraryIntegrationConfiguration
@@ -45,6 +63,7 @@ from core.model import (
 from core.model.integration import IntegrationConfiguration
 from core.util.datetime_helpers import utc_now
 from core.util.log import LoggerMixin
+from core.util.problem_detail import ProblemDetail
 
 
 class CirculationInfo:

--- a/api/controller/base.py
+++ b/api/controller/base.py
@@ -3,7 +3,7 @@ from flask import Response
 from flask_babel import lazy_gettext as _
 from werkzeug.datastructures import Authorization
 
-from api.circulation_exceptions import *
+from api.circulation_exceptions import RemoteInitiatedServerError
 from api.problem_details import (
     INVALID_CREDENTIALS,
     LIBRARY_NOT_FOUND,

--- a/api/odl.py
+++ b/api/odl.py
@@ -26,7 +26,18 @@ from api.circulation import (
     LoanInfo,
     PatronActivityCirculationAPI,
 )
-from api.circulation_exceptions import *
+from api.circulation_exceptions import (
+    AlreadyCheckedOut,
+    AlreadyOnHold,
+    CannotFulfill,
+    CannotLoan,
+    CurrentlyAvailable,
+    FormatNotAvailable,
+    NoAvailableCopies,
+    NoLicenses,
+    NotCheckedOut,
+    NotOnHold,
+)
 from api.lcp.hash import Hasher, HasherFactory, HashingAlgorithm
 from core import util
 from core.integration.settings import (

--- a/api/problem_details.py
+++ b/api/problem_details.py
@@ -57,7 +57,7 @@ NO_AVAILABLE_LICENSE = pd(
 
 NO_ACCEPTABLE_FORMAT = pd(
     "http://librarysimplified.org/terms/problem/no-acceptable-format",
-    400,
+    502,
     _("No acceptable format."),
     _("Could not deliver this book in an acceptable format."),
 )
@@ -167,8 +167,8 @@ HOLD_NOT_FOUND = pd(
 
 COULD_NOT_MIRROR_TO_REMOTE = pd(
     "http://librarysimplified.org/terms/problem/cannot-mirror-to-remote",
-    502,
-    _("Could not mirror local state to remote."),
+    503,
+    _("Loan deleted locally but remote failed."),
     _(
         "Could not convince a third party to accept the change you made. It's likely to show up again soon."
     ),
@@ -216,7 +216,7 @@ NOT_AGE_APPROPRIATE = FORBIDDEN_BY_POLICY.detailed(
 
 CANNOT_FULFILL = pd(
     "http://librarysimplified.org/terms/problem/cannot-fulfill-loan",
-    400,
+    500,
     _("Could not fulfill loan."),
     _("Could not fulfill loan."),
 )
@@ -237,8 +237,8 @@ BAD_DELIVERY_MECHANISM = pd(
 
 CANNOT_RELEASE_HOLD = pd(
     "http://librarysimplified.org/terms/problem/cannot-release-hold",
-    400,
-    _("Could not release hold."),
+    503,
+    _("Hold released locally but remote failed."),
     _("Could not release hold."),
 )
 

--- a/api/util/patron.py
+++ b/api/util/patron.py
@@ -3,7 +3,12 @@ import datetime
 import dateutil
 from money import Money
 
-from api.circulation_exceptions import *
+from api.circulation_exceptions import (
+    AuthorizationBlocked,
+    AuthorizationExpired,
+    CannotLoan,
+    OutstandingFines,
+)
 from api.config import Configuration
 from core.model.patron import Patron
 from core.util import MoneyUtility
@@ -69,7 +74,7 @@ class PatronUtility:
             raise AuthorizationExpired()
 
         if cls.has_excess_fines(patron):
-            raise OutstandingFines()
+            raise OutstandingFines(fines=patron.fines)
 
         from api.authentication.base import PatronData
 
@@ -83,7 +88,7 @@ class PatronUtility:
             # The authentication mechanism itself may know that
             # the patron has outstanding fines, even if the circulation
             # manager is not configured to make that deduction.
-            raise OutstandingFines()
+            raise OutstandingFines(fines=patron.fines)
 
         raise AuthorizationBlocked()
 

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -53,7 +53,7 @@ class IntegrationException(Exception):
     missing or obviously wrong (CannotLoadConfiguration).
     """
 
-    def __init__(self, message, debug_message=None):
+    def __init__(self, message: str | None, debug_message: str | None = None) -> None:
         """Constructor.
 
         :param message: The normal message passed to any Exception

--- a/core/opds2_import.py
+++ b/core/opds2_import.py
@@ -1151,9 +1151,7 @@ class OPDS2ImportMonitor(OPDSImportMonitor):
                 self.MEDIA_TYPE, media_type
             )
 
-            raise BadResponseException(
-                url, message=message, debug_message=feed, status_code=status_code
-            )
+            raise BadResponseException(url, message=message, status_code=status_code)
 
     def _get_accept_header(self) -> str:
         return "{}, {};q=0.9, */*;q=0.1".format(

--- a/core/opds_import.py
+++ b/core/opds_import.py
@@ -1871,9 +1871,7 @@ class OPDSImportMonitor(CollectionMonitor):
             x in media_type for x in (OPDSFeed.ATOM_LIKE_TYPES)
         ):
             message = "Expected Atom feed, got %s" % media_type
-            raise BadResponseException(
-                url, message=message, debug_message=feed, status_code=status_code
-            )
+            raise BadResponseException(url, message=message, status_code=status_code)
 
     def follow_one_link(
         self, url: str, do_get: Callable[..., HttpResponseTuple] | None = None

--- a/core/util/problem_detail.py
+++ b/core/util/problem_detail.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json as j
 import logging
+from abc import ABC, abstractmethod
 
 from flask_babel import LazyString
 from pydantic import BaseModel
@@ -131,8 +132,35 @@ class ProblemDetail:
             self.debug_message,
         )
 
+    def __eq__(self, other: object) -> bool:
+        """Compares two ProblemDetail objects.
 
-class ProblemDetailException(BaseError):
+        :param other: ProblemDetail object
+        :return: Boolean value indicating whether two items are equal
+        """
+        if not isinstance(other, ProblemDetail):
+            return False
+
+        return (
+            self.uri == other.uri
+            and self.title == other.title
+            and self.status_code == other.status_code
+            and self.detail == other.detail
+            and self.debug_message == other.debug_message
+        )
+
+
+class BaseProblemDetailException(Exception, ABC):
+    """Mixin for exceptions that can be converted into a ProblemDetail."""
+
+    @property
+    @abstractmethod
+    def problem_detail(self) -> ProblemDetail:
+        """Convert this object into a ProblemDetail."""
+        ...
+
+
+class ProblemDetailException(BaseError, BaseProblemDetailException):
     """Exception class allowing to raise and catch ProblemDetail objects."""
 
     def __init__(self, problem_detail: ProblemDetail) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ module = [
     "api.adobe_vendor_id",
     "api.axis",
     "api.circulation",
+    "api.circulation_exceptions",
     "api.controller.marc",
     "api.discovery.*",
     "api.enki",

--- a/tests/api/metadata/test_nyt.py
+++ b/tests/api/metadata/test_nyt.py
@@ -136,6 +136,7 @@ class TestNYTBestSellerAPI:
             raise Exception("Expected an IntegrationException!")
         except IntegrationException as e:
             assert "Unknown API error (status 500)" == str(e)
+            assert e.debug_message is not None
             assert e.debug_message.startswith("Response from")
             assert e.debug_message.endswith("was: 'bad value'")
 

--- a/tests/api/test_axis.py
+++ b/tests/api/test_axis.py
@@ -32,7 +32,16 @@ from api.axis import (
     JSONResponseParser,
 )
 from api.circulation import FulfillmentInfo, HoldInfo, LoanInfo
-from api.circulation_exceptions import *
+from api.circulation_exceptions import (
+    AlreadyCheckedOut,
+    AlreadyOnHold,
+    CannotFulfill,
+    NoActiveLoan,
+    NotFoundOnRemote,
+    NotOnHold,
+    PatronAuthorizationFailedException,
+    RemoteInitiatedServerError,
+)
 from api.web_publication_manifest import FindawayManifest, SpineItem
 from core.analytics import Analytics
 from core.coverage import CoverageFailure

--- a/tests/api/test_bibliotheca.py
+++ b/tests/api/test_bibliotheca.py
@@ -4,7 +4,7 @@ import json
 import random
 from datetime import datetime, timedelta
 from io import BytesIO, StringIO
-from typing import TYPE_CHECKING, ClassVar, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, cast
 from unittest import mock
 from unittest.mock import MagicMock, create_autospec
 
@@ -64,7 +64,6 @@ from core.model import (
 from core.scripts import RunCollectionCoverageProviderScript
 from core.util.datetime_helpers import datetime_utc, utc_now
 from core.util.http import BadResponseException
-from core.util.problem_detail import ProblemDetail
 from core.util.web_publication_manifest import AudiobookManifest
 from tests.api.mockapi.bibliotheca import MockBibliothecaAPI
 
@@ -856,86 +855,49 @@ class TestErrorParser:
         "</Message></Error>"
     )
 
-    @runtime_checkable
-    class CirculationExceptionWithProblemDetail(Protocol):
-        status_code: ClassVar[int]
-
-        def as_problem_detail_document(self, debug=False) -> ProblemDetail:
-            ...
-
     @pytest.mark.parametrize(
-        "incoming_message, error_class, error_code, problem_detail_title, problem_detail_code",
+        "incoming_message, error_class",
         [
             (
                 "Patron cannot loan more than 12 documents",
                 PatronLoanLimitReached,
-                500,
-                "Loan limit reached.",
-                403,
             ),
             (
                 "Patron cannot have more than 15 holds",
                 PatronHoldLimitReached,
-                500,
-                "Limit reached.",
-                403,
             ),
             (
                 "the patron document status was CAN_WISH and not one of CAN_LOAN,RESERVATION",
                 NoLicenses,
-                404,
-                "No licenses.",
-                404,
             ),
             (
                 "the patron document status was CAN_HOLD and not one of CAN_LOAN,RESERVATION",
                 NoAvailableCopies,
-                400,
-                None,
-                None,
             ),
             (
                 "the patron document status was LOAN and not one of CAN_LOAN,RESERVATION",
                 AlreadyCheckedOut,
-                400,
-                None,
-                None,
             ),
             (
                 "The patron has no eBooks checked out",
                 NotCheckedOut,
-                400,
-                None,
-                None,
             ),
             (
                 "the patron document status was CAN_LOAN and not one of CAN_HOLD",
                 CurrentlyAvailable,
-                400,
-                None,
-                None,
             ),
             (
                 "the patron document status was HOLD and not one of CAN_HOLD",
                 AlreadyOnHold,
-                400,
-                None,
-                None,
             ),
             (
                 "The patron does not have the book on hold",
                 NotOnHold,
-                400,
-                None,
-                None,
             ),
             # This is such a weird case we don't have a special exception for it.
             (
                 "the patron document status was LOAN and not one of CAN_HOLD",
                 CannotHold,
-                500,
-                None,
-                None,
             ),
         ],
     )
@@ -943,22 +905,13 @@ class TestErrorParser:
         self,
         incoming_message: str,
         error_class: type[CirculationException],
-        error_code: int,
-        problem_detail_title: str,
-        problem_detail_code: int,
     ):
         document = self.BIBLIOTHECA_ERROR_RESPONSE_BODY_TEMPLATE.format(
             message=incoming_message
         )
         error = ErrorParser().process_first(document)
-        assert isinstance(error, error_class)
+        assert error.__class__ is error_class
         assert incoming_message == str(error)
-        assert error_code == error.status_code
-
-        if isinstance(error, self.CirculationExceptionWithProblemDetail):
-            problem = error.as_problem_detail_document()
-            assert problem_detail_code == problem.status_code
-            assert problem_detail_title == problem.title
 
     @pytest.mark.parametrize(
         "incoming_message, incoming_message_from_file, error_string",
@@ -968,6 +921,18 @@ class TestErrorParser:
                 "The server has encountered an error",
                 None,
                 "The server has encountered an error",
+            ),
+            (
+                # Simulate an unexpected response, which is not a unicode string.
+                b"Beep boop bytes",
+                None,
+                "Beep boop bytes",
+            ),
+            (
+                # Simulate an unexpected response, which cannot be decoded as a string.
+                b"\xDE\xAD\xBE\xEF",
+                None,
+                "Unreadable error message (Unicode decode error).",
             ),
             (
                 # Simulate the message we get when the server gives a vague error.
@@ -998,7 +963,7 @@ class TestErrorParser:
     )
     def test_remote_initiated_server_error(
         self,
-        incoming_message: str | None,
+        incoming_message: str | bytes | None,
         incoming_message_from_file: str | None,
         error_string: str,
         api_bibliotheca_files_fixture: BibliothecaFilesFixture,
@@ -1012,10 +977,9 @@ class TestErrorParser:
         assert isinstance(error, RemoteInitiatedServerError)
 
         assert BibliothecaAPI.SERVICE_NAME == error.service_name
-        assert 502 == error.status_code
         assert error_string == str(error)
 
-        problem = error.as_problem_detail_document()
+        problem = error.problem_detail
         assert 502 == problem.status_code
         assert "Integration error communicating with Bibliotheca" == problem.detail
         assert "Third-party service failed." == problem.title

--- a/tests/api/test_circulation_exceptions.py
+++ b/tests/api/test_circulation_exceptions.py
@@ -1,54 +1,172 @@
+import pytest
 from flask_babel import lazy_gettext as _
 
-from api.circulation_exceptions import *
+from api.circulation_exceptions import (
+    AlreadyCheckedOut,
+    AlreadyOnHold,
+    AuthorizationBlocked,
+    AuthorizationExpired,
+    CannotFulfill,
+    CannotHold,
+    CannotLoan,
+    CannotReleaseHold,
+    CannotRenew,
+    CannotReturn,
+    CirculationException,
+    CurrentlyAvailable,
+    DeliveryMechanismConflict,
+    DeliveryMechanismError,
+    DeliveryMechanismMissing,
+    FormatNotAvailable,
+    FulfilledOnIncompatiblePlatform,
+    InternalServerError,
+    InvalidInputException,
+    LibraryAuthorizationFailedException,
+    LibraryInvalidInputException,
+    LimitReached,
+    NoAcceptableFormat,
+    NoActiveLoan,
+    NoAvailableCopies,
+    NoLicenses,
+    NotCheckedOut,
+    NotFoundOnRemote,
+    NotOnHold,
+    OutstandingFines,
+    PatronAuthorizationFailedException,
+    PatronHoldLimitReached,
+    PatronLoanLimitReached,
+    RemoteInitiatedServerError,
+)
+from api.problem_details import (
+    HOLD_LIMIT_REACHED,
+    LOAN_LIMIT_REACHED,
+    OUTSTANDING_FINES,
+)
+from core.problem_details import INTEGRATION_ERROR, INTERNAL_SERVER_ERROR
 from core.util.problem_detail import ProblemDetail
-from tests.fixtures.database import DatabaseTransactionFixture
 
 
 class TestCirculationExceptions:
-    def test_as_problem_detail_document(self):
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            PatronAuthorizationFailedException,
+            LibraryAuthorizationFailedException,
+            InvalidInputException,
+            LibraryInvalidInputException,
+            DeliveryMechanismError,
+            DeliveryMechanismMissing,
+            DeliveryMechanismConflict,
+            CannotLoan,
+            AuthorizationExpired,
+            AuthorizationBlocked,
+            CannotReturn,
+            CannotHold,
+            CannotReleaseHold,
+            CannotFulfill,
+            FormatNotAvailable,
+            NotFoundOnRemote,
+            NoLicenses,
+            CannotRenew,
+            NoAvailableCopies,
+            AlreadyCheckedOut,
+            AlreadyOnHold,
+            NotCheckedOut,
+            NotOnHold,
+            CurrentlyAvailable,
+            NoAcceptableFormat,
+            FulfilledOnIncompatiblePlatform,
+            NoActiveLoan,
+            OutstandingFines,
+            PatronLoanLimitReached,
+            PatronHoldLimitReached,
+        ],
+    )
+    def test_problem_detail(self, exception: type[CirculationException]) -> None:
         """Verify that circulation exceptions can be turned into ProblemDetail
         documents.
         """
+        e = exception()
+        expected_pd = e.base
 
-        e = RemoteInitiatedServerError("message", "some service")
-        doc = e.as_problem_detail_document()
-        assert "Integration error communicating with some service" == doc.detail
+        assert e.problem_detail == expected_pd
 
-        e = AuthorizationExpired()
-        assert EXPIRED_CREDENTIALS == e.as_problem_detail_document()
+        e_with_detail = exception("A message")
+        assert e_with_detail.problem_detail == expected_pd.detailed("A message")
 
-        e = AuthorizationBlocked()
-        assert BLOCKED_CREDENTIALS == e.as_problem_detail_document()
+        e_with_debug = exception(debug_info="A debug message")
+        assert e_with_debug.problem_detail == expected_pd.with_debug("A debug message")
 
-        e = PatronHoldLimitReached()
-        assert HOLD_LIMIT_REACHED == e.as_problem_detail_document()
+        e_with_detail_and_debug = exception("A message", "A debug message")
+        assert e_with_detail_and_debug.problem_detail == expected_pd.detailed(
+            "A message"
+        ).with_debug("A debug message")
 
-        e = NoLicenses()
-        assert NO_LICENSES == e.as_problem_detail_document()
+    def test_outstanding_fines(self) -> None:
+        e = OutstandingFines()
+        assert e.problem_detail == OUTSTANDING_FINES
 
+        e = OutstandingFines(fines="$5,000,000.001")
+        assert e.problem_detail == OUTSTANDING_FINES.detailed(
+            "You must pay your $5000000.00 outstanding fines before you can borrow more books."
+        )
 
-class TestLimitReached:
-    """Test LimitReached, which may send different messages depending on the limit."""
+        e = OutstandingFines(fines="invalid amount")
+        assert e.problem_detail == OUTSTANDING_FINES
 
-    def test_as_problem_detail_document(self, db: DatabaseTransactionFixture):
+    def test_limit_reached(self) -> None:
         generic_message = _(
             "You exceeded the limit, but I don't know what the limit was."
         )
         pd = ProblemDetail("http://uri/", 403, _("Limit exceeded."), generic_message)
 
         class Mock(LimitReached):
-            BASE_DOC = pd
-            MESSAGE_WITH_LIMIT = _("The limit was %(limit)d.")
+            @property
+            def message_with_limit(self) -> str:
+                return _("The limit was %(limit)d.")
+
+            @property
+            def base(self) -> ProblemDetail:
+                return pd
 
         # No limit -> generic message.
         ex = Mock()
-        pd = ex.as_problem_detail_document()
+        pd = ex.problem_detail
         assert ex.limit is None
         assert generic_message == pd.detail
 
         # Limit -> specific message.
         ex = Mock(limit=14)
         assert 14 == ex.limit
-        pd = ex.as_problem_detail_document()
+        pd = ex.problem_detail
         assert "The limit was 14." == pd.detail
+
+    @pytest.mark.parametrize(
+        "exception,pd,limit_type",
+        [
+            (PatronHoldLimitReached, HOLD_LIMIT_REACHED, "hold"),
+            (PatronLoanLimitReached, LOAN_LIMIT_REACHED, "loan"),
+        ],
+    )
+    def test_patron_limit_reached(
+        self, exception: type[LimitReached], pd: ProblemDetail, limit_type: str
+    ) -> None:
+        e = exception()
+        assert e.problem_detail == pd
+
+        limit = 10
+        e = exception(limit=limit)
+        assert e.problem_detail.detail is not None
+        assert e.problem_detail.detail.startswith(
+            f"You have reached your {limit_type} limit of {limit}."
+        )
+
+    def test_internal_server_error(self) -> None:
+        e = InternalServerError("message", "debug")
+        assert e.problem_detail == INTERNAL_SERVER_ERROR
+
+    def test_remote_initiated_server_error(self) -> None:
+        e = RemoteInitiatedServerError("debug message", "some service")
+        assert e.problem_detail == INTEGRATION_ERROR.detailed(
+            "Integration error communicating with some service"
+        ).with_debug("debug message")

--- a/tests/api/test_circulationapi.py
+++ b/tests/api/test_circulationapi.py
@@ -18,7 +18,21 @@ from api.circulation import (
     HoldInfo,
     LoanInfo,
 )
-from api.circulation_exceptions import *
+from api.circulation_exceptions import (
+    AlreadyCheckedOut,
+    AlreadyOnHold,
+    AuthorizationBlocked,
+    AuthorizationExpired,
+    CannotRenew,
+    CurrentlyAvailable,
+    FormatNotAvailable,
+    NoActiveLoan,
+    NoAvailableCopies,
+    NoLicenses,
+    OutstandingFines,
+    PatronHoldLimitReached,
+    PatronLoanLimitReached,
+)
 from core.analytics import Analytics
 from core.mock_analytics_provider import MockAnalyticsProvider
 from core.model import (

--- a/tests/api/test_opds_for_distributors.py
+++ b/tests/api/test_opds_for_distributors.py
@@ -5,7 +5,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from api.circulation_exceptions import *
+from api.circulation_exceptions import (
+    CannotFulfill,
+    LibraryAuthorizationFailedException,
+)
 from api.opds_for_distributors import (
     OPDSForDistributorsAPI,
     OPDSForDistributorsImporter,

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -15,7 +15,18 @@ from requests import Response
 from sqlalchemy.orm.exc import StaleDataError
 
 from api.circulation import CirculationAPI, FulfillmentInfo, HoldInfo, LoanInfo
-from api.circulation_exceptions import *
+from api.circulation_exceptions import (
+    CannotFulfill,
+    CannotHold,
+    CannotLoan,
+    CannotRenew,
+    FormatNotAvailable,
+    FulfilledOnIncompatiblePlatform,
+    NoAcceptableFormat,
+    NoAvailableCopies,
+    PatronHoldLimitReached,
+    PatronLoanLimitReached,
+)
 from api.config import Configuration
 from api.overdrive import (
     GenerateOverdriveAdvantageAccountList,

--- a/tests/api/test_patron_utility.py
+++ b/tests/api/test_patron_utility.py
@@ -5,7 +5,11 @@ import dateutil
 import pytest
 
 from api.authentication.base import PatronData
-from api.circulation_exceptions import *
+from api.circulation_exceptions import (
+    AuthorizationBlocked,
+    AuthorizationExpired,
+    OutstandingFines,
+)
 from api.util.patron import Patron, PatronUtility
 from core.util import MoneyUtility
 from core.util.datetime_helpers import utc_now

--- a/tests/core/test_app_server.py
+++ b/tests/core/test_app_server.py
@@ -31,7 +31,11 @@ from core.model import Identifier
 from core.problem_details import INTEGRATION_ERROR, INVALID_INPUT, INVALID_URN
 from core.service.logging.configuration import LogLevel
 from core.util.opds_writer import OPDSFeed, OPDSMessage
-from core.util.problem_detail import ProblemDetailException
+from core.util.problem_detail import (
+    BaseProblemDetailException,
+    ProblemDetail,
+    ProblemDetailException,
+)
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.library import LibraryFixture
 
@@ -304,7 +308,7 @@ class TestURNLookupController:
         controller = Mock(session)
         with data.app.test_request_context("/?urn=foobar"):
             response = controller.work_lookup(annotator=object())
-            assert INVALID_INPUT == response
+            assert response is INVALID_INPUT
 
     def test_permalink(self, urn_lookup_controller_fixture: URNLookupControllerFixture):
         data, session = (
@@ -473,12 +477,13 @@ class TestLoadMethods:
         # pagination classes.
 
 
-class CanBeProblemDetailDocument(Exception):
+class CanBeProblemDetailDocument(BaseProblemDetailException):
     """A fake exception that can be represented as a problem
     detail document.
     """
 
-    def as_problem_detail_document(self, debug):
+    @property
+    def problem_detail(self) -> ProblemDetail:
         return INVALID_URN.detailed(
             _("detail info"),
             debug_message="A debug_message which should only appear in debug mode.",


### PR DESCRIPTION
## Description

This refactors how we are handling `CirculationExceptions`, so they all inherit from `BaseProblemDetailException` and are able to be turned into a ProblemDetail. This lets us simplify the exception handlers in the Loans controller to catch any `CirculationException` that the Circulation APIs might throw, and return the appropriate ProblemDetail, instead of continuing to grow the huge list of different Exceptions and actions we were handling.

## Motivation and Context

Reviewing the list of unhandled exceptions we are seeing in production, multiple in the top 10 were CirculationExceptions that were not in the `Except` block, or were handled for some actions like `borrow` but not others like `hold`. This PR makes the handling we have here more consistent. 

Having a base class `BaseProblemDetailException` also makes it easier to know if we are able to turn an exception into a ProblemDetail or not. 

## How Has This Been Tested?

- Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
