### PR TITLE
Remove setting to disable token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,17 +250,6 @@ the logging:
       [documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials).
 - `PALACE_LOG_CLOUDWATCH_SECRET_KEY`: The secret key to use when sending logs to CloudWatch. This is optional.
 
-#### Patron `Basic Token` authentication
-
-Enables/disables patron "basic token" authentication through setting the designated environment variable to any
-(case-insensitive) value of "true"/"yes"/"on"/"1" or "false"/"no"/"off"/"0", respectively.
-If the value is the empty string or the variable is not present in the environment, it is disabled by default.
-- `SIMPLIFIED_ENABLE_BASIC_TOKEN_AUTH`
-
-```sh
-export SIMPLIFIED_ENABLE_BASIC_TOKEN_AUTH=true
-```
-
 #### Firebase Cloud Messaging
 
 For Firebase Cloud Messaging (FCM) support (e.g., for notifications), `one` (and only one) of the following should be set:

--- a/api/authenticator.py
+++ b/api/authenticator.py
@@ -379,9 +379,7 @@ class LibraryAuthenticator(LoggerMixin):
         ):
             raise CannotLoadConfiguration("Two basic auth providers configured")
         self.basic_auth_provider = provider
-        # TODO: We can remove the configuration test once
-        #  basic token authentication is fully deployed.
-        if self.library is not None and Configuration.basic_token_auth_is_enabled():
+        if self.library is not None:
             self.access_token_authentication_provider = (
                 BasicTokenAuthenticationProvider(
                     self._db, self.library, self.basic_auth_provider

--- a/core/config.py
+++ b/core/config.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import ArgumentError
 # It's convenient for other modules import IntegrationException
 # from this module, alongside CannotLoadConfiguration.
 from core.exceptions import IntegrationException
-from core.util import LanguageCodes, ansible_boolean
+from core.util import LanguageCodes
 from core.util.datetime_helpers import to_utc, utc_now
 
 
@@ -44,10 +44,6 @@ class Configuration(ConfigurationConstants):
     # Environment variables that contain URLs to the database
     DATABASE_TEST_ENVIRONMENT_VARIABLE = "SIMPLIFIED_TEST_DATABASE"
     DATABASE_PRODUCTION_ENVIRONMENT_VARIABLE = "SIMPLIFIED_PRODUCTION_DATABASE"
-
-    # TODO: We can remove this variable once basic token authentication is fully deployed.
-    # Patron token authentication enabled switch.
-    BASIC_TOKEN_AUTH_ENABLED_ENVVAR = "SIMPLIFIED_ENABLE_BASIC_TOKEN_AUTH"
 
     # Environment variables for Firebase Cloud Messaging (FCM) service account key
     FCM_CREDENTIALS_FILE_ENVIRONMENT_VARIABLE = "SIMPLIFIED_FCM_CREDENTIALS_FILE"
@@ -126,26 +122,6 @@ class Configuration(ConfigurationConstants):
         # Calling __to_string__ will hide the password.
         logging.info("Connecting to database: %s" % url_obj.__to_string__())
         return url
-
-    # TODO: We can remove this method once basic token authentication is fully deployed.
-    @classmethod
-    def basic_token_auth_is_enabled(cls) -> bool:
-        """Is basic token authentication enabled?
-
-        Return False, if the variable is unset or is an empty string.
-        Raises CannotLoadConfiguration, if the setting is invalid.
-        :raise CannotLoadConfiguration: If the setting contains an unsupported value.
-        """
-        try:
-            return ansible_boolean(
-                os.environ.get(cls.BASIC_TOKEN_AUTH_ENABLED_ENVVAR),
-                label=cls.BASIC_TOKEN_AUTH_ENABLED_ENVVAR,
-                default=False,
-            )
-        except (TypeError, ValueError) as e:
-            raise CannotLoadConfiguration(
-                f"Invalid value for {cls.BASIC_TOKEN_AUTH_ENABLED_ENVVAR} environment variable."
-            ) from e
 
     @classmethod
     def fcm_credentials(cls) -> dict[str, str]:

--- a/tests/api/test_authenticator.py
+++ b/tests/api/test_authenticator.py
@@ -916,13 +916,9 @@ class TestLibraryAuthenticator:
         two_hours_in_the_future = now + datetime.timedelta(hours=2)
 
         basic = mock_basic()
-        # TODO: We can remove this patch once basic token authentication is fully deployed.
-        with patch.object(
-            Configuration, "basic_token_auth_is_enabled", return_value=True
-        ):
-            authenticator = LibraryAuthenticator(
-                _db=db.session, library=db.default_library(), basic_auth_provider=basic
-            )
+        authenticator = LibraryAuthenticator(
+            _db=db.session, library=db.default_library(), basic_auth_provider=basic
+        )
 
         token_auth_provider, basic_auth_provider = authenticator.providers
         [patron_lookup_provider] = authenticator.unique_patron_lookup_providers
@@ -967,15 +963,11 @@ class TestLibraryAuthenticator:
         def get_library_authenticator(
             basic_auth_provider: BasicAuthenticationProvider | None,
         ) -> LibraryAuthenticator:
-            # TODO: We can remove this patch once basic token authentication is fully deployed.
-            with patch.object(
-                Configuration, "basic_token_auth_is_enabled", return_value=True
-            ):
-                return LibraryAuthenticator(
-                    _db=db.session,
-                    library=db.default_library(),
-                    basic_auth_provider=basic_auth_provider,
-                )
+            return LibraryAuthenticator(
+                _db=db.session,
+                library=db.default_library(),
+                basic_auth_provider=basic_auth_provider,
+            )
 
         basic = mock_basic()
 
@@ -997,21 +989,12 @@ class TestLibraryAuthenticator:
         credential = Authorization(auth_type="bearer", token=token)
         assert authenticator.get_credential_from_header(credential) == "passworx"
 
-    @pytest.mark.parametrize(
-        "token_auth_enabled, auth_count",
-        [
-            [True, 2],
-            [False, 1],
-        ],
-    )
     def test_create_authentication_document(
         self,
         db: DatabaseTransactionFixture,
         mock_basic: MockBasicFixture,
         announcement_fixture: AnnouncementFixture,
         library_fixture: LibraryFixture,
-        token_auth_enabled: bool,
-        auth_count: int,
     ):
         class MockAuthenticator(LibraryAuthenticator):
             """Mock the _geographic_areas method."""
@@ -1026,16 +1009,11 @@ class TestLibraryAuthenticator:
         library_settings = library_fixture.settings(library)
         basic = mock_basic()
         library.name = "A Fabulous Library"
-        # TODO: We can remove this patch once basic token authentication is fully deployed.
-        with patch.object(
-            Configuration, "basic_token_auth_is_enabled"
-        ) as token_auth_enabled_method:
-            token_auth_enabled_method.return_value = token_auth_enabled
-            authenticator = MockAuthenticator(
-                _db=db.session,
-                library=library,
-                basic_auth_provider=basic,
-            )
+        authenticator = MockAuthenticator(
+            _db=db.session,
+            library=library,
+            basic_auth_provider=basic,
+        )
 
         # We're about to call url_for, so we must create an
         # application context.
@@ -1122,13 +1100,9 @@ class TestLibraryAuthenticator:
             # If basic token auth is enabled, then there should be two authentication
             # mechanisms and the first should be for token auth.
             authenticators = doc["authentication"]
-            assert auth_count > 0
-            assert auth_count == len(authenticators)
-            # TODO: We can remove this `if` block/restructure once basic token authentication is fully deployed.
-            if token_auth_enabled:
-                token_doc = authenticators[0]
-                assert BasicTokenAuthenticationProvider.FLOW_TYPE == token_doc["type"]
-            basic_doc = authenticators[auth_count - 1]
+            assert 2 == len(authenticators)
+            [token_doc, basic_doc] = authenticators
+            assert BasicTokenAuthenticationProvider.FLOW_TYPE == token_doc["type"]
 
             expect_basic = basic.authentication_flow_document(db.session)
             assert expect_basic == basic_doc

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -1,7 +1,6 @@
 import json
 import os
 from collections import Counter
-from contextlib import nullcontext as does_not_raise
 from unittest.mock import patch
 
 import pytest
@@ -189,40 +188,3 @@ class TestConfiguration:
             match=r"Cannot parse value of FCM credential environment variable .* as JSON.",
         ):
             Configuration.fcm_credentials()
-
-    @pytest.mark.parametrize(
-        "env_var_value, expected_result, raises_exception",
-        [
-            ["true", True, False],
-            ["True", True, False],
-            [None, False, False],
-            ["", False, False],
-            ["false", False, False],
-            ["False", False, False],
-            ["3", None, True],
-            ["X", None, True],
-        ],
-    )
-    @patch.object(os, "environ", new=dict())
-    def test_basic_token_auth_is_enabled(
-        self, env_var_value, expected_result, raises_exception
-    ):
-        env_var = Configuration.BASIC_TOKEN_AUTH_ENABLED_ENVVAR
-
-        # Simulate an unset environment variable with the `None` value.
-        if env_var_value is None:
-            del os.environ[env_var]
-        else:
-            os.environ[env_var] = env_var_value
-
-        expected_exception = (
-            pytest.raises(
-                CannotLoadConfiguration,
-                match=f"Invalid value for {env_var} environment variable.",
-            )
-            if raises_exception
-            else does_not_raise()
-        )
-
-        with expected_exception:
-            assert expected_result == Configuration.basic_token_auth_is_enabled()


### PR DESCRIPTION
## Description

Now that token auth is rolled out everywhere, remove setting to disable it.

## Motivation and Context

Token auth was rolled out everywhere in PP-951.

## How Has This Been Tested?

- Running tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
