### PR TITLE
Admin must have role for a library to generate inventory report. (PP-1293)

### DIFF
--- a/src/palace/manager/api/admin/controller/report.py
+++ b/src/palace/manager/api/admin/controller/report.py
@@ -2,7 +2,7 @@ import json
 from http import HTTPStatus
 
 import flask
-from flask import Response
+from flask import Request, Response
 from sqlalchemy.orm import Session
 
 from palace.manager.api.admin.model.inventory_report import (
@@ -22,6 +22,28 @@ from palace.manager.util.log import LoggerMixin
 from palace.manager.util.problem_detail import ProblemDetail, ProblemDetailException
 
 
+def _authorize_from_request(
+    request: Request,
+) -> tuple[Admin, Library, None] | tuple[None, None, Response]:
+    """Authorize the admin for the library from the request.
+
+    :param request: A Flask Request object.
+    :return: A 3-tuple of admin, library, and error response.
+        If there is no library, the error response is a 404.
+        Otherwise, we return a valid admin and library, if the admin is authorized.
+    :raise: ProblemDetailException, jf admin not authorized for library.
+    """
+    library: Library | None = getattr(request, "library")
+    if library is None:
+        return None, None, Response(status=404)
+
+    admin: Admin = getattr(request, "admin")
+    if not admin.is_librarian(library):
+        raise ProblemDetailException(ADMIN_NOT_AUTHORIZED)
+
+    return admin, library, None
+
+
 class ReportController(LoggerMixin):
     def __init__(self, db: Session):
         self._db = db
@@ -31,17 +53,12 @@ class ReportController(LoggerMixin):
 
         returns: Inventory report info response, if the library exists and
             the admin is authorized.
-            Otherwise, return a 404 response if the library does not exist
-            or raise an ADMIN_NOT_AUTHORIZED ProblemDetailException, if the
-            admin is not authorized.
         """
-        library: Library | None = getattr(flask.request, "library")
-        if library is None:
-            return Response(status=404)
-
-        admin: Admin = getattr(flask.request, "admin")
-        if not admin.is_librarian(library):
-            raise ProblemDetailException(ADMIN_NOT_AUTHORIZED)
+        admin, library, error_response = _authorize_from_request(flask.request)
+        if error_response:
+            return error_response
+        assert admin is not None
+        assert library is not None
 
         collections = [
             integration.collection
@@ -64,31 +81,29 @@ class ReportController(LoggerMixin):
         )
 
     def generate_inventory_report(self) -> Response | ProblemDetail:
-        library: Library = getattr(flask.request, "library")
-        admin: Admin = getattr(flask.request, "admin")
-        try:
-            # these values should never be None
-            assert admin.email
-            assert admin.id
-            assert library.id
+        admin, library, error_response = _authorize_from_request(flask.request)
+        if error_response:
+            return error_response
+        assert admin is not None
+        assert library is not None
 
+        try:
             task = generate_inventory_and_hold_reports.delay(
                 email_address=admin.email, library_id=library.id
-            )
-
-            msg = (
-                f"An inventory and hold report request was received. Report processing can take a few minutes to "
-                f"finish depending on current server load. The completed reports will be sent to {admin.email}."
-            )
-
-            self.log.info(msg + f"(Task Request Id: {task.id})")
-            return Response(
-                json.dumps(dict(message=msg)),
-                HTTPStatus.ACCEPTED,
-                mimetype=MediaTypes.APPLICATION_JSON_MEDIA_TYPE,
             )
         except Exception as e:
             msg = f"failed to generate inventory report request: {e}"
             self.log.error(msg=msg, exc_info=e)
             self._db.rollback()
             return INTERNAL_SERVER_ERROR.detailed(detail=msg)
+
+        msg = (
+            f"An inventory and hold report request was received. Report processing can take a few minutes to "
+            f"finish depending on current server load. The completed reports will be sent to {admin.email}."
+        )
+        self.log.info(f"({msg} Task Request Id: {task.id})")
+        return Response(
+            json.dumps(dict(message=msg)),
+            HTTPStatus.ACCEPTED,
+            mimetype=MediaTypes.APPLICATION_JSON_MEDIA_TYPE,
+        )

--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -714,7 +714,9 @@ def diagnostics():
 )
 @api_spec.validate(
     resp=SpecResponse(
-        HTTP_200=InventoryReportInfo, HTTP_403=ProblemDetailModel, HTTP_404=None
+        HTTP_200=InventoryReportInfo,
+        HTTP_403=ProblemDetailModel,
+        HTTP_404=ProblemDetailModel,
     ),
     tags=["admin.inventory"],
 )

--- a/tests/manager/api/admin/controller/test_report.py
+++ b/tests/manager/api/admin/controller/test_report.py
@@ -13,6 +13,7 @@ from palace.manager.api.admin.model.inventory_report import (
 )
 from palace.manager.api.admin.problem_details import ADMIN_NOT_AUTHORIZED
 from palace.manager.api.overdrive import OverdriveAPI
+from palace.manager.api.problem_details import LIBRARY_NOT_FOUND
 from palace.manager.core.opds_import import OPDSAPI
 from palace.manager.sqlalchemy.model.admin import Admin, AdminRole
 from palace.manager.sqlalchemy.util import create
@@ -145,8 +146,9 @@ class TestReportController:
 
         # A library must be provided.
         with flask_app_fixture.test_request_context("/", admin=sysadmin, library=None):
-            admin_response_none = method()
-        assert admin_response_none.status_code == 404
+            with pytest.raises(ProblemDetailException) as exc:
+                method()
+        assert exc.value.problem_detail == LIBRARY_NOT_FOUND
 
     def test_inventory_report_info(
         self, db: DatabaseTransactionFixture, flask_app_fixture: FlaskAppFixture
@@ -209,8 +211,9 @@ class TestReportController:
 
         # A library must be provided.
         with flask_app_fixture.test_request_context("/", admin=sysadmin, library=None):
-            admin_response_none = controller.inventory_report_info()
-        assert admin_response_none.status_code == 404
+            with pytest.raises(ProblemDetailException) as exc:
+                controller.inventory_report_info()
+        assert exc.value.problem_detail == LIBRARY_NOT_FOUND
 
     @pytest.mark.parametrize(
         "protocol, settings, expect_collection",


### PR DESCRIPTION
## Description

- Ensures that the admin who requests an inventory report has the right to do so.
- Uses the same authorization mechanism for both report info and report generation requests.
- Adds new test to verify this.

## Motivation and Context

It was possible for an authenticated admin to request and receive the inventory reports of libraries for which they were not authorized.

[Jira [PP-1293](https://ebce-lyrasis.atlassian.net/browse/PP-1293)]

## How Has This Been Tested?

- Manually testing in local dev environment.
- All tests pass locally.
- [CI tests for associated feature branch](https://github.com/ThePalaceProject/circulation/actions/runs/9196344686/job/25294294815) pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1293]: https://ebce-lyrasis.atlassian.net/browse/PP-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ