### PR TITLE
Update some of the configuration defaults for celery (PP-1279)

### DIFF
--- a/src/palace/manager/service/celery/configuration.py
+++ b/src/palace/manager/service/celery/configuration.py
@@ -23,8 +23,8 @@ class CeleryConfiguration(ServiceConfiguration):
     task_track_started: bool = True
 
     worker_cancel_long_running_tasks_on_connection_loss: bool = False
-    worker_max_tasks_per_child: int = 100
-    worker_prefetch_multiplier: int = 1
+    worker_max_tasks_per_child: int = 400
+    worker_prefetch_multiplier: int = 100
     worker_hijack_root_logger: bool = False
     worker_log_color: bool = False
     worker_send_task_events: bool = True


### PR DESCRIPTION
## Description

Update a couple of the defaults for our celery worker config. I determined these values by overriding the config with env variables on the CA CM to determine their impact on performance. Since these seem to drastically help our performance, I'm updating the defaults.

## Motivation and Context

The CA CM has been struggling to keep up with the number of indexing tasks coming in. Now that we have proper metrics, its a bit easier to see whats happening there. We were getting about 1000 indexing tasks coming in every minute, and we were able to process about 500 of them every minute. So the indexing process was continually under water.

Looking at: https://docs.celeryq.dev/en/stable/userguide/optimizing.html#prefetch-limits

And updating some of our config values, the CA CM is able to process about 2700 tasks a minute, which allows the indexing task to keep up with demand.

Since we have some long running tasks, we may want to follow the suggestion in that guide, and add another queue with different workers with different prefetch limits. I'm going to make a ticket to look into that, but this configuration has been helping the CA CMs, so I think its worth making right away.

## How Has This Been Tested?

- Tested with ENV variable overrides on the CA CM

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
