### PR TITLE
[PP-1431] Ensures that audience classifiers with multiple words (such…

### DIFF
--- a/src/palace/manager/search/external_search.py
+++ b/src/palace/manager/search/external_search.py
@@ -1097,10 +1097,16 @@ class JSONQuery(Query):
             value = list(transformed)[0] if len(transformed) > 0 else value
             return value
 
+        @staticmethod
+        def audience(value: str) -> str:
+            """Transform audience to format used by search indexer"""
+            return value.replace(" ", "")
+
     VALUE_TRANSORMS = {
         "data_source": ValueTransforms.data_source,
         "published": ValueTransforms.published,
         "language": ValueTransforms.language,
+        "audience": ValueTransforms.audience,
     }
 
     def __init__(self, query: str | dict, filter=None):

--- a/tests/manager/search/test_external_search.py
+++ b/tests/manager/search/test_external_search.py
@@ -5002,6 +5002,10 @@ class TestJSONQuery:
         q = self._jq(self._leaf("language", "eng"))
         assert q.search_query.to_dict() == {"term": {"language": "eng"}}
 
+        # Test audience value transform
+        q = self._jq(self._leaf("audience", "Young Adult"))
+        assert q.search_query.to_dict() == {"term": {"audience": "YoungAdult"}}
+
     def test_operator_restrictions(self):
         q = self._jq(self._leaf("data_source", DataSource.GUTENBERG, "gt"))
         with pytest.raises(QueryParseException) as exc:


### PR DESCRIPTION
… as "Young Adult" and "Adults Only") returns results in the list search interface.

## Description
Before audience is indexed in the search index, the spaces are removed. So "Young Adult" is being put in the search index as "YoungAdult".  When incoming queries come in from the user interface however "Young Adult" was not being transformed.  That is why searching on "YoungAdult" produced results as well as "Young" and "Adult", but not "Young Adult".   I fixed the problem by adding a missing value transform for audience.  Incidentally this will also fix the problem for lists intended for "Adults Only".
<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1431
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested.  Unit test added.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
