### PR TITLE
ODL2 collections can disallow holds at the collection level. (PP-1316)

### DIFF
--- a/src/palace/manager/api/circulation_exceptions.py
+++ b/src/palace/manager/api/circulation_exceptions.py
@@ -13,6 +13,7 @@ from palace.manager.api.problem_details import (
     EXPIRED_CREDENTIALS,
     HOLD_FAILED,
     HOLD_LIMIT_REACHED,
+    HOLDS_NOT_PERMITTED,
     INVALID_CREDENTIALS,
     LOAN_LIMIT_REACHED,
     NO_ACCEPTABLE_FORMAT,
@@ -250,6 +251,12 @@ class CannotHold(CirculationException):
     @property
     def base(self) -> ProblemDetail:
         return HOLD_FAILED
+
+
+class HoldsNotPermitted(CannotHold):
+    @property
+    def base(self) -> ProblemDetail:
+        return HOLDS_NOT_PERMITTED
 
 
 class PatronHoldLimitReached(CannotHold, LimitReached):

--- a/src/palace/manager/api/problem_details.py
+++ b/src/palace/manager/api/problem_details.py
@@ -94,6 +94,12 @@ HOLD_LIMIT_REACHED = pd(
     _("Limit reached."),
     GENERIC_HOLD_LIMIT_MESSAGE,
 )
+HOLDS_NOT_PERMITTED = pd(
+    "http://palaceproject.io/terms/problem/holds-not-allowed",
+    403,
+    _("Holds not permitted."),
+    _("Holds are not permitted for this book."),
+)
 
 OUTSTANDING_FINES = pd(
     "http://librarysimplified.org/terms/problem/outstanding-fines",

--- a/tests/manager/api/admin/test_validator.py
+++ b/tests/manager/api/admin/test_validator.py
@@ -139,6 +139,7 @@ class TestValidator:
         assert response.detail == '"invalid_url" is not a valid URL.'
         assert response.status_code == 400
 
+    # TODO: Do we still need this?
     def test_validate_number(self):
         settings_form = [
             {

--- a/tests/manager/api/test_odl2.py
+++ b/tests/manager/api/test_odl2.py
@@ -421,6 +421,8 @@ class TestODL2API:
         odl2api.api.hold_limit = 0
         with pytest.raises(HoldsNotPermitted) as exc:
             odl2api.api.place_hold(odl2api.patron, "pin", pool, "")
+        assert exc.value.problem_detail.title is not None
+        assert exc.value.problem_detail.detail is not None
         assert "Holds not permitted" in exc.value.problem_detail.title
         assert "Holds are not permitted" in exc.value.problem_detail.detail
 
@@ -446,9 +448,9 @@ class TestODL2API:
         )
 
         # Hold should fail
-        with pytest.raises(PatronHoldLimitReached) as exc:
+        with pytest.raises(PatronHoldLimitReached) as exc2:
             odl2api.api.place_hold(odl2api.patron, "pin", pool, "")
-        assert exc.value.limit == 1
+        assert exc2.value.limit == 1
 
 
 class TestODL2HoldReaper:

--- a/tests/manager/api/test_odl2.py
+++ b/tests/manager/api/test_odl2.py
@@ -452,6 +452,20 @@ class TestODL2API:
             odl2api.api.place_hold(odl2api.patron, "pin", pool, "")
         assert exc2.value.limit == 1
 
+        # Set the hold limit to None (unlimited) and ensure hold succeeds.
+        odl2api.api.hold_limit = None
+        hold_response = odl2api.api.place_hold(odl2api.patron, "pin", pool, "")
+        assert hold_response.hold_position == 1
+        create(db.session, Hold, patron_id=odl2api.patron.id, license_pool=pool)
+        # Verify that there are now two holds that  our test patron has both of them.
+        assert 2 == db.session.query(Hold).count()
+        assert (
+            2
+            == db.session.query(Hold)
+            .filter(Hold.patron_id == odl2api.patron.id)
+            .count()
+        )
+
 
 class TestODL2HoldReaper:
     def test_run_once(


### PR DESCRIPTION
## Description

- ODL2 collections can disable holds by setting `holds_limit` to `0`.
- Attempting to place a hold on a book in that collection with this setting in effect results in a (new) `HoldsNotPermitted` problem detail exception.
- As with library-level `dont_display_reserves` setting, books for collections with this configuration will be filtered from work lists when there is no availability; so, in most cases, holds for these books won't even be attempted and we should not even need to return a problem detail.

## Motivation and Context

Need to be able to prevent holds on an entire collection, but without forcing a library to disable holds for all of its collections.

[Jira [PP-1316](https://ebce-lyrasis.atlassian.net/browse/PP-1316)]

## How Has This Been Tested?

- Function tested locally.
- Added new tests and updated others.
- [CI tests for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/9386205068) pass.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.


[PP-1316]: https://ebce-lyrasis.atlassian.net/browse/PP-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ