### PR TITLE
Update quicksight configuration (PP-1154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ More details in the [FCM documentation](https://firebase.google.com/docs/admin/s
 #### Quicksight Dashboards
 
 For generating quicksight dashboard links the following environment variable is required
-`QUICKSIGHT_AUTHORIZED_ARNS` - A dictionary of the format `"<dashboard name>": ["arn:aws:quicksight:...",...]`
+`PALACE_QUICKSIGHT_AUTHORIZED_ARNS` - A dictionary of the format `"<dashboard name>": ["arn:aws:quicksight:...",...]`
 where each quicksight dashboard gets treated with an arbitrary "name", and a list of "authorized arns".
 The first the "authorized arns" is always considered as the `InitialDashboardID` when creating an embed URL
 for the respective "dashboard name".

--- a/api/admin/controller/__init__.py
+++ b/api/admin/controller/__init__.py
@@ -63,5 +63,7 @@ def setup_admin_controllers(manager: CirculationManager):
     manager.admin_catalog_services_controller = CatalogServicesController(manager)
     manager.admin_announcement_service = AnnouncementSettings(manager._db)
     manager.admin_search_controller = AdminSearchController(manager)
-    manager.admin_quicksight_controller = QuickSightController(manager)
+    manager.admin_quicksight_controller = QuickSightController(
+        manager._db, manager.services.config.sitewide.quicksight_authorized_arns()
+    )
     manager.admin_report_controller = ReportController(manager._db)

--- a/core/config.py
+++ b/core/config.py
@@ -55,10 +55,6 @@ class Configuration(ConfigurationConstants):
     OD_FULFILLMENT_CLIENT_KEY_SUFFIX = "OVERDRIVE_FULFILLMENT_CLIENT_KEY"
     OD_FULFILLMENT_CLIENT_SECRET_SUFFIX = "OVERDRIVE_FULFILLMENT_CLIENT_SECRET"
 
-    # Quicksight
-    # Comma separated aws arns
-    QUICKSIGHT_AUTHORIZED_ARNS_KEY = "QUICKSIGHT_AUTHORIZED_ARNS"
-
     # Environment variable for SirsiDynix Auth
     SIRSI_DYNIX_APP_ID = "SIMPLIFIED_SIRSI_DYNIX_APP_ID"
 
@@ -178,12 +174,6 @@ class Configuration(ConfigurationConstants):
         if not key:
             raise CannotLoadConfiguration("Invalid fulfillment credentials.")
         return {"key": key, "secret": secret}
-
-    @classmethod
-    def quicksight_authorized_arns(cls) -> dict[str, list[str]]:
-        """Split the comma separated arns"""
-        arns_str = os.environ.get(cls.QUICKSIGHT_AUTHORIZED_ARNS_KEY, "")
-        return json.loads(arns_str)
 
     @classmethod
     def localization_languages(cls):

--- a/core/service/configuration.py
+++ b/core/service/configuration.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from pydantic import BaseSettings, ValidationError
+from pydantic.env_settings import SettingsError
 
 from core.config import CannotLoadConfiguration
 
@@ -52,3 +53,7 @@ class ServiceConfiguration(BaseSettings):
                 env_var_name = f"{self.__config__.env_prefix}{error_location}"
                 error_log_message += f"\n  {env_var_name}:  {error['msg']}"
             raise CannotLoadConfiguration(error_log_message) from error_exception
+        except SettingsError as settings_error:
+            # The settings failed to load, we capture the SettingsError and raise a more
+            # specific CannotLoadConfiguration error.
+            raise CannotLoadConfiguration(str(settings_error)) from settings_error

--- a/core/service/sitewide.py
+++ b/core/service/sitewide.py
@@ -11,6 +11,7 @@ class SitewideConfiguration(ServiceConfiguration):
     base_url: AnyHttpUrl | None = None
     patron_web_hostnames: list[AnyHttpUrl] | Literal["*"] = []
     authentication_document_cache_time: NonNegativeInt = 3600
+    quicksight_authorized_arns: dict[str, list[str]] | None = None
 
     @validator("base_url")
     def validate_base_url(cls, v: AnyHttpUrl | None) -> AnyHttpUrl | None:

--- a/tests/api/admin/controller/test_quicksight.py
+++ b/tests/api/admin/controller/test_quicksight.py
@@ -1,284 +1,245 @@
 import uuid
-from typing import cast
+from collections.abc import Generator
+from functools import partial
+from typing import Any, cast
 from unittest import mock
 
 import pytest
 
+from api.admin.controller import QuickSightController
 from core.model import Library, create
 from core.model.admin import Admin, AdminRole
 from core.util.problem_detail import ProblemDetailException
-from tests.fixtures.api_admin import AdminControllerFixture
-from tests.fixtures.api_controller import ControllerFixture
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.flask import FlaskAppFixture
 
 
-class QuickSightControllerFixture(AdminControllerFixture):
-    def __init__(self, controller_fixture: ControllerFixture):
-        super().__init__(controller_fixture)
+class QuickSightControllerFixture:
+    def __init__(self, db: DatabaseTransactionFixture, mock_boto: mock.MagicMock):
+        self.mock_boto = mock_boto
+        self.db = db
+        self.mock_generate = (
+            self.mock_boto.client.return_value.generate_embed_url_for_anonymous_user
+        )
+        self.mock_generate.return_value = {"Status": 201, "EmbedUrl": "https://embed"}
+        self.arns = dict(
+            primary=[
+                "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid1",
+                "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid2",
+            ],
+        )
+        self.controller = partial(
+            QuickSightController, db.session, authorized_arns=self.arns
+        )
 
 
 @pytest.fixture
 def quicksight_fixture(
-    controller_fixture: ControllerFixture,
-) -> QuickSightControllerFixture:
-    return QuickSightControllerFixture(controller_fixture)
+    db: DatabaseTransactionFixture,
+) -> Generator[QuickSightControllerFixture, None, None]:
+    with mock.patch("api.admin.controller.quicksight.boto3") as mock_boto:
+        yield QuickSightControllerFixture(db, mock_boto)
 
 
 class TestQuicksightController:
     def test_generate_quicksight_url(
-        self, quicksight_fixture: QuickSightControllerFixture
+        self,
+        db: DatabaseTransactionFixture,
+        quicksight_fixture: QuickSightControllerFixture,
+        flask_app_fixture: FlaskAppFixture,
     ):
-        ctrl = quicksight_fixture.manager.admin_quicksight_controller
-        db = quicksight_fixture.ctrl.db
-
         system_admin, _ = create(db.session, Admin, email="admin@email.com")
         system_admin.add_role(AdminRole.SYSTEM_ADMIN)
         default = db.default_library()
         library1 = db.library()
 
-        with mock.patch(
-            "api.admin.controller.quicksight.boto3"
-        ) as mock_boto, mock.patch(
-            "api.admin.controller.quicksight.Configuration.quicksight_authorized_arns"
-        ) as mock_qs_arns:
-            arns = dict(
-                primary=[
-                    "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid1",
-                    "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid2",
-                ],
-                secondary=[
-                    "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid2",
-                    "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid1",
-                ],
-            )
-            mock_qs_arns.return_value = arns
-            generate_method: mock.MagicMock = (
-                mock_boto.client().generate_embed_url_for_anonymous_user
-            )
-            generate_method.return_value = {"Status": 201, "EmbedUrl": "https://embed"}
+        arns = dict(
+            primary=[
+                "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid1",
+                "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid2",
+            ],
+            secondary=[
+                "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid2",
+                "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid1",
+            ],
+        )
 
-            random_uuid = str(uuid.uuid4())
-            with quicksight_fixture.request_context_with_admin(
-                f"/?library_uuids={default.uuid},{library1.uuid},{random_uuid}",
-                admin=system_admin,
-            ) as ctx:
-                response = ctrl.generate_quicksight_url("primary")
+        ctrl = quicksight_fixture.controller(authorized_arns=arns)
+        random_uuid = str(uuid.uuid4())
 
-                # Assert the right client was created, with a region
-                assert mock_boto.client.call_args == mock.call(
-                    "quicksight", region_name="us-west-1"
+        with flask_app_fixture.test_request_context(
+            f"/?library_uuids={default.uuid},{library1.uuid},{random_uuid}",
+            admin=system_admin,
+        ):
+            response = ctrl.generate_quicksight_url("primary")
+
+        # Assert the right client was created, with a region
+        assert quicksight_fixture.mock_boto.client.call_args == mock.call(
+            "quicksight", region_name="us-west-1"
+        )
+        # Assert the request and response formats
+        assert response["embedUrl"] == "https://embed"
+        assert quicksight_fixture.mock_generate.call_args == mock.call(
+            AwsAccountId="aws-account-id",
+            Namespace="default",
+            AuthorizedResourceArns=arns["primary"],
+            ExperienceConfiguration={"Dashboard": {"InitialDashboardId": "uuid1"}},
+            SessionTags=[
+                dict(
+                    Key="library_short_name_0",
+                    Value="|".join([str(library1.short_name), str(default.short_name)]),
                 )
-                # Assert the reqest and response formats
-                assert response["embedUrl"] == "https://embed"
-                assert generate_method.call_args == mock.call(
-                    AwsAccountId="aws-account-id",
-                    Namespace="default",
-                    AuthorizedResourceArns=arns["primary"],
-                    ExperienceConfiguration={
-                        "Dashboard": {"InitialDashboardId": "uuid1"}
-                    },
-                    SessionTags=[
-                        dict(
-                            Key="library_short_name_0",
-                            Value="|".join(
-                                [str(library1.short_name), str(default.short_name)]
-                            ),
-                        )
-                    ],
+            ],
+        )
+
+        # Specific library roles
+        admin1, _ = create(db.session, Admin, email="admin1@email.com")
+        admin1.add_role(AdminRole.LIBRARY_MANAGER, library1)
+
+        with flask_app_fixture.test_request_context(
+            f"/?library_uuids={default.uuid},{library1.uuid}",
+            admin=admin1,
+        ):
+            quicksight_fixture.mock_generate.reset_mock()
+            ctrl.generate_quicksight_url("secondary")
+
+        assert quicksight_fixture.mock_generate.call_args == mock.call(
+            AwsAccountId="aws-account-id",
+            Namespace="default",
+            AuthorizedResourceArns=arns["secondary"],
+            ExperienceConfiguration={"Dashboard": {"InitialDashboardId": "uuid2"}},
+            SessionTags=[
+                dict(
+                    Key="library_short_name_0",
+                    Value="|".join([str(library1.short_name)]),
                 )
-
-            # Specific library roles
-            admin1, _ = create(db.session, Admin, email="admin1@email.com")
-            admin1.add_role(AdminRole.LIBRARY_MANAGER, library1)
-
-            with quicksight_fixture.request_context_with_admin(
-                f"/?library_uuids={default.uuid},{library1.uuid}",
-                admin=admin1,
-            ) as ctx:
-                generate_method.reset_mock()
-                ctrl.generate_quicksight_url("secondary")
-
-                assert generate_method.call_args == mock.call(
-                    AwsAccountId="aws-account-id",
-                    Namespace="default",
-                    AuthorizedResourceArns=arns["secondary"],
-                    ExperienceConfiguration={
-                        "Dashboard": {"InitialDashboardId": "uuid2"}
-                    },
-                    SessionTags=[
-                        dict(
-                            Key="library_short_name_0",
-                            Value="|".join([str(library1.short_name)]),
-                        )
-                    ],
-                )
+            ],
+        )
 
     def test_generate_quicksight_url_with_a_large_number_of_libraries(
-        self, quicksight_fixture: QuickSightControllerFixture
+        self,
+        db: DatabaseTransactionFixture,
+        quicksight_fixture: QuickSightControllerFixture,
+        flask_app_fixture: FlaskAppFixture,
     ):
-        ctrl = quicksight_fixture.manager.admin_quicksight_controller
-        db = quicksight_fixture.ctrl.db
-
         system_admin, _ = create(db.session, Admin, email="admin@email.com")
         system_admin.add_role(AdminRole.SYSTEM_ADMIN)
-        default = db.default_library()
+        db.default_library()
+        ctrl = quicksight_fixture.controller()
 
         libraries: list[Library] = []
         for x in range(0, 37):
             libraries.append(db.library(short_name="TL" + str(x).zfill(4)))
 
-        with mock.patch(
-            "api.admin.controller.quicksight.boto3"
-        ) as mock_boto, mock.patch(
-            "api.admin.controller.quicksight.Configuration.quicksight_authorized_arns"
-        ) as mock_qs_arns:
-            arns = dict(
-                primary=[
-                    "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid1",
-                    "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid2",
-                ],
-            )
-            mock_qs_arns.return_value = arns
-            generate_method: mock.MagicMock = (
-                mock_boto.client().generate_embed_url_for_anonymous_user
-            )
-            generate_method.return_value = {"Status": 201, "EmbedUrl": "https://embed"}
+        with flask_app_fixture.test_request_context(
+            f"/?library_uuids={','.join(cast(list[str], [x.uuid for x in libraries ]))}",
+            admin=system_admin,
+        ):
+            ctrl.generate_quicksight_url("primary")
 
-            random_uuid = str(uuid.uuid4())
-            with quicksight_fixture.request_context_with_admin(
-                f"/?library_uuids={','.join(cast(list[str], [x.uuid for x in libraries ]))}",
-                admin=system_admin,
-            ) as ctx:
-                response = ctrl.generate_quicksight_url("primary")
-
-                # Assert the right client was created, with a region
-                assert mock_boto.client.call_args == mock.call(
-                    "quicksight", region_name="us-west-1"
-                )
-                # Assert the reqest and response formats
-                assert response["embedUrl"] == "https://embed"
-                assert generate_method.call_args == mock.call(
-                    AwsAccountId="aws-account-id",
-                    Namespace="default",
-                    AuthorizedResourceArns=arns["primary"],
-                    ExperienceConfiguration={
-                        "Dashboard": {"InitialDashboardId": "uuid1"}
-                    },
-                    SessionTags=[
-                        dict(
-                            Key="library_short_name_0",
-                            Value="|".join(
-                                cast(list[str], [x.short_name for x in libraries[0:36]])
-                            ),
-                        ),
-                        dict(
-                            Key="library_short_name_1",
-                            Value="|".join(
-                                cast(
-                                    list[str], [x.short_name for x in libraries[36:37]]
-                                )
-                            ),
-                        ),
-                    ],
-                )
+        assert quicksight_fixture.mock_generate.call_args == mock.call(
+            AwsAccountId="aws-account-id",
+            Namespace="default",
+            AuthorizedResourceArns=quicksight_fixture.arns["primary"],
+            ExperienceConfiguration={"Dashboard": {"InitialDashboardId": "uuid1"}},
+            SessionTags=[
+                dict(
+                    Key="library_short_name_0",
+                    Value="|".join(
+                        cast(list[str], [x.short_name for x in libraries[0:36]])
+                    ),
+                ),
+                dict(
+                    Key="library_short_name_1",
+                    Value="|".join(
+                        cast(list[str], [x.short_name for x in libraries[36:37]])
+                    ),
+                ),
+            ],
+        )
 
     def test_generate_quicksight_url_errors(
-        self, quicksight_fixture: QuickSightControllerFixture
+        self,
+        db: DatabaseTransactionFixture,
+        quicksight_fixture: QuickSightControllerFixture,
+        flask_app_fixture: FlaskAppFixture,
     ):
-        ctrl = quicksight_fixture.manager.admin_quicksight_controller
-        db = quicksight_fixture.ctrl.db
-
         library = db.library()
         library_not_allowed = db.library()
         admin, _ = create(db.session, Admin, email="admin@email.com")
         admin.add_role(AdminRole.LIBRARY_MANAGER, library=library)
 
-        with mock.patch(
-            "api.admin.controller.quicksight.boto3"
-        ) as mock_boto, mock.patch(
-            "api.admin.controller.quicksight.Configuration.quicksight_authorized_arns"
-        ) as mock_qs_arns:
-            arns = dict(
-                primary=[
-                    "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid1",
-                    "arn:aws:quicksight:us-west-1:aws-account-id:dashboard/uuid2",
-                ]
+        ctrl = quicksight_fixture.controller(authorized_arns=None)
+        with flask_app_fixture.test_request_context(
+            f"/?library_uuids={library.uuid}",
+            admin=admin,
+        ):
+            with pytest.raises(ProblemDetailException) as raised:
+                ctrl.generate_quicksight_url("primary")
+            assert (
+                raised.value.problem_detail.detail
+                == "Quicksight has not been configured for this server."
             )
-            mock_qs_arns.return_value = arns
 
-            with quicksight_fixture.request_context_with_admin(
-                f"/?library_uuids={library.uuid}",
-                admin=admin,
-            ) as ctx:
-                with pytest.raises(ProblemDetailException) as raised:
-                    ctrl.generate_quicksight_url("secondary")
-                assert (
-                    raised.value.problem_detail.detail
-                    == "The requested Dashboard ARN is not recognized by this server."
-                )
+        ctrl = quicksight_fixture.controller()
+        with flask_app_fixture.test_request_context(
+            f"/?library_uuids={library.uuid}",
+            admin=admin,
+        ):
+            with pytest.raises(ProblemDetailException) as raised:
+                ctrl.generate_quicksight_url("secondary")
+            assert (
+                raised.value.problem_detail.detail
+                == "The requested Dashboard ARN is not recognized by this server."
+            )
 
-                mock_qs_arns.return_value = []
-                with pytest.raises(ProblemDetailException) as raised:
-                    ctrl.generate_quicksight_url("primary")
-                assert (
-                    raised.value.problem_detail.detail
-                    == "Quicksight has not been configured for this server."
-                )
+        with flask_app_fixture.test_request_context(
+            f"/?library_uuids={library_not_allowed.uuid}",
+            admin=admin,
+        ):
+            with pytest.raises(ProblemDetailException) as raised:
+                ctrl.generate_quicksight_url("primary")
+            assert (
+                raised.value.problem_detail.detail
+                == "No library was found for this Admin that matched the request."
+            )
 
-            with quicksight_fixture.request_context_with_admin(
-                f"/?library_uuids={library_not_allowed.uuid}",
-                admin=admin,
-            ) as ctx:
-                mock_qs_arns.return_value = arns
-                with pytest.raises(ProblemDetailException) as raised:
-                    ctrl.generate_quicksight_url("primary")
-                assert (
-                    raised.value.problem_detail.detail
-                    == "No library was found for this Admin that matched the request."
-                )
-
-            with quicksight_fixture.request_context_with_admin(
-                f"/?library_uuids={library.uuid}",
-                admin=admin,
-            ) as ctx:
-                # Bad response from boto
-                mock_boto.generate_embed_url_for_anonymous_user.return_value = dict(
-                    status=400, embed_url="http://embed"
-                )
-                with pytest.raises(ProblemDetailException) as raised:
-                    ctrl.generate_quicksight_url("primary")
-                assert (
-                    raised.value.problem_detail.detail
-                    == "Error while fetching the Quicksight Embed url."
-                )
-
-                # 200 status, but no url
-                mock_boto.generate_embed_url_for_anonymous_user.return_value = dict(
-                    status=200,
-                )
-                with pytest.raises(ProblemDetailException) as raised:
-                    ctrl.generate_quicksight_url("primary")
-                assert (
-                    raised.value.problem_detail.detail
-                    == "Error while fetching the Quicksight Embed url."
-                )
-
-                # Boto threw an error
-                mock_boto.generate_embed_url_for_anonymous_user.side_effect = Exception(
-                    ""
-                )
-                with pytest.raises(ProblemDetailException) as raised:
-                    ctrl.generate_quicksight_url("primary")
-                assert (
-                    raised.value.problem_detail.detail
-                    == "Error while fetching the Quicksight Embed url."
-                )
+    @pytest.mark.parametrize(
+        "generate_response",
+        [
+            pytest.param(dict(Status=400, ErrorMsg="Bad Request"), id="400"),
+            pytest.param(dict(Status=200), id="Missing EmbedUrl"),
+            pytest.param(dict(EmbedUrl="http://embed"), id="Missing Status"),
+            pytest.param(Exception("Boto error"), id="Boto exception"),
+        ],
+    )
+    def test_generate_quicksight_url_boto_errors(
+        self,
+        db: DatabaseTransactionFixture,
+        quicksight_fixture: QuickSightControllerFixture,
+        flask_app_fixture: FlaskAppFixture,
+        generate_response: dict[str, Any] | Exception,
+    ):
+        library = db.library()
+        ctrl = quicksight_fixture.controller()
+        with flask_app_fixture.test_request_context_system_admin(
+            f"/?library_uuids={library.uuid}",
+        ):
+            if isinstance(generate_response, Exception):
+                quicksight_fixture.mock_generate.side_effect = generate_response
+            else:
+                quicksight_fixture.mock_generate.return_value = generate_response
+            with pytest.raises(ProblemDetailException) as raised:
+                ctrl.generate_quicksight_url("primary")
+            assert (
+                raised.value.problem_detail.detail
+                == "Error while fetching the Quicksight Embed url."
+            )
 
     def test_get_dashboard_names(self, quicksight_fixture: QuickSightControllerFixture):
-        with mock.patch(
-            "api.admin.controller.quicksight.Configuration.quicksight_authorized_arns"
-        ) as mock_qs_arns:
-            mock_qs_arns.return_value = dict(primary=[], secondary=[], tertiary=[])
-            ctrl = quicksight_fixture.manager.admin_quicksight_controller
-            assert ctrl.get_dashboard_names() == {
-                "names": ["primary", "secondary", "tertiary"]
-            }
+        ctrl = quicksight_fixture.controller(
+            authorized_arns=dict(primary=[], secondary=[], tertiary=[])
+        )
+        assert ctrl.get_dashboard_names() == {
+            "names": ["primary", "secondary", "tertiary"]
+        }

--- a/tests/core/service/test_sitewide.py
+++ b/tests/core/service/test_sitewide.py
@@ -1,3 +1,4 @@
+import json
 from contextlib import AbstractContextManager, nullcontext
 from typing import Any
 
@@ -141,3 +142,27 @@ class TestSitewideConfiguration:
         with context:
             config = SitewideConfiguration()
             assert config.authentication_document_cache_time == expected
+
+    @pytest.mark.parametrize(
+        "quicksight_authorized_arns, expected",
+        [
+            ("invalid json", CannotLoadConfiguration),
+            (json.dumps(["a", "b"]), CannotLoadConfiguration),
+            (json.dumps({"a": "b"}), CannotLoadConfiguration),
+            (json.dumps({"a": ["b", "c"]}), {"a": ["b", "c"]}),
+        ],
+    )
+    def test_quicksight_authorized_arns(
+        self,
+        sitewide_configuration_fixture: SitewideConfigurationFixture,
+        quicksight_authorized_arns: str | None,
+        expected: dict[str, str] | None | type[Exception],
+    ):
+        sitewide_configuration_fixture.set(
+            "PALACE_QUICKSIGHT_AUTHORIZED_ARNS",
+            quicksight_authorized_arns,
+        )
+        context = sitewide_configuration_fixture.get_context_manager(expected)
+        with context:
+            config = SitewideConfiguration()
+            assert config.quicksight_authorized_arns == expected


### PR DESCRIPTION
## Description

Updates quicksight configuration to load via Pydantic from the `PALACE_QUICKSIGHT_AUTHORIZED_ARNS` environment variable. Previously it was loaded from `QUICKSIGHT_AUTHORIZED_ARNS`. 

🚨 This one can't get merged until there is a hosting playbook PR to update the env variable name.

PP-1154

## Motivation and Context

Two reasons:
- Trying to move all our env vars to be prefixed with `PALACE_`
- Trying to make sure all our config is loaded via Pydantic settings classes

## How Has This Been Tested?

- Running tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
