### PR TITLE
Ensure configuration up-to-date on each request.

### DIFF
--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -16,6 +16,11 @@ from palace.manager.sqlalchemy.hassessioncache import HasSessionCache
 from palace.manager.util.problem_detail import ProblemDetail
 
 
+@app.before_request
+def before_request():
+    app.manager.reload_settings_if_changed()
+
+
 @app.after_request
 def print_cache(response):
     if hasattr(app, "_db") and HasSessionCache.CACHE_ATTRIBUTE in app._db.info:

--- a/tests/manager/api/controller/test_base.py
+++ b/tests/manager/api/controller/test_base.py
@@ -578,6 +578,10 @@ class TestBaseController:
             assert expect_default == value
             assert expect_default == flask.request.library  # type: ignore
 
+    # TODO: Remove this test. It's just prove that it passes once in the PR.
+    #  The `reload_settings_if_changed` call has been moved from the relative
+    #  obscurity of `BaseCirculationManagerController.library_for_request`
+    #  into a Flask `before_request` function.
     def test_library_for_request_reloads_settings_if_necessary(
         self, circulation_fixture: CirculationControllerFixture
     ):
@@ -588,6 +592,8 @@ class TestBaseController:
         # will fail.
         assert new_name not in circulation_fixture.manager.auth.library_authenticators
         with circulation_fixture.app.test_request_context("/"):
+            # Ensure that any `before_request` handlers are run, as in real request.
+            circulation_fixture.app.preprocess_request()
             problem = circulation_fixture.controller.library_for_request(new_name)
             assert LIBRARY_NOT_FOUND == problem
 
@@ -607,6 +613,8 @@ class TestBaseController:
         # But the first time we make a request that calls the library
         # by its new name, those settings are reloaded.
         with circulation_fixture.app.test_request_context("/"):
+            # Ensure that any `before_request` handlers are run, as in real request.
+            circulation_fixture.app.preprocess_request()
             value = circulation_fixture.controller.library_for_request(new_name)
             assert circulation_fixture.db.default_library() == value
 

--- a/tests/manager/api/test_routes.py
+++ b/tests/manager/api/test_routes.py
@@ -1,6 +1,12 @@
+from unittest.mock import patch
+
 import pytest
 
 from palace.manager.api import routes
+from palace.manager.api.problem_details import LIBRARY_NOT_FOUND
+from palace.manager.sqlalchemy.listeners import site_configuration_has_changed
+from palace.manager.sqlalchemy.model.library import Library
+from tests.fixtures.api_controller import ControllerFixture
 from tests.fixtures.api_routes import RouteTestFixture
 
 
@@ -8,6 +14,61 @@ class TestAppConfiguration:
     # Test the configuration of the real Flask app.
     def test_configuration(self):
         assert False == routes.app.url_map.merge_slashes
+
+
+class TestAdminRequestLifecycle:
+    def test_requests_check_if_settings_need_reload(
+        self, controller_fixture: ControllerFixture
+    ):
+        with patch(
+            "palace.manager.api.circulation_manager.CirculationManager.reload_settings_if_changed"
+        ) as mock_reload:
+            mock_reload.assert_not_called()
+            with controller_fixture.app.test_request_context("/"):
+                mock_reload.assert_not_called()
+                controller_fixture.app.preprocess_request()
+                mock_reload.assert_called()
+
+    def test_request_reloads_settings_if_necessary(
+        self, controller_fixture: ControllerFixture
+    ):
+        # We're about to change the shortname of the default library.
+        new_name = "newname" + controller_fixture.db.fresh_str()
+
+        # Before we make the change, a request to the library's new name
+        # will fail.
+        assert new_name not in controller_fixture.manager.auth.library_authenticators
+        with controller_fixture.app.test_request_context("/"):
+            # Ensure that any `before_request` handlers are run, as in real request.
+            controller_fixture.app.preprocess_request()
+            problem = controller_fixture.controller.library_for_request(new_name)
+            assert LIBRARY_NOT_FOUND == problem
+
+        # Make the change.
+        controller_fixture.db.default_library().short_name = new_name
+        controller_fixture.db.session.commit()
+
+        # Bypass the 1-second cooldown and make sure the app knows
+        # the configuration has actually changed.
+        site_configuration_has_changed(controller_fixture.db.session, cooldown=0)
+
+        # Just making the change and calling `site_configuration_has_changed`
+        # was not enough to update the CirculationManager's settings.
+        assert new_name not in controller_fixture.manager.auth.library_authenticators
+
+        # But the next time we make a request -- any request -- the
+        # configuration will be up-to-date.
+        with controller_fixture.app.test_request_context("/"):
+            # Ensure that any `before_request` handlers are run, as in real request.
+            controller_fixture.app.preprocess_request()
+
+            # An assertion that would have failed before works now.
+            assert new_name in controller_fixture.manager.auth.library_authenticators
+
+            #
+            new_library = controller_fixture.controller.library_for_request(new_name)
+            assert isinstance(new_library, Library)
+            assert new_library.short_name == new_name
 
 
 class TestIndex:


### PR DESCRIPTION
## Description

Moves the check to reload configuration if it has changed to a Flask `before_request` lifecycle function.

## Motivation and Context

I happened to notice the location of this call when working on something else. It seemed that is should be moved to a more "expected" place in the codebase for a couple of reasons:
- The check was being performed in only a subset of cases. It would probably be triggered on a fairly regular basis, but there might be some weird edge cases in which it could lead to unexpected and hard to reproduce behavior. 
- It was in an unexpected place.

## How Has This Been Tested?

- Added new tests.
- CI tests for associated feature branch pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
