### PR TITLE
Sirsi configuration was missing item type (PP-1415)

### DIFF
--- a/src/palace/manager/api/sirsidynix_authentication_provider.py
+++ b/src/palace/manager/api/sirsidynix_authentication_provider.py
@@ -86,6 +86,7 @@ class SirsiDynixHorizonAuthLibrarySettings(BasicAuthProviderLibrarySettings):
                 "barcode": "Barcode",
                 "patrontype": "Patron Type",
             },
+            type=ConfigurationFormItemType.SELECT,
         ),
     )
 


### PR DESCRIPTION
## Description

For PP-1415 I was testing Sirsi configuration, and I noticed that even though we have options set, the type of the form item isn't set to select, so they weren't being displayed. 

## Motivation and Context

This updates the form so it works as I would expect.

## How Has This Been Tested?

Tested locally.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
