### PR TITLE
Additional information for web process in JSONFormatter (PP-1148)

### DIFF
--- a/core/service/logging/log.py
+++ b/core/service/logging/log.py
@@ -70,8 +70,6 @@ class JSONFormatter(logging.Formatter):
             data["traceback"] = self.formatException(record.exc_info)
         if record.process:
             data["process"] = record.process
-        if record.thread:
-            data["thread"] = record.thread
 
         # If we are running in a Flask context, we include the request data in the log
         try:
@@ -84,7 +82,7 @@ class JSONFormatter(logging.Formatter):
             }
             if request.query_string:
                 data["request"]["query"] = request.query_string.decode()
-        except RuntimeError:
+        except (RuntimeError, ImportError):
             pass
 
         # If we are running in uwsgi context, we include the worker id in the log

--- a/core/service/logging/log.py
+++ b/core/service/logging/log.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 try:
     from flask import request as flask_request
 except ImportError:
-    flask_request = None
+    flask_request = None  # type: ignore[assignment]
 
 try:
     import uwsgi

--- a/core/service/logging/log.py
+++ b/core/service/logging/log.py
@@ -83,17 +83,13 @@ class JSONFormatter(logging.Formatter):
 
         # If we are running in a Flask context, we include the request data in the log
         if flask_request:
-            try:
-                data["request"] = {
-                    "path": flask_request.path,
-                    "method": flask_request.method,
-                    "host": flask_request.host_url,
-                }
-                if flask_request.query_string:
-                    data["request"]["query"] = flask_request.query_string.decode()
-            except RuntimeError:
-                # We are not in a Flask context
-                pass
+            data["request"] = {
+                "path": flask_request.path,
+                "method": flask_request.method,
+                "host": flask_request.host_url,
+            }
+            if flask_request.query_string:
+                data["request"]["query"] = flask_request.query_string.decode()
 
         # If we are running in uwsgi context, we include the worker id in the log
         if uwsgi:

--- a/docker/services/uwsgi/uwsgi.d/40_log.ini
+++ b/docker/services/uwsgi/uwsgi.d/40_log.ini
@@ -1,5 +1,5 @@
 [uwsgi]
-log-format = [uwsgi] %(var.HTTP_X_FORWARDED_FOR) (%(addr)) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
+log-format = [uwsgi] %(var.HTTP_X_FORWARDED_FOR) (%(addr)) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs) process=%(pid) worker=%(wid)
 logfile-chmod = 644
 logger = stdio:
 logger = file:/var/log/uwsgi/uwsgi.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ module = [
     "pyld",
     "textblob.*",
     "unicodecsv",
+    "uwsgi",
     "wcag_contrast_ratio",
     "webpub_manifest_parser.*",
 ]

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -4,6 +4,7 @@ pytest_plugins = [
     "tests.fixtures.announcements",
     "tests.fixtures.csv_files",
     "tests.fixtures.database",
+    "tests.fixtures.flask",
     "tests.fixtures.library",
     "tests.fixtures.opds2_files",
     "tests.fixtures.opds_files",

--- a/tests/core/service/logging/test_log.py
+++ b/tests/core/service/logging/test_log.py
@@ -167,7 +167,7 @@ class TestJSONFormatter:
             assert request["query"] == "query=string&foo=bar"
 
         # If flask is not installed, the request data is not included in the log.
-        monkeypatch.delitem(sys.modules, "flask", raising=False)
+        monkeypatch.setitem(sys.modules, "flask", None)
         data = json.loads(formatter.format(record))
         assert "request" not in data
 


### PR DESCRIPTION
## Description

Add some additional keys to the output of `JSONFormatter` and to our UWSGI log output, so we can better correlate logs to requests.

After this change the logs will look like this:
```
{"host": "1c7ec4e6c45d", "name": "core.util.http.HTTP", "level": "INFO", "filename": "http.py", "message": "Request time for https://registry.thepalaceproject.org took 1.01 seconds", "timestamp": "2024-04-09T16:50:27.738825+00:00", "process": 68, "request": {"path": "/admin/discovery_service_library_registrations", "method": "GET", "host": "http://localhost:6500/"}, "uwsgi": {"worker": 1}}
{"host": "1c7ec4e6c45d", "name": "root", "level": "INFO", "filename": "http.py", "message": "Making debuggable GET request to https://registry.thepalaceproject.org/register: kwargs {}", "timestamp": "2024-04-09T16:50:27.746639+00:00", "process": 68, "request": {"path": "/admin/discovery_service_library_registrations", "method": "GET", "host": "http://localhost:6500/"}, "uwsgi": {"worker": 1}}
{"host": "1c7ec4e6c45d", "name": "core.util.http.HTTP", "level": "INFO", "filename": "http.py", "message": "Request time for https://registry.thepalaceproject.org/register took 0.57 seconds", "timestamp": "2024-04-09T16:50:28.314406+00:00", "process": 68, "request": {"path": "/admin/discovery_service_library_registrations", "method": "GET", "host": "http://localhost:6500/"}, "uwsgi": {"worker": 1}}
[uwsgi] - (192.168.65.1) - - [09/Apr/2024:16:50:26 +0000] "GET /admin/discovery_service_library_registrations HTTP/1.1" 200 1000 "http://localhost:6500/admin/web/config/discovery/create" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:124.0) Gecko/20100101 Firefox/124.0" host_hdr=localhost:6500 req_time_elapsed=1706 process=68 worker=1
```

## Motivation and Context

When troubleshooting issues though cloudwatch logs on a busy server, its difficult to correlate particular requests made to the server to the log messages that are output, since many requests are coming in at once. I've come across this a couple times recently when troubleshooting.

## How Has This Been Tested?

- CI Tests
- Tests with docker-compose

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
