### PR TITLE
Ensure LibraryAnnotator passes its associated library when resolving active license pools.

### DIFF
--- a/core/feed/annotator/circulation.py
+++ b/core/feed/annotator/circulation.py
@@ -23,6 +23,7 @@ from core.analytics import Analytics
 from core.classifier import Classifier
 from core.config import CannotLoadConfiguration
 from core.entrypoint import EverythingEntryPoint
+from core.exceptions import BasePalaceException
 from core.external_search import WorkSearchResult
 from core.feed.annotator.base import Annotator
 from core.feed.opds import UnfulfillableWork
@@ -954,6 +955,17 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             entry.computed.other_links.append(
                 Link(href=group_uri, rel=OPDSFeed.GROUP_REL, title=str(group_title))
             )
+
+    def active_licensepool_for(
+        self, work: Work, library: Library | None = None
+    ) -> LicensePool | None:
+        if library and library != self.library:
+            raise BasePalaceException(
+                message=f"This is a LibraryAnnotator: does it ever make sense to lookup get the "
+                f"active license pool a library not associated with this library?  "
+                f"self.library = {self.library} vs library arg = {library}"
+            )
+        return super().active_licensepool_for(work=work, library=self.library)
 
     @classmethod
     def related_books_available(cls, work: Work, library: Library) -> bool:

--- a/core/feed/annotator/circulation.py
+++ b/core/feed/annotator/circulation.py
@@ -961,9 +961,9 @@ class LibraryAnnotator(CirculationManagerAnnotator):
     ) -> LicensePool | None:
         if library and library != self.library:
             raise BasePalaceException(
-                message=f"This is a LibraryAnnotator: does it ever make sense to lookup get the "
-                f"active license pool a library not associated with this library?  "
-                f"self.library = {self.library} vs library arg = {library}"
+                message=f"An active license pool cannot be resolved for a library not associated with this annotator: "
+                f"self.library = {self.library} vs library arg = {library}. This condition is likely arising from "
+                f"a programming error."
             )
         return super().active_licensepool_for(work=work, library=self.library)
 

--- a/tests/api/feed/test_library_annotator.py
+++ b/tests/api/feed/test_library_annotator.py
@@ -1813,12 +1813,13 @@ class TestLibraryAnnotator:
         annotator_fixture: LibraryAnnotatorFixture,
         library_fixture: LibraryFixture,
     ):
-        # we would never want to
-        other_library = library_fixture.library("otherlibrary")
+        # we would never want to resolve an active license pool with a library other
+        # than the library that was passed to construct the LibraryAnnotator.
         annotator = LibraryAnnotator(None, None, annotator_fixture.db.default_library())
 
-        # This book has two delivery mechanisms
         work = annotator_fixture.db.work(with_license_pool=True)
+
+        other_library = library_fixture.library("otherlibrary")
 
         with pytest.raises(BasePalaceException) as execinfo:
             annotator.active_licensepool_for(work, other_library)

--- a/tests/api/feed/test_library_annotator.py
+++ b/tests/api/feed/test_library_annotator.py
@@ -1820,5 +1820,10 @@ class TestLibraryAnnotator:
         # This book has two delivery mechanisms
         work = annotator_fixture.db.work(with_license_pool=True)
 
-        with pytest.raises(BasePalaceException):
+        with pytest.raises(BasePalaceException) as execinfo:
             annotator.active_licensepool_for(work, other_library)
+
+        assert (
+            "An active license pool cannot be resolved for a library not associated with this annotator"
+            in str(execinfo.value)
+        )

--- a/tests/api/feed/test_loan_and_hold_annotator.py
+++ b/tests/api/feed/test_loan_and_hold_annotator.py
@@ -214,6 +214,7 @@ class TestLibraryLoanAndHoldAnnotator:
 
         # Annotate time tracking
         opds_for_distributors = db.collection(protocol=OPDSForDistributorsAPI.label())
+        opds_for_distributors.libraries.append(library)
         work = db.work(with_license_pool=True, collection=opds_for_distributors)
         work.active_license_pool().should_track_playtime = True
         edition = work.presentation_edition


### PR DESCRIPTION
… resolving the active license pool for a work.


## Description

The issue appears to be that the library associated with the annotator in the context of the call to book linked via a lane (vs via search) - that execution passes through https://github.com/ThePalaceProject/circulation/blob/main/api/admin/controller/work_editor.py#L53 via (https://github.com/ThePalaceProject/circulation/blob/main/api/admin/routes.py#L152) is not being passed to the active license pool resolver resulting in potentially the wrong license pool being returned.

<!--- Describe your changes -->
This update ensures that 1) LibraryAnnotators may not pass a library other than the one associated with the annotator to the active license pool resolver method and 2) a LibraryAnnotator will pass the annotator's library to the super class' resolver method even when the library is not explicitly passed as an argument to the subclass method.
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-989
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
