### PR TITLE
Support running `app.py` with a base URL again.

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,5 +39,5 @@ def run(url=None):
 
 
 if __name__ == "__main__":
-    url = sys.argv.pop()
+    url = sys.argv.pop() if len(sys.argv) > 1 else None
     run(url)

--- a/app.py
+++ b/app.py
@@ -39,7 +39,5 @@ def run(url=None):
 
 
 if __name__ == "__main__":
-    url = None
-    if len(sys.argv) > 1:
-        url = sys.argv[1]
+    url = sys.argv.pop()
     run(url)


### PR DESCRIPTION
## Description

Quick fix to support running `app.py` with a base URL again. It just `pop`s the URL argument from the command line args, so that future `ArgParser`s don't get confused by it and exit.

## Motivation and Context

- Running `app.py` with a URL would result in [`InstanceInitializationScript.run`'s arg parser](https://github.com/ThePalaceProject/circulation/blob/5be6f9adf334afc5d63ec205a43fe934a4068d53/src/palace/manager/scripts/initialization.py#L175-L177) erroring, because it wasn't expecting any args. 

## How Has This Been Tested?

- Ran locally.
- CI tests pass.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.
