### PR TITLE
[PP-1280] Capture User-Agent header value in S3 Analytics.

### DIFF
--- a/src/palace/manager/api/s3_analytics_provider.py
+++ b/src/palace/manager/api/s3_analytics_provider.py
@@ -31,6 +31,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         old_value,
         new_value,
         neighborhood: str | None = None,
+        user_agent: str | None = None,
     ) -> dict:
         """Create a Python dict containing required information about the event.
 
@@ -47,6 +48,8 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         :param new_value: New value of the metric changed by the event
 
         :param neighborhood: Geographic location of the event
+
+        :param user_agent: the user agent string of the caller
 
         :return: Python dict containing required information about the event
         """
@@ -126,6 +129,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
             "series_position": work.series_position if work else None,
             "language": work.language if work else None,
             "open_access": license_pool.open_access if license_pool else None,
+            "user_agent": user_agent,
         }
 
         return event
@@ -138,6 +142,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         time,
         old_value=None,
         new_value=None,
+        user_agent: str | None = None,
         **kwargs,
     ):
         """Log the event using the appropriate for the specific provider's mechanism.
@@ -165,13 +170,22 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
 
         :param new_value: New value of the metric changed by the event
         :type new_value: Any
+
+        :param user_agent: The user_agent of the caller.
+        :type user_agent:  str
         """
 
         if not library and not license_pool:
             raise ValueError("Either library or license_pool must be provided.")
 
         event = self._create_event_object(
-            library, license_pool, event_type, time, old_value, new_value
+            library,
+            license_pool,
+            event_type,
+            time,
+            old_value,
+            new_value,
+            user_agent=user_agent,
         )
         content = json.dumps(
             event,

--- a/src/palace/manager/service/analytics/analytics.py
+++ b/src/palace/manager/service/analytics/analytics.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import flask
+
 from palace.manager.api.s3_analytics_provider import S3AnalyticsProvider
 from palace.manager.core.local_analytics_provider import LocalAnalyticsProvider
 from palace.manager.util.datetime_helpers import utc_now
@@ -33,8 +35,12 @@ class Analytics(LoggerMixin):
         if not time:
             time = utc_now()
 
+        user_agent = flask.request.user_agent
+
         for provider in self.providers:
-            provider.collect_event(library, license_pool, event_type, time, **kwargs)
+            provider.collect_event(
+                library, license_pool, event_type, time, user_agent=user_agent, **kwargs
+            )
 
     def is_configured(self) -> bool:
         return len(self.providers) > 0

--- a/src/palace/manager/service/analytics/analytics.py
+++ b/src/palace/manager/service/analytics/analytics.py
@@ -35,7 +35,9 @@ class Analytics(LoggerMixin):
         if not time:
             time = utc_now()
 
-        user_agent = flask.request.user_agent
+        user_agent = (
+            flask.request.user_agent.string if flask.request.user_agent else None
+        )
 
         for provider in self.providers:
             provider.collect_event(

--- a/tests/manager/core/test_s3_analytics_provider.py
+++ b/tests/manager/core/test_s3_analytics_provider.py
@@ -117,7 +117,7 @@ class TestS3AnalyticsProvider:
         event_time = datetime.datetime.utcnow()
         event_time_formatted = self.timestamp_to_string(event_time)
         event_type = CirculationEvent.CM_CHECKOUT
-
+        user_agent = "the-user-agent"
         s3_analytics_fixture.analytics_provider._get_file_key = MagicMock()
 
         # Act
@@ -126,6 +126,7 @@ class TestS3AnalyticsProvider:
             license_pool,
             event_type,
             event_time,
+            user_agent=user_agent,
         )
 
         # Assert
@@ -178,3 +179,4 @@ class TestS3AnalyticsProvider:
         assert event["series"] == work.series
         assert event["series_position"] == work.series_position
         assert event["language"] == work.language
+        assert event["user_agent"] == user_agent


### PR DESCRIPTION
## Description

Adds user-agent field to the S3 Analytics.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1280
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests have been updated.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
