### PR TITLE
More accurately monitor celery queue length (PP-1397)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ module = [
     "html_sanitizer",
     "isbnlib",
     "jwcrypto",
-    "kombu",
+    "kombu.*",
     "lxml.*",
     "money",
     "multipledispatch",

--- a/src/palace/manager/core/exceptions.py
+++ b/src/palace/manager/core/exceptions.py
@@ -10,6 +10,10 @@ class BasePalaceException(Exception):
         self.message = message
 
 
+class PalaceValueError(BasePalaceException, ValueError):
+    ...
+
+
 class IntegrationException(BasePalaceException):
     """An exception that happens when the site's connection to a
     third-party service is broken.


### PR DESCRIPTION
## Description

We monitor the length of the celery queues by directly querying Redis, rather then tracking the length based on the task snapshot. This gives us a more accurate count when unexpected events happen, like queues being purged, or a flood of messages comes in and messages get dropped from the Camera classes buffers.

This ties our monitoring implementation to the Redis broker, but this should be okay. If we end up switching to another broker like SQS we may just want to remove this monitoring class completely, since SQS directly gives us stats we can use without having to track them ourselves.

## Motivation and Context

While troubleshooting the indexing queue issues, I saw several instances where the queue length being reported in cloudwatch was incorrect. This cannot be the case anymore, since we are directly querying it from Redis.

## How Has This Been Tested?

- Tested locally
- Unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
