### PR TITLE
Override Celery automatic task naming

### DIFF
--- a/src/palace/manager/celery/celery.py
+++ b/src/palace/manager/celery/celery.py
@@ -1,0 +1,14 @@
+import celery
+
+
+class Celery(celery.Celery):
+    def gen_task_name(self, name: str, module: str):
+        """
+        This method is used to generate the task name for the Celery task.
+
+        The default implementation is repetitive for our use case, because all our tasks
+        live in the `palace.manager.celery.tasks` module. This method removes that prefix
+        from the task name to make it more readable.
+        """
+        module = module.removeprefix("palace.manager.celery.tasks.")
+        return super().gen_task_name(name, module)

--- a/src/palace/manager/celery/celery.py
+++ b/src/palace/manager/celery/celery.py
@@ -9,6 +9,8 @@ class Celery(celery.Celery):
         The default implementation is repetitive for our use case, because all our tasks
         live in the `palace.manager.celery.tasks` module. This method removes that prefix
         from the task name to make it more readable.
+
+        See: https://docs.celeryq.dev/en/stable/userguide/tasks.html#changing-the-automatic-naming-behavior
         """
         module = module.removeprefix("palace.manager.celery.tasks.")
         return super().gen_task_name(name, module)

--- a/src/palace/manager/celery/celery.py
+++ b/src/palace/manager/celery/celery.py
@@ -2,7 +2,7 @@ import celery
 
 
 class Celery(celery.Celery):
-    def gen_task_name(self, name: str, module: str):
+    def gen_task_name(self, name: str, module: str) -> str:
         """
         This method is used to generate the task name for the Celery task.
 
@@ -13,4 +13,4 @@ class Celery(celery.Celery):
         See: https://docs.celeryq.dev/en/stable/userguide/tasks.html#changing-the-automatic-naming-behavior
         """
         module = module.removeprefix("palace.manager.celery.tasks.")
-        return super().gen_task_name(name, module)
+        return super().gen_task_name(name, module)  # type: ignore[no-any-return]

--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -2,9 +2,10 @@ import sys
 from enum import auto
 from typing import Any
 
-from celery import Celery
 from celery.schedules import crontab
 from kombu import Exchange, Queue
+
+from palace.manager.celery.celery import Celery
 
 # TODO: Remove this when we drop support for Python 3.10
 if sys.version_info >= (3, 11):
@@ -29,7 +30,7 @@ def beat_schedule() -> dict[str, Any]:
     """
     return {
         "update_custom_lists": {
-            "task": "palace.manager.celery.tasks.custom_list.update_custom_lists",
+            "task": "custom_list.update_custom_lists",
             "schedule": crontab(minute="5"),  # Run every hour at 5 minutes past
         }
     }

--- a/tests/manager/celery/test_celery.py
+++ b/tests/manager/celery/test_celery.py
@@ -1,0 +1,16 @@
+import pytest
+
+from palace.manager.celery.celery import Celery
+
+
+class TestCelery:
+    @pytest.mark.parametrize(
+        "name, module, expected",
+        [
+            ("baz", "foo.bar", "foo.bar.baz"),
+            ("task", "palace.manager.celery.tasks.test", "test.task"),
+        ],
+    )
+    def test_gen_task_name(self, name: str, module: str, expected: str):
+        celery = Celery()
+        assert celery.gen_task_name(name, module) == expected


### PR DESCRIPTION
## Description

Override Celery automatic task naming, so that all of our tasks are not prefixed with: `palace.manager.celery.tasks`. 

See Celery docs: https://docs.celeryq.dev/en/stable/userguide/tasks.html#changing-the-automatic-naming-behavior

I'd like to make sure this one gets merged before we cut a release containing: https://github.com/ThePalaceProject/circulation/pull/1802.

## Motivation and Context

Make it easier to reference our tasks on the command line, in config and move them around in the package in the future if we want to.

## How Has This Been Tested?

- Tested locally
- Tested in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
