### PR TITLE
[PP-978] Add work suppression for library api calls.

### DIFF
--- a/src/palace/manager/api/admin/controller/work_editor.py
+++ b/src/palace/manager/api/admin/controller/work_editor.py
@@ -367,13 +367,14 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
         return Response("", 200)
 
-    def suppress(self, identifier_type, identifier):
+    def suppress(self, identifier_type, identifier) -> Response | ProblemDetail:
         """Suppress the license pool associated with a book."""
-        self.require_library_manager(flask.request.library)
+        library = flask.request.library  # type: ignore
+        self.require_library_manager(library)
 
         # Turn source + identifier into a LicensePool
         pools = self.load_licensepools(
-            flask.request.library, identifier_type, identifier
+            flask.request.library, identifier_type, identifier  # type: ignore
         )
         if isinstance(pools, ProblemDetail):
             # Something went wrong.
@@ -386,19 +387,18 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
             pool.suppressed = True
         return Response("", 200)
 
-    def unsuppress(self, identifier_type, identifier):
+    def unsuppress(self, identifier_type, identifier) -> Response | ProblemDetail:
         """Unsuppress all license pools associated with a book.
 
         TODO: This will need to be revisited when we distinguish
         between complaints about a work and complaints about a
         LicensePoool.
         """
-        self.require_library_manager(flask.request.library)
+        library = flask.request.library  # type: ignore
+        self.require_library_manager(library)
 
         # Turn source + identifier into a group of LicensePools
-        pools = self.load_licensepools(
-            flask.request.library, identifier_type, identifier
-        )
+        pools = self.load_licensepools(library, identifier_type, identifier)
         if isinstance(pools, ProblemDetail):
             # Something went wrong.
             return pools
@@ -408,7 +408,9 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
             pool.suppressed = False
         return Response("", 200)
 
-    def suppress_for_library(self, identifier_type: str, identifier: str):
+    def suppress_for_library(
+        self, identifier_type: str, identifier: str
+    ) -> Response | ProblemDetail:
         """Suppress a book at the level of a library."""
 
         library = flask.request.library  # type: ignore
@@ -430,7 +432,9 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
         return Response("", 200)
 
-    def unsuppress_for_library(self, identifier_type: str, identifier: str):
+    def unsuppress_for_library(
+        self, identifier_type: str, identifier: str
+    ) -> Response | ProblemDetail:
         """Unsuppress book at the level of a library"""
 
         library = flask.request.library  # type: ignore

--- a/src/palace/manager/api/admin/controller/work_editor.py
+++ b/src/palace/manager/api/admin/controller/work_editor.py
@@ -23,14 +23,16 @@ from palace.manager.api.admin.problem_details import (
 from palace.manager.api.controller.circulation_manager import (
     CirculationManagerController,
 )
-from palace.manager.api.problem_details import REMOTE_INTEGRATION_FAILED
+from palace.manager.api.problem_details import (
+    LIBRARY_NOT_FOUND,
+    REMOTE_INTEGRATION_FAILED,
+)
 from palace.manager.core.classifier import (
     NO_NUMBER,
     NO_VALUE,
     SimplifiedGenreClassifier,
     genres,
 )
-from palace.manager.core.problem_details import INVALID_INPUT
 from palace.manager.feed.acquisition import OPDSAcquisitionFeed
 from palace.manager.feed.annotator.admin import AdminAnnotator
 from palace.manager.sqlalchemy.model.classification import (
@@ -738,6 +740,6 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
             return Response(str(_("Success")), 200)
 
     def no_library_response(self) -> ProblemDetail:
-        return INVALID_INPUT.detailed(
+        return LIBRARY_NOT_FOUND.detailed(
             "A library must be specified in the request. No library specified."
         )

--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -198,9 +198,9 @@ def edit(identifier_type, identifier):
 
 
 @library_route(
-    "/admin/works/<identifier_type>/<path:identifier>/suppress", methods=["POST"]
+    "/admin/works/<identifier_type>/<path:identifier>/suppression", methods=["POST"]
 )
-@has_library
+@allows_library
 @returns_problem_detail
 @requires_admin
 @requires_csrf_token
@@ -209,42 +209,38 @@ def suppress(identifier_type, identifier):
 
 
 @library_route(
-    "/admin/works/<identifier_type>/<path:identifier>/unsuppress", methods=["POST"]
+    "/admin/works/<identifier_type>/<path:identifier>/suppression", methods=["DELETe"]
 )
-@has_library
+@allows_library
 @returns_problem_detail
 @requires_admin
 @requires_csrf_token
-def unsuppress(identifier_type, identifier):
+def unsurpress(identifier_type, identifier):
     return app.manager.admin_work_controller.unsuppress(identifier_type, identifier)
 
 
+@DeprecationWarning
 @library_route(
-    "/admin/works/<identifier_type>/<path:identifier>/suppress-for-library",
-    methods=["POST"],
+    "/admin/works/<identifier_type>/<path:identifier>/suppress", methods=["POST"]
 )
-@has_library
+@allows_library
 @returns_problem_detail
 @requires_admin
 @requires_csrf_token
-def suppress_for_library(identifier_type, identifier):
-    return app.manager.admin_work_controller.suppress_for_library(
-        identifier_type, identifier
-    )
+def suppress_deprecated(identifier_type, identifier):
+    return app.manager.admin_work_controller.suppress(identifier_type, identifier)
 
 
+@DeprecationWarning
 @library_route(
-    "/admin/works/<identifier_type>/<path:identifier>/unsuppress-for-library",
-    methods=["POST"],
+    "/admin/works/<identifier_type>/<path:identifier>/unsuppress", methods=["POST"]
 )
-@has_library
+@allows_library
 @returns_problem_detail
 @requires_admin
 @requires_csrf_token
-def unsuppress_for_library(identifier_type, identifier):
-    return app.manager.admin_work_controller.unsuppress_for_library(
-        identifier_type, identifier
-    )
+def unsuppress_deprecated(identifier_type, identifier):
+    return app.manager.admin_work_controller.unsuppress(identifier_type, identifier)
 
 
 @library_route("/works/<identifier_type>/<path:identifier>/refresh", methods=["POST"])

--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -209,7 +209,7 @@ def suppress(identifier_type, identifier):
 
 
 @library_route(
-    "/admin/works/<identifier_type>/<path:identifier>/suppression", methods=["DELETe"]
+    "/admin/works/<identifier_type>/<path:identifier>/suppression", methods=["DELETE"]
 )
 @allows_library
 @returns_problem_detail

--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -215,7 +215,7 @@ def suppress(identifier_type, identifier):
 @returns_problem_detail
 @requires_admin
 @requires_csrf_token
-def unsurpress(identifier_type, identifier):
+def unsuppress(identifier_type, identifier):
     return app.manager.admin_work_controller.unsuppress(identifier_type, identifier)
 
 

--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -219,6 +219,34 @@ def unsuppress(identifier_type, identifier):
     return app.manager.admin_work_controller.unsuppress(identifier_type, identifier)
 
 
+@library_route(
+    "/admin/works/<identifier_type>/<path:identifier>/suppress-for-library",
+    methods=["POST"],
+)
+@has_library
+@returns_problem_detail
+@requires_admin
+@requires_csrf_token
+def suppress_for_library(identifier_type, identifier):
+    return app.manager.admin_work_controller.suppress_for_library(
+        identifier_type, identifier
+    )
+
+
+@library_route(
+    "/admin/works/<identifier_type>/<path:identifier>/unsuppress-for-library",
+    methods=["POST"],
+)
+@has_library
+@returns_problem_detail
+@requires_admin
+@requires_csrf_token
+def unsuppress_for_library(identifier_type, identifier):
+    return app.manager.admin_work_controller.unsuppress_for_library(
+        identifier_type, identifier
+    )
+
+
 @library_route("/works/<identifier_type>/<path:identifier>/refresh", methods=["POST"])
 @has_library
 @returns_problem_detail

--- a/tests/manager/api/admin/controller/test_work_editor.py
+++ b/tests/manager/api/admin/controller/test_work_editor.py
@@ -676,7 +676,7 @@ class TestWorkController:
             response = work_fixture.manager.admin_work_controller.suppress(
                 lp.identifier.type, lp.identifier.identifier
             )
-            assert 400 == response.status_code
+            assert 404 == response.status_code
             assert "No library specified" in str(response.detail)  # type: ignore[union-attr]
 
         # test unauthorized
@@ -719,7 +719,7 @@ class TestWorkController:
             response = work_fixture.manager.admin_work_controller.unsuppress(
                 lp.identifier.type, lp.identifier.identifier
             )
-            assert 400 == response.status_code
+            assert 404 == response.status_code
             assert "No library specified" in str(response.detail)  # type: ignore[union-attr]
 
         work_fixture.admin.remove_role(AdminRole.LIBRARY_MANAGER, library=library)

--- a/tests/manager/api/admin/controller/test_work_editor.py
+++ b/tests/manager/api/admin/controller/test_work_editor.py
@@ -22,6 +22,7 @@ from palace.manager.api.admin.problem_details import (
     UNKNOWN_ROLE,
 )
 from palace.manager.core.classifier import SimplifiedGenreClassifier
+from palace.manager.sqlalchemy.constants import IdentifierType
 from palace.manager.sqlalchemy.model.admin import AdminRole
 from palace.manager.sqlalchemy.model.classification import (
     Classification,
@@ -36,6 +37,7 @@ from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.sqlalchemy.model.licensing import RightsStatus
 from palace.manager.sqlalchemy.util import create
 from palace.manager.util.datetime_helpers import datetime_utc
+from palace.manager.util.problem_detail import ProblemDetail
 from tests.fixtures.api_admin import AdminControllerFixture
 from tests.fixtures.api_controller import ControllerFixture
 from tests.mocks.flask import add_request_context
@@ -783,6 +785,12 @@ class TestWorkController:
             assert 200 == response.status_code
             assert library in work.suppressed_for
 
+        with work_fixture.request_context_with_library_and_admin("/"):
+            response = work_fixture.manager.admin_work_controller.suppress_for_library(
+                IdentifierType.URI.value, "http://non-existent-id"
+            )
+            assert isinstance(response, ProblemDetail)
+
         work_fixture.admin.remove_role(AdminRole.LIBRARY_MANAGER, library=library)
         with work_fixture.request_context_with_library_and_admin("/"):
             pytest.raises(
@@ -811,6 +819,14 @@ class TestWorkController:
 
             assert 200 == response.status_code
             assert library not in work.suppressed_for
+
+        with work_fixture.request_context_with_library_and_admin("/"):
+            response = (
+                work_fixture.manager.admin_work_controller.unsuppress_for_library(
+                    IdentifierType.URI.value, "http://non-existent-id"
+                )
+            )
+            assert isinstance(response, ProblemDetail)
 
         work_fixture.admin.remove_role(AdminRole.LIBRARY_MANAGER, library=library)
 

--- a/tests/manager/api/admin/test_routes.py
+++ b/tests/manager/api/admin/test_routes.py
@@ -367,7 +367,7 @@ class TestAdminWork:
         url = "/admin/works/<identifier_type>/an/identifier/suppression"
         fixture.assert_authenticated_request_calls(
             url,
-            fixture.controller.suppression,  # type: ignore
+            fixture.controller.suppress,  # type: ignore
             "<identifier_type>",
             "an/identifier",
             http_method="POST",

--- a/tests/manager/api/admin/test_routes.py
+++ b/tests/manager/api/admin/test_routes.py
@@ -364,21 +364,10 @@ class TestAdminWork:
         )
 
     def test_suppression_post(self, fixture: AdminRouteFixture):
-        url = "/admin/works/<identifier_type>/an/identifier/suppress"
+        url = "/admin/works/<identifier_type>/an/identifier/suppression"
         fixture.assert_authenticated_request_calls(
             url,
             fixture.controller.suppression,  # type: ignore
-            "<identifier_type>",
-            "an/identifier",
-            http_method="POST",
-        )
-
-        # TODO: when /suppress end point is removed (currently deprecated) we'll want to remove the following two lines
-        # since these tests will start failing here.
-        url = "/admin/works/<identifier_type>/an/identifier/suppress"
-        fixture.assert_authenticated_request_calls(
-            url,
-            fixture.controller.suppress,  # type: ignore
             "<identifier_type>",
             "an/identifier",
             http_method="POST",
@@ -394,19 +383,22 @@ class TestAdminWork:
             http_method="DELETE",
         )
 
-        # TODO: when /suppress end point is removed (currently deprecated we'll want to remove the following two lines
+    @DeprecationWarning
+    def test_suppress(self, fixture: AdminRouteFixture):
+        # TODO: when /suppress end point is removed (currently deprecated) we'll want to remove this test
         # since these tests will start failing here.
         url = "/admin/works/<identifier_type>/an/identifier/suppress"
         fixture.assert_authenticated_request_calls(
             url,
-            fixture.controller.unsuppress,  # type: ignore
+            fixture.controller.suppress,  # type: ignore
             "<identifier_type>",
             "an/identifier",
-            http_method="DELETE",
+            http_method="POST",
         )
 
     @DeprecationWarning
     def test_unsuppress(self, fixture: AdminRouteFixture):
+        # TODO when deprecated /unsuppress endpoint is removed we'll want to remove this test.
         url = "/admin/works/<identifier_type>/an/identifier/unsuppress"
         fixture.assert_authenticated_request_calls(
             url,

--- a/tests/manager/api/admin/test_routes.py
+++ b/tests/manager/api/admin/test_routes.py
@@ -383,6 +383,26 @@ class TestAdminWork:
             http_method="POST",
         )
 
+    def test_suppress_for_library(self, fixture: AdminRouteFixture):
+        url = "/admin/works/<identifier_type>/an/identifier/suppress-for-library"
+        fixture.assert_authenticated_request_calls(
+            url,
+            fixture.controller.suppress_for_library,  # type: ignore
+            "<identifier_type>",
+            "an/identifier",
+            http_method="POST",
+        )
+
+    def test_unsuppress_for_library(self, fixture: AdminRouteFixture):
+        url = "/admin/works/<identifier_type>/an/identifier/unsuppress-for-library"
+        fixture.assert_authenticated_request_calls(
+            url,
+            fixture.controller.unsuppress_for_library,  # type: ignore
+            "<identifier_type>",
+            "an/identifier",
+            http_method="POST",
+        )
+
     def test_refresh_metadata(self, fixture: AdminRouteFixture):
         url = "/admin/works/<identifier_type>/an/identifier/refresh"
         fixture.assert_authenticated_request_calls(

--- a/tests/manager/api/admin/test_routes.py
+++ b/tests/manager/api/admin/test_routes.py
@@ -363,7 +363,18 @@ class TestAdminWork:
             http_method="POST",
         )
 
-    def test_suppress(self, fixture: AdminRouteFixture):
+    def test_suppression_post(self, fixture: AdminRouteFixture):
+        url = "/admin/works/<identifier_type>/an/identifier/suppress"
+        fixture.assert_authenticated_request_calls(
+            url,
+            fixture.controller.suppression,  # type: ignore
+            "<identifier_type>",
+            "an/identifier",
+            http_method="POST",
+        )
+
+        # TODO: when /suppress end point is removed (currently deprecated) we'll want to remove the following two lines
+        # since these tests will start failing here.
         url = "/admin/works/<identifier_type>/an/identifier/suppress"
         fixture.assert_authenticated_request_calls(
             url,
@@ -373,31 +384,33 @@ class TestAdminWork:
             http_method="POST",
         )
 
-    def test_unsuppress(self, fixture: AdminRouteFixture):
-        url = "/admin/works/<identifier_type>/an/identifier/unsuppress"
+    def test_suppression_delete(self, fixture: AdminRouteFixture):
+        url = "/admin/works/<identifier_type>/an/identifier/suppression"
         fixture.assert_authenticated_request_calls(
             url,
             fixture.controller.unsuppress,  # type: ignore
             "<identifier_type>",
             "an/identifier",
-            http_method="POST",
+            http_method="DELETE",
         )
 
-    def test_suppress_for_library(self, fixture: AdminRouteFixture):
-        url = "/admin/works/<identifier_type>/an/identifier/suppress-for-library"
+        # TODO: when /suppress end point is removed (currently deprecated we'll want to remove the following two lines
+        # since these tests will start failing here.
+        url = "/admin/works/<identifier_type>/an/identifier/suppress"
         fixture.assert_authenticated_request_calls(
             url,
-            fixture.controller.suppress_for_library,  # type: ignore
+            fixture.controller.unsuppress,  # type: ignore
             "<identifier_type>",
             "an/identifier",
-            http_method="POST",
+            http_method="DELETE",
         )
 
-    def test_unsuppress_for_library(self, fixture: AdminRouteFixture):
-        url = "/admin/works/<identifier_type>/an/identifier/unsuppress-for-library"
+    @DeprecationWarning
+    def test_unsuppress(self, fixture: AdminRouteFixture):
+        url = "/admin/works/<identifier_type>/an/identifier/unsuppress"
         fixture.assert_authenticated_request_calls(
             url,
-            fixture.controller.unsuppress_for_library,  # type: ignore
+            fixture.controller.unsuppress,  # type: ignore
             "<identifier_type>",
             "an/identifier",
             http_method="POST",


### PR DESCRIPTION
## Description
This update adds support to the HTTP API for suppressing/unsuppresessing a work for a given library.

The API end points are as follows:

`<host>/admin/works/<identifier_type>/<identifier>/suppress-for-library`
`<host>/admin/works/<identifier_type>/<identifier>/unsuppress-for-library`

These calls require LIBRARY_MANAGER level privileges.

Additionally,  I have updated the suppress/unsuppress work across a CM to require LIBRARY_MANAGER level privileges since suppression of titles across license pools vs across libraries seem to me to be similar in terms of the level of responsibility associated with the action.  If I'm wrong about that I'm happy to revert those changes.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-978

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New tests have been added,  broken tests have been fixed.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
