### PR TITLE
Remove old update-search-index work coverage records (PP-1279)

### DIFF
--- a/alembic/versions/20240522_50746a3bd243_remove_update_search_index_work_.py
+++ b/alembic/versions/20240522_50746a3bd243_remove_update_search_index_work_.py
@@ -1,0 +1,26 @@
+"""Remove update-search-index work coverage records.
+
+Revision ID: 50746a3bd243
+Revises: f532186a3d48
+Create Date: 2024-05-22 19:08:51.390547+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "50746a3bd243"
+down_revision = "f532186a3d48"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Delete the coverage records with operation='update_search_index', since they are no longer used.
+    op.execute(
+        "DELETE FROM workcoveragerecords WHERE operation = 'update-search-index'"
+    )
+
+
+def downgrade() -> None:
+    # These records are unused, so there is no need to restore them.
+    pass

--- a/src/palace/manager/sqlalchemy/model/coverage.py
+++ b/src/palace/manager/sqlalchemy/model/coverage.py
@@ -619,7 +619,6 @@ class WorkCoverageRecord(Base, BaseCoverageRecord):
     CLASSIFY_OPERATION = "classify"
     SUMMARY_OPERATION = "summary"
     QUALITY_OPERATION = "quality"
-    UPDATE_SEARCH_INDEX_OPERATION = "update-search-index"
 
     id = Column(Integer, primary_key=True)
     work_id = Column(Integer, ForeignKey("works.id"), index=True)


### PR DESCRIPTION
## Description

🚨 This one shouldn't get merged until https://github.com/ThePalaceProject/circulation/pull/1849 goes into a release. I'll leave this in draft until its good to get merged.

## Motivation and Context

Just cleaning up old no longer used DB rows.

## How Has This Been Tested?

- Tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
