### PR TITLE
Overdrive API patron_activity returning None

### DIFF
--- a/src/palace/manager/api/overdrive.py
+++ b/src/palace/manager/api/overdrive.py
@@ -8,6 +8,7 @@ import logging
 import re
 import time
 import urllib.parse
+from collections.abc import Iterable
 from threading import RLock
 from typing import Any
 from urllib.parse import quote, urlsplit, urlunsplit
@@ -52,7 +53,7 @@ from palace.manager.api.circulation_exceptions import (
 from palace.manager.api.selftest import HasCollectionSelfTests, SelfTestResult
 from palace.manager.core.config import CannotLoadConfiguration, Configuration
 from palace.manager.core.coverage import BibliographicCoverageProvider
-from palace.manager.core.exceptions import IntegrationException
+from palace.manager.core.exceptions import BasePalaceException, IntegrationException
 from palace.manager.core.metadata_layer import (
     CirculationData,
     ContributorData,
@@ -1445,7 +1446,9 @@ class OverdriveAPI(
             return d
         return strptime_utc(d, cls.TIME_FORMAT)
 
-    def patron_activity(self, patron, pin):
+    def patron_activity(
+        self, patron: Patron, pin: str | None
+    ) -> Iterable[LoanInfo | HoldInfo]:
         try:
             loans = self.get_patron_checkouts(patron, pin)
             holds = self.get_patron_holds(patron, pin)
@@ -1463,10 +1466,16 @@ class OverdriveAPI(
             )
             loans = {}
             holds = {}
+        collection = self.collection
+        if collection is None:
+            raise BasePalaceException(
+                "No collection available for Overdrive patron activity."
+            )
 
         for checkout in loans.get("checkouts", []):
-            loan_info = self.process_checkout_data(checkout, self.collection)
-            yield loan_info
+            loan_info = self.process_checkout_data(checkout, collection)
+            if loan_info is not None:
+                yield loan_info
 
         for hold in holds.get("holds", []):
             overdrive_identifier = hold["reserveId"].lower()
@@ -1481,7 +1490,7 @@ class OverdriveAPI(
                 # 0, not whatever position Overdrive had for them.
                 position = 0
             yield HoldInfo(
-                self.collection,
+                collection,
                 DataSource.OVERDRIVE,
                 Identifier.OVERDRIVE_ID,
                 overdrive_identifier,
@@ -1491,7 +1500,9 @@ class OverdriveAPI(
             )
 
     @classmethod
-    def process_checkout_data(cls, checkout: dict[str, Any], collection: Collection):
+    def process_checkout_data(
+        cls, checkout: dict[str, Any], collection: Collection
+    ) -> LoanInfo | None:
         """Convert one checkout from Overdrive's list of checkouts
         into a LoanInfo object.
 

--- a/src/palace/manager/api/overdrive.py
+++ b/src/palace/manager/api/overdrive.py
@@ -1449,6 +1449,12 @@ class OverdriveAPI(
     def patron_activity(
         self, patron: Patron, pin: str | None
     ) -> Iterable[LoanInfo | HoldInfo]:
+        collection = self.collection
+        if collection is None:
+            raise BasePalaceException(
+                "No collection available for Overdrive patron activity."
+            )
+
         try:
             loans = self.get_patron_checkouts(patron, pin)
             holds = self.get_patron_holds(patron, pin)
@@ -1466,11 +1472,6 @@ class OverdriveAPI(
             )
             loans = {}
             holds = {}
-        collection = self.collection
-        if collection is None:
-            raise BasePalaceException(
-                "No collection available for Overdrive patron activity."
-            )
 
         for checkout in loans.get("checkouts", []):
             loan_info = self.process_checkout_data(checkout, collection)

--- a/tests/manager/api/test_overdrive.py
+++ b/tests/manager/api/test_overdrive.py
@@ -2570,6 +2570,7 @@ class TestExtractData:
         loan_info = MockOverdriveAPI.process_checkout_data(
             not_on_kindle, overdrive_api_fixture.collection
         )
+        assert loan_info is not None
         assert "2fadd2ac-a8ec-4938-a369-4c3260e8922b" == loan_info.identifier
 
         # Since there are two usable formats (Adobe EPUB and Adobe
@@ -2584,7 +2585,9 @@ class TestExtractData:
         loan_info = MockOverdriveAPI.process_checkout_data(
             format_locked_in, overdrive_api_fixture.collection
         )
+        assert loan_info is not None
         delivery = loan_info.locked_to
+        assert delivery is not None
         assert Representation.EPUB_MEDIA_TYPE == delivery.content_type
         assert DeliveryMechanism.ADOBE_DRM == delivery.drm_scheme
 
@@ -2598,8 +2601,9 @@ class TestExtractData:
         loan_info = MockOverdriveAPI.process_checkout_data(
             no_format_locked_in, overdrive_api_fixture.collection
         )
-        assert loan_info != None
+        assert loan_info is not None
         delivery = loan_info.locked_to
+        assert delivery is not None
         assert Representation.EPUB_MEDIA_TYPE == delivery.content_type
         assert DeliveryMechanism.ADOBE_DRM == delivery.drm_scheme
 

--- a/tests/manager/api/test_overdrive.py
+++ b/tests/manager/api/test_overdrive.py
@@ -49,6 +49,7 @@ from palace.manager.api.overdrive import (
 )
 from palace.manager.core.config import CannotLoadConfiguration
 from palace.manager.core.coverage import CoverageFailure
+from palace.manager.core.exceptions import BasePalaceException
 from palace.manager.core.metadata_layer import LinkData, TimestampData
 from palace.manager.integration.goals import Goals
 from palace.manager.scripts.coverage_provider import RunCollectionCoverageProviderScript
@@ -144,6 +145,20 @@ def overdrive_api_fixture(
 
 
 class TestOverdriveAPI:
+    def test_patron_activity_exception_collection_none(
+        self,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        api = OverdriveAPI(db.session, overdrive_api_fixture.collection)
+        db.session.delete(overdrive_api_fixture.collection)
+        patron = db.patron()
+        with pytest.raises(BasePalaceException) as excinfo:
+            api.sync_patron_activity(patron, "pin")
+        assert "No collection available for Overdrive patron activity." in str(
+            excinfo.value
+        )
+
     def test_errors_not_retried(
         self,
         overdrive_api_fixture: OverdriveAPIFixture,


### PR DESCRIPTION
## Description

Add a few type hints to the OD API class and make sure the `patron_activity` function don't return `None`.

## Motivation and Context

While monitoring the production roll out for https://github.com/ThePalaceProject/circulation/pull/1894 I saw a few tasks failing with the following exception: 

```
remote_holds_and_loans
    key = self.IdentifierKey(activity.identifier_type, activity.identifier)
AttributeError: 'NoneType' object has no attribute 'identifier_type'
```

It turns out this is because the OD API can return None, which wasn't expected.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
