### PR TITLE
Update concurrency groups 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Docker Build
 on: [push]
 
 concurrency:
-  group: test-build-${{ github.ref_name }}-${{ github.event_name }}
+  group: build-${{ github.ref_name }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 concurrency:
-  group: test-build-${{ github.ref_name }}-${{ github.event_name }}
+  group: test-${{ github.ref_name }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

Fix the duplicated concurrency groups that resulted from splitting the docker build in https://github.com/ThePalaceProject/circulation/pull/1722

## Motivation and Context

Right now, when merging into `main` only the docker build or the tests are run, not both, because they are erroneously sharing a concurrency group name.

## How Has This Been Tested?

Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
