### PR TITLE
Add some better logging when we get unexpected responses from ODL (PP-1283)

### DIFF
--- a/src/palace/manager/api/odl.py
+++ b/src/palace/manager/api/odl.py
@@ -330,6 +330,21 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
             )
 
         response = self._get(url)
+        if response.status_code != 200:
+            header_string = ", ".join(
+                {f"{k}: {v}" for k, v in response.headers.items()}
+            )
+            response_string = (
+                response.text
+                if len(response.text) < 100
+                else response.text[:100] + "..."
+            )
+            self.log.error(
+                f"Error getting License Status Document for loan ({loan.id}):  Url '{url}' returned "
+                f"status code {response.status_code}. Expected 200. Response headers: {header_string}. "
+                f"Response content: {response_string}."
+            )
+            raise BadResponseException(url, "License Status Document request failed.")
 
         try:
             status_doc = json.loads(response.content)

--- a/tests/manager/api/test_odl.py
+++ b/tests/manager/api/test_odl.py
@@ -113,7 +113,7 @@ class TestODLAPI:
         assert loan.external_identifier == requested_url
 
     def test_get_license_status_document_errors(
-        self, odl_api_test_fixture: ODLAPITestFixture
+        self, odl_api_test_fixture: ODLAPITestFixture, caplog: pytest.LogCaptureFixture
     ) -> None:
         loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
 
@@ -132,6 +132,15 @@ class TestODLAPI:
             odl_api_test_fixture.api.get_license_status_document,
             loan,
         )
+
+        odl_api_test_fixture.api.queue_response(403, content="just junk " * 100)
+        pytest.raises(
+            BadResponseException,
+            odl_api_test_fixture.api.get_license_status_document,
+            loan,
+        )
+        assert "returned status code 403. Expected 200." in caplog.text
+        assert "just junk ..." in caplog.text
 
     def test_checkin_success(
         self, db: DatabaseTransactionFixture, odl_api_test_fixture: ODLAPITestFixture


### PR DESCRIPTION
## Description

Gives some more information in our logs when we get unexpected status back from ODL feeds, so that its easier to pass the information on to DeMarque.

## Motivation and Context

This information would have helped while troubleshooting PP-1283. 

## How Has This Been Tested?

- Ran tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
