### PR TITLE
Additional test for Axis token refresh

### DIFF
--- a/tests/api/files/axis/availability_expired_token.xml
+++ b/tests/api/files/axis/availability_expired_token.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><availabilityResponse xmlns="http://axis360api.baker-taylor.com/vendorAPI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><status><code>1002</code><statusMessage>Authorization token is expired</statusMessage></status></availabilityResponse>


### PR DESCRIPTION
## Description

Adds one more test case for https://github.com/ThePalaceProject/circulation/pull/1746, the case where we get a expired token response. Also does a little bit of cleanup of the tests, since they were getting a little duplicative. 

## Motivation and Context

When I was working on https://github.com/ThePalaceProject/circulation/pull/1746 I hadn't actually been able to test with an expired token response. However today I was able to use a token I was testing with yesterday to generate one and verify that the API behavior matched the docs. Since I had the response, I figured it was also worth adding to the tests.

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
