### PR TITLE
[PP-930] Remove search fuzziness

### DIFF
--- a/src/palace/manager/search/external_search.py
+++ b/src/palace/manager/search/external_search.py
@@ -1071,8 +1071,6 @@ class JSONQuery(Query):
     RESERVED_CHARS_MAP = dict(map(lambda ch: (ord(ch), f"\\{ch}"), RESERVED_CHARS))
 
     _KEYWORD_ONLY = {"keyword": True}
-    _LONG_TYPE = {"type": "long"}
-    _BOOL_TYPE = {"type": "bool"}
 
     # The fields mappings in the search DB
     FIELD_MAPPING: dict[str, dict] = {
@@ -1101,7 +1099,7 @@ class JSONQuery(Query):
         "licensepools.availability_time": dict(path="licensepools"),
         "licensepools.collection_id": dict(path="licensepools"),
         "licensepools.data_source_id": dict(
-            path="licensepools", ops=[Operators.EQ, Operators.EQ]
+            path="licensepools", ops=[Operators.EQ, Operators.NEQ]
         ),
         "licensepools.licensed": dict(path="licensepools"),
         "licensepools.medium": dict(path="licensepools"),
@@ -1109,7 +1107,7 @@ class JSONQuery(Query):
         "licensepools.quality": dict(path="licensepools"),
         "licensepools.suppressed": dict(path="licensepools"),
         "medium": _KEYWORD_ONLY,
-        "presentation_ready": _BOOL_TYPE,
+        "presentation_ready": dict(),
         "publisher": _KEYWORD_ONLY,
         "quality": dict(),
         "series": _KEYWORD_ONLY,
@@ -1293,7 +1291,7 @@ class JSONQuery(Query):
     def _parse_json_join(self, query: dict) -> dict:
         if len(query.keys()) != 1:
             raise QueryParseException(
-                detail="A conjuction cannot have multiple parts in the same sub-query"
+                detail="A conjunction cannot have multiple parts in the same sub-query"
             )
 
         join = list(query.keys())[0]

--- a/tests/manager/search/test_external_search.py
+++ b/tests/manager/search/test_external_search.py
@@ -5039,26 +5039,18 @@ class TestJSONQuery:
     def _jq(query):
         return JSONQuery(dict(query=query))
 
-    match_args = JSONQuery.MATCH_ARGS
-
     def test_search_query(self, external_search_fixture: ExternalSearchFixture):
         q_dict = {"key": "medium", "value": "Book"}
         q = self._jq(q_dict)
-        assert q.search_query.to_dict() == {
-            "match": {"medium.keyword": {"query": "Book", **self.match_args}}
-        }
+        assert q.search_query.to_dict() == {"term": {"medium.keyword": "Book"}}
 
         q = {"or": [self._leaf("medium", "Book"), self._leaf("medium", "Audio")]}
         q = self._jq(q)
         assert q.search_query.to_dict() == {
             "bool": {
                 "should": [
-                    {"match": {"medium.keyword": {"query": "Book", **self.match_args}}},
-                    {
-                        "match": {
-                            "medium.keyword": {"query": "Audio", **self.match_args}
-                        }
-                    },
+                    {"term": {"medium.keyword": "Book"}},
+                    {"term": {"medium.keyword": "Audio"}},
                 ]
             }
         }
@@ -5068,12 +5060,8 @@ class TestJSONQuery:
         assert q.search_query.to_dict() == {
             "bool": {
                 "must": [
-                    {"match": {"medium.keyword": {"query": "Book", **self.match_args}}},
-                    {
-                        "match": {
-                            "medium.keyword": {"query": "Audio", **self.match_args}
-                        }
-                    },
+                    {"term": {"medium.keyword": "Book"}},
+                    {"term": {"medium.keyword": "Audio"}},
                 ]
             }
         }
@@ -5088,29 +5076,8 @@ class TestJSONQuery:
         assert q.search_query.to_dict() == {
             "bool": {
                 "must": [
-                    {"match": {"title.keyword": {"query": "Title", **self.match_args}}},
-                    {
-                        "bool": {
-                            "should": [
-                                {
-                                    "match": {
-                                        "medium.keyword": {
-                                            "query": "Book",
-                                            **self.match_args,
-                                        }
-                                    }
-                                },
-                                {
-                                    "match": {
-                                        "medium.keyword": {
-                                            "query": "Audio",
-                                            **self.match_args,
-                                        }
-                                    }
-                                },
-                            ]
-                        }
-                    },
+                    {"term": {"medium.keyword": "Book"}},
+                    {"term": {"medium.keyword": "Audio"}},
                 ]
             }
         }
@@ -5120,21 +5087,8 @@ class TestJSONQuery:
         assert q.search_query.to_dict() == {
             "bool": {
                 "should": [
-                    {"match": {"medium.keyword": {"query": "Book", **self.match_args}}},
-                    {
-                        "bool": {
-                            "must_not": [
-                                {
-                                    "match": {
-                                        "medium.keyword": {
-                                            "query": "Audio",
-                                            **self.match_args,
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
+                    {"term": {"medium.keyword": "Book"}},
+                    {"term": {"medium.keyword": "Audio"}},
                 ]
             }
         }
@@ -5149,21 +5103,8 @@ class TestJSONQuery:
         assert q.search_query.to_dict() == {
             "bool": {
                 "must": [
-                    {"match": {"title.keyword": {"query": "Title", **self.match_args}}},
-                    {
-                        "bool": {
-                            "must_not": [
-                                {
-                                    "match": {
-                                        "author.keyword": {
-                                            "query": "Geoffrey",
-                                            **self.match_args,
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
+                    {"term": {"title.keyword": "Title"}},
+                    {"bool": {"must_not": [{"term": {"author.keyword": "Geoffrey"}}]}},
                 ]
             }
         }
@@ -5188,7 +5129,7 @@ class TestJSONQuery:
             ("contributors.display_name", "name", True),
             ("contributors.lc", "name", False),
             ("genres.name", "name", False),
-            ("licensepools.medium", "Book", False),
+            ("licensepools.open_access", True, False),
         ],
     )
     def test_search_query_nested(self, key, value, is_keyword):
@@ -5196,10 +5137,7 @@ class TestJSONQuery:
         term = key if not is_keyword else f"{key}.keyword"
         root = key.split(".")[0]
         assert q.search_query.to_dict() == {
-            "nested": {
-                "path": root,
-                "query": {"match": {term: {"query": value, **self.match_args}}},
-            }
+            "nested": {"path": root, "query": {"term": {term: value}}}
         }
 
     @pytest.mark.parametrize(
@@ -5234,9 +5172,7 @@ class TestJSONQuery:
     def test_field_transforms(self):
         q = self._jq(self._leaf("classification", "cls"))
         assert q.search_query.to_dict() == {
-            "match": {
-                "classifications.term.keyword": {"query": "cls", **self.match_args}
-            }
+            "term": {"classifications.term.keyword": "cls"}
         }
         q = self._jq(self._leaf("open_access", True))
         assert q.search_query.to_dict() == {
@@ -5336,19 +5272,6 @@ class TestJSONQuery:
                 "query": {"term": {"licensepools.data_source_id": gutenberg.id}},
             }
         }
-
-    @pytest.mark.parametrize(
-        "key,value,is_text",
-        [
-            ("title", "value", True),
-            ("licensepools.open_access", True, False),
-            ("published", "1990-01-01", False),
-        ],
-    )
-    def test_type_queries(self, key, value, is_text):
-        """Bool and long types are term queries, whereas text is a match query"""
-        q = self._jq(self._leaf(key, value))
-        q.search_query.to_dict().keys() == ["match" if is_text else "term"]
 
     @pytest.mark.parametrize(
         "value,escaped,contains",

--- a/tests/manager/search/test_external_search.py
+++ b/tests/manager/search/test_external_search.py
@@ -5076,8 +5076,15 @@ class TestJSONQuery:
         assert q.search_query.to_dict() == {
             "bool": {
                 "must": [
-                    {"term": {"medium.keyword": "Book"}},
-                    {"term": {"medium.keyword": "Audio"}},
+                    {"term": {"title.keyword": "Title"}},
+                    {
+                        "bool": {
+                            "should": [
+                                {"term": {"medium.keyword": "Book"}},
+                                {"term": {"medium.keyword": "Audio"}},
+                            ]
+                        }
+                    },
                 ]
             }
         }
@@ -5088,7 +5095,7 @@ class TestJSONQuery:
             "bool": {
                 "should": [
                     {"term": {"medium.keyword": "Book"}},
-                    {"term": {"medium.keyword": "Audio"}},
+                    {"bool": {"must_not": [{"term": {"medium.keyword": "Audio"}}]}},
                 ]
             }
         }
@@ -5149,7 +5156,7 @@ class TestJSONQuery:
                 dict(kew="author", op="eq", value="name"),
                 "Could not make sense of the query",
             ),
-            ({"and": [], "or": []}, "A conjuction cannot have multiple parts"),
+            ({"and": [], "or": []}, "A conjunction cannot have multiple parts"),
         ],
     )
     def test_errors(self, query, error_match):
@@ -5289,9 +5296,7 @@ class TestJSONQuery:
                 == f".*{escaped}.*"
             )
         else:
-            assert (
-                q.search_query.to_dict()["match"]["title.keyword"]["query"] == escaped
-            )
+            assert q.search_query.to_dict()["term"]["title.keyword"] == escaped
 
 
 class TestExternalSearchJSONQueryData:


### PR DESCRIPTION
## Description
This PR reverts the changes made in [Rishi's PR to add fuzziness to 'equal to' and 'not equal to' operations ](https://github.com/ThePalaceProject/circulation/pull/702) which he did a couple of years ago,. 

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-930
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I've updated the tests so it should be in good working order.  Before being merged, I plan to test it locally.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
