### PR TITLE
Fix celery log folder creation (PP-1142)

### DIFF
--- a/core/celery/tasks/custom_list.py
+++ b/core/celery/tasks/custom_list.py
@@ -125,5 +125,7 @@ def update_custom_lists(task: Task) -> None:
             select(CustomList.id).where(CustomList.auto_update_enabled == True)
         ).all()
 
+    task.log.info(f"Updating {len(custom_lists)} custom lists.")
+
     for custom_list in custom_lists:
         update_custom_list.delay(custom_list.id)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,10 +46,6 @@ FROM common AS scripts
 # Set the local timezone and setup cron
 ENV TZ=US/Eastern
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    mkdir /var/log/celery && \
-    chown simplified:simplified /var/log/celery && \
-    mkdir /var/run/celery && \
-    chown simplified:simplified /var/run/celery && \
     touch /var/log/cron.log
 
 # Copy cron config into container

--- a/docker/runit-scripts/beat/run
+++ b/docker/runit-scripts/beat/run
@@ -1,6 +1,17 @@
 #!/bin/bash
 set -e
 
+# Set the working directory to the root of the project
 cd /var/www/circulation
 source env/bin/activate
+
+# Make sure the log directory exists and is writable
+mkdir -p /var/log/celery
+chown 1000:adm /var/log/celery
+
+# Make sure the run directory exists and is writable
+mkdir -p /var/run/celery
+chown 1000:1000 /var/run/celery
+
+# Start the celery beat process
 exec env/bin/celery -A "core.celery.worker.app" beat --uid 1000 --gid 1000 --logfile /var/log/celery/beat.log -s /var/run/celery/beat-schedule

--- a/docker/runit-scripts/worker-default/run
+++ b/docker/runit-scripts/worker-default/run
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+# Set the working directory to the root of the project
 cd /var/www/circulation
 source env/bin/activate
+
+# Make sure the log directory exists and is writable
+mkdir -p /var/log/celery
+chown 1000:adm /var/log/celery
+
+# Start the celery worker
 exec env/bin/celery -A "core.celery.worker.app" worker --uid 1000 --gid 1000 --autoscale 4,1 --hostname default@%h -Q high,default --logfile /var/log/celery/default.log

--- a/docker/runit-scripts/worker-high/run
+++ b/docker/runit-scripts/worker-high/run
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+# Set the working directory to the root of the project
 cd /var/www/circulation
 source env/bin/activate
+
+# Make sure the log directory exists and is writable
+mkdir -p /var/log/celery
+chown 1000:adm /var/log/celery
+
+# Start the celery worker
 exec env/bin/celery -A "core.celery.worker.app" worker --uid 1000 --gid 1000 --concurrency 1 --hostname high@%h -Q high --logfile /var/log/celery/high.log


### PR DESCRIPTION
## Description

Move the Celery log directory creation to the celery worker init script, instead of as part of the docker image build and add an additional log line to the `update_custom_lists` task.

## Motivation and Context

When I was doing a quick QA of PP-1142, I noticed that that celery log folders were not created. This error message was emitted in the logs:
```
{"host": "38309de599c6", "name": "celery.utils.dispatch.signal", "level": "ERROR", "filename": "signal.py", "message": "Signal handler <function celery_logger_setup at 0x7feedf44bbe0> raised: FileNotFoundError(2, 'No such file or directory')", "timestamp": "2024-04-16T04:01:25.281378+00:00", "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/celery/utils/dispatch/signal.py\", line 276, in send\n    response = receiver(signal=self, sender=sender, **named)\n  File \"/var/www/circulation/core/celery/worker.py\", line 51, in celery_logger_setup\n    handler = WatchedFileHandler(logfile, encoding=\"utf-8\")\n  File \"/usr/lib/python3.10/logging/handlers.py\", line 479, in __init__\n    logging.FileHandler.__init__(self, filename, mode=mode,\n  File \"/usr/lib/python3.10/logging/__init__.py\", line 1169, in __init__\n    StreamHandler.__init__(self, self._open())\n  File \"/usr/lib/python3.10/logging/__init__.py\", line 1201, in _open\n    return open_func(self.baseFilename, self.mode,\nFileNotFoundError: [Errno 2] No such file or directory: '/var/log/celery/high.log'", "process": 75}
```

This is because the logs folder is mounted as a volume, so for an already existing volume the logs directory created during the docker build isn't present when the worker starts up. Instead of creating the directory as part of the docker build, create the directory when starting the worker process, if it doesn't already exist.

## How Has This Been Tested?

- Tested locally via docker-compose

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
