### PR TITLE
Add library name to loan notifications (PP-1011)

### DIFF
--- a/core/util/notifications.py
+++ b/core/util/notifications.py
@@ -106,8 +106,9 @@ class PushNotifications(LoggerMixin):
         edition = loan.license_pool.presentation_edition
         identifier = loan.license_pool.identifier
         library_short_name = loan.library.short_name
+        library_name = loan.library.name
         title = f"Only {days_to_expiry} {'days' if days_to_expiry != 1 else 'day'} left on your loan!"
-        body = f"Your loan on {edition.title} is expiring soon"
+        body = f'Your loan for "{edition.title}" at {library_name} is expiring soon'
         data = dict(
             title=title,
             body=body,

--- a/tests/core/util/test_notifications.py
+++ b/tests/core/util/test_notifications.py
@@ -106,7 +106,7 @@ class TestPushNotifications:
                     ),
                     "data": dict(
                         title="Only 1 day left on your loan!",
-                        body=f"Your loan on {work.presentation_edition.title} is expiring soon",
+                        body=f'Your loan for "{work.presentation_edition.title}" at {loan.library.name} is expiring soon',
                         event_type=NotificationConstants.LOAN_EXPIRY_TYPE,
                         loans_endpoint="http://localhost/default/loans",
                         external_identifier=patron.external_identifier,


### PR DESCRIPTION
## Description

Currently, holds and loan expiry notifications from the Palace app do not contain the library name. While many users likely have only one library added in the Palace app, for any user having more than 1 library added to the app, the library name not included in the Hold Ready notification can be confusing when trying to borrow a book that has become available. 

## Motivation and Context

See: PP-1011. Related to the changes in https://github.com/ThePalaceProject/circulation/pull/1714.

## How Has This Been Tested?

Running unit tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
