### PR TITLE
Add support for stack_info parameter in JSONFormatter

### DIFF
--- a/src/palace/manager/service/logging/log.py
+++ b/src/palace/manager/service/logging/log.py
@@ -89,6 +89,8 @@ class JSONFormatter(logging.Formatter):
             data["process"] = record.process
         if record.thread and record.thread != self.main_thread_id:
             data["thread"] = record.thread
+        if record.stack_info:
+            data["stack"] = self.formatStack(record.stack_info)
 
         # If we are running in a Flask context, we include the request data in the log
         if flask_request:

--- a/tests/manager/service/logging/test_log.py
+++ b/tests/manager/service/logging/test_log.py
@@ -94,6 +94,17 @@ class TestJSONFormatter:
         assert "traceback" in data
         assert "ValueError: fake exception" in data["traceback"]
 
+    def test_format_stack_info(self, log_record: LogRecordCallable) -> None:
+        formatter = JSONFormatter()
+        record = log_record(sinfo="some info")
+        data = json.loads(formatter.format(record))
+        assert data["stack"] == "some info"
+
+        # if no stack info is provided, the stack field is not included in the log.
+        record = log_record()
+        data = json.loads(formatter.format(record))
+        assert "stack" not in data
+
     @pytest.mark.parametrize(
         "msg, args, expected",
         [


### PR DESCRIPTION
## Description

As of [Python 3.3 logging calls take a `stack_info` parameter](https://docs.python.org/3.10/library/logging.html#logging.Logger.debug), which adds a stack trace to the log message. This PR adds support for this parameter to the `JSONFormatter`, so the stack trace is included in a `stack` key of the log message, when it is available.

## Motivation and Context

While debugging I needed to include a stack trace in my log messages, and before this change `JSONFormatter` did not include this information when a log record requested it.

## How Has This Been Tested?

- Tested locally
- Added unit test

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
