### PR TITLE
Don't fail to delete work just because it's missing from search index.

### DIFF
--- a/core/model/work.py
+++ b/core/model/work.py
@@ -9,6 +9,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, cast
 
+import opensearchpy
 import pytz
 from dependency_injector.wiring import Provide, inject
 from sqlalchemy import (
@@ -1811,7 +1812,12 @@ class Work(Base):
     ) -> None:
         """Delete the work from both the DB and search index."""
         _db = Session.object_session(self)
-        search_index.remove_work(self)
+        try:
+            search_index.remove_work(self)
+        except opensearchpy.exceptions.NotFoundError:
+            logging.warning(
+                f"Work {self.id} not found in search index while attempting to delete it."
+            )
         _db.delete(self)
 
 

--- a/tests/core/models/test_work.py
+++ b/tests/core/models/test_work.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock
 import opensearchpy
 import pytest
 import pytz
-from _pytest.logging import LogCaptureFixture
 from psycopg2.extras import NumericRange
+from pytest import LogCaptureFixture
 from sqlalchemy import select
 
 from core.classifier import Classifier, Fantasy, Romance, Science_Fiction

--- a/tests/core/models/test_work.py
+++ b/tests/core/models/test_work.py
@@ -1,8 +1,11 @@
 import datetime
+from contextlib import nullcontext
 from unittest.mock import MagicMock
 
+import opensearchpy
 import pytest
 import pytz
+from _pytest.logging import LogCaptureFixture
 from psycopg2.extras import NumericRange
 from sqlalchemy import select
 
@@ -18,10 +21,11 @@ from core.model.identifier import Identifier
 from core.model.licensing import LicensePool
 from core.model.resource import Hyperlink, Representation, Resource
 from core.model.work import Work, WorkGenre, work_library_suppressions
+from core.service.logging.configuration import LogLevel
 from core.util.datetime_helpers import datetime_utc, from_timestamp, utc_now
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.sample_covers import SampleCoversFixture
-from tests.fixtures.search import ExternalSearchFixtureFake
+from tests.fixtures.search import EndToEndSearchFixture, ExternalSearchFixtureFake
 
 
 class TestWork:
@@ -1795,6 +1799,85 @@ class TestWork:
         assert [] == db.session.query(Work).filter(Work.id == work.id).all()
         assert 1 == len(s.removed)
         assert s.removed == [work]
+
+    @pytest.mark.parametrize(
+        "search_exception, raises, expect_success",
+        (
+            (None, None, True),
+            (opensearchpy.exceptions.NotFoundError, None, True),
+            (
+                opensearchpy.exceptions.ConnectionError,
+                opensearchpy.exceptions.ConnectionError,
+                False,
+            ),
+            (
+                opensearchpy.exceptions.TransportError,
+                opensearchpy.exceptions.TransportError,
+                False,
+            ),
+        ),
+    )
+    def test_delete_work_search_index_exceptions(
+        self,
+        caplog: LogCaptureFixture,
+        db: DatabaseTransactionFixture,
+        search_exception: type[Exception] | None,
+        raises: type[Exception] | None,
+        expect_success: bool,
+    ):
+        caplog.set_level(LogLevel.warning)
+        search_index = MagicMock()
+        search_index.remove_work.side_effect = (
+            None if search_exception is None else search_exception()
+        )
+
+        # The warning should be present only if we should succeed in
+        # spite of a search engine exception.
+        expect_warning = expect_success and search_exception is not None
+
+        # Deleting a work should show an exception for only some search exceptions.
+        exception_context = (
+            pytest.raises(raises) if raises is not None else nullcontext()
+        )
+
+        # Create a work, but don't index it. Then try to delete it.
+        work = db.work(with_license_pool=True)
+
+        with exception_context:
+            work.delete(search_index=search_index)
+
+        works_remaining = db.session.query(Work).filter(Work.id == work.id).all()
+        warning_message = (
+            f"Work {work.id} not found in search index while attempting to delete it."
+        )
+        warning_is_present = any(warning_message in msg for msg in caplog.messages)
+
+        assert len(works_remaining) == 0 if expect_success else 1
+        assert expect_warning == warning_is_present
+
+    def test_delete_work_not_in_search_end2end(
+        self,
+        caplog: LogCaptureFixture,
+        db: DatabaseTransactionFixture,
+        end_to_end_search_fixture: EndToEndSearchFixture,
+    ):
+        caplog.set_level(LogLevel.warning)
+        s = end_to_end_search_fixture.external_search_index
+
+        # Create a work, but don't index it.
+        work = db.work(with_license_pool=True)
+        # Now delete it the normal way, even though it's not in the search index.
+        work.delete(search_index=s)
+
+        warning_is_present = any(
+            f"Work {work.id} not found in search index while attempting to delete it."
+            in msg
+            for msg in caplog.messages
+        )
+
+        # Ensure work removed from the DB and error message logged.
+        assert db.session.query(Work).filter(Work.id == work.id).all() == []
+        assert warning_is_present
 
 
 class TestWorkConsolidation:


### PR DESCRIPTION
## Description

- Changes work deletion behavior, such that:
  - deletion does not fail just because the work is missing from the search index (for whatever reason); and
  - a warning is emitted if the work is missing from the search index, so that we can track how often that is happening, if we need to.

## Motivation and Context

Work deletion was failing when we attempted to delete the work from the search index, if the work was not present there. Since our goal was to delete the work anyway, we still ended up in the desired state, so it doesn't make sense to fail here.

The failure to delete the work could prevent other parts of the `database_reaper` from completing successfully.

## How Has This Been Tested?

- Created new tests for this behavior.
- Ran tests locally.
- [CI tests passed](https://github.com/ThePalaceProject/circulation/actions/runs/8653273302) for associated branch.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
