### PR TITLE
Cleanup superfluous websever fixture

### DIFF
--- a/tests/manager/api/test_overdrive.py
+++ b/tests/manager/api/test_overdrive.py
@@ -84,19 +84,6 @@ if TYPE_CHECKING:
     from tests.fixtures.time import Time
 
 
-@pytest.fixture
-def mock_web_server():
-    """A test fixture that yields a usable mock web server for the lifetime of the test."""
-    _server = MockAPIServer("127.0.0.1", 10256)
-    _server.start()
-    logging.info(f"starting mock web server on {_server.address()}:{_server.port()}")
-    yield _server
-    logging.info(
-        f"shutting down mock web server on {_server.address()}:{_server.port()}"
-    )
-    _server.stop()
-
-
 class OverdriveFilesFixture(FilesFixture):
     """A fixture providing access to Overdrive files."""
 


### PR DESCRIPTION
## Description

The overdrive tests contain a copy & paste of the webserver fixture. This PR removes it, and lets the OD tests rely on the copy of the fixture in the `tests.fixtures` package.

## Motivation and Context

No need to have a copy of the fixture here.

## How Has This Been Tested?

Tested in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
