### PR TITLE
Remove AUTOINITIALIZE env variable

### DIFF
--- a/tests/manager/api/test_app.py
+++ b/tests/manager/api/test_app.py
@@ -1,6 +1,11 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from palace.manager.api.app import initialize_application
+import pytest
+
+from palace.manager.api.app import (
+    initialize_application,
+    initialize_circulation_manager,
+)
 from palace.manager.util.http import HTTP
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.services import ServicesFixture
@@ -18,3 +23,30 @@ def test_initialize_application_http(
 
     # Make sure that the HTTP configuration was set
     mock_set_quick_failure_settings.assert_called_once()
+
+
+def test_initialize_circulation_manager(caplog: pytest.LogCaptureFixture):
+    with (
+        patch("palace.manager.api.app.app") as mock_app,
+        patch("palace.manager.api.app.CirculationManager") as mock_circulation_manager,
+        patch("palace.manager.api.app.CachedData") as mock_cached_data,
+    ):
+        # If app is already initialized, it should not be re-initialized
+        mock_app.manager = MagicMock()
+        initialize_circulation_manager()
+        mock_circulation_manager.assert_not_called()
+        mock_cached_data.initialize.assert_not_called()
+
+        # If app is not initialized, it should be initialized
+        mock_app.manager = None
+        initialize_circulation_manager()
+        mock_circulation_manager.assert_called_once()
+        mock_cached_data.initialize.assert_called_once()
+        assert mock_app.manager == mock_circulation_manager.return_value
+
+        # If an exception is raised, it should be logged
+        mock_app.manager = None
+        mock_circulation_manager.side_effect = Exception("Test exception")
+        with pytest.raises(Exception):
+            initialize_circulation_manager()
+        assert "Error instantiating circulation manager!" in caplog.text

--- a/tests/manager/api/test_authenticator.py
+++ b/tests/manager/api/test_authenticator.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import datetime
 import json
-import os
 import re
 from collections.abc import Callable
 from decimal import Decimal
@@ -1020,11 +1019,7 @@ class TestLibraryAuthenticator:
 
         # We're about to call url_for, so we must create an
         # application context.
-        os.environ["AUTOINITIALIZE"] = "False"
         from palace.manager.api.app import app
-
-        self.app = app
-        del os.environ["AUTOINITIALIZE"]
 
         # Set up configuration settings for links.
         library_settings.terms_of_service = "http://terms.com"  # type: ignore[assignment]
@@ -1091,7 +1086,7 @@ class TestLibraryAuthenticator:
             finish=announcement_fixture.yesterday,
         )
 
-        with self.app.test_request_context("/"):
+        with app.test_request_context("/"):
             url = authenticator.authentication_document_url()
             assert url.endswith("/%s/authentication_document" % library.short_name)
 


### PR DESCRIPTION
## Description

Since importing `app` no longer automatically initializes anything, we are able to clean up this conditional code.

## Motivation and Context

Nice to not have our tests rely on env variables be set. After https://github.com/ThePalaceProject/circulation/pull/1817 goes in, i believe there aren't any more environment variables we depend on to change test initialization.

## How Has This Been Tested?

Running tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
