### PR TITLE
SIP2 patron location restriction. (PP-1375)

### DIFF
--- a/src/palace/manager/api/sip/__init__.py
+++ b/src/palace/manager/api/sip/__init__.py
@@ -201,9 +201,9 @@ class SIP2LibrarySettings(BasicAuthProviderLibrarySettings):
         form=ConfigurationFormItem(
             label="Patron Location Restriction",
             description=(
-                "A code for the library or branch which, when specified, "
+                "A code for the library or branch, which, when specified, "
                 "must exactly match the permanent location for the patron."
-                "<br>If an ILS does not include a location for patrons, specifying"
+                "<br>If an ILS does not return a location for its patrons, specifying "
                 "a value here will always result in authentication failure."
             ),
         ),

--- a/src/palace/manager/api/sip/__init__.py
+++ b/src/palace/manager/api/sip/__init__.py
@@ -362,7 +362,8 @@ class SIP2AuthenticationProvider(
         the location associated with the patron exactly matches that of the library.
         """
         if (
-            self.patron_location_restriction is not None
+            not isinstance(info, ProblemDetail)
+            and self.patron_location_restriction is not None
             and info.get("permanent_location") != self.patron_location_restriction
         ):
             raise ProblemDetailException(PATRON_OF_ANOTHER_LIBRARY)

--- a/src/palace/manager/api/sip/__init__.py
+++ b/src/palace/manager/api/sip/__init__.py
@@ -358,8 +358,9 @@ class SIP2AuthenticationProvider(
         """Raise an exception if patron location does not match the restriction.
 
         If a location restriction is specified for the library against which the
-        patron is attempting to authenticate, then the authentication will fail unless
-        the location associated with the patron exactly matches that of the library.
+        patron is attempting to authenticate, then the authentication will fail
+        if either (1) the patron does not have an associated location or (2) the
+        patron's location does not exactly match the one configured.
         """
         if (
             not isinstance(info, ProblemDetail)

--- a/src/palace/manager/api/sip/client.py
+++ b/src/palace/manager/api/sip/client.py
@@ -186,6 +186,10 @@ named._add("sequence_number", "AY")
 named._add("screen_message", "AF", allow_multiple=True)
 named._add("print_line", "AG")
 
+# This is a standard field for items, but Evergreen allows it to
+# be returned in a Patron Information response (64) message.
+named._add("permanent_location", "AQ")
+
 # SIP extensions defined by Georgia Public Library Service's SIP
 # server, used by Evergreen and Koha.
 named._add("sipserver_patron_expiration", "PA")
@@ -712,6 +716,7 @@ class SIPClient(Constants, LoggerMixin):
             named.screen_message,
             named.print_line,
             # Add common extension fields.
+            named.permanent_location,
             named.sipserver_patron_expiration,
             named.polaris_patron_expiration,
             named.sipserver_patron_class,


### PR DESCRIPTION
## Description

- Add support for a patron location restriction based on use of the AQ "permanent location" field. 

NB: The SIP2 spec specifies the use of this field only in "item" responses, but the Evergreen ILS extends its use to the Patron Information Response (64) message.

## Motivation and Context

Support patron library affiliation restriction based on this field.

[Jira [PP-1375](https://ebce-lyrasis.atlassian.net/browse/PP-1375)]

## How Has This Been Tested?

- Manually tested locally.
- [CI tests for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/9883742846) pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1375]: https://ebce-lyrasis.atlassian.net/browse/PP-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ