### PR TITLE
Fix `contextmanager` in the test fixtures that weren't handling exceptions

### DIFF
--- a/tests/fixtures/api_admin.py
+++ b/tests/fixtures/api_admin.py
@@ -44,8 +44,10 @@ class AdminControllerFixture:
             flask.request.files = {}
             self.ctrl.db.session.begin_nested()
             flask.request.admin = admin
-            yield c
-            self.ctrl.db.session.commit()
+            try:
+                yield c
+            finally:
+                self.ctrl.db.session.commit()
 
     @contextmanager
     def request_context_with_library_and_admin(self, route, *args, **kwargs):
@@ -57,8 +59,10 @@ class AdminControllerFixture:
             flask.request.files = {}
             self.ctrl.db.session.begin_nested()
             flask.request.admin = admin
-            yield c
-            self.ctrl.db.session.commit()
+            try:
+                yield c
+            finally:
+                self.ctrl.db.session.commit()
 
 
 @pytest.fixture(scope="function")

--- a/tests/fixtures/flask.py
+++ b/tests/fixtures/flask.py
@@ -47,13 +47,14 @@ class FlaskAppFixture:
             flask.request.admin = admin  # type: ignore[attr-defined]
             flask.request.form = ImmutableMultiDict()
             flask.request.files = ImmutableMultiDict()
-            yield c
-
-            # Flush any changes that may have occurred during the request, then
-            # expire all objects to ensure that the next request will see the
-            # changes.
-            self.db.session.commit()
-            self.db.session.expire_all()
+            try:
+                yield c
+            finally:
+                # Flush any changes that may have occurred during the request, then
+                # expire all objects to ensure that the next request will see the
+                # changes.
+                self.db.session.commit()
+                self.db.session.expire_all()
 
     @contextmanager
     def test_request_context_system_admin(

--- a/tests/fixtures/services.py
+++ b/tests/fixtures/services.py
@@ -34,8 +34,10 @@ def mock_services_container(
     from palace.manager.service import container
 
     container._container_instance = services_container
-    yield
-    container._container_instance = None
+    try:
+        yield
+    finally:
+        container._container_instance = None
 
 
 @dataclass
@@ -197,8 +199,10 @@ class ServicesFixture:
     @contextmanager
     def wired(self) -> Generator[None, None, None]:
         wire_container(self.services)
-        yield
-        self.services.unwire()
+        try:
+            yield
+        finally:
+            self.services.unwire()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

A couple of the `contextmanager` decorators in our fixtures were not properly handling an exception occurring within the context manager. I searched for any uses of a `contextmanager` in our fixtures, and made sure we were handling exceptions.

## Motivation and Context

A test failure in https://github.com/ThePalaceProject/circulation/pull/1872 was causing other tests to fail, because the fixture was not properly being unloaded.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
