### PR TITLE
Bump up the timeouts for axis 360 audiobook metadata requests

### DIFF
--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -381,7 +381,10 @@ class Axis360API(
         base_url = self.base_url
         url = base_url + self.audiobook_metadata_endpoint
         params = dict(fndcontentid=findaway_content_id)
-        response = self.request(url, "POST", params=params)
+        # We set an explicit timeout because this request can take a long time and
+        # the default was too short. Ideally B&T would fix this on their end, but
+        # in the meantime we need to work around it.
+        response = self.request(url, "POST", params=params, timeout=10)
         return response
 
     def checkin(self, patron: Patron, pin: str, licensepool: LicensePool) -> None:

--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -384,7 +384,7 @@ class Axis360API(
         # We set an explicit timeout because this request can take a long time and
         # the default was too short. Ideally B&T would fix this on their end, but
         # in the meantime we need to work around it.
-        response = self.request(url, "POST", params=params, timeout=10)
+        response = self.request(url, "POST", params=params, timeout=15)
         return response
 
     def checkin(self, patron: Patron, pin: str, licensepool: LicensePool) -> None:


### PR DESCRIPTION
## Description

Bump up the timeout for the B&T audiobook metadata endpoint.

## Motivation and Context

Requests to the B&T `getaudiobookmetadata` endpoint have been failing with a timeout. Which is causing audiobook fulfillment not to work. Try to resolve it by bumping up the timeout for this endpoint.

## How Has This Been Tested?

- Unit tests

## Checklist
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
