### PR TITLE
Update the CustomListsController to use ProblemDetailException

### DIFF
--- a/api/admin/controller/custom_lists.py
+++ b/api/admin/controller/custom_lists.py
@@ -180,7 +180,7 @@ class CustomListsController(
             if auto_update_query is not None:
                 try:
                     auto_update_query_str = json.dumps(auto_update_query)
-                except json.JSONDecodeError:
+                except TypeError:
                     raise ProblemDetailException(
                         INVALID_INPUT.detailed(
                             "auto_update_query is not JSON serializable"

--- a/api/admin/controller/custom_lists.py
+++ b/api/admin/controller/custom_lists.py
@@ -199,7 +199,7 @@ class CustomListsController(
             if auto_update_facets is not None:
                 try:
                     auto_update_facets_str = json.dumps(auto_update_facets)
-                except json.JSONDecodeError:
+                except TypeError:
                     raise ProblemDetailException(
                         INVALID_INPUT.detailed(
                             "auto_update_facets is not JSON serializable"

--- a/tests/api/admin/controller/test_custom_lists.py
+++ b/tests/api/admin/controller/test_custom_lists.py
@@ -1176,7 +1176,7 @@ class TestCustomListsController:
             [],
             id=None,
             auto_update=True,
-            auto_update_query={"foo": object()},  # type: ignore[arg-type]
+            auto_update_query={"foo": object()},  # type: ignore[dict-item]
         )
 
         assert isinstance(response, ProblemDetail)

--- a/tests/api/admin/controller/test_custom_lists.py
+++ b/tests/api/admin/controller/test_custom_lists.py
@@ -1162,7 +1162,7 @@ class TestCustomListsController:
         assert custom_list.auto_update_status == CustomList.REPOPULATE
         assert [e.work_id for e in custom_list.entries] == [w1.id]
 
-    def test_auto_update_create_invalid_json(
+    def test_auto_update_create_unable_to_serialize_query(
         self,
         admin_librarian_fixture: AdminLibrarianFixture,
         db: DatabaseTransactionFixture,
@@ -1182,6 +1182,28 @@ class TestCustomListsController:
         assert isinstance(response, ProblemDetail)
         assert response.status_code == 400
         assert response.detail == "auto_update_query is not JSON serializable"
+
+    def test_auto_update_create_unable_to_serialize_facets(
+        self,
+        admin_librarian_fixture: AdminLibrarianFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        library = db.default_library()
+        response = admin_librarian_fixture.manager.admin_custom_lists_controller._create_or_update_list(
+            library,
+            "test list",
+            [],
+            [],
+            [],
+            id=None,
+            auto_update=True,
+            auto_update_query={"query": "foo"},
+            auto_update_facets={"foo": object()},  # type: ignore[dict-item]
+        )
+
+        assert isinstance(response, ProblemDetail)
+        assert response.status_code == 400
+        assert response.detail == "auto_update_facets is not JSON serializable"
 
     def test_auto_update_deleted_entries(
         self,


### PR DESCRIPTION
## Description

Instead of using `Exception` and checking if it contains a `ProblemDetail`, just use the `ProblemDetailException` class.
 
## Motivation and Context

Noticed this as part of #1760, but I wanted to break it out since its not directly related.

## How Has This Been Tested?

- Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
