### PR TITLE
PP-1219: Fixes overdrive monitor failures.

### DIFF
--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -2036,14 +2036,8 @@ class NewTitlesOverdriveCollectionMonitor(OverdriveCirculationMonitor):
     DEFAULT_START_TIME = OverdriveCirculationMonitor.NEVER
     MAX_CONSECUTIVE_OUT_OF_SCOPE_DATES = 1000
 
-    def __init__(
-        self,
-        _db,
-        collection,
-        api_class=OverdriveAPI,
-        analytics: Analytics = Provide[Services.analytics.analytics],
-    ):
-        super().__init__(_db, collection, api_class, analytics)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._consecutive_items_out_of_scope = 0
 
     def recently_changed_ids(self, start, cutoff):

--- a/api/overdrive.py
+++ b/api/overdrive.py
@@ -311,7 +311,7 @@ class OverdriveAPI(
     METADATA_ENDPOINT = (
         "%(host)s/v1/collections/%(collection_token)s/products/%(item_id)s/metadata"
     )
-    EVENTS_ENDPOINT = "%(host)s/v1/collections/%(collection_token)s/products?lastUpdateTime=%(lastupdatetime)s&sort=%(sort)s&limit=%(limit)s"
+    EVENTS_ENDPOINT = "%(host)s/v1/collections/%(collection_token)s/products?lastUpdateTime=%(lastupdatetime)s&limit=%(limit)s"
     AVAILABILITY_ENDPOINT = "%(host)s/v2/collections/%(collection_token)s/products/%(product_id)s/availability"
 
     PATRON_INFORMATION_ENDPOINT = "%(patron_host)s/v1/patrons/me"

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -2233,6 +2233,15 @@ class TestOverdriveAPI:
         assert fulfill.content_link_redirect is True
         assert fulfill.content_link == "https://example.org/epub-redirect"
 
+    def test_bug_fix_pp_1219(self, overdrive_api_fixture: OverdriveAPIFixture):
+        with patch.object(
+            overdrive_api_fixture.api, "_get_book_list_page"
+        ) as get_book_list:
+            get_book_list.return_value = ([], None)
+            result = overdrive_api_fixture.api.recently_changed_ids(utc_now(), None)
+            # this should no longer fail.
+            assert [i for i in result] == []
+
 
 class TestOverdriveAPICredentials:
     def test_patron_correct_credentials_for_multiple_overdrive_collections(

--- a/tests/api/test_overdrive.py
+++ b/tests/api/test_overdrive.py
@@ -2233,13 +2233,14 @@ class TestOverdriveAPI:
         assert fulfill.content_link_redirect is True
         assert fulfill.content_link == "https://example.org/epub-redirect"
 
-    def test_bug_fix_pp_1219(self, overdrive_api_fixture: OverdriveAPIFixture):
+    def test_no_recently_changed_books(
+        self, overdrive_api_fixture: OverdriveAPIFixture
+    ):
         with patch.object(
             overdrive_api_fixture.api, "_get_book_list_page"
         ) as get_book_list:
             get_book_list.return_value = ([], None)
             result = overdrive_api_fixture.api.recently_changed_ids(utc_now(), None)
-            # this should no longer fail.
             assert [i for i in result] == []
 
 


### PR DESCRIPTION
## Description
This update fixes a bug introduced in https://github.com/ThePalaceProject/circulation/pull/1783.  It appears that the way I have overridden the NewTitlesOverdriveMonitor construct is resulting in a failure in the dependency injection code when running in production.  Additionally there was a string interpolation bug in an area of the code that was not previously covered.
<!--- Describe your changes -->
When this PR has been approved I'll deploy a hotfix as well as create a PR against main with these changes and I'll create a 20.0.1 release before deploying out to staging.
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1219
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
