### PR TITLE
Fix issue with monitoring queue stats (PP-1312)

### DIFF
--- a/src/palace/manager/celery/monitoring.py
+++ b/src/palace/manager/celery/monitoring.py
@@ -175,7 +175,14 @@ class Cloudwatch(Polaroid):
             QueueStats,
             {queue.name: QueueStats() for queue in self.app.conf.get("task_queues")},
         )
-        self.tasks: defaultdict[str, TaskStats] = defaultdict(TaskStats)
+        self.tasks: defaultdict[str, TaskStats] = defaultdict(
+            TaskStats,
+            {
+                task: TaskStats()
+                for task in self.app.tasks.keys()
+                if not self.is_celery_task(task)
+            },
+        )
 
     @staticmethod
     def is_celery_task(task_name: str) -> bool:

--- a/src/palace/manager/celery/monitoring.py
+++ b/src/palace/manager/celery/monitoring.py
@@ -175,7 +175,7 @@ class Cloudwatch(Polaroid):
             QueueStats,
             {queue.name: QueueStats() for queue in self.app.conf.get("task_queues")},
         )
-        self.tasks = defaultdict(TaskStats)
+        self.tasks: defaultdict[str, TaskStats] = defaultdict(TaskStats)
 
     @staticmethod
     def is_celery_task(task_name: str) -> bool:
@@ -190,12 +190,15 @@ class Cloudwatch(Polaroid):
             ]
         )
 
+    def reset_tasks(self) -> None:
+        for task in self.tasks.values():
+            task.reset()
+
     def on_shutter(self, state: State) -> None:
         timestamp = utc_now()
 
         # Reset the task stats for each snapshot
-        for task in self.tasks.values():
-            task.reset()
+        self.reset_tasks()
 
         for task in state.tasks.values():
             # Update task stats for each task

--- a/tests/manager/celery/test_monitoring.py
+++ b/tests/manager/celery/test_monitoring.py
@@ -266,7 +266,7 @@ class TestCloudwatch:
         }
         assert time.isoformat() == "2021-01-01T00:00:00+00:00"
 
-        # We can also handle the case where we see a task with an unknown queue.
+        # We can also handle the case where we see a task with an unknown queue or unknown name.
         cloudwatch_camera.state.tasks = cloudwatch_camera.task_list(
             [
                 cloudwatch_camera.mock_task(
@@ -275,6 +275,14 @@ class TestCloudwatch:
                     started=False,
                     succeeded=False,
                     uuid="uuid5",
+                    runtime=3.0,
+                ),
+                cloudwatch_camera.mock_task(
+                    "unknown_task",
+                    "queue1",
+                    failed=True,
+                    succeeded=False,
+                    uuid="uuid6",
                 ),
             ]
         )
@@ -283,6 +291,7 @@ class TestCloudwatch:
         assert tasks == {
             "task1": TaskStats(),
             "task2": TaskStats(),
+            "unknown_task": TaskStats(failed=1),
         }
         assert queues == {
             "queue1": QueueStats(),
@@ -295,7 +304,7 @@ class TestCloudwatch:
         cloudwatch_camera.state.tasks = cloudwatch_camera.task_list(
             [
                 cloudwatch_camera.mock_task(
-                    None, routing_key="unknown_queue", started=True, uuid="uuid6"
+                    None, routing_key="unknown_queue", started=True, uuid="uuid7"
                 ),
                 cloudwatch_camera.mock_task(None, None, started=True, uuid="uuid5"),
             ]
@@ -305,6 +314,7 @@ class TestCloudwatch:
         assert tasks == {
             "task1": TaskStats(),
             "task2": TaskStats(),
+            "unknown_task": TaskStats(),
         }
         assert queues == {
             "queue1": QueueStats(),
@@ -315,7 +325,7 @@ class TestCloudwatch:
         # We log the information about tasks with no name or routing key.
         no_name_warning_1, no_name_warning_2, no_routing_key_warning = caplog.messages
         assert (
-            "Task has no name. [routing_key]:unknown_queue, [sent]:True, [started]:True, [uuid]:uuid6."
+            "Task has no name. [routing_key]:unknown_queue, [sent]:True, [started]:True, [uuid]:uuid7."
             in no_name_warning_1
         )
         assert (

--- a/tests/manager/celery/test_monitoring.py
+++ b/tests/manager/celery/test_monitoring.py
@@ -304,7 +304,10 @@ class TestCloudwatch:
         cloudwatch_camera.state.tasks = cloudwatch_camera.task_list(
             [
                 cloudwatch_camera.mock_task(
-                    None, routing_key="unknown_queue", started=True, uuid="uuid7"
+                    None, "unknown_queue", started=True, uuid="uuid7"
+                ),
+                cloudwatch_camera.mock_task(
+                    "task2", None, started=False, succeeded=False, uuid="uuid8"
                 ),
                 cloudwatch_camera.mock_task(None, None, started=True, uuid="uuid5"),
             ]
@@ -323,10 +326,19 @@ class TestCloudwatch:
         }
 
         # We log the information about tasks with no name or routing key.
-        no_name_warning_1, no_name_warning_2, no_routing_key_warning = caplog.messages
+        (
+            no_name_warning_1,
+            no_routing_key_warning_1,
+            no_name_warning_2,
+            no_routing_key_warning_2,
+        ) = caplog.messages
         assert (
             "Task has no name. [routing_key]:unknown_queue, [sent]:True, [started]:True, [uuid]:uuid7."
             in no_name_warning_1
+        )
+        assert (
+            "Task has no routing_key. [name]:task2, [sent]:True, [started]:False, [uuid]:uuid8."
+            in no_routing_key_warning_1
         )
         assert (
             "Task has no name. [sent]:True, [started]:True, [uuid]:uuid5."
@@ -334,7 +346,7 @@ class TestCloudwatch:
         )
         assert (
             "Task has no routing_key. [sent]:True, [started]:True, [uuid]:uuid5."
-            in no_routing_key_warning
+            in no_routing_key_warning_2
         )
 
     def test_publish(


### PR DESCRIPTION
## Description

Update our metrics agent to better handle tasks that do not have a routing key. This also adds more information when there is an error to the logs, so that we have more info if we continue to have issues.

## Motivation and Context

Because of the way Celery tracks tasks, its possible for our monitor to get a task without `routing_key` when the task is complete. This happens if a task is started in one snapshot and completed in another, which is a common case when there are a lot of tasks in the queue. 

I'm not sure that this has solved the issue, because its a hard one to reproduce locally, but the changes here should help and give more info in the logs if we do continue to see issues. 

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
