### PR TITLE
Playback time tables are independent of related tables. (PP-1044)

### DIFF
--- a/alembic/versions/20240318_3e43ed59f256_playtime_tables_have_no_dependencies.py
+++ b/alembic/versions/20240318_3e43ed59f256_playtime_tables_have_no_dependencies.py
@@ -1,0 +1,287 @@
+"""Playtime tables have no dependencies.
+
+Revision ID: 3e43ed59f256
+Revises: 9d2dccb0d6ff
+Create Date: 2024-03-18 01:34:28.381129+00:00
+
+"""
+from functools import cache
+
+import sqlalchemy as sa
+from sqlalchemy.engine import Connection
+from sqlalchemy.orm.session import Session
+
+from alembic import op
+from core.model import Identifier, get_one
+from core.model.time_tracking import _isbn_for_identifier, _title_for_identifier
+
+# revision identifiers, used by Alembic.
+revision = "3e43ed59f256"
+down_revision = "9d2dccb0d6ff"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    session = Session(bind=op.get_bind())
+    conn = session.connection()
+
+    op.add_column(
+        "playtime_entries", sa.Column("identifier_str", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "playtime_entries", sa.Column("collection_name", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "playtime_entries", sa.Column("library_name", sa.String(), nullable=True)
+    )
+
+    # Migrate the existing playtime records before we set the new columns to not nullable.
+    update_playtime_entries(conn)
+
+    op.alter_column(
+        "playtime_entries", "identifier_str", existing_type=sa.String(), nullable=False
+    )
+    op.alter_column(
+        "playtime_entries", "collection_name", existing_type=sa.String(), nullable=False
+    )
+    op.alter_column(
+        "playtime_entries", "library_name", existing_type=sa.String(), nullable=False
+    )
+
+    op.alter_column(
+        "playtime_entries", "identifier_id", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.alter_column(
+        "playtime_entries", "collection_id", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.alter_column(
+        "playtime_entries", "library_id", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.drop_constraint(
+        "playtime_entries_identifier_id_collection_id_library_id_tra_key",
+        "playtime_entries",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "playtime_entries_collection_id_fkey", "playtime_entries", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "playtime_entries_identifier_id_fkey", "playtime_entries", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "playtime_entries_library_id_fkey", "playtime_entries", type_="foreignkey"
+    )
+
+    op.create_unique_constraint(
+        "unique_playtime_entry",
+        "playtime_entries",
+        ["tracking_id", "identifier_str", "collection_name", "library_name"],
+    )
+    op.create_foreign_key(
+        "playtime_entries_identifier_id_fkey",
+        "playtime_entries",
+        "identifiers",
+        ["identifier_id"],
+        ["id"],
+        onupdate="CASCADE",
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "playtime_entries_collection_id_fkey",
+        "playtime_entries",
+        "collections",
+        ["collection_id"],
+        ["id"],
+        onupdate="CASCADE",
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "playtime_entries_library_id_fkey",
+        "playtime_entries",
+        "libraries",
+        ["library_id"],
+        ["id"],
+        onupdate="CASCADE",
+        ondelete="SET NULL",
+    )
+
+    op.add_column("playtime_summaries", sa.Column("title", sa.String(), nullable=True))
+    op.add_column("playtime_summaries", sa.Column("isbn", sa.String(), nullable=True))
+    op.alter_column(
+        "playtime_summaries", "identifier_id", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.alter_column(
+        "playtime_summaries", "collection_id", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.alter_column(
+        "playtime_summaries", "library_id", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.drop_constraint(
+        "playtime_summaries_identifier_str_collection_name_library_n_key",
+        "playtime_summaries",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "unique_playtime_summary",
+        "playtime_summaries",
+        ["timestamp", "identifier_str", "collection_name", "library_name"],
+    )
+
+    # Update ISBN, where available, and title in summary table.
+    update_summary_isbn_and_title(session)
+
+
+def downgrade() -> None:
+    op.drop_constraint("unique_playtime_summary", "playtime_summaries", type_="unique")
+    op.create_unique_constraint(
+        "playtime_summaries_identifier_str_collection_name_library_n_key",
+        "playtime_summaries",
+        ["identifier_str", "collection_name", "library_name", "timestamp"],
+    )
+    op.drop_column("playtime_summaries", "isbn")
+    op.drop_column("playtime_summaries", "title")
+
+    op.drop_constraint(
+        "playtime_entries_identifier_id_fkey", "playtime_entries", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "playtime_entries_collection_id_fkey", "playtime_entries", type_="foreignkey"
+    )
+    op.drop_constraint(
+        "playtime_entries_library_id_fkey", "playtime_entries", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        "playtime_entries_library_id_fkey",
+        "playtime_entries",
+        "libraries",
+        ["library_id"],
+        ["id"],
+        onupdate="CASCADE",
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "playtime_entries_identifier_id_fkey",
+        "playtime_entries",
+        "identifiers",
+        ["identifier_id"],
+        ["id"],
+        onupdate="CASCADE",
+        ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "playtime_entries_collection_id_fkey",
+        "playtime_entries",
+        "collections",
+        ["collection_id"],
+        ["id"],
+        onupdate="CASCADE",
+        ondelete="CASCADE",
+    )
+    op.drop_constraint("unique_playtime_entry", "playtime_entries", type_="unique")
+    op.create_unique_constraint(
+        "playtime_entries_identifier_id_collection_id_library_id_tra_key",
+        "playtime_entries",
+        ["identifier_id", "collection_id", "library_id", "tracking_id"],
+    )
+    op.alter_column(
+        "playtime_entries", "library_id", existing_type=sa.INTEGER(), nullable=False
+    )
+    op.alter_column(
+        "playtime_entries", "collection_id", existing_type=sa.INTEGER(), nullable=False
+    )
+    op.alter_column(
+        "playtime_entries", "identifier_id", existing_type=sa.INTEGER(), nullable=False
+    )
+    op.drop_column("playtime_entries", "library_name")
+    op.drop_column("playtime_entries", "collection_name")
+    op.drop_column("playtime_entries", "identifier_str")
+
+
+def update_summary_isbn_and_title(session: Session) -> None:
+    """Update existing playtime summary records in the database."""
+    conn = session.connection()
+    rows = conn.execute("SELECT id, identifier_id FROM playtime_summaries").all()
+
+    for row in rows:
+        identifier = get_one(session, Identifier, id=row.identifier_id)
+        isbn = cached_isbn_lookup(identifier)
+        title = cached_title_lookup(identifier)
+        conn.execute(
+            """
+            UPDATE playtime_summaries
+            SET isbn = %(isbn)s, title = %(title)s
+            WHERE id = %(id)s
+            """,
+            {"id": row.id, "isbn": isbn, "title": title},
+        )
+
+
+@cache
+def cached_isbn_lookup(identifier: Identifier) -> str | None:
+    """Given an identifier, return its ISBN."""
+    return _isbn_for_identifier(identifier)
+
+
+@cache
+def cached_title_lookup(identifier: Identifier) -> str | None:
+    """Given an identifier, return its title."""
+    return _title_for_identifier(identifier)
+
+
+def update_playtime_entries(conn: Connection) -> None:
+    """Update existing playtime entries in the database."""
+    rows = conn.execute(
+        "SELECT id, identifier_id, collection_id, library_id FROM playtime_entries"
+    ).all()
+
+    for row in rows:
+        conn.execute(
+            """
+            UPDATE playtime_entries
+            SET identifier_str = %(urn)s, collection_name = %(collection_name)s, library_name = %(library_name)s
+            WHERE id = %(id)s
+            """,
+            {
+                "id": row.id,
+                "urn": get_identifier_urn(conn, row.identifier_id),
+                "collection_name": get_collection_name(conn, row.collection_id),
+                "library_name": get_library_name(conn, row.library_id),
+            },
+        )
+
+
+@cache
+def get_collection_name(conn: Connection, collection_id: int) -> str:
+    """Given the id of a collection, return its name."""
+    return conn.execute(
+        """
+        SELECT ic.name
+        FROM collections c
+        JOIN integration_configurations ic on c.integration_configuration_id = ic.id
+        WHERE c.id = %s
+        """,
+        (collection_id,),
+    ).scalar_one()
+
+
+@cache
+def get_identifier_urn(conn: Connection, identifier_id: int) -> str:
+    """Given the id of an identifier id, return its urn."""
+    row = conn.execute(
+        """
+        SELECT type, identifier
+        FROM identifiers
+        WHERE id = %s
+        """,
+        (identifier_id,),
+    ).one()
+    return Identifier._urn_from_type_and_value(row.type, row.identifier)
+
+
+@cache
+def get_library_name(conn: Connection, library_id: int) -> str:
+    """Given the id of a library, return its name."""
+    return conn.execute(
+        "SELECT name FROM libraries WHERE id = %s", (library_id,)
+    ).scalar_one()

--- a/alembic/versions/20240318_3e43ed59f256_playtime_tables_have_no_dependencies.py
+++ b/alembic/versions/20240318_3e43ed59f256_playtime_tables_have_no_dependencies.py
@@ -109,9 +109,6 @@ def upgrade() -> None:
     op.add_column("playtime_summaries", sa.Column("title", sa.String(), nullable=True))
     op.add_column("playtime_summaries", sa.Column("isbn", sa.String(), nullable=True))
     op.alter_column(
-        "playtime_summaries", "identifier_id", existing_type=sa.INTEGER(), nullable=True
-    )
-    op.alter_column(
         "playtime_summaries", "collection_id", existing_type=sa.INTEGER(), nullable=True
     )
     op.alter_column(
@@ -138,6 +135,15 @@ def downgrade() -> None:
         "playtime_summaries_identifier_str_collection_name_library_n_key",
         "playtime_summaries",
         ["identifier_str", "collection_name", "library_name", "timestamp"],
+    )
+    op.alter_column(
+        "playtime_summaries",
+        "collection_id",
+        existing_type=sa.INTEGER(),
+        nullable=False,
+    )
+    op.alter_column(
+        "playtime_summaries", "library_id", existing_type=sa.INTEGER(), nullable=False
     )
     op.drop_column("playtime_summaries", "isbn")
     op.drop_column("playtime_summaries", "title")

--- a/core/query/playtime_entries.py
+++ b/core/query/playtime_entries.py
@@ -51,6 +51,9 @@ class PlaytimeEntries:
                         identifier_id=identifier.id,
                         collection_id=collection.id,
                         library_id=library.id,
+                        identifier_str=identifier.urn,
+                        collection_name=collection.name,
+                        library_name=library.name,
                         timestamp=entry.during_minute,
                         total_seconds_played=entry.seconds_played,
                     )

--- a/core/util/datetime_helpers.py
+++ b/core/util/datetime_helpers.py
@@ -93,3 +93,12 @@ def previous_months(number_of_months: int) -> tuple[datetime.date, datetime.date
     start = start.replace(day=1)
     until = now.replace(day=1)
     return start.date(), until.date()
+
+
+def minute_timestamp(dt: datetime.datetime) -> datetime.datetime:
+    """Minute resolution timestamp by truncating the seconds from a datetime object.
+
+    :param dt: datetime object with seconds resolution
+    :return: datetime object with minute resolution
+    """
+    return datetime.datetime(dt.year, dt.month, dt.day, dt.hour, dt.minute)

--- a/tests/api/controller/test_playtime_entries.py
+++ b/tests/api/controller/test_playtime_entries.py
@@ -103,6 +103,8 @@ class TestPlaytimeEntriesController:
         db = circulation_fixture.db
         identifier = db.identifier()
         collection = db.default_collection()
+        library = db.default_library()
+
         # Attach the identifier to the collection
         pool = db.licensepool(
             db.edition(
@@ -119,7 +121,10 @@ class TestPlaytimeEntriesController:
                 total_seconds_played=12,
                 identifier_id=identifier.id,
                 collection_id=collection.id,
-                library_id=db.default_library().id,
+                library_id=library.id,
+                identifier_str=identifier.urn,
+                collection_name=collection.name,
+                library_name=library.name,
             )
         )
 

--- a/tests/core/models/test_time_tracking.py
+++ b/tests/core/models/test_time_tracking.py
@@ -217,8 +217,8 @@ class TestPlaytimeSummaries:
         db.session.delete(identifier)
         db.session.refresh(entry)
 
-        assert entry.identifier is None
         assert entry.identifier_str == urn
+        assert entry.identifier is None
 
 
 class TestHelpers:

--- a/tests/core/util/test_datetime_helpers.py
+++ b/tests/core/util/test_datetime_helpers.py
@@ -7,6 +7,7 @@ import pytz
 from core.util.datetime_helpers import (
     datetime_utc,
     from_timestamp,
+    minute_timestamp,
     previous_months,
     strptime_utc,
     to_utc,
@@ -273,3 +274,36 @@ class TestPreviousMonths:
             # Both dates should be the 1st of the month.
             assert 1 == computed_start.day
             assert 1 == computed_until.day
+
+
+class TestMinuteTimestamp:
+    @pytest.mark.parametrize(
+        "dt, expected",
+        [
+            (
+                datetime.datetime(2022, 1, 1, 12, 30, 45),
+                datetime.datetime(2022, 1, 1, 12, 30),
+            ),
+            (
+                datetime.datetime(2022, 1, 1, 12, 30),
+                datetime.datetime(2022, 1, 1, 12, 30),
+            ),
+            (
+                datetime.datetime(2022, 2, 15, 9, 45, 30),
+                datetime.datetime(2022, 2, 15, 9, 45),
+            ),
+            (
+                datetime.datetime(2023, 12, 31, 23, 59, 59),
+                datetime.datetime(2023, 12, 31, 23, 59),
+            ),
+            (
+                datetime.datetime(2024, 5, 10, 0, 0),
+                datetime.datetime(2024, 5, 10, 0, 0),
+            ),
+        ],
+    )
+    def test_minute_resolution(
+        self, dt: datetime.datetime, expected: datetime.datetime
+    ):
+        result = minute_timestamp(dt)
+        assert result == expected


### PR DESCRIPTION
## Description

- Removes dependency on related identifier, collection, and library tables from the audio playback time entry (from clients) and summary tables.
- Removes constraints that require the associated keys not to be null.
- Captures the identifier urn, collection name, library name, isbn, and title at multiple points along the way.
- Adds tests to verify this functionality.

## Motivation and Context

Need to be able to remove collections, libraries, and identifiers without losing tracked playback time.

[Jira [PP-1044](https://ebce-lyrasis.atlassian.net/browse/PP-1044)]

## How Has This Been Tested?

- New tests to verify functionality.
- Performed tests in local dev environment.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/8351483916) pass for associated branch.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1044]: https://ebce-lyrasis.atlassian.net/browse/PP-1044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ