### PR TITLE
Use admin UI v1.20.0. (PP-1277)

### DIFF
--- a/src/palace/manager/api/admin/config.py
+++ b/src/palace/manager/api/admin/config.py
@@ -16,7 +16,7 @@ class OperationalMode(str, Enum):
 class Configuration(LoggerMixin):
     APP_NAME = "Palace Collection Manager"
     PACKAGE_NAME = "@thepalaceproject/circulation-admin"
-    PACKAGE_VERSION = "1.19.0"
+    PACKAGE_VERSION = "1.20.0"
 
     STATIC_ASSETS = {
         "admin_js": "circulation-admin.js",


### PR DESCRIPTION
## Description

- Configure PM to use [admin UI v1.20.0](https://github.com/ThePalaceProject/circulation-admin/releases/tag/v1.20.0) by default.

## Motivation and Context

[Jira [PP-1277](https://ebce-lyrasis.atlassian.net/browse/PP-1277)]

## How Has This Been Tested?

- Manually tested locally to ensure that the new admin UI version is fetched.
- All tests pass locally.
- CI tests for associated branch pass.

## Checklist

- [X] - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1277]: https://ebce-lyrasis.atlassian.net/browse/PP-1277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ