### PR TITLE
Raise RemoteInitiatedServerError on expired session key (PP-996)

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -1773,12 +1773,12 @@ class Axis360FulfillmentInfoResponseParser(
         checkoutId = k("FNDTransactionID", parsed)
 
         if sessionKey == "Expired":
-            if license_pool.identifier is None:
-                identifier = f"LicensePool {license_pool.id}"
-            else:
-                identifier = f"{license_pool.identifier.type}/{license_pool.identifier.identifier}"
+            try:
+                identifier_msg = f"{license_pool.identifier.type}/{license_pool.identifier.identifier}"
+            except AttributeError:
+                identifier_msg = f"LicensePool.id {license_pool.id}"
 
-            message = f"Expired findaway session key for {identifier}. Request data: {json.dumps(parsed)}"
+            message = f"Expired findaway session key for {identifier_msg}. Request data: {json.dumps(parsed)}"
             self.log.error(message)
             raise RemoteInitiatedServerError(
                 message,

--- a/api/axis.py
+++ b/api/axis.py
@@ -1703,7 +1703,8 @@ class JSONResponseParser(Generic[T], ResponseParser, ABC):
 class Axis360FulfillmentInfoResponseParser(
     JSONResponseParser[
         tuple[Union[FindawayManifest, "AxisNowManifest"], datetime.datetime]
-    ]
+    ],
+    LoggerMixin,
 ):
     """Parse JSON documents into Findaway audiobook manifests or AxisNow manifests."""
 
@@ -1770,6 +1771,19 @@ class Axis360FulfillmentInfoResponseParser(
         licenseId = k("FNDLicenseID", parsed)
         sessionKey = k("FNDSessionKey", parsed)
         checkoutId = k("FNDTransactionID", parsed)
+
+        if sessionKey == "Expired":
+            if license_pool.identifier is None:
+                identifier = f"LicensePool {license_pool.id}"
+            else:
+                identifier = f"{license_pool.identifier.type}/{license_pool.identifier.identifier}"
+
+            message = f"Expired findaway session key for {identifier}. Request data: {json.dumps(parsed)}"
+            self.log.error(message)
+            raise RemoteInitiatedServerError(
+                message,
+                self.SERVICE_NAME,
+            )
 
         # Acquire the TOC information
         metadata_response = self.api.get_audiobook_metadata(fulfillmentId)

--- a/api/controller/loan.py
+++ b/api/controller/loan.py
@@ -8,7 +8,7 @@ from flask_babel import lazy_gettext as _
 from lxml import etree
 from werkzeug import Response as wkResponse
 
-from api.circulation_exceptions import CirculationException
+from api.circulation_exceptions import CirculationException, RemoteInitiatedServerError
 from api.controller.circulation_manager import CirculationManagerController
 from api.problem_details import (
     BAD_DELIVERY_MECHANISM,
@@ -146,7 +146,7 @@ class LoanController(CirculationManagerController):
                 patron, credential, pool, mechanism
             )
             result = loan or hold
-        except CirculationException as e:
+        except (CirculationException, RemoteInitiatedServerError) as e:
             result = e.problem_detail
 
         if result is None:
@@ -322,7 +322,7 @@ class LoanController(CirculationManagerController):
                 requested_license_pool,
                 mechanism,
             )
-        except CirculationException as e:
+        except (CirculationException, RemoteInitiatedServerError) as e:
             return e.problem_detail
 
         # A subclass of FulfillmentInfo may want to bypass the whole
@@ -446,7 +446,7 @@ class LoanController(CirculationManagerController):
         if loan:
             try:
                 self.circulation.revoke_loan(patron, credential, pool)
-            except CirculationException as e:
+            except (CirculationException, RemoteInitiatedServerError) as e:
                 return e.problem_detail
         elif hold:
             if not self.circulation.can_revoke_hold(pool, hold):
@@ -454,7 +454,7 @@ class LoanController(CirculationManagerController):
                 return CANNOT_RELEASE_HOLD.detailed(title, 400)
             try:
                 self.circulation.release_hold(patron, credential, pool)
-            except CirculationException as e:
+            except (CirculationException, RemoteInitiatedServerError) as e:
                 return e.problem_detail
 
         work = pool.work

--- a/tests/api/test_axis.py
+++ b/tests/api/test_axis.py
@@ -1639,6 +1639,13 @@ class TestAxis360FulfillmentInfoResponseParser:
             m(bad_date, license_pool=pool)
         assert "Could not parse expiration date: not-a-date" in str(excinfo.value)
 
+        # Try with an expired session key.
+        expired_session_key = get_data()
+        expired_session_key["FNDSessionKey"] = "Expired"
+        with pytest.raises(RemoteInitiatedServerError) as excinfo:
+            m(expired_session_key, license_pool=pool)
+        assert "Expired findaway session key" in str(excinfo.value)
+
     def test__parse_axisnow(self, axis360parsers: Axis360FixturePlusParsers) -> None:
         # _parse will create a valid AxisNowManifest given a
         # complete document.


### PR DESCRIPTION
## Description

When doing a Findaway fulfillment from B&T, we now check if `FNDSessionKey` is set to `Expired` and raise a `RemoteInitiatedServerError` if that is the case.

The `debug_info` included with this problem_detail gives the response details they want when troubleshooting these messages, so its easier to resolve them in the future. 

JIRA: PP-996

## Motivation and Context

This appears to be a re-occurring problem, and B&T isn't putting a systematic fix in place, instead they are fixing individual accounts when we make support requests. So we want to make it easier to get this information, and to track in our logs when this is happening. 

## How Has This Been Tested?

- Ran unit tests locally
- Tested locally with prod CM DB where this error was occurring

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
