### PR TITLE
Rename fixture classes that were causing warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -314,6 +314,9 @@ addopts = [
     "--numprocesses=auto",
     "--strict-markers",
 ]
+filterwarnings = [
+    "error::pytest.PytestWarning",
+]
 markers = [
     "minio: mark test as requiring minio",
     "opensearch: mark test as requiring opensearch",

--- a/tests/manager/core/test_http.py
+++ b/tests/manager/core/test_http.py
@@ -10,7 +10,7 @@ from tests.manager.util.test_mock_web_server import MockAPIServer, MockAPIServer
 
 
 @dataclass
-class TestHttpFixture:
+class HttpTestFixture:
     server: MockAPIServer
     request_with_timeout: Callable[..., requests.Response]
 
@@ -21,13 +21,13 @@ def test_http_fixture(mock_web_server: MockAPIServer):
     request_with_timeout = functools.partial(
         HTTP.request_with_timeout, timeout=1, backoff_factor=0
     )
-    return TestHttpFixture(
+    return HttpTestFixture(
         server=mock_web_server, request_with_timeout=request_with_timeout
     )
 
 
 class TestHTTP:
-    def test_retries_unspecified(self, test_http_fixture: TestHttpFixture):
+    def test_retries_unspecified(self, test_http_fixture: HttpTestFixture):
         for i in range(1, 7):
             response = MockAPIServerResponse()
             response.content = b"Ouch."
@@ -44,7 +44,7 @@ class TestHTTP:
         assert request.path == "/test"
         assert request.method == "GET"
 
-    def test_retries_none(self, test_http_fixture: TestHttpFixture):
+    def test_retries_none(self, test_http_fixture: HttpTestFixture):
         response = MockAPIServerResponse()
         response.content = b"Ouch."
         response.status_code = 502
@@ -60,7 +60,7 @@ class TestHTTP:
         assert request.path == "/test"
         assert request.method == "GET"
 
-    def test_retries_3(self, test_http_fixture: TestHttpFixture):
+    def test_retries_3(self, test_http_fixture: HttpTestFixture):
         response0 = MockAPIServerResponse()
         response0.content = b"Ouch."
         response0.status_code = 502

--- a/tests/manager/sqlalchemy/model/test_licensing.py
+++ b/tests/manager/sqlalchemy/model/test_licensing.py
@@ -265,7 +265,7 @@ class TestRightsStatus:
         pytest.raises(IntegrityError, db.session.commit)
 
 
-class TestLicenseFixture:
+class LicenseTestFixture:
     def __init__(self, db: DatabaseTransactionFixture) -> None:
         self.db = db
         self.pool = db.licensepool(None)
@@ -327,12 +327,12 @@ class TestLicenseFixture:
 
 
 @pytest.fixture(scope="function")
-def licenses(db: DatabaseTransactionFixture) -> TestLicenseFixture:
-    return TestLicenseFixture(db)
+def licenses(db: DatabaseTransactionFixture) -> LicenseTestFixture:
+    return LicenseTestFixture(db)
 
 
 class TestLicense:
-    def test_loan_to(self, licenses: TestLicenseFixture):
+    def test_loan_to(self, licenses: LicenseTestFixture):
         # Verify that loaning a license also loans its pool.
         pool = licenses.pool
         license = licenses.perpetual
@@ -379,7 +379,7 @@ class TestLicense:
         is_inactive,
         total_remaining_loans,
         currently_available_loans,
-        licenses: TestLicenseFixture,
+        licenses: LicenseTestFixture,
     ):
         license = getattr(licenses, license_type)
         assert is_perpetual == license.is_perpetual
@@ -402,7 +402,7 @@ class TestLicense:
         ],
     )
     def test_license_checkout(
-        self, license_type, left, available, licenses: TestLicenseFixture
+        self, license_type, left, available, licenses: LicenseTestFixture
     ):
         license = getattr(licenses, license_type)
         license.checkout()
@@ -460,14 +460,14 @@ class TestLicense:
         ],
     )
     def test_license_checkin(
-        self, license_params, left, available, licenses: TestLicenseFixture
+        self, license_params, left, available, licenses: LicenseTestFixture
     ):
         l = licenses.db.license(licenses.pool, **license_params)
         l.checkin()
         assert left == l.checkouts_left
         assert available == l.checkouts_available
 
-    def test_best_available_license(self, licenses: TestLicenseFixture):
+    def test_best_available_license(self, licenses: LicenseTestFixture):
         next_week = utc_now() + datetime.timedelta(days=7)
         time_limited_2 = licenses.db.license(
             licenses.pool,


### PR DESCRIPTION
## Description

Rename two fixture classes to avoid warnings. And make pytest treat `PytestWarning` as an error, so that we notice these sooner in the future. Since its easy to name fixture classes incorrectly by accident.

## Motivation and Context

Two fixture classes `TestHttpFixture` and `TestLicenseFixture` were causing Pytest warnings because they were being loaded as tests because the class name started with `Test`. 

## How Has This Been Tested?

Running tests in CI

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
