### PR TITLE
Cache poetry install

### DIFF
--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -18,18 +18,18 @@ runs:
     - uses: actions/cache@v4
       id: cache
       with:
-        path: $HOME/.poetry
+        path: ${{ runner.temp }}/poetry
         key: ${{ runner.os }}-poetry-install-${{ inputs.version }}
 
     - run: curl -sSL https://install.python-poetry.org | python - --yes --version ${{ inputs.version }}
       env:
-        POETRY_HOME: $HOME/.poetry
+        POETRY_HOME: ${{ runner.temp }}/poetry
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
 
     - run: echo "$POETRY_HOME/bin" >> $GITHUB_PATH
       env:
-        POETRY_HOME: $HOME/.poetry
+        POETRY_HOME: ${{ runner.temp }}/poetry
       shell: bash
 
     - id: poetry-version

--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -15,9 +15,21 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: |
-        curl -sSL https://install.python-poetry.org | python - --yes --version ${{ inputs.version }}
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
+    - uses: actions/cache@v4
+      id: cache
+      with:
+        path: $HOME/.poetry
+        key: ${{ runner.os }}-poetry-install-${{ inputs.version }}
+
+    - run: curl -sSL https://install.python-poetry.org | python - --yes --version ${{ inputs.version }}
+      env:
+        POETRY_HOME: $HOME/.poetry
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+
+    - run: echo "$POETRY_HOME/bin" >> $GITHUB_PATH
+      env:
+        POETRY_HOME: $HOME/.poetry
       shell: bash
 
     - id: poetry-version

--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: "Version of poetry to install"
     required: false
-    default: "1.5.1"
+    default: "1.7.1"
 
 outputs:
   version:


### PR DESCRIPTION
## Description

Cache our poetry install, so we don't have to download it every time and bump up the poetry version we install, to match the version being used by dependabot.

## Motivation and Context

Makes poetry install slightly faster. Also should eliminate the build failures we get every now and then, when poetry fails to install.

## How Has This Been Tested?

- Running the actions

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
