### PR TITLE
Extend timeout for base image build

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -15,7 +15,7 @@ jobs:
   docker-build-baseimage:
     name: Build Base Image
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Description

Our base image build has been timing out. Try extending how long we build for in order to get it to complete

## Motivation and Context

See failed image builds here:
https://github.com/ThePalaceProject/circulation/actions/runs/8506965460

## How Has This Been Tested?

- Running CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
