### PR TITLE
Remove old search index parameters in work

### DIFF
--- a/src/palace/manager/sqlalchemy/model/work.py
+++ b/src/palace/manager/sqlalchemy/model/work.py
@@ -667,7 +667,7 @@ class Work(Base, LoggerMixin):
         return query
 
     @classmethod
-    def reject_covers(cls, _db, works_or_identifiers, search_index_client=None):
+    def reject_covers(cls, _db, works_or_identifiers):
         """Suppresses the currently visible covers of a number of Works"""
         from palace.manager.sqlalchemy.model.licensing import LicensePool
         from palace.manager.sqlalchemy.model.resource import Hyperlink, Resource
@@ -725,9 +725,7 @@ class Work(Base, LoggerMixin):
         # cached OPDS entries.
         policy = PresentationCalculationPolicy.reset_cover()
         for work in works:
-            work.calculate_presentation(
-                policy=policy, search_index_client=search_index_client
-            )
+            work.calculate_presentation(policy=policy)
         for edition in editions:
             edition.calculate_presentation(policy=policy)
         _db.commit()
@@ -910,7 +908,6 @@ class Work(Base, LoggerMixin):
     def calculate_presentation(
         self,
         policy=None,
-        search_index_client=None,
         exclude_search=False,
         default_fiction=None,
         default_audience=None,
@@ -1240,9 +1237,7 @@ class Work(Base, LoggerMixin):
         """
         return self._reset_coverage(WorkCoverageRecord.CHOOSE_EDITION_OPERATION)
 
-    def set_presentation_ready(
-        self, as_of=None, search_index_client=None, exclude_search=False
-    ):
+    def set_presentation_ready(self, as_of=None, exclude_search=False):
         """Set this work as presentation-ready, no matter what.
 
         This assumes that we know the work has the minimal information
@@ -1259,7 +1254,7 @@ class Work(Base, LoggerMixin):
         if not exclude_search:
             self.external_index_needs_updating()
 
-    def set_presentation_ready_based_on_content(self, search_index_client=None):
+    def set_presentation_ready_based_on_content(self):
         """Set this work as presentation ready, if it appears to
         be ready based on its data.
 
@@ -1270,8 +1265,6 @@ class Work(Base, LoggerMixin):
         The absolute minimum data necessary is a title, a language,
         and a medium. We don't need a cover or an author -- we can
         fill in that info later if it exists.
-
-        TODO: search_index_client is redundant here.
         """
         if (
             not self.presentation_edition
@@ -1287,7 +1280,7 @@ class Work(Base, LoggerMixin):
             self.external_index_needs_updating()
             self.log.warning("Work is not presentation ready: %r", self)
         else:
-            self.set_presentation_ready(search_index_client=search_index_client)
+            self.set_presentation_ready()
 
     def calculate_quality(self, identifier_ids, default_quality=0):
         _db = Session.object_session(self)

--- a/tests/manager/sqlalchemy/model/test_work.py
+++ b/tests/manager/sqlalchemy/model/test_work.py
@@ -243,7 +243,7 @@ class TestWork:
         work.presentation_ready = True
         index = external_search_fake_fixture.external_search
 
-        work.calculate_presentation(search_index_client=index)
+        work.calculate_presentation()
 
         # The author of the Work has not changed.
         assert "Alice Adder, Bob Bitshifter" == work.author
@@ -308,7 +308,7 @@ class TestWork:
         # knows it's no longer the champ.
         pool2.suppressed = True
 
-        work.calculate_presentation(search_index_client=index)
+        work.calculate_presentation()
 
         # The title of the Work is the title of its new primary work record.
         assert "The 1st Title" == work.title
@@ -348,7 +348,7 @@ class TestWork:
         staff_edition.author = Edition.UNKNOWN_AUTHOR
         staff_edition.sort_author = Edition.UNKNOWN_AUTHOR
 
-        work.calculate_presentation(search_index_client=index)
+        work.calculate_presentation()
 
         # The title of the Work got superseded.
         assert "The Staff Title" == work.title
@@ -495,7 +495,7 @@ class TestWork:
 
         search = external_search_fake_fixture.external_search
         presentation = work.presentation_edition
-        work.set_presentation_ready_based_on_content(search_index_client=search)
+        work.set_presentation_ready_based_on_content()
         assert True == work.presentation_ready
 
         # The work has not been added to the search index.
@@ -508,7 +508,7 @@ class TestWork:
         # Remove the title, and the work stops being presentation
         # ready.
         presentation.title = None
-        work.set_presentation_ready_based_on_content(search_index_client=search)
+        work.set_presentation_ready_based_on_content()
         assert False == work.presentation_ready
 
         # The work has been queued for reindexing, so that the search
@@ -518,32 +518,32 @@ class TestWork:
 
         # Restore the title, and everything is fixed.
         presentation.title = "foo"
-        work.set_presentation_ready_based_on_content(search_index_client=search)
+        work.set_presentation_ready_based_on_content()
         assert True == work.presentation_ready
 
         # Remove the medium, and the work stops being presentation ready.
         presentation.medium = None
-        work.set_presentation_ready_based_on_content(search_index_client=search)
+        work.set_presentation_ready_based_on_content()
         assert False == work.presentation_ready
 
         presentation.medium = Edition.BOOK_MEDIUM
-        work.set_presentation_ready_based_on_content(search_index_client=search)
+        work.set_presentation_ready_based_on_content()
         assert True == work.presentation_ready
 
         # Remove the language, and it stops being presentation ready.
         presentation.language = None
-        work.set_presentation_ready_based_on_content(search_index_client=search)
+        work.set_presentation_ready_based_on_content()
         assert False == work.presentation_ready
 
         presentation.language = "eng"
-        work.set_presentation_ready_based_on_content(search_index_client=search)
+        work.set_presentation_ready_based_on_content()
         assert True == work.presentation_ready
 
         # Remove the fiction status, and the work is still
         # presentation ready. Fiction status used to make a difference, but
         # it no longer does.
         work.fiction = None
-        work.set_presentation_ready_based_on_content(search_index_client=search)
+        work.set_presentation_ready_based_on_content()
         assert True == work.presentation_ready
 
     def test_assign_genres_from_weights(self, db: DatabaseTransactionFixture):
@@ -948,19 +948,25 @@ class TestWork:
             r = cover_link.resource
             r.votes_for_quality = r.voted_quality = 0
             r.update_quality()
-            work.calculate_presentation(search_index_client=index)
+            work.calculate_presentation()
             assert full_url == work.cover_full_url
             assert thumbnail_url == work.cover_thumbnail_url
 
         # Suppressing the cover removes the cover from the work.
         index = external_search_fake_fixture.external_search
-        Work.reject_covers(db.session, [work], search_index_client=index)
+        Work.reject_covers(
+            db.session,
+            [work],
+        )
         assert has_no_cover(work)
         reset_cover()
 
         # It also works with Identifiers.
         identifier = work.license_pools[0].identifier
-        Work.reject_covers(db.session, [identifier], search_index_client=index)
+        Work.reject_covers(
+            db.session,
+            [identifier],
+        )
         assert has_no_cover(work)
         reset_cover()
 
@@ -972,7 +978,10 @@ class TestWork:
         other_work_ed.set_cover(cover_link.resource)
         other_work = db.work(presentation_edition=other_work_ed)
 
-        Work.reject_covers(db.session, [work], search_index_client=index)
+        Work.reject_covers(
+            db.session,
+            [work],
+        )
         assert has_no_cover(other_edition)
         assert has_no_cover(other_work)
 


### PR DESCRIPTION
## Description

Remove unused `search_index_client` parameters.

## Motivation and Context

Noticed a comment pointing this out while working on some other code, so I figured I'd drop the unused parameters.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
