### PR TITLE
Update type hint for send_email

### DIFF
--- a/core/service/email/email.py
+++ b/core/service/email/email.py
@@ -43,6 +43,12 @@ def send_email(
         receivers=receivers,
         text=text,
         html=html,
+        # Attachments are not typed correctly in the library, so we need to ignore the
+        # type hint here. Since no one has responded to the PR above to fix the other
+        # type hint issue, I'm not going to bother submitting a PR to fix this one.
+        # We define attachments as a Mapping rather than a dict so that its covariant
+        # and can accept a dict of the types that the library accepts.
+        # See: https://mypy.readthedocs.io/en/stable/common_issues.html#variance
         attachments=attachments,  # type: ignore[arg-type]
     )
 

--- a/core/service/email/email.py
+++ b/core/service/email/email.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Mapping
 from email.message import EmailMessage
 from typing import Any, Protocol
 
@@ -34,7 +35,7 @@ def send_email(
     receivers: list[str] | str,
     html: str | None = None,
     text: str | None = None,
-    attachments: dict[str, str | os.PathLike[Any] | bytes] | None = None,
+    attachments: Mapping[str, str | os.PathLike[Any] | bytes] | None = None,
 ) -> EmailMessage:
     return emailer.send(
         subject=subject,
@@ -42,7 +43,7 @@ def send_email(
         receivers=receivers,
         text=text,
         html=html,
-        attachments=attachments,
+        attachments=attachments,  # type: ignore[arg-type]
     )
 
 
@@ -54,6 +55,6 @@ class SendEmailCallable(Protocol):
         receivers: list[str] | str,
         html: str | None = None,
         text: str | None = None,
-        attachments: dict[str, str | os.PathLike[Any] | bytes] | None = None,
+        attachments: Mapping[str, str | os.PathLike[Any] | bytes] | None = None,
     ) -> EmailMessage:
         ...


### PR DESCRIPTION
## Description

Small change to update the type hint for `send_email`. Update attachments to be a Mapping rather then a dict.

## Motivation and Context

Since Mapping is immutable, it allows covariance for the value type. See https://mypy.readthedocs.io/en/stable/common_issues.html#variance. Updating this type hint to be a mapping allows us to pass `dict[bytes]` into `send_email` rather then always having to make sure `attachments` has all the types defined in the function type hint.

## How Has This Been Tested?

- Tested locally

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
