### PR TITLE
Update how we handle axis availability information 401 response (PP-1081)

### DIFF
--- a/api/axis.py
+++ b/api/axis.py
@@ -948,12 +948,9 @@ class StatusResponseParser(Axis360Parser[tuple[int, str]]):
     def process_one(
         self, tag: _Element, namespaces: dict[str, str] | None
     ) -> tuple[int, str] | None:
-        try:
-            status_code = self.int_of_subtag(tag, "axis:code", namespaces)
-            message = self.text_of_subtag(tag, "axis:statusMessage", namespaces)
-            return status_code, message
-        except ValueError:
-            return None
+        status_code = self.int_of_subtag(tag, "axis:code", namespaces)
+        message = self.text_of_subtag(tag, "axis:statusMessage", namespaces)
+        return status_code, message
 
     def process_first(
         self,
@@ -962,7 +959,12 @@ class StatusResponseParser(Axis360Parser[tuple[int, str]]):
         if not xml:
             return None
 
-        return super().process_first(xml)
+        # Since this is being used to parse error codes, we want to generally be
+        # very forgiving of errors in the XML, and return None if we can't parse it.
+        try:
+            return super().process_first(xml)
+        except (etree.XMLSyntaxError, AssertionError, ValueError):
+            return None
 
 
 class BibliographicParser(Axis360Parser[tuple[Metadata, CirculationData]], LoggerMixin):

--- a/api/axis.py
+++ b/api/axis.py
@@ -333,12 +333,11 @@ class Axis360API(
         )
         if response.status_code == 401 and not request_retried:
             parsed = StatusResponseParser().process_first(response.content)
-            if parsed is None or parsed[0] in [1001, 1002, 1003]:
+            if parsed is None or parsed[0] in [1001, 1002]:
                 # The token is probably expired. Get a new token and try again.
                 # Axis 360's status codes mean:
                 #   1001: Invalid token
                 #   1002: Token expired
-                #   1003: Token is invalid for given library
                 self.token = None
                 return self.request(
                     url=url,

--- a/tests/api/files/axis/availability_invalid_token.xml
+++ b/tests/api/files/axis/availability_invalid_token.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><availabilityResponse xmlns="http://axis360api.baker-taylor.com/vendorAPI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><status><code>1001</code><statusMessage>Authorization token is invalid</statusMessage></status></availabilityResponse>

--- a/tests/api/files/axis/availability_patron_not_found.xml
+++ b/tests/api/files/axis/availability_patron_not_found.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><availabilityResponse xmlns="http://axis360api.baker-taylor.com/vendorAPI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><status><code>3122</code><statusMessage>Patron information is not found.</statusMessage></status></availabilityResponse>

--- a/tests/api/test_axis.py
+++ b/tests/api/test_axis.py
@@ -1049,6 +1049,7 @@ class TestParsers:
         assert parser.process_first(data) is None
         assert parser.process_first(None) is None
         assert parser.process_first(b"") is None
+        assert parser.process_first(b"not xml") is None
 
     def test_bibliographic_parser(self, axis360: Axis360Fixture):
         # Make sure the bibliographic information gets properly

--- a/tests/api/test_axis.py
+++ b/tests/api/test_axis.py
@@ -312,7 +312,7 @@ class TestAxis360API:
         # The fourth request never got made.
         assert [301] == [x.status_code for x in axis360.api.responses]
 
-    def test_bearer_token_only_refreshed_when_axis_status_code_is_401(
+    def test_bearer_token_not_refreshed_for_patron_not_found(
         self, axis360: Axis360Fixture
     ):
         axis360.api.queue_response(
@@ -327,6 +327,17 @@ class TestAxis360API:
 
         # Only a single request was made.
         assert len(axis360.api.requests) == 1
+
+    def test_refresh_bearer_token_on_invalid_token_status(
+        self, axis360: Axis360Fixture
+    ):
+        axis360.api.queue_response(
+            401, content=axis360.sample_data("availability_invalid_token.xml")
+        )
+        axis360.api.queue_response(200, content=json.dumps(dict(access_token="foo")))
+        axis360.api.queue_response(200, content="The data")
+        response = axis360.api.request("http://url/")
+        assert b"The data" == response.content
 
     def test_update_availability(self, axis360: Axis360Fixture):
         # Test the Axis 360 implementation of the update_availability method

--- a/tests/api/test_axis.py
+++ b/tests/api/test_axis.py
@@ -30,6 +30,7 @@ from api.axis import (
     HoldReleaseResponseParser,
     HoldResponseParser,
     JSONResponseParser,
+    StatusResponseParser,
 )
 from api.circulation import FulfillmentInfo, HoldInfo, LoanInfo
 from api.circulation_exceptions import (
@@ -295,9 +296,9 @@ class TestAxis360API:
             in str(excinfo.value)
         )
 
-    def test_exception_after_401_with_fresh_token(self, axis360: Axis360Fixture):
-        # If we get a 401 immediately after refreshing the token, we will
-        # raise an exception.
+    def test_bearer_token_only_refreshed_once_after_401(self, axis360: Axis360Fixture):
+        # If we get a 401 immediately after refreshing the token, we just
+        # return the response instead of refreshing the token again.
 
         axis360.api.queue_response(401)
         axis360.api.queue_response(200, content=json.dumps(dict(access_token="foo")))
@@ -305,14 +306,27 @@ class TestAxis360API:
 
         axis360.api.queue_response(301)
 
-        with pytest.raises(RemoteIntegrationException) as excinfo:
-            axis360.api.request("http://url/")
-        assert "Got status code 401 from external server, cannot continue." in str(
-            excinfo.value
-        )
+        response = axis360.api.request("http://url/")
+        assert response.status_code == 401
 
         # The fourth request never got made.
         assert [301] == [x.status_code for x in axis360.api.responses]
+
+    def test_bearer_token_only_refreshed_when_axis_status_code_is_401(
+        self, axis360: Axis360Fixture
+    ):
+        axis360.api.queue_response(
+            401, content=axis360.sample_data("availability_patron_not_found.xml")
+        )
+        axis360.api.queue_response(301)
+
+        # This request will fail with a 401, but the bearer token will not be refreshed because it has
+        # an axis:code set in the response XML, and the code does not indicate that the token is invalid.
+        response = axis360.api.request("http://url/")
+        assert response.status_code == 401
+
+        # Only a single request was made.
+        assert len(axis360.api.requests) == 1
 
     def test_update_availability(self, axis360: Axis360Fixture):
         # Test the Axis 360 implementation of the update_availability method
@@ -998,6 +1012,44 @@ class TestReaper:
 
 
 class TestParsers:
+    def test_status_parser(self, axis360: Axis360Fixture):
+        data = axis360.sample_data("availability_patron_not_found.xml")
+        parser = StatusResponseParser()
+        parsed = parser.process_first(data)
+        assert parsed is not None
+        status, message = parsed
+        assert status == 3122
+        assert message == "Patron information is not found."
+
+        data = axis360.sample_data("availability_with_loans.xml")
+        parsed = parser.process_first(data)
+        assert parsed is not None
+        status, message = parsed
+        assert status == 0
+        assert message == "Availability Data is Successfully retrieved."
+
+        data = axis360.sample_data("availability_with_ebook_fulfillment.xml")
+        parsed = parser.process_first(data)
+        assert parsed is not None
+        status, message = parsed
+        assert status == 0
+        assert message == "Availability Data is Successfully retrieved."
+
+        data = axis360.sample_data("checkin_failure.xml")
+        parsed = parser.process_first(data)
+        assert parsed is not None
+        status, message = parsed
+        assert status == 3103
+        assert message == "Invalid Title Id"
+
+        data = axis360.sample_data("invalid_error_code.xml")
+        assert parser.process_first(data) is None
+
+        data = axis360.sample_data("missing_error_code.xml")
+        assert parser.process_first(data) is None
+        assert parser.process_first(None) is None
+        assert parser.process_first(b"") is None
+
     def test_bibliographic_parser(self, axis360: Axis360Fixture):
         # Make sure the bibliographic information gets properly
         # collated in preparation for creating Edition objects.
@@ -1489,6 +1541,13 @@ class TestAvailabilityResponseParser:
         # The API object is present in the FulfillmentInfo and ready to go
         # make that extra request.
         assert axis360parsers.api == fulfillment.api
+
+    def test_patron_not_found(self, axis360parsers: Axis360FixturePlusParsers):
+        # If the patron is not found, the parser will return an empty list, since
+        # that patron can't have any loans or holds.
+        data = axis360parsers.sample_data("availability_patron_not_found.xml")
+        parser = AvailabilityResponseParser(axis360parsers.api)
+        assert list(parser.process_all(data)) == []
 
 
 class TestJSONResponseParser:


### PR DESCRIPTION
## Description

This updates the logic we use to refresh the token when the axis API returns a 401 response. Looking at their API documentation, they don't always use a 401 response to mean that the token needs a refresh. 

When we are asking for availability information for patrons that haven't loaned content from a particular library before, the API returns a 401 response that looks like this:
```xml
<availabilityResponse xmlns="http://axis360api.baker-taylor.com/vendorAPI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
  <status>
    <code>3122</code>
    <statusMessage>Patron information is not found.</statusMessage>
  </status>
</availabilityResponse>
```

Now we parse the message that comes back with the 401 response. If we are unable to parse the response, or if the response has a code in it that indicates we need to refresh the token then we attempt a token refresh.

## Motivation and Context

In PP-1081 the patron was seeing a book on their bookshelf that shouldn't have been there. This was happening because we were getting a failure when refreshing the users bookshelf from Axis which meant that we were not cleaning up the bookshelf entries since we didn't know the complete state of the bookshelf. 

Looking through our logs, it seems like this is happening fairly commonly. It looks like we saw the log message that this happened 4532 times in the last week. This could be causing these users to see their bookshelf as out of sync, so this will be good to get fixed.

## How Has This Been Tested?

- Running tests in CI
- Tested against the VT DB with the user noted in PP-1081

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
