### PR TITLE
Fix patron activity sync not persisting (PP-1448)

### DIFF
--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -822,8 +822,8 @@ class PatronActivityCirculationAPI(
                 # This was just created, we shouldn't delete it.
                 continue
             self.log.info(
-                "Deleting %s (%r) for patron (%s)"
-                % (item.__class__.__name__, item, item.patron.authorization_identifier)
+                f"Deleting {item.__class__.__name__} ({item.id}) on license pool (id: {item.license_pool_id}) "
+                f"for patron ({item.patron.authorization_identifier})"
             )
             self._db.delete(item)
 

--- a/src/palace/manager/celery/tasks/patron_activity.py
+++ b/src/palace/manager/celery/tasks/patron_activity.py
@@ -37,7 +37,7 @@ def sync_patron_activity(
             )
             return
 
-        with task.session() as session:
+        with task.transaction() as session:
             patron = get_one(session, Patron, id=patron_id)
             collection = get_one(session, Collection, id=collection_id)
 


### PR DESCRIPTION
## Description

This fixes a bug where the patron activity sync task, is not committing its changes to the DB. The main change here is to update the task to use `task.transaction()`, so that the data from the sync is automatically committed to the database.

The PR also adds some additional testing to verify that a successful sync creates a loan and hold. 

## Motivation and Context

Looking into PP-1448, I saw that loans were syncing from B&T, but that the loan never updated the loans feed. This was because the updated loans were not ever being committed into the database.

## How Has This Been Tested?

- Tested locally
- Updated unit test

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
