### PR TITLE
Separate docker builds to own workflow (PP-810)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,10 +7,6 @@
 # Readmes
 **/*.md
 
-# Tests
-tests/
-integration_tests/
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -6,32 +6,84 @@ inputs:
     description: "Version of poetry to install"
     required: false
     default: "1.7.1"
+  cache:
+    description: "Cache poetry packages"
+    required: false
+    default: "false"
+  cache-restore-only:
+    description: "Restore cache only, never save new cache"
+    required: false
+    default: "false"
+  cache-name:
+    description: "Cache name"
+    required: false
+    default: "default"
 
 outputs:
   version:
     description: "Installed version"
-    value: ${{ steps.poetry-version.outputs.version }}
+    value: ${{ steps.poetry-info.outputs.version }}
+  home:
+    description: "Poetry home"
+    value: ${{ steps.poetry-dir.outputs.home }}
+  cache-dir:
+    description: "Poetry cache directory"
+    value: ${{ steps.poetry-info.outputs.cache-dir }}
+
 
 runs:
   using: "composite"
   steps:
+    - id: python-version
+      run: >
+        echo "version=$(
+          python -c 'import sys; version=sys.version_info[:3]; print("{0}.{1}.{2}".format(*version))'
+        )" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - id: poetry-dir
+      run: echo "home=$POETRY_HOME" >> $GITHUB_OUTPUT
+      env:
+          POETRY_HOME: ${{ runner.temp }}/poetry
+      shell: bash
+
     - uses: actions/cache@v4
       id: cache
       with:
-        path: ${{ runner.temp }}/poetry
-        key: ${{ runner.os }}-poetry-install-${{ inputs.version }}
+        path: ${{ steps.poetry-dir.outputs.home }}
+        key: ${{ runner.os }}-poetry${{ inputs.version }}-install-py${{ steps.python-version.outputs.version }}
 
     - run: curl -sSL https://install.python-poetry.org | python - --yes --version ${{ inputs.version }}
       env:
-        POETRY_HOME: ${{ runner.temp }}/poetry
+        POETRY_HOME: ${{ steps.poetry-dir.outputs.home }}
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
 
-    - run: echo "$POETRY_HOME/bin" >> $GITHUB_PATH
-      env:
-        POETRY_HOME: ${{ runner.temp }}/poetry
+    - run: echo "${{ steps.poetry-dir.outputs.home }}/bin" >> $GITHUB_PATH
       shell: bash
 
-    - id: poetry-version
-      run: echo "version=$(poetry --version)" >> $GITHUB_OUTPUT
+    - id: poetry-info
+      run: |
+        echo "version=$(poetry --version | grep -o "\d\.\d\.\d")" >> $GITHUB_OUTPUT
+        echo "cache-dir=$(poetry config cache-dir)" >> $GITHUB_OUTPUT
       shell: bash
+
+    - uses: actions/cache@v4
+      with:
+        path: ${{ steps.poetry-info.outputs.cache-dir }}
+        key: |
+          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-${{ hashFiles('**/poetry.lock') }}
+          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-
+          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-
+      if: inputs.cache != 'false' && inputs.cache-restore-only == 'false'
+
+    - uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.poetry-info.outputs.cache-dir }}
+        restore-keys: |
+          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-${{ hashFiles('**/poetry.lock') }}
+          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-
+          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-
+      if: inputs.cache != 'false' && inputs.cache-restore-only != 'false'

--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -74,7 +74,6 @@ runs:
         key: |
           ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-${{ hashFiles('**/poetry.lock') }}
         restore-keys: |
-          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-${{ hashFiles('**/poetry.lock') }}
           ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-
           ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-
       if: inputs.cache != 'false' && inputs.cache-restore-only == 'false'
@@ -82,8 +81,9 @@ runs:
     - uses: actions/cache/restore@v4
       with:
         path: ${{ steps.poetry-info.outputs.cache-dir }}
-        restore-keys: |
+        key: |
           ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
           ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-
           ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-
       if: inputs.cache != 'false' && inputs.cache-restore-only != 'false'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
           docker compose run --build webapp
           bash -c "
             source env/bin/activate &&
-            poetry install --without ci --sync &&
+            poetry install --without ci --no-root --sync &&
             pytest --no-cov tests/${{ matrix.module }}
           "
         env:
@@ -246,7 +246,7 @@ jobs:
         uses: ./.github/actions/poetry
 
       - name: Setup Dunamai
-        run: poetry install --only ci
+        run: poetry install --only ci --no-root
         env:
           POETRY_VIRTUALENVS_CREATE: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,157 +1,17 @@
-name: Test & Build
-on: [push, pull_request]
+name: Docker Build
+on: [push]
 
 concurrency:
   group: test-build-${{ github.ref_name }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: ${{ matrix.module }} Tests (Py ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11"]
-        module: [Api, Core]
-
-    # We want to run on external PRs, but not on our own internal PRs as they'll be run
-    # by the push to the branch. This prevents duplicated runs on internal PRs.
-    # Some discussion of this here:
-    # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
-      - name: Disable network offload
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Apt Packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes libxmlsec1-dev libxml2-dev
-
-      - name: Install Poetry
-        uses: ./.github/actions/poetry
-
-      - name: Install Tox
-        run: |
-          poetry install --only ci
-        env:
-          POETRY_VIRTUALENVS_CREATE: false
-
-      - name: Run Tests
-        run: tox
-        env:
-          MODULE: ${{ matrix.module }}
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          flags: ${{ matrix.module }}
-          name: ${{ matrix.module }}-${{ matrix.python-version }}
-          verbose: true
-
-  test-migrations:
-    name: Migration Tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    # We want to run on external PRs, but not on our own internal PRs as they'll be run
-    # by the push to the branch. This prevents duplicated runs on internal PRs.
-    # Some discussion of this here:
-    # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
-      - name: Disable network offload
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
-      - name: Install Apt Packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes libxmlsec1-dev libxml2-dev
-
-      - name: Install Poetry
-        uses: ./.github/actions/poetry
-
-      - name: Install Tox
-        run: |
-          poetry install --only ci
-        env:
-          POETRY_VIRTUALENVS_CREATE: false
-
-      - name: Run Migration Tests
-        run: tox -e "migration-docker"
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          flags: migration
-          name: "migration-3.10"
-          verbose: true
-
-  docker-test-migrations:
-    name: Docker migration test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    # We want to run on external PRs, but not on our own internal PRs as they'll be run
-    # by the push to the branch. This prevents duplicated runs on internal PRs.
-    # Some discussion of this here:
-    # https://github.community/t/duplicate-checks-on-push-and-pull-request-simultaneous-event/18012
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
-      - name: Disable network offload
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Test migrations
-        run: ./docker/ci/test_migrations.sh
-
-  docker-image-build:
+  build:
     name: Docker build
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
-    # Only build docker containers on a push event. Otherwise, we won't have
-    # permissions to push the built containers into registry.
-    if: github.event_name == 'push'
 
     outputs:
       baseimage-changed: ${{ steps.changes.outputs.baseimage }}
@@ -262,10 +122,10 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ steps.baseimage.outputs.tag }}
 
-  docker-image-test:
-    name: Docker test circ-${{ matrix.image }} (${{ matrix.platform }})
+  integration-test:
+    name: Test circ-${{ matrix.image }} (${{ matrix.platform }})
     runs-on: ubuntu-latest
-    needs: [docker-image-build]
+    needs: [build]
     permissions:
       contents: read
     strategy:
@@ -307,10 +167,46 @@ jobs:
         if: always()
         run: docker compose down
 
-  docker-image-push:
+  unit-test:
+    name: Unit tests (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ["api", "core"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable network offload
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run unit tests
+        run: docker compose run --build webapp bash -c "source env/bin/activate && poetry install --without ci --sync && pytest tests/${{ matrix.module }}"
+        env:
+          BUILD_CACHE_FROM: type=gha,scope=buildkit-${{ github.run_id }}
+          BUILD_BASE_IMAGE: ${{ needs.docker-image-build.outputs.baseimage }}
+
+      - name: Stop container
+        if: always()
+        run: docker compose down
+
+  push:
     name: Push circ-${{ matrix.image }}
     runs-on: ubuntu-latest
-    needs: [test, test-migrations, docker-test-migrations, docker-image-build, docker-image-test]
+    needs: [build, integration-test, unit-test]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,13 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Run unit tests
-        run: docker compose run --build webapp bash -c "source env/bin/activate && poetry install --without ci --sync && pytest tests/${{ matrix.module }}"
+        run: >
+          docker compose run --build webapp
+          bash -c "
+            source env/bin/activate &&
+            poetry install --without ci --sync &&
+            pytest --no-cov tests/${{ matrix.module }}
+          "
         env:
           BUILD_CACHE_FROM: type=gha,scope=buildkit-${{ github.run_id }}
           BUILD_BASE_IMAGE: ${{ needs.build.outputs.baseimage }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,7 @@ jobs:
         env:
           BUILD_PLATFORM: ${{ matrix.platform }}
           BUILD_CACHE_FROM: type=gha,scope=buildkit-${{ github.run_id }}
-          BUILD_BASE_IMAGE: ${{ needs.docker-image-build.outputs.baseimage }}
+          BUILD_BASE_IMAGE: ${{ needs.build.outputs.baseimage }}
 
       - name: Run tests
         run: ./docker/ci/test_${{ matrix.image }}.sh ${{ matrix.image }}
@@ -197,7 +197,7 @@ jobs:
         run: docker compose run --build webapp bash -c "source env/bin/activate && poetry install --without ci --sync && pytest tests/${{ matrix.module }}"
         env:
           BUILD_CACHE_FROM: type=gha,scope=buildkit-${{ github.run_id }}
-          BUILD_BASE_IMAGE: ${{ needs.docker-image-build.outputs.baseimage }}
+          BUILD_BASE_IMAGE: ${{ needs.build.outputs.baseimage }}
 
       - name: Stop container
         if: always()
@@ -280,4 +280,4 @@ jobs:
           cache-from: type=gha,scope=buildkit-${{ github.run_id }}
           platforms: linux/amd64, linux/arm64
           build-args: |
-            BASE_IMAGE=${{ needs.docker-image-build.outputs.baseimage }}
+            BASE_IMAGE=${{ needs.build.outputs.baseimage }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Lint
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 env:
   PYTHON_VERSION: "3.10"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install Pre-commit
         run: |
-          poetry install --only ci
+          poetry install --only ci --no-root
         env:
           POETRY_VIRTUALENVS_CREATE: false
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Install Poetry
         uses: ./.github/actions/poetry
+        with:
+          cache: true
+          cache-restore-only: true
 
       - name: Install Pre-commit
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,5 @@
 name: Lint
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: [push, pull_request]
 env:
   PYTHON_VERSION: "3.10"
 

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,5 +1,9 @@
 name: Mypy (Type check)
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 env:
   PYTHON_VERSION: "3.10"
 

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get install --yes libxmlsec1-dev libxml2-dev
 
       - name: Install Python Packages 📦
-        run: poetry install --without ci
+        run: poetry install --without ci --no-root
 
       - name: Run MyPy 🪄
         run: poetry run mypy

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,9 +1,5 @@
 name: Mypy (Type check)
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: [push, pull_request]
 env:
   PYTHON_VERSION: "3.10"
 

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -19,6 +19,9 @@ jobs:
 
       - name: Install Poetry 🎸
         uses: ./.github/actions/poetry
+        with:
+          cache: true
+          cache-restore-only: true
 
       - name: Install OS Packages 🧰
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,125 @@
+name: Test & Build
+on: [pull_request]
+
+concurrency:
+  group: test-build-${{ github.ref_name }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: ${{ matrix.module }} Tests (Py ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+        module: [Api, Core]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable network offload
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Apt Packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libxmlsec1-dev libxml2-dev
+
+      - name: Install Poetry
+        uses: ./.github/actions/poetry
+
+      - name: Install Tox
+        run: |
+          poetry install --only ci
+        env:
+          POETRY_VIRTUALENVS_CREATE: false
+
+      - name: Run Tests
+        run: tox
+        env:
+          MODULE: ${{ matrix.module }}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: ${{ matrix.module }}
+          name: ${{ matrix.module }}-${{ matrix.python-version }}
+          verbose: true
+
+  test-migrations:
+    name: Migration Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable network offload
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Apt Packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libxmlsec1-dev libxml2-dev
+
+      - name: Install Poetry
+        uses: ./.github/actions/poetry
+
+      - name: Install Tox
+        run: |
+          poetry install --only ci
+        env:
+          POETRY_VIRTUALENVS_CREATE: false
+
+      - name: Run Migration Tests
+        run: tox -e "migration-docker"
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: migration
+          name: "migration-3.10"
+          verbose: true
+
+  docker-test-migrations:
+    name: Docker migration test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable network offload
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Test migrations
+        run: ./docker/ci/test_migrations.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,14 @@ jobs:
       - name: Install Poetry
         uses: ./.github/actions/poetry
 
+      - name: Cache Poetry packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-cache
+
       - name: Install Tox
         run: |
           poetry install --only ci
@@ -87,6 +95,14 @@ jobs:
 
       - name: Install Poetry
         uses: ./.github/actions/poetry
+
+      - name: Cache Poetry packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-cache
 
       - name: Install Tox
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
-name: Test & Build
-on: [pull_request]
+name: Test
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
   group: test-build-${{ github.ref_name }}-${{ github.event_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,14 +41,8 @@ jobs:
 
       - name: Install Poetry
         uses: ./.github/actions/poetry
-
-      - name: Cache Poetry packages
-        uses: actions/cache@v2
         with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-cache
+          cache: true
 
       - name: Install Tox
         run: |
@@ -95,14 +89,8 @@ jobs:
 
       - name: Install Poetry
         uses: ./.github/actions/poetry
-
-      - name: Cache Poetry packages
-        uses: actions/cache@v2
         with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-cache-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-cache
+          cache: true
 
       - name: Install Tox
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install Tox
         run: |
-          poetry install --only ci
+          poetry install --only ci --no-root
         env:
           POETRY_VIRTUALENVS_CREATE: false
 
@@ -106,7 +106,7 @@ jobs:
 
       - name: Install Tox
         run: |
-          poetry install --only ci
+          poetry install --only ci --no-root
         env:
           POETRY_VIRTUALENVS_CREATE: false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ x-cm-variables: &cm
     # Set up the environment variables used for testing as well
     SIMPLIFIED_TEST_DATABASE: "postgresql://palace:test@pg:5432/circ"
     PALACE_TEST_SEARCH_URL: "http://os:9200"
+    PALACE_TEST_MINIO_ENDPOINT_URL: "http://minio:9000"
+    PALACE_TEST_MINIO_USER: "palace"
+    PALACE_TEST_MINIO_PASSWORD: "test123456789"
   depends_on:
     pg:
       condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ x-cm-variables: &cm
     PALACE_SECRET_KEY: "SECRET_KEY_USED_FOR_ADMIN_UI_COOKIES"
     PALACE_PATRON_WEB_HOSTNAMES: "*"
     PALACE_BASE_URL: "http://localhost:6500"
+
+    # Set up the environment variables used for testing as well
+    SIMPLIFIED_TEST_DATABASE: "postgresql://palace:test@pg:5432/circ"
+    PALACE_TEST_SEARCH_URL: "http://os:9200"
   depends_on:
     pg:
       condition: service_healthy

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ COPY --chmod=644 docker/services/logrotate /etc/
 # Copy our poetry files into the image and install our dependencies.
 COPY --chown=simplified:simplified poetry.lock pyproject.toml /var/www/circulation/
 RUN . env/bin/activate && \
-    poetry install --only main,pg --sync
+    poetry install --only main,pg --sync --no-root
 
 COPY --chown=simplified:simplified . /var/www/circulation
 

--- a/docker/Dockerfile.baseimage
+++ b/docker/Dockerfile.baseimage
@@ -65,7 +65,7 @@ RUN python3 -m venv env && \
     echo "if [ -f $SIMPLIFIED_ENVIRONMENT ]; then source $SIMPLIFIED_ENVIRONMENT; fi" >> env/bin/activate && \
     . env/bin/activate && \
     pip install --upgrade pip && \
-    poetry install --only main,pg --sync && \
+    poetry install --only main,pg --sync --no-root && \
     python3 -m textblob.download_corpora lite && \
     mv /root/nltk_data /usr/lib/ && \
     find /usr/lib/nltk_data -name *.zip -delete && \

--- a/tests/api/discovery/test_opds_registration.py
+++ b/tests/api/discovery/test_opds_registration.py
@@ -717,8 +717,12 @@ class TestOpdsRegistrationService:
 
 class TestLibraryRegistrationScript:
     def test_constructor(
-        self, db: DatabaseTransactionFixture, services_fixture: ServicesFixture
+        self,
+        db: DatabaseTransactionFixture,
+        services_fixture: ServicesFixture,
     ):
+        # Make sure that we raise an error if the base URL is not set.
+        services_fixture.set_base_url(None)
         with pytest.raises(CannotLoadConfiguration) as excinfo:
             LibraryRegistrationScript(db.session, services=services_fixture.services)
         assert "Missing required environment variable: PALACE_BASE_URL" in str(

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = true
 
 [testenv]
 commands_pre =
-    poetry install --without ci -v
+    poetry install --without ci --no-root -v
     python -m textblob.download_corpora
 commands =
     api: pytest {posargs:tests/api}


### PR DESCRIPTION
## Description

Updates CI so that:
- Docker builds and unit testing are separate workflows
- Unit tests run on PRs and on push to `main`
- Docker builds run on `pushes`
- Unit tests get run inside of the built docker container before the container gets pushed
- A couple small test updates to address issues with the tests found running in the container
- Adds some caching, so we don't have to compile the lxml wheel every time

## Motivation and Context

As part of PP-810, we need to update how we install lxml to address a segfault. This segfault was happening when running the unit tests, and is resolved be making sure lxml gets built from source. However since we don't run the tests inside out our containers, its hard to make sure the issue is resolved there as well.

I've been using these changes to make sure things are properly compiled in the docker build in https://github.com/ThePalaceProject/circulation/pull/1602 and they have been helpful there. Wanted to merge them as a separate PR though, since these changes are directly related to https://github.com/ThePalaceProject/circulation/pull/1602.

## How Has This Been Tested?

- Running workflows

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
