### PR TITLE
Move docker migration test into the docker workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,10 +205,36 @@ jobs:
         if: always()
         run: docker compose down
 
+  migration-test:
+    name: Migration test
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable network offload
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Test migrations
+        run: ./docker/ci/test_migrations.sh
+        env:
+          BUILD_CACHE_FROM: type=gha,scope=buildkit-${{ github.run_id }}
+          BUILD_BASE_IMAGE: ${{ needs.build.outputs.baseimage }}
+
   push:
     name: Push circ-${{ matrix.image }}
     runs-on: ubuntu-latest
-    needs: [build, integration-test, unit-test]
+    needs: [build, integration-test, unit-test, migration-test]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,25 +54,3 @@ jobs:
           files: ./coverage.xml
           name: test-${{ matrix.python-version }}
           verbose: true
-
-  docker-test-migrations:
-    name: Docker migration test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
-      - name: Disable network offload
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Test migrations
-        run: ./docker/ci/test_migrations.sh


### PR DESCRIPTION
## Description

Move the docker migration test into the docker workflow.

## Motivation and Context

When I split up the workflows, I left the docker migration test as part of the main test workflow, but it should really exist as part of the docker build. That way it can benefit from the caching done there, and make sure it uses the correct base image. This change would have let us find the issue in https://github.com/ThePalaceProject/circulation/pull/1800 before it got merged to main.

## How Has This Been Tested?

Running tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
