### PR TITLE
Fix flaky lane test

### DIFF
--- a/tests/core/test_lane.py
+++ b/tests/core/test_lane.py
@@ -1878,7 +1878,7 @@ class TestWorkList:
         # 'all the CustomLists from that DataSource'.
         worklist = WorkList()
         worklist.initialize(db.default_library(), list_datasource=gutenberg)
-        assert [customlist1.id, customlist2.id] == worklist.customlist_ids
+        assert {customlist1.id, customlist2.id} == set(worklist.customlist_ids)
         assert gutenberg.id == worklist.list_datasource_id
 
     def test_initialize_without_library(self, db: DatabaseTransactionFixture):


### PR DESCRIPTION
## Description

Updates assertion to compare a set, rather then a list, since order doesn't matter here, and can change.

## Motivation and Context

Saw this test failing randomly in CI.

## How Has This Been Tested?

Running tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
