### PR TITLE
Search index rebuild script undefined variable

### DIFF
--- a/src/palace/manager/core/scripts.py
+++ b/src/palace/manager/core/scripts.py
@@ -2388,9 +2388,9 @@ class RebuildSearchIndexScript(RunWorkCoverageProviderScript, RemovesSearchCover
     """Completely delete the search index and recreate it."""
 
     def __init__(self, *args, **kwargs):
-        search = kwargs.get("search_index_client", None)
-        self.search: ExternalSearchIndex = search or self.services.search.index()
+        search = kwargs.pop("search_index_client", None)
         super().__init__(SearchIndexCoverageProvider, *args, **kwargs)
+        self.search: ExternalSearchIndex = search or self.services.search.index()
 
     def do_run(self):
         self.search.clear_search_documents()


### PR DESCRIPTION
## Description

Small fix to search index rebuild script. It raising a undefined variable exception because `self.services` was being accessed before the parent `__init__` function had been called to set it up.

## Motivation and Context

Script was failing when trying to rebuild index.

## How Has This Been Tested?

Tested locally.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
