### PR TITLE
Add thread info to the logger

### DIFF
--- a/core/service/logging/log.py
+++ b/core/service/logging/log.py
@@ -85,6 +85,8 @@ class JSONFormatter(logging.Formatter):
             data["traceback"] = self.formatException(record.exc_info)
         if record.process:
             data["process"] = record.process
+        if record.thread:
+            data["thread"] = record.thread
 
         # If we are running in a Flask context, we include the request data in the log
         if flask_request:

--- a/core/service/logging/log.py
+++ b/core/service/logging/log.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import socket
+import threading
 from collections.abc import Callable, Mapping, Sequence
 from logging import Handler
 from typing import TYPE_CHECKING, Any
@@ -39,6 +40,7 @@ class JSONFormatter(logging.Formatter):
         if len(fqdn) > len(hostname):
             hostname = fqdn
         self.hostname = hostname
+        self.main_thread_id = threading.main_thread().ident
 
     def format(self, record: logging.LogRecord) -> str:
         def ensure_str(s: Any) -> Any:
@@ -85,7 +87,7 @@ class JSONFormatter(logging.Formatter):
             data["traceback"] = self.formatException(record.exc_info)
         if record.process:
             data["process"] = record.process
-        if record.thread:
+        if record.thread and record.thread != self.main_thread_id:
             data["thread"] = record.thread
 
         # If we are running in a Flask context, we include the request data in the log

--- a/tests/core/service/logging/test_log.py
+++ b/tests/core/service/logging/test_log.py
@@ -61,6 +61,24 @@ class TestJSONFormatter:
         data = json.loads(formatter.format(record))
         assert "process" not in data
 
+    def test_format_thread(self, log_record: LogRecordCallable) -> None:
+        formatter = JSONFormatter()
+        record = log_record()
+
+        # Since we are in the main thread, the thread field is not included in the log.
+        data = json.loads(formatter.format(record))
+        assert "thread" not in data
+
+        # If the thread is None we also don't include it in the log.
+        record.thread = None
+        data = json.loads(formatter.format(record))
+        assert "thread" not in data
+
+        # But if we are not in the main thread, the thread field is included in the log.
+        record.thread = 12
+        data = json.loads(formatter.format(record))
+        assert data["thread"] == 12
+
     def test_format_exception(self, log_record: LogRecordCallable) -> None:
         formatter = JSONFormatter()
 


### PR DESCRIPTION
## Description

Add `thread` to the log output, to help troubleshoot threading issues.

## Motivation and Context

This was very helpful when trying to troubleshoot what was going on in https://github.com/ThePalaceProject/circulation/pull/1793, so I decided to add it here.

## How Has This Been Tested?

- Running tests in CI
- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
