### PR TITLE
Replace _pytest imports with public pytest types

### DIFF
--- a/tests/api/admin/controller/test_collections.py
+++ b/tests/api/admin/controller/test_collections.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock, create_autospec
 
 import flask
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from flask import Response
+from pytest import MonkeyPatch
 from werkzeug.datastructures import ImmutableMultiDict
 
 from api.admin.controller.collection_settings import CollectionSettingsController

--- a/tests/api/admin/controller/test_metadata_services.py
+++ b/tests/api/admin/controller/test_metadata_services.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock, create_autospec
 
 import flask
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from flask import Response
+from pytest import MonkeyPatch
 from werkzeug.datastructures import ImmutableMultiDict
 
 from api.admin.controller.metadata_services import MetadataServicesController

--- a/tests/api/admin/controller/test_patron_auth.py
+++ b/tests/api/admin/controller/test_patron_auth.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock
 
 import flask
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from flask import Response
+from pytest import MonkeyPatch
 from werkzeug.datastructures import ImmutableMultiDict
 
 from api.admin.controller.patron_auth_services import PatronAuthServicesController

--- a/tests/api/admin/test_config.py
+++ b/tests/api/admin/test_config.py
@@ -3,7 +3,7 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 from requests import RequestException
 
 from api.admin.config import Configuration as AdminConfig

--- a/tests/api/admin/test_password_admin_authentication_provider.py
+++ b/tests/api/admin/test_password_admin_authentication_provider.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-from _pytest.logging import LogCaptureFixture
+from pytest import LogCaptureFixture
 
 from api.admin.password_admin_authentication_provider import (
     PasswordAdminAuthenticationProvider,

--- a/tests/api/authentication/test_access_token.py
+++ b/tests/api/authentication/test_access_token.py
@@ -7,10 +7,10 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from dateutil import tz
 from freezegun import freeze_time
 from jwcrypto import jwe, jwk
+from pytest import LogCaptureFixture
 from sqlalchemy import delete
 
 from api.authentication.access_token import PatronJWEAccessTokenProvider

--- a/tests/api/discovery/test_opds_registration.py
+++ b/tests/api/discovery/test_opds_registration.py
@@ -8,9 +8,9 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from Crypto.Cipher import PKCS1_OAEP
 from Crypto.PublicKey import RSA
+from pytest import MonkeyPatch
 from requests_mock import Mocker
 
 from api.discovery.opds_registration import OpdsRegistrationService

--- a/tests/api/metadata/test_novelist.py
+++ b/tests/api/metadata/test_novelist.py
@@ -3,7 +3,7 @@ import json
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 
 from api.config import CannotLoadConfiguration
 from api.metadata.novelist import NoveListAPI, NoveListApiSettings

--- a/tests/api/sip/test_client.py
+++ b/tests/api/sip/test_client.py
@@ -7,7 +7,7 @@ from functools import partial
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 
 from api.sip.client import SIPClient
 from api.sip.dialect import Dialect

--- a/tests/api/test_controller_cm.py
+++ b/tests/api/test_controller_cm.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, create_autospec
 
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 
 from api.authenticator import LibraryAuthenticator
 from api.circulation_manager import CirculationManager

--- a/tests/api/test_scripts.py
+++ b/tests/api/test_scripts.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, call, create_autospec, patch
 
 import pytest
-from _pytest.logging import LogCaptureFixture
+from pytest import LogCaptureFixture
 from sqlalchemy.exc import NoResultFound
 
 from alembic.util import CommandError

--- a/tests/api/test_sirsidynix_auth_provider.py
+++ b/tests/api/test_sirsidynix_auth_provider.py
@@ -5,7 +5,7 @@ from typing import Any
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 
 from api.authentication.base import PatronData
 from api.authentication.basic import LibraryIdentifierRestriction

--- a/tests/core/service/test_configuration.py
+++ b/tests/core/service/test_configuration.py
@@ -10,7 +10,7 @@ from core.config import CannotLoadConfiguration
 from core.service.configuration import ServiceConfiguration
 
 if TYPE_CHECKING:
-    from _pytest.monkeypatch import MonkeyPatch
+    from pytest import MonkeyPatch
 
 
 class MockServiceConfiguration(ServiceConfiguration):

--- a/tests/core/service/test_sitewide.py
+++ b/tests/core/service/test_sitewide.py
@@ -2,9 +2,9 @@ from contextlib import AbstractContextManager, nullcontext
 from typing import Any
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
 from coverage.annotate import os
 from pydantic.env_settings import SettingsSourceCallable
+from pytest import MonkeyPatch
 
 from core.config import CannotLoadConfiguration
 from core.service.sitewide import SitewideConfiguration

--- a/tests/core/test_app_server.py
+++ b/tests/core/test_app_server.py
@@ -6,11 +6,11 @@ from unittest.mock import MagicMock, PropertyMock
 
 import flask
 import pytest
-from _pytest.logging import LogCaptureFixture
 from flask import Flask, Response, make_response
 from flask_babel import Babel
 from flask_babel import lazy_gettext as _
 from psycopg2 import OperationalError
+from pytest import LogCaptureFixture
 
 import core
 from api.admin.config import Configuration as AdminUiConfig

--- a/tests/core/test_marc.py
+++ b/tests/core/test_marc.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from pymarc import MARCReader, Record
+from pytest import LogCaptureFixture
 
 from core.marc import Annotator, MARCExporter
 from core.model import (

--- a/tests/core/test_opds2_import.py
+++ b/tests/core/test_opds2_import.py
@@ -3,7 +3,7 @@ from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
-from _pytest.logging import LogCaptureFixture
+from pytest import LogCaptureFixture
 from requests import Response
 
 from api.circulation import CirculationAPI, FulfillmentInfo

--- a/tests/core/test_selftest.py
+++ b/tests/core/test_selftest.py
@@ -9,7 +9,7 @@ import datetime
 from collections.abc import Generator
 from unittest.mock import MagicMock, create_autospec
 
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 from sqlalchemy.orm import Session
 
 from core.integration.goals import Goals

--- a/tests/core/util/test_log.py
+++ b/tests/core/util/test_log.py
@@ -1,5 +1,5 @@
 import pytest
-from _pytest.logging import LogCaptureFixture
+from pytest import LogCaptureFixture
 
 from core.service.logging.configuration import LogLevel
 from core.util.log import LoggerMixin, log_elapsed_time

--- a/tests/fixtures/odl.py
+++ b/tests/fixtures/odl.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
-from _pytest.monkeypatch import MonkeyPatch
+from pytest import MonkeyPatch
 
 from api.circulation import LoanInfo
 from api.odl import ODLAPI, BaseODLAPI

--- a/tests/migration/test_20231206_e06f965879ab.py
+++ b/tests/migration/test_20231206_e06f965879ab.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, call
 
 import pytest
-from _pytest.logging import LogCaptureFixture
+from pytest import LogCaptureFixture
 from pytest_alembic import MigrationContext
 from sqlalchemy import inspect
 from sqlalchemy.engine import Connection, Engine


### PR DESCRIPTION
## Description

Previously pytest didn't export the types for their fixtures in the public package. This made type checking hard. It looks like at some point they did start doing so in this PR: https://github.com/pytest-dev/pytest/pull/8017

## Motivation and Context

Update to use the public types rather then the internal `_pytest` package.

## How Has This Been Tested?

- Running in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
