### PR TITLE
Fixes a bug in retrieving the user agent header.  For whatever reason…

### DIFF
--- a/src/palace/manager/service/analytics/analytics.py
+++ b/src/palace/manager/service/analytics/analytics.py
@@ -35,9 +35,13 @@ class Analytics(LoggerMixin):
         if not time:
             time = utc_now()
 
-        user_agent = (
-            flask.request.user_agent.string if flask.request.user_agent else None
-        )
+        user_agent: str | None = None
+        try:
+            user_agent = flask.request.user_agent.string
+            if user_agent == "":
+                user_agent = None
+        except Exception as e:
+            self.log.warning(f"Unable to resolve the user_agent: {repr(e)}")
 
         for provider in self.providers:
             provider.collect_event(

--- a/tests/manager/service/analytics/test_analytics.py
+++ b/tests/manager/service/analytics/test_analytics.py
@@ -1,8 +1,25 @@
+import datetime
+from collections.abc import Generator
 from unittest.mock import MagicMock
+
+import pytest
 
 from palace.manager.api.s3_analytics_provider import S3AnalyticsProvider
 from palace.manager.core.local_analytics_provider import LocalAnalyticsProvider
 from palace.manager.service.analytics.analytics import Analytics
+from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
+from tests.fixtures.api_controller import ControllerFixture
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.services import ServicesFixture
+
+
+@pytest.fixture(scope="function")
+def analytics_fixture(
+    db: DatabaseTransactionFixture, services_fixture: ServicesFixture
+) -> Generator[ControllerFixture, None, None]:
+    fixture = ControllerFixture(db, services_fixture)
+    with fixture.wired_container():
+        yield fixture
 
 
 class TestAnalytics:
@@ -31,3 +48,53 @@ class TestAnalytics:
         assert len(analytics.providers) == 2
         assert type(analytics.providers[0]) == LocalAnalyticsProvider
         assert type(analytics.providers[1]) == S3AnalyticsProvider
+
+    def test_user_agent_capture(
+        self,
+        analytics_fixture: ControllerFixture,
+    ):
+        db = analytics_fixture.db
+        edition = db.edition()
+        pool = db.licensepool(edition=edition)
+        library = db.default_library()
+
+        # user agent present
+        user_agent = "test_user_agent"
+        headers = {"User-Agent": user_agent}
+        analytics, provider = self.setup_analytics_mocks()
+        with analytics_fixture.request_context_with_library("/", headers=headers):
+            analytics.collect_event(library, pool, CirculationEvent.CM_CHECKOUT)
+            kwargs = provider.collect_event.call_args.kwargs
+            assert kwargs["user_agent"] == user_agent
+            args = provider.collect_event.call_args[0]
+            assert args[0] == library
+            assert args[1] == pool
+            assert args[2] == CirculationEvent.CM_CHECKOUT
+            assert isinstance(args[3], datetime.datetime)
+
+        # user agent empty
+        user_agent = ""
+        headers = {"User-Agent": user_agent}
+        analytics, provider = self.setup_analytics_mocks()
+        with analytics_fixture.request_context_with_library("/", headers=headers):
+            analytics.collect_event(library, pool, CirculationEvent.CM_CHECKOUT)
+            kwargs = provider.collect_event.call_args.kwargs
+            assert kwargs["user_agent"] is None
+
+        # no user agent header.
+        headers = {}
+        analytics, provider = self.setup_analytics_mocks()
+        with analytics_fixture.request_context_with_library("/", headers=headers):
+            analytics.collect_event(library, pool, CirculationEvent.CM_CHECKOUT)
+            assert provider.collect_event.call_args.kwargs["user_agent"] is None
+
+        # call outside of request context
+        analytics, provider = self.setup_analytics_mocks()
+        analytics.collect_event(library, pool, CirculationEvent.CM_CHECKOUT)
+        assert provider.collect_event.call_args.kwargs["user_agent"] is None
+
+    def setup_analytics_mocks(self):
+        provider = MagicMock()
+        analytics = Analytics()
+        analytics.providers.append(provider)
+        return analytics, provider


### PR DESCRIPTION
…, flask.request.user_agent is evaluating to False as the predicate of the if statement (possibly because it is a cached property) causing us not to capture the user agent value.

## Description
This fixes a bug in https://github.com/ThePalaceProject/circulation/pull/1859 which was not evident to me until was examining the user agent values on minotaur.  Initially I thought it has something to do with the headers not being passed to flask from uwsgi or nginx but it turned out to be another issue.  Since flask.request.user_agent is never None and flask.request.user_agent.string will return an empty string  if no header is set,  this change ensures that  None is passed to S3 Analytics if there is no value set.  The ETL process will be responsible for translating the null in to a default value.
<!--- Describe your changes -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
