### PR TITLE
Fix ODL License status document checks (PP-1331)

### DIFF
--- a/src/palace/manager/api/odl.py
+++ b/src/palace/manager/api/odl.py
@@ -330,7 +330,7 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
             )
 
         response = self._get(url)
-        if not response.ok:
+        if not (200 <= response.status_code < 300):
             header_string = ", ".join(
                 {f"{k}: {v}" for k, v in response.headers.items()}
             )

--- a/src/palace/manager/api/odl.py
+++ b/src/palace/manager/api/odl.py
@@ -341,7 +341,7 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
             )
             self.log.error(
                 f"Error getting License Status Document for loan ({loan.id}):  Url '{url}' returned "
-                f"status code {response.status_code}. Expected 200. Response headers: {header_string}. "
+                f"status code {response.status_code}. Response headers: {header_string}. "
                 f"Response content: {response_string}."
             )
             raise BadResponseException(url, "License Status Document request failed.")

--- a/src/palace/manager/api/odl.py
+++ b/src/palace/manager/api/odl.py
@@ -330,7 +330,7 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
             )
 
         response = self._get(url)
-        if response.status_code != 200:
+        if not response.ok:
             header_string = ", ".join(
                 {f"{k}: {v}" for k, v in response.headers.items()}
             )

--- a/src/palace/manager/api/odl.py
+++ b/src/palace/manager/api/odl.py
@@ -341,7 +341,7 @@ class BaseODLAPI(PatronActivityCirculationAPI[SettingsType, LibrarySettingsType]
             )
             self.log.error(
                 f"Error getting License Status Document for loan ({loan.id}):  Url '{url}' returned "
-                f"status code {response.status_code}. Response headers: {header_string}. "
+                f"status code {response.status_code}. Expected 2XX. Response headers: {header_string}. "
                 f"Response content: {response_string}."
             )
             raise BadResponseException(url, "License Status Document request failed.")

--- a/tests/manager/api/test_odl.py
+++ b/tests/manager/api/test_odl.py
@@ -52,7 +52,7 @@ class TestODLAPI:
     def test_get_license_status_document_success(
         self, odl_api_test_fixture: ODLAPITestFixture
     ) -> None:
-        # With a new loan.
+        # With a new loan. New loan returns a 201 status.
         loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
         odl_api_test_fixture.api.queue_response(
             201, content=json.dumps(dict(status="ready"))
@@ -101,7 +101,7 @@ class TestODLAPI:
             == notification_url
         )
 
-        # With an existing loan.
+        # With an existing loan. Existing loan returns a 200 status.
         loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
         loan.external_identifier = odl_api_test_fixture.db.fresh_str()
 
@@ -139,7 +139,7 @@ class TestODLAPI:
             odl_api_test_fixture.api.get_license_status_document,
             loan,
         )
-        assert "returned status code 403." in caplog.text
+        assert "returned status code 403. Expected 2XX." in caplog.text
         assert "just junk ..." in caplog.text
 
     def test_checkin_success(

--- a/tests/manager/api/test_odl.py
+++ b/tests/manager/api/test_odl.py
@@ -55,7 +55,7 @@ class TestODLAPI:
         # With a new loan.
         loan, _ = odl_api_test_fixture.license.loan_to(odl_api_test_fixture.patron)
         odl_api_test_fixture.api.queue_response(
-            200, content=json.dumps(dict(status="ready"))
+            201, content=json.dumps(dict(status="ready"))
         )
         odl_api_test_fixture.api.get_license_status_document(loan)
         requested_url = odl_api_test_fixture.api.requests[0][0]
@@ -139,7 +139,7 @@ class TestODLAPI:
             odl_api_test_fixture.api.get_license_status_document,
             loan,
         )
-        assert "returned status code 403. Expected 200." in caplog.text
+        assert "returned status code 403." in caplog.text
         assert "just junk ..." in caplog.text
 
     def test_checkin_success(


### PR DESCRIPTION
## Description

Relax the check we are doing on the response from the license status endpoint to make sure its a 2xx response instead of `response.status_code == 200`, since we are seeing 201 responses come back that weren't being taken into account.

## Motivation and Context

In https://github.com/ThePalaceProject/circulation/pull/1851 I added some extra logging when we get bad responses back from the license status document endpoint. It turns out I was overly zealous with my checks there. New loans return a 201 status, and I'm strictly checking for a 200 status.

## How Has This Been Tested?

- Unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
