### PR TITLE
Output URNs for hrefs in findaway manfiests

### DIFF
--- a/api/web_publication_manifest.py
+++ b/api/web_publication_manifest.py
@@ -118,11 +118,11 @@ class FindawayManifest(AudiobookManifest):
         for item in spine_items:
             kwargs = {part_key: item.part, sequence_key: item.sequence}
             self.add_reading_order(
-                href=None,
+                href=f"urn:org.thepalaceproject:findaway:{item.part}:{item.sequence}",
                 title=item.title,
                 duration=item.duration,
                 type=item.media_type,
-                **kwargs
+                **kwargs,
             )
             total_duration += item.duration
 

--- a/api/web_publication_manifest.py
+++ b/api/web_publication_manifest.py
@@ -111,6 +111,9 @@ class FindawayManifest(AudiobookManifest):
         # Add the SpineItems as reading order items. None of them will
         # have working 'href' fields -- it's just to give the client a
         # picture of the structure of the timeline.
+        # For the href we return a URN that includes the part and sequence
+        # numbers, these URNs are not expected to be resolved, but the client
+        # can use them to identify the reading order items for bookmarks etc.
         part_key = "findaway:part"
         sequence_key = "findaway:sequence"
         total_duration = 0

--- a/api/web_publication_manifest.py
+++ b/api/web_publication_manifest.py
@@ -121,7 +121,7 @@ class FindawayManifest(AudiobookManifest):
         for item in spine_items:
             kwargs = {part_key: item.part, sequence_key: item.sequence}
             self.add_reading_order(
-                href=f"urn:org.thepalaceproject:findaway:{item.part}:{item.sequence}",
+                href=f"urn:org.thepalaceproject:findaway:{fulfillmentId}:{item.part}:{item.sequence}",
                 title=item.title,
                 duration=item.duration,
                 type=item.media_type,

--- a/tests/api/test_bibliotheca.py
+++ b/tests/api/test_bibliotheca.py
@@ -692,10 +692,14 @@ class TestBibliothecaAPI:
         # part #0. Within that part, the items have been sorted by
         # their sequence.
         for i, item in enumerate(reading_order):
-            assert None == item.get("href", None)
             assert Representation.MP3_MEDIA_TYPE == item["type"]
-            assert 0 == item["findaway:part"]
-            assert i + 1 == item["findaway:sequence"]
+            part = item["findaway:part"]
+            assert 0 == part
+            sequence = item["findaway:sequence"]
+            assert i + 1 == sequence
+            assert (
+                f"urn:org.thepalaceproject:findaway:{part}:{sequence}" == item["href"]
+            )
 
         # The total duration, in seconds, has been added to metadata.
         assert 28371 == int(metadata["duration"])

--- a/tests/api/test_bibliotheca.py
+++ b/tests/api/test_bibliotheca.py
@@ -684,7 +684,7 @@ class TestBibliothecaAPI:
         assert 16.201 == first["duration"]
         assert "Track 1" == first["title"]
 
-        # There is no 'href' value for the readingOrder items because the
+        # The 'href' value for the readingOrder is a URN because the
         # files must be obtained through the Findaway SDK rather than
         # through regular HTTP requests.
         #

--- a/tests/api/test_bibliotheca.py
+++ b/tests/api/test_bibliotheca.py
@@ -668,7 +668,8 @@ class TestBibliothecaAPI:
         assert "abcdef01234789abcdef0123" == encrypted["findaway:checkoutId"]
         assert "1234567890987654321ababa" == encrypted["findaway:licenseId"]
         assert "3M" == encrypted["findaway:accountId"]
-        assert "123456" == encrypted["findaway:fulfillmentId"]
+        fullfillment_id = encrypted["findaway:fulfillmentId"]
+        assert "123456" == fullfillment_id
         assert (
             "aaaaaaaa-4444-cccc-dddd-666666666666" == encrypted["findaway:sessionKey"]
         )
@@ -698,7 +699,8 @@ class TestBibliothecaAPI:
             sequence = item["findaway:sequence"]
             assert i + 1 == sequence
             assert (
-                f"urn:org.thepalaceproject:findaway:{part}:{sequence}" == item["href"]
+                f"urn:org.thepalaceproject:findaway:{fullfillment_id}:{part}:{sequence}"
+                == item["href"]
             )
 
         # The total duration, in seconds, has been added to metadata.


### PR DESCRIPTION
## Description

Output manifests with href that look like: `urn:org.thepalaceproject:findaway:{fulfillmentId}:{item.part}:{item.sequence}` instead of `None` for findaway, so its easier for the mobile clients to use the readingOrder href to track things like bookmarks.

## Motivation and Context

See slack thread here: https://lyrasis.slack.com/archives/C03GKDAKU0H/p1710949080047149

## How Has This Been Tested?

Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
