### PR TITLE
[PP-1274] Removes ODL Hold Reaper and replaces with ODL 2 Hold Reaper.

### DIFF
--- a/bin/odl2_hold_reaper
+++ b/bin/odl2_hold_reaper
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+"""Check for ODL 2 holds that have expired and delete them."""
+
+
+from palace.manager.api.odl import ODL2HoldReaper
+from palace.manager.scripts.monitor import RunCollectionMonitorScript
+
+RunCollectionMonitorScript(ODL2HoldReaper).run()

--- a/bin/odl_hold_reaper
+++ b/bin/odl_hold_reaper
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-"""Check for ODL holds that have expired and delete them."""
-
-
-from palace.manager.api.odl import ODLHoldReaper
-from palace.manager.scripts.monitor import RunCollectionMonitorScript
-
-RunCollectionMonitorScript(ODLHoldReaper).run()

--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -81,11 +81,11 @@ HOME=/var/www/circulation
 # OPDS 1.x + ODL
 #
 15 * * * * root bin/run odl_import_monitor >> /var/log/cron.log 2>&1
-0 */8 * * * root bin/run odl_hold_reaper >> /var/log/cron.log 2>&1
 
 # OPDS 2.x + ODL import
 #
 45 * * * * root bin/run odl2_import_monitor >> /var/log/cron.log 2>&1
+0 */8 * * * root bin/run odl2_hold_reaper >> /var/log/cron.log 2>&1
 
 # SAML
 #

--- a/tests/fixtures/api_odl.py
+++ b/tests/fixtures/api_odl.py
@@ -19,7 +19,6 @@ from tests.fixtures.files import FilesFixture
 
 if TYPE_CHECKING:
     from tests.fixtures.database import DatabaseTransactionFixture
-    from tests.fixtures.odl import ODLTestFixture
 
 
 class LicenseHelper:
@@ -133,7 +132,7 @@ def odl_mock_get() -> MockGet:
 @pytest.fixture()
 def odl_importer(
     db: DatabaseTransactionFixture,
-    odl_test_fixture: ODLTestFixture,
+    odl_test_fixture,
     odl_mock_get: MockGet,
 ) -> ODLImporter:
     library = odl_test_fixture.library()
@@ -147,7 +146,7 @@ def odl_importer(
 @pytest.fixture()
 def odl2_importer(
     db: DatabaseTransactionFixture,
-    odl_test_fixture: ODLTestFixture,
+    odl_test_fixture,
     odl_mock_get: MockGet,
 ) -> ODL2Importer:
     library = odl_test_fixture.library()

--- a/tests/fixtures/odl.py
+++ b/tests/fixtures/odl.py
@@ -247,7 +247,7 @@ class ODLAPITestFixture:
 
 
 @pytest.fixture(scope="function")
-def odl_api_test_fixture(odl_test_fixture: ODLTestFixture) -> ODLAPITestFixture:
+def odl_api_test_fixture(odl_test_fixture) -> ODLAPITestFixture:
     library = odl_test_fixture.library()
     collection = odl_test_fixture.collection(library)
     work = odl_test_fixture.work(collection)

--- a/tests/manager/api/admin/test_dashboard_stats.py
+++ b/tests/manager/api/admin/test_dashboard_stats.py
@@ -82,7 +82,7 @@ def test_stats_patrons(admin_statistics_session: AdminStatisticsSessionFixture):
 
     # patron2 has a hold.
     patron2 = db.patron()
-    pool.on_hold_to(patron2)
+    pool.on_hold_to(patron2, position=0)
 
     # patron3 has an open access loan with no end date, but it doesn't count
     # because we don't know if it is still active.
@@ -106,7 +106,7 @@ def test_stats_patrons(admin_statistics_session: AdminStatisticsSessionFixture):
     pool.loan_to(patron4, end=utc_now() + timedelta(days=5))
 
     patron5 = db.patron(library=l2)
-    pool.on_hold_to(patron5)
+    pool.on_hold_to(patron5, position=1)
 
     response = session.get_statistics()
     library_stats = response.libraries_by_key.get(default_library.short_name)

--- a/tests/manager/api/test_odl.py
+++ b/tests/manager/api/test_odl.py
@@ -22,10 +22,9 @@ from palace.manager.api.circulation_exceptions import (
     NotCheckedOut,
     NotOnHold,
 )
-from palace.manager.api.odl import ODLHoldReaper, ODLImporter, ODLSettings
+from palace.manager.api.odl import ODLImporter, ODLSettings
 from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.collection import Collection
-from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.sqlalchemy.model.licensing import (
     DeliveryMechanism,
@@ -2046,56 +2045,3 @@ class TestOdlAndOdl2Importer:
 
             # Two licenses expired
             assert sum(l.is_inactive for l in imported_pool.licenses) == 2
-
-
-class TestODLHoldReaper:
-    def test_run_once(
-        self, odl_test_fixture: ODLTestFixture, db: DatabaseTransactionFixture
-    ):
-        library = odl_test_fixture.library()
-        collection = odl_test_fixture.collection(library)
-        work = odl_test_fixture.work(collection)
-        license = odl_test_fixture.license(work)
-        api = odl_test_fixture.api(collection)
-        pool = odl_test_fixture.pool(license)
-
-        data_source = DataSource.lookup(db.session, "Feedbooks", autocreate=True)
-        DatabaseTransactionFixture.set_settings(
-            collection.integration_configuration,
-            **{Collection.DATA_SOURCE_NAME_SETTING: data_source.name},
-        )
-        reaper = ODLHoldReaper(db.session, collection, api=api)
-
-        now = utc_now()
-        yesterday = now - datetime.timedelta(days=1)
-
-        license.setup(concurrency=3, available=3)
-        expired_hold1, ignore = pool.on_hold_to(db.patron(), end=yesterday, position=0)
-        expired_hold2, ignore = pool.on_hold_to(db.patron(), end=yesterday, position=0)
-        expired_hold3, ignore = pool.on_hold_to(db.patron(), end=yesterday, position=0)
-        current_hold, ignore = pool.on_hold_to(db.patron(), position=3)
-        # This hold has an end date in the past, but its position is greater than 0
-        # so the end date is not reliable.
-        bad_end_date, ignore = pool.on_hold_to(db.patron(), end=yesterday, position=4)
-
-        progress = reaper.run_once(reaper.timestamp().to_data())
-
-        # The expired holds have been deleted and the other holds have been updated.
-        assert 2 == db.session.query(Hold).count()
-        assert [current_hold, bad_end_date] == db.session.query(Hold).order_by(
-            Hold.start
-        ).all()
-        assert 0 == current_hold.position
-        assert 0 == bad_end_date.position
-        assert current_hold.end > now
-        assert bad_end_date.end > now
-        assert 1 == pool.licenses_available
-        assert 2 == pool.licenses_reserved
-
-        # The TimestampData returned reflects what work was done.
-        assert "Holds deleted: 3. License pools updated: 1" == progress.achievements
-
-        # The TimestampData does not include any timing information --
-        # that will be applied by run().
-        assert None == progress.start
-        assert None == progress.finish

--- a/tests/manager/api/test_odl2.py
+++ b/tests/manager/api/test_odl2.py
@@ -12,14 +12,16 @@ from palace.manager.api.circulation_exceptions import (
     PatronHoldLimitReached,
     PatronLoanLimitReached,
 )
-from palace.manager.api.odl2 import ODL2Importer
+from palace.manager.api.odl2 import ODL2HoldReaper, ODL2Importer
 from palace.manager.core.coverage import CoverageFailure
 from palace.manager.sqlalchemy.constants import (
     EditionConstants,
     IdentifierConstants,
     MediaTypes,
 )
+from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.contributor import Contribution, Contributor
+from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.sqlalchemy.model.licensing import (
     DeliveryMechanism,
@@ -30,6 +32,7 @@ from palace.manager.sqlalchemy.model.patron import Hold
 from palace.manager.sqlalchemy.model.resource import Hyperlink
 from palace.manager.sqlalchemy.model.work import Work
 from palace.manager.sqlalchemy.util import create
+from palace.manager.util.datetime_helpers import utc_now
 from tests.fixtures.api_odl import (
     LicenseHelper,
     LicenseInfoHelper,
@@ -37,7 +40,7 @@ from tests.fixtures.api_odl import (
     ODL2APIFilesFixture,
 )
 from tests.fixtures.database import DatabaseTransactionFixture
-from tests.fixtures.odl import ODL2APITestFixture
+from tests.fixtures.odl import ODL2APITestFixture, ODL2TestFixture
 
 
 class TestODL2Importer:
@@ -437,3 +440,56 @@ class TestODL2API:
         with pytest.raises(PatronHoldLimitReached) as exc:
             odl2api.api.place_hold(odl2api.patron, "pin", pool, "")
         assert exc.value.limit == 1
+
+
+class TestODL2HoldReaper:
+    def test_run_once(
+        self, odl2_test_fixture: ODL2TestFixture, db: DatabaseTransactionFixture
+    ):
+        library = odl2_test_fixture.library()
+        collection = odl2_test_fixture.collection(library)
+        work = odl2_test_fixture.work(collection)
+        license = odl2_test_fixture.license(work)
+        api = odl2_test_fixture.api(collection)
+        pool = odl2_test_fixture.pool(license)
+
+        data_source = DataSource.lookup(db.session, "Feedbooks", autocreate=True)
+        DatabaseTransactionFixture.set_settings(
+            collection.integration_configuration,
+            **{Collection.DATA_SOURCE_NAME_SETTING: data_source.name},
+        )
+        reaper = ODL2HoldReaper(db.session, collection, api=api)
+
+        now = utc_now()
+        yesterday = now - datetime.timedelta(days=1)
+
+        license.setup(concurrency=3, available=3)
+        expired_hold1, ignore = pool.on_hold_to(db.patron(), end=yesterday, position=0)
+        expired_hold2, ignore = pool.on_hold_to(db.patron(), end=yesterday, position=0)
+        expired_hold3, ignore = pool.on_hold_to(db.patron(), end=yesterday, position=0)
+        current_hold, ignore = pool.on_hold_to(db.patron(), position=3)
+        # This hold has an end date in the past, but its position is greater than 0
+        # so the end date is not reliable.
+        bad_end_date, ignore = pool.on_hold_to(db.patron(), end=yesterday, position=4)
+
+        progress = reaper.run_once(reaper.timestamp().to_data())
+
+        # The expired holds have been deleted and the other holds have been updated.
+        assert 2 == db.session.query(Hold).count()
+        assert [current_hold, bad_end_date] == db.session.query(Hold).order_by(
+            Hold.start
+        ).all()
+        assert 0 == current_hold.position
+        assert 0 == bad_end_date.position
+        assert current_hold.end > now
+        assert bad_end_date.end > now
+        assert 1 == pool.licenses_available
+        assert 2 == pool.licenses_reserved
+
+        # The TimestampData returned reflects what work was done.
+        assert "Holds deleted: 3. License pools updated: 1" == progress.achievements
+
+        # The TimestampData does not include any timing information --
+        # that will be applied by run().
+        assert None == progress.start
+        assert None == progress.finish


### PR DESCRIPTION

## Description
This update removes the ODLHoldsReaper which currently is not doing anything because there are no longer any ODL based collections.

I added in the ODL2HoldsReaper odl2.py which reaps holds associated with  ODL2 collections.

Furthermore, in order to keep the dashboard stats as up to date as possible, I modified the active holds query to hide holds that are expired (and will be reaped within 8 hours when the reaper runs).
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1274
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
