### PR TITLE
Bugfix for hold notifications happening for expired holds (PP-1048)

### DIFF
--- a/core/jobs/holds_notification.py
+++ b/core/jobs/holds_notification.py
@@ -39,11 +39,13 @@ class HoldsNotificationMonitor(SweepMonitor):
         return qu
 
     def item_query(self) -> Query:
+        now = utc_now()
         query = super().item_query()
         query = query.filter(
             Hold.position == 0,
+            Hold.end > now,
             or_(
-                Hold.patron_last_notified != utc_now().date(),
+                Hold.patron_last_notified != now.date(),
                 Hold.patron_last_notified == None,
             ),
         )

--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -184,8 +184,9 @@ class PushNotifications(LoggerMixin):
                 loans_api = f"{url}/{hold.patron.library.short_name}/loans"
                 work: Work = hold.work
                 identifier: Identifier = hold.license_pool.identifier
+                library_name = hold.patron.library.name
                 title = "Your hold is available!"
-                body = f'Your hold on "{work.title}" is available!'
+                body = f'Your hold on "{work.title}" is available at {library_name}!'
                 data = dict(
                     title=title,
                     body=body,

--- a/tests/core/util/test_notifications.py
+++ b/tests/core/util/test_notifications.py
@@ -297,7 +297,7 @@ class TestPushNotifications:
         ) -> None:
             data = dict(
                 title="Your hold is available!",
-                body=f'Your hold on "{work.title}" is available!',
+                body=f'Your hold on "{work.title}" is available at {hold.library.name}!',
                 event_type=NotificationConstants.HOLD_AVAILABLE_TYPE,
                 loans_endpoint=loans_api,
                 identifier=hold.license_pool.identifier.identifier,


### PR DESCRIPTION
## Description

This PR makes two changes:
- Makes sure we only send hold notifications for holds that are not expired
- Add the library name to the hold notification text

For collections not coming in through ODL where we control the holds queues, we don't clean up old holds until they are very old. So we just keep notifying patrons 😓. This will make sure we are only notifying for valid holds.

## Motivation and Context

In PP-997 Courtney is getting holds for an item where the hold has expired and its not clear which library the hold is coming from.

PP-1048

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
