### PR TITLE
Fix run script path for custom list update script

### DIFF
--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -93,7 +93,7 @@ HOME=/var/www/circulation
 
 # Auto update lists
 # Every hour between 7AM - 1AM
-5 0,1,7-23 * * * root core/bin/run custom_list_update_new_entries >> /var/log/cron.log 2>&1
+5 0,1,7-23 * * * root bin/run custom_list_update_new_entries >> /var/log/cron.log 2>&1
 
 # Rotate the patron auth JWE access token key daily
 #


### PR DESCRIPTION
## Description

Fix the run script path for the custom list update script. 

## Motivation and Context

I missed when I did the revert that the path for the run script has changed from `core/bin/run` to `bin/run`, so the custom list update script isn't running.

## How Has This Been Tested?

N/A

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
