### PR TITLE
Fix book suppression links in admin feeds (PP-1318, PP-1348)

### DIFF
--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -204,7 +204,7 @@ def edit(identifier_type, identifier):
 @returns_problem_detail
 @requires_admin
 @requires_csrf_token
-def suppress(identifier_type, identifier):
+def suppress_for_library(identifier_type, identifier):
     return app.manager.admin_work_controller.suppress(identifier_type, identifier)
 
 
@@ -215,7 +215,7 @@ def suppress(identifier_type, identifier):
 @returns_problem_detail
 @requires_admin
 @requires_csrf_token
-def unsuppress(identifier_type, identifier):
+def unsuppress_for_library(identifier_type, identifier):
     return app.manager.admin_work_controller.unsuppress(identifier_type, identifier)
 
 

--- a/src/palace/manager/feed/annotator/admin.py
+++ b/src/palace/manager/feed/annotator/admin.py
@@ -23,6 +23,7 @@ class AdminAnnotator(LibraryAnnotator):
 
         identifier = entry.identifier
         active_license_pool = entry.license_pool
+        work = entry.work
 
         # Find staff rating and add a tag for it.
         for measurement in identifier.measurements:
@@ -35,19 +36,7 @@ class AdminAnnotator(LibraryAnnotator):
                     self.rating(measurement.quantity_measured, measurement.value)
                 )
 
-        if active_license_pool and active_license_pool.suppressed:
-            entry.computed.other_links.append(
-                Link(
-                    href=self.url_for(
-                        "unsuppress",
-                        identifier_type=identifier.type,
-                        identifier=identifier.identifier,
-                        _external=True,
-                    ),
-                    rel="http://librarysimplified.org/terms/rel/restore",
-                )
-            )
-        else:
+        if active_license_pool and not active_license_pool.suppressed:
             entry.computed.other_links.append(
                 Link(
                     href=self.url_for(
@@ -57,6 +46,44 @@ class AdminAnnotator(LibraryAnnotator):
                         _external=True,
                     ),
                     rel="http://librarysimplified.org/terms/rel/hide",
+                )
+            )
+            if self.library in work.suppressed_for:
+                entry.computed.other_links.append(
+                    Link(
+                        href=self.url_for(
+                            "unsuppress_for_library",
+                            identifier_type=identifier.type,
+                            identifier=identifier.identifier,
+                            library_short_name=self.library.short_name,
+                            _external=True,
+                        ),
+                        rel="http://palaceproject.io/terms/rel/unsuppress-for-library",
+                    )
+                )
+            else:
+                entry.computed.other_links.append(
+                    Link(
+                        href=self.url_for(
+                            "suppress_for_library",
+                            identifier_type=identifier.type,
+                            identifier=identifier.identifier,
+                            library_short_name=self.library.short_name,
+                            _external=True,
+                        ),
+                        rel="http://palaceproject.io/terms/rel/suppress-for-library",
+                    )
+                )
+        elif active_license_pool and active_license_pool.suppressed:
+            entry.computed.other_links.append(
+                Link(
+                    href=self.url_for(
+                        "unsuppress",
+                        identifier_type=identifier.type,
+                        identifier=identifier.identifier,
+                        _external=True,
+                    ),
+                    rel="http://librarysimplified.org/terms/rel/restore",
                 )
             )
 


### PR DESCRIPTION
## Description

- Adds library-level book un/suppress links from the admin client book detail feed.
- Removes collection-level book un/suppress links from same.

## Motivation and Context

Support book suppression at the library level.

[Jira [PP-1318](https://ebce-lyrasis.atlassian.net/browse/PP-1318), [PP-1348](https://ebce-lyrasis.atlassian.net/browse/PP-1348)]

## How Has This Been Tested?

- Manual testing in local dev environment.
- All tests pass locally.
- CI tests pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
