### PR TITLE
Adds API to get library-specific info on inventory reports. (PP-1210)

### DIFF
--- a/src/palace/manager/api/admin/controller/report.py
+++ b/src/palace/manager/api/admin/controller/report.py
@@ -3,22 +3,79 @@ from http import HTTPStatus
 
 import flask
 from flask import Response
+from sqlalchemy import not_, select
 from sqlalchemy.orm import Session
 
+from palace.manager.api.admin.model.inventory_report import (
+    InventoryReportCollectionInfo,
+    InventoryReportInfo,
+)
+from palace.manager.api.admin.problem_details import ADMIN_NOT_AUTHORIZED
 from palace.manager.celery.tasks.generate_inventory_and_hold_reports import (
     generate_inventory_and_hold_reports,
 )
 from palace.manager.core.problem_details import INTERNAL_SERVER_ERROR
+from palace.manager.integration.goals import Goals
 from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.admin import Admin
+from palace.manager.sqlalchemy.model.collection import Collection
+from palace.manager.sqlalchemy.model.integration import (
+    IntegrationConfiguration,
+    IntegrationLibraryConfiguration,
+)
 from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.util.log import LoggerMixin
-from palace.manager.util.problem_detail import ProblemDetail
+from palace.manager.util.problem_detail import ProblemDetail, ProblemDetailException
 
 
 class ReportController(LoggerMixin):
     def __init__(self, db: Session):
         self._db = db
+
+    def inventory_report_info(self) -> Response:
+        """InventoryReportInfo response of reportable collections for a library.
+
+        returns: Inventory report info response, if the library exists and
+            the admin is authorized.
+            Otherwise, return a 404 response if the library does not exist
+            or raise an ADMIN_NOT_AUTHORIZED ProblemDetailException, if the
+            admin is not authorized.
+        """
+        library: Library | None = getattr(flask.request, "library")
+        if library is None:
+            return Response(status=404)
+
+        admin: Admin = getattr(flask.request, "admin")
+        if not admin.is_librarian(library):
+            raise ProblemDetailException(ADMIN_NOT_AUTHORIZED)
+
+        collections = self._db.scalars(
+            select(Collection)
+            .join(IntegrationConfiguration)
+            .join(IntegrationLibraryConfiguration)
+            .where(
+                IntegrationLibraryConfiguration.library_id == library.id,
+                IntegrationConfiguration.goal == Goals.LICENSE_GOAL,
+                not_(
+                    IntegrationConfiguration.settings_dict.contains(
+                        {"include_in_inventory_report": False}
+                    )
+                ),
+            )
+        ).all()
+        info = InventoryReportInfo(
+            collections=[
+                InventoryReportCollectionInfo(
+                    id=c.id, name=c.integration_configuration.name
+                )
+                for c in collections
+            ]
+        )
+        return Response(
+            json.dumps(info.api_dict()),
+            status=HTTPStatus.OK,
+            mimetype=MediaTypes.APPLICATION_JSON_MEDIA_TYPE,
+        )
 
     def generate_inventory_report(self) -> Response | ProblemDetail:
         library: Library = getattr(flask.request, "library")

--- a/src/palace/manager/api/admin/model/inventory_report.py
+++ b/src/palace/manager/api/admin/model/inventory_report.py
@@ -1,0 +1,18 @@
+from pydantic import Field
+
+from palace.manager.util.flask_util import CustomBaseModel
+
+
+class InventoryReportCollectionInfo(CustomBaseModel):
+    """Collection information."""
+
+    id: int = Field(..., description="Collection identifier.")
+    name: str = Field(..., description="Collection name.")
+
+
+class InventoryReportInfo(CustomBaseModel):
+    """Inventory report information."""
+
+    collections: list[InventoryReportCollectionInfo] = Field(
+        ..., description="List of collections."
+    )

--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -12,6 +12,7 @@ from palace.manager.api.admin.config import OperationalMode
 from palace.manager.api.admin.controller.custom_lists import CustomListsController
 from palace.manager.api.admin.dashboard_stats import generate_statistics
 from palace.manager.api.admin.model.dashboard_statistics import StatisticsResponse
+from palace.manager.api.admin.model.inventory_report import InventoryReportInfo
 from palace.manager.api.admin.model.quicksight import (
     QuicksightDashboardNamesResponse,
     QuicksightGenerateUrlRequest,
@@ -705,6 +706,23 @@ def search_field_values():
 @returns_json_or_response_or_problem_detail
 def diagnostics():
     return app.manager.timestamps_controller.diagnostics()
+
+
+@app.route(
+    "/admin/reports/inventory_report/<path:library_short_name>",
+    methods=["GET"],
+)
+@api_spec.validate(
+    resp=SpecResponse(
+        HTTP_200=InventoryReportInfo, HTTP_403=ProblemDetailModel, HTTP_404=None
+    ),
+    tags=["admin.inventory"],
+)
+@allows_library
+@returns_json_or_response_or_problem_detail
+@requires_admin
+def inventory_report_info():
+    return app.manager.admin_report_controller.inventory_report_info()
 
 
 @app.route(

--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -726,7 +726,7 @@ def inventory_report_info():
 
 
 @app.route(
-    "/admin/reports/generate_inventory_report/<path:library_short_name>",
+    "/admin/reports/inventory_report/<path:library_short_name>",
     methods=["POST"],
 )
 @allows_library

--- a/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
+++ b/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
@@ -64,7 +64,7 @@ def library_report_integrations(
             ),
         )
     ).all()
-    return sorted(eligible_integrations(integrations), key=lambda i: i.name)
+    return sorted(eligible_integrations(integrations), key=lambda i: i.name or "")
 
 
 class GenerateInventoryAndHoldsReportsJob(Job):

--- a/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
+++ b/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
@@ -44,13 +44,10 @@ def eligible_integrations(
 
 
 def library_report_integrations(
-    library: Library, session: Session | None = None
+    library: Library, session: Session
 ) -> list[IntegrationConfiguration]:
-    """Return a list of collections to report for the given library."""
-    if session is None:
-        session = Session.object_session(library)
+    """Return a list of collection integrations to report for the given library."""
 
-    # resolve integrations
     integrations = session.scalars(
         select(IntegrationConfiguration)
         .join(IntegrationLibraryConfiguration)

--- a/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
+++ b/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
@@ -28,6 +28,45 @@ from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.util import get_one
 
 
+def eligible_integrations(
+    integrations: list[IntegrationConfiguration],
+) -> list[IntegrationConfiguration]:
+    """Subset a list of integrations to only those that are eligible for the inventory report."""
+    registry = LicenseProvidersRegistry()
+
+    def is_eligible(integration: IntegrationConfiguration) -> bool:
+        if integration.protocol is None:
+            return False
+        settings = registry[integration.protocol].settings_load(integration)
+        return isinstance(settings, OPDSImporterSettings)
+
+    return [integration for integration in integrations if is_eligible(integration)]
+
+
+def library_report_integrations(
+    library: Library, session: Session | None = None
+) -> list[IntegrationConfiguration]:
+    """Return a list of collections to report for the given library."""
+    if session is None:
+        session = Session.object_session(library)
+
+    # resolve integrations
+    integrations = session.scalars(
+        select(IntegrationConfiguration)
+        .join(IntegrationLibraryConfiguration)
+        .where(
+            IntegrationLibraryConfiguration.library_id == library.id,
+            IntegrationConfiguration.goal == Goals.LICENSE_GOAL,
+            not_(
+                IntegrationConfiguration.settings_dict.contains(
+                    {"include_in_inventory_report": False}
+                )
+            ),
+        )
+    ).all()
+    return sorted(eligible_integrations(integrations), key=lambda i: i.name)
+
+
 class GenerateInventoryAndHoldsReportsJob(Job):
     def __init__(
         self,
@@ -63,27 +102,12 @@ class GenerateInventoryAndHoldsReportsJob(Job):
 
             file_name_modifier = f"{library.short_name}-{date_str}"
 
-            # resolve integrations
-            integrations = session.scalars(
-                select(IntegrationConfiguration)
-                .join(IntegrationLibraryConfiguration)
-                .where(
-                    IntegrationLibraryConfiguration.library_id == self.library_id,
-                    IntegrationConfiguration.goal == Goals.LICENSE_GOAL,
-                    not_(
-                        IntegrationConfiguration.settings_dict.contains(
-                            {"include_in_inventory_report": False}
-                        )
-                    ),
+            integration_ids = [
+                integration.id
+                for integration in library_report_integrations(
+                    library=library, session=session
                 )
-            ).all()
-            registry = LicenseProvidersRegistry()
-            integration_ids: list[int] = []
-            for integration in integrations:
-                settings = registry[integration.protocol].settings_load(integration)
-                if not isinstance(settings, OPDSImporterSettings):
-                    continue
-                integration_ids.append(integration.id)
+            ]
 
             # generate inventory report csv file
             sql_params: dict[str, Any] = {

--- a/tests/fixtures/api_routes.py
+++ b/tests/fixtures/api_routes.py
@@ -51,6 +51,9 @@ class MockControllerMethod:
         self.name = name
         self.callable_name = name
 
+    def response(self):
+        return flask.Response(f"I called {repr(self)}", 200)
+
     def __call__(self, *args, **kwargs):
         """Simulate a successful method call.
 
@@ -59,7 +62,7 @@ class MockControllerMethod:
         """
         self.args = args
         self.kwargs = kwargs
-        response = flask.Response("I called %s" % repr(self), 200)
+        response = self.response()
         response.method = self
         return response
 

--- a/tests/manager/api/admin/controller/test_report.py
+++ b/tests/manager/api/admin/controller/test_report.py
@@ -4,10 +4,19 @@ from unittest.mock import patch
 import pytest
 from flask import Response
 
+from palace.manager.api.admin.controller import ReportController
+from palace.manager.api.admin.model.inventory_report import (
+    InventoryReportCollectionInfo,
+    InventoryReportInfo,
+)
+from palace.manager.api.admin.problem_details import ADMIN_NOT_AUTHORIZED
 from palace.manager.sqlalchemy.model.admin import Admin, AdminRole
 from palace.manager.sqlalchemy.util import create
+from palace.manager.util.problem_detail import ProblemDetailException
 from tests.fixtures.api_admin import AdminControllerFixture
 from tests.fixtures.api_controller import ControllerFixture
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.flask import FlaskAppFixture
 
 
 class ReportControllerFixture(AdminControllerFixture):
@@ -52,3 +61,106 @@ class TestReportController:
         mock_generate_reports.delay.assert_called_once_with(
             email_address=email_address, library_id=library_id
         )
+
+    def test_inventory_report_info(
+        self, db: DatabaseTransactionFixture, flask_app_fixture: FlaskAppFixture
+    ):
+        controller = ReportController(db.session)
+
+        library1 = db.library()
+        library2 = db.library()
+
+        sysadmin = flask_app_fixture.admin_user(
+            email="sysadmin@example.org", role=AdminRole.SYSTEM_ADMIN
+        )
+        librarian1 = flask_app_fixture.admin_user(
+            email="librarian@example.org", role=AdminRole.LIBRARIAN, library=library1
+        )
+
+        collection = db.collection()
+        collection.libraries = [library1, library2]
+
+        success_payload_dict = InventoryReportInfo(
+            collections=[
+                InventoryReportCollectionInfo(
+                    id=collection.id, name=collection.integration_configuration.name
+                )
+            ]
+        ).api_dict()
+
+        # Sysadmin can get info for any library.
+        with flask_app_fixture.test_request_context(
+            "/", admin=sysadmin, library=library1
+        ):
+            admin_response1 = controller.inventory_report_info()
+        assert admin_response1.status_code == 200
+        assert admin_response1.get_json() == success_payload_dict
+
+        with flask_app_fixture.test_request_context(
+            "/", admin=sysadmin, library=library2
+        ):
+            admin_response2 = controller.inventory_report_info()
+        assert admin_response2.status_code == 200
+        assert admin_response2.get_json() == success_payload_dict
+
+        # The librarian for library 1 can get info only for that library...
+        with flask_app_fixture.test_request_context(
+            "/", admin=librarian1, library=library1
+        ):
+            librarian1_response1 = controller.inventory_report_info()
+        assert librarian1_response1.status_code == 200
+        assert librarian1_response1.get_json() == success_payload_dict
+        # ... since it does not have an admin role for library2.
+        with flask_app_fixture.test_request_context(
+            "/", admin=librarian1, library=library2
+        ):
+            with pytest.raises(ProblemDetailException) as exc:
+                controller.inventory_report_info()
+        assert exc.value.problem_detail == ADMIN_NOT_AUTHORIZED
+
+        # A library must be provided.
+        with flask_app_fixture.test_request_context("/", admin=sysadmin, library=None):
+            admin_response_none = controller.inventory_report_info()
+        assert admin_response_none.status_code == 404
+
+    @pytest.mark.parametrize(
+        "settings, expect_collection",
+        (
+            ({}, True),
+            ({"include_in_inventory_report": False}, False),
+            ({"include_in_inventory_report": True}, True),
+        ),
+    )
+    def test_inventory_report_info_reportable_collections(
+        self,
+        db: DatabaseTransactionFixture,
+        flask_app_fixture: FlaskAppFixture,
+        settings: dict,
+        expect_collection: bool,
+    ):
+        controller = ReportController(db.session)
+        sysadmin = flask_app_fixture.admin_user(role=AdminRole.SYSTEM_ADMIN)
+
+        library = db.library()
+        collection = db.collection()
+        collection.libraries = [library]
+        collection._set_settings(**settings)
+
+        expected_collections = (
+            [InventoryReportCollectionInfo(id=collection.id, name=collection.name)]
+            if expect_collection
+            else []
+        )
+        expected_collection_count = 1 if expect_collection else 0
+        success_payload_dict = InventoryReportInfo(
+            collections=expected_collections
+        ).api_dict()
+        assert len(expected_collections) == expected_collection_count
+
+        # Sysadmin can get info for any library.
+        with flask_app_fixture.test_request_context(
+            "/", admin=sysadmin, library=library
+        ):
+            response = controller.inventory_report_info()
+        assert response.status_code == 200
+        assert response.get_json() == success_payload_dict

--- a/tests/manager/api/admin/test_routes.py
+++ b/tests/manager/api/admin/test_routes.py
@@ -753,18 +753,20 @@ class TestAdminLanes:
 
 class TestAdminInventoryReports:
     CONTROLLER_NAME = "admin_report_controller"
+    URL = "/admin/reports/inventory_report/<library_short_name>"
 
     @pytest.fixture(scope="function")
     def fixture(self, admin_route_fixture: AdminRouteFixture) -> AdminRouteFixture:
         admin_route_fixture.set_controller_name(self.CONTROLLER_NAME)
         return admin_route_fixture
 
+    def test_inventory_report(self, fixture: AdminRouteFixture):
+        fixture.assert_supported_methods(self.URL, "GET", "POST")
+
     def test_inventory_report_info(
         self, fixture: AdminRouteFixture, monkeypatch: pytest.MonkeyPatch
     ):
-        url = "/admin/reports/inventory_report/<library_short_name>"
-        fixture.assert_supported_methods(url, "GET")
-
+        url = self.URL
         mock_response = MagicMock(
             return_value=Response(
                 '{"collections": []}',
@@ -774,7 +776,23 @@ class TestAdminInventoryReports:
         )
         monkeypatch.setattr(fixture.controller.inventory_report_info, "response", mock_response)  # type: ignore
         fixture.assert_authenticated_request_calls(
-            url, fixture.controller.inventory_report_info  # type: ignore
+            url, fixture.controller.inventory_report_info, http_method="GET"  # type: ignore
+        )
+
+    def test_generate_inventory_report(
+        self, fixture: AdminRouteFixture, monkeypatch: pytest.MonkeyPatch
+    ):
+        url = self.URL
+        mock_response = MagicMock(
+            return_value=Response(
+                '{"message": "A success message."}',
+                status=HTTPStatus.ACCEPTED,
+                mimetype=MediaTypes.APPLICATION_JSON_MEDIA_TYPE,
+            )
+        )
+        monkeypatch.setattr(fixture.controller.generate_inventory_report, "response", mock_response)  # type: ignore
+        fixture.assert_authenticated_request_calls(
+            url, fixture.controller.generate_inventory_report, http_method="POST"  # type: ignore
         )
 
 


### PR DESCRIPTION
## Description

- Adds the `/admin/reports/generate_inventory_report/:library_short_name` GET method endpoint to provide information about the collections that will be included if an inventory report is generated.
- Includes API documentation at:
  - Swagger: `.../apidoc/swagger#/admin.inventory`
  - ReDoc: `.../apidoc/redoc#tag/admin.inventory`
- Small refactoring in `...api_routes.MockControllerMethod` class to make it a little easier to verify calls to controller methods on routes for which content is validated on the way out.

## Motivation and Context

It is useful to know which collections will be included in the inventory reports. This is primarily for users of the Palace Manage admin user interface.

[Jira [PP-1210](https://ebce-lyrasis.atlassian.net/browse/PP-1210)]

## How Has This Been Tested?

- Adds new tests for the new feature.
- Tested locally via `curl` and with an updated Admin UI client.
- Added new tests to the test suite.
- [CI tests for the associated feature branch pass](https://github.com/ThePalaceProject/circulation/actions/runs/9052055225).

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1210]: https://ebce-lyrasis.atlassian.net/browse/PP-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ