### PR TITLE
Fix potentially flaky saml test

### DIFF
--- a/tests/manager/api/saml/test_auth.py
+++ b/tests/manager/api/saml/test_auth.py
@@ -310,7 +310,6 @@ class TestSAMLAuthenticationManager:
     ):
         # Arrange
         identity_provider_entity_id = "http://idp.hilbertteam.net/idp/shibboleth"
-        service_provider_host_name = "opds.hilbertteam.net"
 
         identity_providers = [
             copy(identity_provider) for identity_provider in IDENTITY_PROVIDERS
@@ -350,10 +349,6 @@ class TestSAMLAuthenticationManager:
                 "onelogin.saml2.response.OneLogin_Saml2_Utils.validate_sign",
                 validate_mock,
             ):
-                controller_fixture.app.config[
-                    "SERVER_NAME"
-                ] = service_provider_host_name
-
                 with controller_fixture.app.test_request_context(
                     "/SAML2/POST", data={"SAMLResponse": saml_response}
                 ):

--- a/tests/manager/api/saml/test_controller.py
+++ b/tests/manager/api/saml/test_controller.py
@@ -228,9 +228,7 @@ class TestSAMLController:
 
         query = urlencode(params)
 
-        with controller_fixture.app.test_request_context(
-            "http://circulationmanager.org/saml_authenticate?" + query
-        ):
+        with controller_fixture.app.test_request_context("/saml_authenticate?" + query):
             request.library = controller_fixture.db.default_library()  # type: ignore[attr-defined]
 
             # Act
@@ -424,9 +422,7 @@ class TestSAMLController:
 
         controller = SAMLController(controller_fixture.app.manager, authenticator)
 
-        with controller_fixture.app.test_request_context(
-            "http://circulationmanager.org/saml_callback", data=data
-        ):
+        with controller_fixture.app.test_request_context("/saml_callback", data=data):
             # Act
             result = controller.saml_authentication_callback(
                 request, controller_fixture.db.session


### PR DESCRIPTION
## Description

Update the SAML tests not to depend on a particular domain being configured in the app for their test run. This eliminates warnings from flask and should make the tests safer.

## Motivation and Context

The SAML tests are updating the global flask apps configuration to set `SERVER_NAME`, which could impact other tests, since the app is shared across tests. This can cause some tests to fail, especially when running in parallel. I think this caused one of the failures @tdilauro saw yesterday.

## How Has This Been Tested?

Running tests in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
