### PR TITLE
Initialize CachedData cache for `distributor` customlist searches. (PP-1045)

### DIFF
--- a/bin/custom_list_update_new_entries
+++ b/bin/custom_list_update_new_entries
@@ -8,6 +8,11 @@ import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..")
 sys.path.append(os.path.abspath(package_dir))
-from core.scripts import CustomListUpdateEntriesScript
 
+from core.model import production_session
+from core.scripts import CustomListUpdateEntriesScript
+from core.util.cache import CachedData
+
+# The cache needs to be initialized for this script to work properly.
+CachedData.initialize(production_session(initialize_data=False))
 CustomListUpdateEntriesScript().run()


### PR DESCRIPTION
## Description

Initializes `CacheData` in the `bin/custom_list_update_new_entries` CLI script, so that custom list searches that include `distributor` work properly.

## Motivation and Context

Some custom lists were not properly updating or repopulating.

[Jira [PP-1045](https://ebce-lyrasis.atlassian.net/browse/PP-1045)]

## How Has This Been Tested?

- Tested locally in a local development environment.
- Ran a version of the script on two production servers that were impacted by the problem.
- CI tests pass for associated branch.

## Checklist

- N/A I have updated the documentation accordingly.
- [ ] All new and existing tests passed.


[PP-1045]: https://ebce-lyrasis.atlassian.net/browse/PP-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ