### PR TITLE
Add type hints for the circulation loans controller

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,8 @@ module = [
     "palace.manager.api.axis",
     "palace.manager.api.circulation",
     "palace.manager.api.circulation_exceptions",
+    "palace.manager.api.controller.circulation_manager",
+    "palace.manager.api.controller.loan",
     "palace.manager.api.controller.marc",
     "palace.manager.api.discovery.*",
     "palace.manager.api.enki",

--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -426,7 +426,7 @@ class Axis360API(
     def checkout(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
     ) -> LoanInfo:
@@ -490,7 +490,7 @@ class Axis360API(
     def place_hold(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         hold_notification_email: str | None,
     ) -> HoldInfo:

--- a/src/palace/manager/api/bibliotheca.py
+++ b/src/palace/manager/api/bibliotheca.py
@@ -430,7 +430,7 @@ class BibliothecaAPI(
     def checkout(
         self,
         patron_obj: Patron,
-        patron_password: str,
+        patron_password: str | None,
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
     ) -> LoanInfo:

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -627,7 +627,7 @@ class BaseCirculationAPI(
 
     @classmethod
     def default_notification_email_address(
-        self, library_or_patron: Library | Patron, pin: str
+        self, library_or_patron: Library | Patron, pin: str | None
     ) -> str:
         """What email address should be used to notify this library's
         patrons of changes?
@@ -675,7 +675,7 @@ class BaseCirculationAPI(
     def checkout(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
     ) -> LoanInfo | HoldInfo:
@@ -714,7 +714,7 @@ class BaseCirculationAPI(
     def place_hold(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         notification_email_address: str | None,
     ) -> HoldInfo:
@@ -753,7 +753,7 @@ class PatronActivityCirculationAPI(
 
     @abstractmethod
     def patron_activity(
-        self, patron: Patron, pin: str
+        self, patron: Patron, pin: str | None
     ) -> Iterable[LoanInfo | HoldInfo]:
         """Return a patron's current checkouts and holds."""
         ...
@@ -774,7 +774,7 @@ class PatronActivityThread(Thread, LoggerMixin):
         api_cls: type[PatronActivityCirculationApiType],
         collection_id: int | None,
         patron_id: int | None,
-        pin: str,
+        pin: str | None,
     ) -> None:
         self.db = db
         self.api_cls = api_cls
@@ -979,9 +979,9 @@ class CirculationAPI(LoggerMixin):
     def borrow(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
-        delivery_mechanism: LicensePoolDeliveryMechanism,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
         hold_notification_email: str | None = None,
     ) -> tuple[Loan | None, Hold | None, bool]:
         """Either borrow a book or put it on hold. Don't worry about fulfilling
@@ -1076,7 +1076,7 @@ class CirculationAPI(LoggerMixin):
         # last looked.
         try:
             loan_info = api.checkout(
-                patron, pin, licensepool, delivery_mechanism=delivery_mechanism
+                patron, pin, licensepool, delivery_mechanism=delivery_mechanism  # type: ignore[arg-type]
             )
 
             if isinstance(loan_info, HoldInfo):
@@ -1522,7 +1522,7 @@ class CirculationAPI(LoggerMixin):
         message_prefix="patron_activity sync", log_level=LogLevel.debug, skip_start=True
     )
     def patron_activity(
-        self, patron: Patron, pin: str
+        self, patron: Patron, pin: str | None
     ) -> tuple[list[LoanInfo], list[HoldInfo], bool]:
         """Return a record of the patron's current activity
         vis-a-vis all relevant external loan sources.
@@ -1586,7 +1586,7 @@ class CirculationAPI(LoggerMixin):
         )
 
     def sync_bookshelf(
-        self, patron: Patron, pin: str, force: bool = False
+        self, patron: Patron, pin: str | None, force: bool = False
     ) -> tuple[list[Loan] | Query[Loan], list[Hold] | Query[Hold]]:
         """Sync our internal model of a patron's bookshelf with any external
         vendors that provide books to the patron's library.

--- a/src/palace/manager/api/controller/base.py
+++ b/src/palace/manager/api/controller/base.py
@@ -50,7 +50,7 @@ class BaseCirculationManagerController(LoggerMixin):
 
         return flask.request.patron
 
-    def authenticated_patron_from_request(self):
+    def authenticated_patron_from_request(self) -> ProblemDetail | Patron | Response:
         """Try to authenticate a patron for the incoming request.
 
         When this method returns, flask.request.patron will
@@ -61,7 +61,7 @@ class BaseCirculationManagerController(LoggerMixin):
           authentication, a ProblemDetail.
         """
         # Start off by assuming authentication will not work.
-        flask.request.patron = None
+        flask.request.patron = None  # type: ignore[attr-defined]
 
         auth = self.authorization_header()
 
@@ -80,7 +80,7 @@ class BaseCirculationManagerController(LoggerMixin):
             # to identify anyone in particular.
             return self.authenticate()
         if isinstance(patron, Patron):
-            flask.request.patron = patron
+            flask.request.patron = patron  # type: ignore[attr-defined]
         return patron
 
     def authenticated_patron(self, authorization_header: Authorization):
@@ -102,7 +102,7 @@ class BaseCirculationManagerController(LoggerMixin):
 
         return patron
 
-    def authenticate(self):
+    def authenticate(self) -> Response:
         """Sends a 401 response that demands authentication."""
         headers = self.manager.auth.create_authentication_headers()
         data = self.manager.authentication_for_opds_document

--- a/src/palace/manager/api/enki.py
+++ b/src/palace/manager/api/enki.py
@@ -401,7 +401,7 @@ class EnkiAPI(
     def checkout(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
     ) -> LoanInfo:
@@ -600,7 +600,7 @@ class EnkiAPI(
     def place_hold(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         notification_email_address: str | None,
     ) -> HoldInfo:

--- a/src/palace/manager/api/odl.py
+++ b/src/palace/manager/api/odl.py
@@ -424,7 +424,7 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
     def checkout(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
     ) -> LoanInfo:
@@ -795,7 +795,7 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
     def place_hold(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         notification_email_address: str | None,
     ) -> HoldInfo:
@@ -869,7 +869,9 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
         self.update_licensepool(licensepool)
         return True
 
-    def patron_activity(self, patron: Patron, pin: str) -> list[LoanInfo | HoldInfo]:
+    def patron_activity(
+        self, patron: Patron, pin: str | None
+    ) -> list[LoanInfo | HoldInfo]:
         """Look up non-expired loans for this collection in the database."""
         _db = Session.object_session(patron)
         loans = (

--- a/src/palace/manager/api/opds_for_distributors.py
+++ b/src/palace/manager/api/opds_for_distributors.py
@@ -272,7 +272,7 @@ class OPDSForDistributorsAPI(
     def checkout(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
     ) -> LoanInfo:
@@ -356,7 +356,9 @@ class OPDSForDistributorsAPI(
             content_expires=credential.expires,
         )
 
-    def patron_activity(self, patron: Patron, pin: str) -> list[LoanInfo | HoldInfo]:
+    def patron_activity(
+        self, patron: Patron, pin: str | None
+    ) -> list[LoanInfo | HoldInfo]:
         # Look up loans for this collection in the database.
         _db = Session.object_session(patron)
         loans = (
@@ -385,7 +387,7 @@ class OPDSForDistributorsAPI(
     def place_hold(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         notification_email_address: str | None,
     ) -> HoldInfo:

--- a/src/palace/manager/api/overdrive.py
+++ b/src/palace/manager/api/overdrive.py
@@ -991,7 +991,7 @@ class OverdriveAPI(
     def checkout(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
     ) -> LoanInfo:

--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -439,7 +439,7 @@ def revoke_loan_or_hold(license_pool_id):
     return app.manager.loans.revoke(license_pool_id)
 
 
-@library_route("/loans/<identifier_type>/<path:identifier>", methods=["GET", "DELETE"])
+@library_route("/loans/<identifier_type>/<path:identifier>", methods=["GET"])
 @has_library
 @allows_patron_web
 @requires_auth

--- a/src/palace/manager/core/opds_import.py
+++ b/src/palace/manager/core/opds_import.py
@@ -237,7 +237,7 @@ class BaseOPDSAPI(
     def place_hold(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         notification_email_address: str | None,
     ) -> HoldInfo:
@@ -354,7 +354,7 @@ class BaseOPDSAPI(
     def checkout(
         self,
         patron: Patron,
-        pin: str,
+        pin: str | None,
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
     ) -> LoanInfo:

--- a/src/palace/manager/feed/acquisition.py
+++ b/src/palace/manager/feed/acquisition.py
@@ -523,7 +523,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
     def single_entry_loans_feed(
         cls,
         circulation: Any,
-        item: LicensePool | Loan,
+        item: LicensePool | Loan | Hold | None,
         annotator: LibraryAnnotator | None = None,
         fulfillment: FulfillmentInfo | None = None,
         **response_kwargs: Any,

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -268,7 +268,7 @@ class LicensePool(Base):
     licenses_owned: int = Column(Integer, default=0, index=True)
     licenses_available: int = Column(Integer, default=0, index=True)
     licenses_reserved: int = Column(Integer, default=0)
-    patrons_in_hold_queue = Column(Integer, default=0)
+    patrons_in_hold_queue: int = Column(Integer, default=0)
     should_track_playtime = Column(Boolean, default=False, nullable=False)
 
     # This lets us cache the work of figuring out the best open access

--- a/tests/manager/api/admin/controller/test_custom_lists.py
+++ b/tests/manager/api/admin/controller/test_custom_lists.py
@@ -778,12 +778,6 @@ class TestCustomListsController:
         list.add_entry(w1)
         list.add_entry(w2)
 
-        # Whenever the mocked search engine is asked how many
-        # works are in a Lane, it will say there are two.
-        admin_librarian_fixture.ctrl.controller.search_engine.docs = dict(
-            id1="doc1", id2="doc2"
-        )
-
         # Create a second CustomList, from another data source,
         # containing a single work.
         nyt = DataSource.lookup(admin_librarian_fixture.ctrl.db.session, DataSource.NYT)

--- a/tests/manager/api/admin/controller/test_lanes.py
+++ b/tests/manager/api/admin/controller/test_lanes.py
@@ -329,9 +329,6 @@ class TestLanesController:
         # search engine to update lane.size, and it will think there
         # are two works in the lane.
         assert 0 == lane.size
-        alm_fixture.ctrl.controller.search_engine.docs = dict(
-            id1="value1", id2="value2"
-        )
 
         with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
             flask.request.form = ImmutableMultiDict(

--- a/tests/manager/api/admin/controller/test_work_editor.py
+++ b/tests/manager/api/admin/controller/test_work_editor.py
@@ -930,10 +930,6 @@ class TestWorkController:
         work = work_fixture.ctrl.db.work(with_license_pool=True)
         identifier = work.presentation_edition.primary_identifier
 
-        # Whenever the mocked search engine is asked how many
-        # works are in a Lane, it will say there are two.
-        work_fixture.ctrl.controller.search_engine.docs = dict(id1="doc1", id2="doc2")
-
         # Create a Lane that depends on this CustomList for its membership.
         lane = work_fixture.ctrl.db.lane()
         lane.customlists.append(list)
@@ -954,7 +950,6 @@ class TestWorkController:
             assert True == work.custom_list_entries[0].featured
 
         # Now remove the work from the list.
-        work_fixture.ctrl.controller.search_engine.docs = dict(id1="doc1")
         with work_fixture.request_context_with_library_and_admin("/", method="POST"):
             flask.request.form = ImmutableMultiDict(
                 [

--- a/tests/manager/api/controller/test_annotation.py
+++ b/tests/manager/api/controller/test_annotation.py
@@ -6,7 +6,7 @@ from wsgiref.handlers import format_date_time
 import pytest
 
 from palace.manager.api.annotations import AnnotationWriter
-from palace.manager.sqlalchemy.model.patron import Annotation
+from palace.manager.sqlalchemy.model.patron import Annotation, Patron
 from palace.manager.sqlalchemy.util import create
 from palace.manager.util.datetime_helpers import utc_now
 from tests.fixtures.api_controller import CirculationControllerFixture
@@ -162,6 +162,7 @@ class TestAnnotationController:
             patron = (
                 annotation_fixture.manager.annotations.authenticated_patron_from_request()
             )
+            assert isinstance(patron, Patron)
             patron.synchronize_annotations = True
             # The patron doesn't have any annotations yet.
             annotations = (

--- a/tests/manager/api/controller/test_base.py
+++ b/tests/manager/api/controller/test_base.py
@@ -4,6 +4,7 @@ import random
 from unittest.mock import MagicMock, patch
 
 import flask
+from flask import Response
 from werkzeug.datastructures import Authorization
 
 from palace.manager.api.circulation_exceptions import RemoteInitiatedServerError
@@ -27,8 +28,6 @@ from palace.manager.sqlalchemy.model.resource import Representation
 from palace.manager.sqlalchemy.util import create, tuple_to_numericrange
 from palace.manager.util.datetime_helpers import datetime_utc, utc_now
 from palace.manager.util.problem_detail import ProblemDetail
-
-# TODO: we can drop this when we drop support for Python 3.6 and 3.7
 from tests.fixtures.api_controller import CirculationControllerFixture
 from tests.fixtures.library import LibraryFixture
 
@@ -96,7 +95,7 @@ class TestBaseController:
                 result = (
                     circulation_fixture.controller.authenticated_patron_from_request()
                 )
-                assert isinstance(result, ProblemDetail)
+                assert isinstance(result, Response)
                 assert 401 == result.status_code
                 assert None == flask.request.patron  # type: ignore
 
@@ -131,7 +130,7 @@ class TestBaseController:
                 result = (
                     circulation_fixture.controller.authenticated_patron_from_request()
                 )
-                assert isinstance(result, ProblemDetail)
+                assert isinstance(result, Response)
                 assert 401 == result.status_code
                 assert None == flask.request.patron  # type: ignore
 

--- a/tests/manager/api/controller/test_base.py
+++ b/tests/manager/api/controller/test_base.py
@@ -96,6 +96,7 @@ class TestBaseController:
                 result = (
                     circulation_fixture.controller.authenticated_patron_from_request()
                 )
+                assert isinstance(result, ProblemDetail)
                 assert 401 == result.status_code
                 assert None == flask.request.patron  # type: ignore
 
@@ -130,6 +131,7 @@ class TestBaseController:
                 result = (
                     circulation_fixture.controller.authenticated_patron_from_request()
                 )
+                assert isinstance(result, ProblemDetail)
                 assert 401 == result.status_code
                 assert None == flask.request.patron  # type: ignore
 
@@ -214,6 +216,7 @@ class TestBaseController:
             response = circulation_fixture.controller.handle_conditional_request(
                 now_datetime
             )
+            assert response is not None
             assert 304 == response.status_code
 
         # Try with a few specific values that comply to a greater or lesser
@@ -230,6 +233,7 @@ class TestBaseController:
                 response = circulation_fixture.controller.handle_conditional_request(
                     very_old
                 )
+                assert response is not None
                 assert 304 == response.status_code
 
         # All remaining test cases are failures: for whatever reason,
@@ -318,6 +322,7 @@ class TestBaseController:
         loaded = circulation_fixture.controller.load_licensepools(
             circulation_fixture.db.default_library(), i1.type, i1.identifier
         )
+        assert not isinstance(loaded, ProblemDetail)
 
         # Two LicensePools were loaded: the LicensePool for the first
         # Identifier in Collection 1, and the LicensePool for the same
@@ -342,6 +347,7 @@ class TestBaseController:
             "bad identifier type",
             i1.identifier,
         )
+        assert isinstance(problem_detail, ProblemDetail)
         assert NO_LICENSES.uri == problem_detail.uri
         expect = (
             "The item you're asking about (bad identifier type/%s) isn't in this collection."
@@ -356,6 +362,7 @@ class TestBaseController:
             lp5.identifier.type,
             lp5.identifier.identifier,
         )
+        assert isinstance(problem_detail, ProblemDetail)
         assert NO_LICENSES.uri == problem_detail.uri
 
     def test_load_work(self, circulation_fixture: CirculationControllerFixture):
@@ -428,6 +435,7 @@ class TestBaseController:
         delivery = circulation_fixture.controller.load_licensepooldelivery(
             licensepool, lpdm.delivery_mechanism.id
         )
+        assert not isinstance(delivery, ProblemDetail)
 
         # We don't know which LicensePoolDeliveryMechanism this is,
         # but we know it's one of the matches.
@@ -441,6 +449,7 @@ class TestBaseController:
         problem_detail = circulation_fixture.controller.load_licensepooldelivery(
             adobe_licensepool, lpdm.delivery_mechanism.id
         )
+        assert isinstance(problem_detail, ProblemDetail)
         assert BAD_DELIVERY_MECHANISM.uri == problem_detail.uri
 
     def test_apply_borrowing_policy_succeeds_for_unlimited_access_books(
@@ -500,6 +509,7 @@ class TestBaseController:
             problem = circulation_fixture.controller.apply_borrowing_policy(
                 patron, pool
             )
+            assert isinstance(problem, ProblemDetail)
             assert FORBIDDEN_BY_POLICY.uri == problem.uri
 
     def test_apply_borrowing_policy_for_age_inappropriate_book(
@@ -539,6 +549,7 @@ class TestBaseController:
             problem = circulation_fixture.controller.apply_borrowing_policy(
                 patron, pool
             )
+            assert isinstance(problem, ProblemDetail)
             assert FORBIDDEN_BY_POLICY.uri == problem.uri
 
             # If the lane is expanded to allow the book's age range, there's
@@ -644,7 +655,7 @@ class TestBaseController:
             # If a lane cannot be looked up by ID, a problem detail
             # is returned.
             for bad_id in ("nosuchlane", -1):
-                not_found = circulation_fixture.controller.load_lane(bad_id)
+                not_found = circulation_fixture.controller.load_lane(bad_id)  # type: ignore[arg-type]
                 assert isinstance(not_found, ProblemDetail)
                 assert not_found.uri == NO_SUCH_LANE.uri
                 assert (

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -698,7 +698,7 @@ class TestLoanController:
             response = loan_fixture.manager.loans.borrow(
                 pool.identifier.type, pool.identifier.identifier
             )
-            assert isinstance(response, wkResponse)
+            assert isinstance(response, ProblemDetail)
             assert 404 == response.status_code
             assert NO_LICENSES == response
 

--- a/tests/manager/api/controller/test_multilib.py
+++ b/tests/manager/api/controller/test_multilib.py
@@ -1,5 +1,6 @@
 from palace.manager.core.opds_import import OPDSAPI
 from palace.manager.sqlalchemy.model.collection import Collection
+from palace.manager.sqlalchemy.model.patron import Patron
 from tests.fixtures.api_controller import (
     CirculationControllerFixture,
     ControllerFixtureSetupOverrides,
@@ -45,6 +46,7 @@ class TestMultipleLibraries:
                 patron = (
                     controller_fixture.manager.loans.authenticated_patron_from_request()
                 )
+                assert isinstance(patron, Patron)
                 assert library == patron.library
                 response = controller_fixture.manager.index_controller()
                 assert (

--- a/tests/manager/api/controller/test_opds_feed.py
+++ b/tests/manager/api/controller/test_opds_feed.py
@@ -23,6 +23,7 @@ from palace.manager.sqlalchemy.model.lane import (
     WorkList,
 )
 from palace.manager.util.flask_util import Response
+from palace.manager.util.problem_detail import ProblemDetail
 from tests.fixtures.api_controller import CirculationControllerFixture, WorkSpec
 from tests.fixtures.library import LibraryFixture
 
@@ -319,6 +320,7 @@ class TestOPDSFeedController:
             # Thus, when we pass lane=None into groups(), we're asking for a
             # feed for the sole top-level lane, "World Languages".
             expect_lane = circulation_fixture.manager.opds_feeds.load_lane(None)
+            assert not isinstance(expect_lane, ProblemDetail)
             assert "World Languages" == expect_lane.display_name
 
             # Ask for that feed.

--- a/tests/manager/api/controller/test_profile.py
+++ b/tests/manager/api/controller/test_profile.py
@@ -6,7 +6,7 @@ import pytest
 
 from palace.manager.api.authenticator import CirculationPatronProfileStorage
 from palace.manager.core.user_profile import ProfileController, ProfileStorage
-from palace.manager.sqlalchemy.model.patron import Annotation
+from palace.manager.sqlalchemy.model.patron import Annotation, Patron
 from palace.manager.util.problem_detail import ProblemDetail
 from tests.fixtures.api_controller import ControllerFixture
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -55,6 +55,7 @@ class TestProfileController:
             "/", method="GET", headers=profile_fixture.auth
         ):
             patron = profile_fixture.controller.authenticated_patron_from_request()
+            assert isinstance(patron, Patron)
             patron.synchronize_annotations = True
             response = profile_fixture.manager.profiles.protocol()
             assert "200 OK" == response.status
@@ -79,6 +80,7 @@ class TestProfileController:
             request_patron = (
                 profile_fixture.controller.authenticated_patron_from_request()
             )
+            assert isinstance(request_patron, Patron)
             assert request_patron.synchronize_annotations is None
 
             # By sending a PUT request...

--- a/tests/manager/api/test_routes.py
+++ b/tests/manager/api/test_routes.py
@@ -188,11 +188,7 @@ class TestLoansController:
             url, fixture.controller.revoke, "<license_pool_id>"  # type: ignore[union-attr]
         )
 
-        # TODO: DELETE shouldn't be in here, but "DELETE
-        # /loans/<license_pool_id>/revoke" is interpreted as an attempt
-        # to match /loans/<identifier_type>/<path:identifier>, the
-        # method tested directly below, which does support DELETE.
-        fixture.assert_supported_methods(url, "GET", "PUT", "DELETE")
+        fixture.assert_supported_methods(url, "GET", "PUT")
 
     def test_loan_or_hold_detail(self, fixture: RouteTestFixture):
         url = "/loans/<identifier_type>/<identifier>"
@@ -203,7 +199,7 @@ class TestLoansController:
             "<identifier>",
             authenticated=True,
         )
-        fixture.assert_supported_methods(url, "GET", "DELETE")
+        fixture.assert_supported_methods(url, "GET")
 
 
 class TestAnnotationsController:

--- a/tests/manager/feed/test_opds_acquisition_feed.py
+++ b/tests/manager/feed/test_opds_acquisition_feed.py
@@ -936,7 +936,7 @@ class TestOPDSAcquisitionFeed:
     def test_single_entry_loans_feed_errors(self, db: DatabaseTransactionFixture):
         with pytest.raises(ValueError) as raised:
             # Mandatory loans item was missing
-            OPDSAcquisitionFeed.single_entry_loans_feed(None, None)  # type: ignore[arg-type]
+            OPDSAcquisitionFeed.single_entry_loans_feed(None, None)
         assert str(raised.value) == "Argument 'item' must be non-empty"
 
         with pytest.raises(ValueError) as raised:


### PR DESCRIPTION
## Description

Add type hints for `palace.manager.api.controller.circulation_manager` and `palace.manager.api.controller.loan`.

## Motivation and Context

As part of the refactoring I'm doing to the loans controller, having some type hints makes things a lot easier to reason about.

## How Has This Been Tested?

Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
