### PR TITLE
Remove patron.last_loan_activity_sync

### DIFF
--- a/alembic/versions/20240612_7ba553f3f80d_remove_patron_last_loan_activity_sync.py
+++ b/alembic/versions/20240612_7ba553f3f80d_remove_patron_last_loan_activity_sync.py
@@ -1,0 +1,32 @@
+"""Remove Patron.last_loan_activity_sync
+
+Revision ID: 7ba553f3f80d
+Revises: 50746a3bd243
+Create Date: 2024-06-12 00:53:37.497861+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "7ba553f3f80d"
+down_revision = "50746a3bd243"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("patrons", "last_loan_activity_sync")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "patrons",
+        sa.Column(
+            "last_loan_activity_sync",
+            postgresql.TIMESTAMP(timezone=True),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )

--- a/src/palace/manager/sqlalchemy/model/patron.py
+++ b/src/palace/manager/sqlalchemy/model/patron.py
@@ -104,12 +104,6 @@ class Patron(Base, RedisKeyMixin):
     # system such as an ILS.
     last_external_sync = Column(DateTime(timezone=True))
 
-    # TODO: This field is no longer used. Its left here for backwards compatibility until
-    #   the release with this change is deployed. It should be removed after that.
-    _REMOVED_last_loan_activity_sync = Column(
-        "last_loan_activity_sync", DateTime(timezone=True), default=None
-    )
-
     # The time, if any, at which the user's authorization to borrow
     # books expires.
     authorization_expires = Column(Date, index=True)


### PR DESCRIPTION
## Description

Removes the patron.last_loan_activity_sync column that is no longer being removed.

🚨 this one shouldn't get merged until https://github.com/ThePalaceProject/circulation/pull/1894 goes into a release. I'll leave this in draft until then.

## Motivation and Context

Follow up migration for https://github.com/ThePalaceProject/circulation/pull/1894.

## How Has This Been Tested?

- Unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
