### PR TITLE
Add logger utility functions

### DIFF
--- a/src/palace/manager/api/lanes.py
+++ b/src/palace/manager/api/lanes.py
@@ -1,5 +1,3 @@
-import logging
-
 from sqlalchemy.orm import Session
 
 import palace.manager.core.classifier as genres
@@ -26,6 +24,7 @@ from palace.manager.sqlalchemy.model.lane import (
 from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.util import create
 from palace.manager.util.languages import LanguageCodes
+from palace.manager.util.log import logger_for_function
 
 
 def load_lanes(_db, library, collection_ids):
@@ -851,7 +850,7 @@ def create_lane_for_small_collection(_db, library, parent, languages, priority=0
     try:
         language_identifier = LanguageCodes.name_for_languageset(languages)
     except ValueError as e:
-        logging.getLogger().warning(
+        logger_for_function().warning(
             "Could not create a lane for small collection with languages %s", languages
         )
         return 0
@@ -923,7 +922,7 @@ def create_lane_for_tiny_collection(_db, library, parent, languages, priority=0)
     try:
         name = LanguageCodes.name_for_languageset(languages)
     except ValueError as e:
-        logging.getLogger().warning(
+        logger_for_function().warning(
             "Could not create a lane for tiny collection with languages %s", languages
         )
         return 0

--- a/src/palace/manager/celery/monitoring.py
+++ b/src/palace/manager/celery/monitoring.py
@@ -13,7 +13,7 @@ from celery.events.state import State, Task
 
 from palace.manager.util import chunks
 from palace.manager.util.datetime_helpers import utc_now
-from palace.manager.util.log import LoggerMixin
+from palace.manager.util.log import LoggerMixin, logger_for_cls
 
 if TYPE_CHECKING:
     from mypy_boto3_cloudwatch.literals import StandardUnitType
@@ -156,7 +156,7 @@ class Cloudwatch(Polaroid):
         # We use logger_for_cls instead of just inheriting from LoggerMixin
         # because the base class Polaroid already defines a logger attribute,
         # which conflicts with the logger() method in LoggerMixin.
-        self.logger = LoggerMixin.logger_for_cls(self.__class__)
+        self.logger = logger_for_cls(self.__class__)
         region = self.app.conf.get("cloudwatch_statistics_region")
         dryrun = self.app.conf.get("cloudwatch_statistics_dryrun")
         self.cloudwatch_client = (

--- a/tests/manager/util/test_log.py
+++ b/tests/manager/util/test_log.py
@@ -1,8 +1,10 @@
+from unittest.mock import patch
+
 import pytest
 from pytest import LogCaptureFixture
 
 from palace.manager.service.logging.configuration import LogLevel
-from palace.manager.util.log import LoggerMixin, log_elapsed_time
+from palace.manager.util.log import LoggerMixin, log_elapsed_time, logger_for_function
 
 
 class MockClass(LoggerMixin):
@@ -51,3 +53,12 @@ def test_log_elapsed_time_invalid(caplog: LogCaptureFixture):
     with pytest.raises(RuntimeError):
         log_elapsed_time(log_level=LogLevel.info, message_prefix="Test")(lambda: None)()
     assert len(caplog.records) == 0
+
+
+def test_logger_for_function():
+    logger = logger_for_function()
+    assert logger.name == "tests.manager.util.test_log.test_logger_for_function"
+
+    with patch("palace.manager.util.log.inspect", side_effect=Exception("Boom")):
+        logger = logger_for_function()
+    assert logger.name == "palace.manager.<unknown>"


### PR DESCRIPTION
## Description

Add a new logger utility function: `logger_for_function` and move `logger_for_cls` from a static method on `LoggerMixin` out to its own utility function.

## Motivation and Context

Similar to https://github.com/ThePalaceProject/circulation/pull/1838, I needed a couple of the lane creation functions to have a consistent logger name. It seemed helpful to add a new `logger_for_function` call so we can get a logger for this purpose.

## How Has This Been Tested?

- Tested running locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
