### PR TITLE
Update suppressed books feed. (PP-1462)

### DIFF
--- a/src/palace/manager/api/admin/controller/feed.py
+++ b/src/palace/manager/api/admin/controller/feed.py
@@ -4,6 +4,7 @@ import flask
 from flask import url_for
 
 from palace.manager.api.admin.controller.base import AdminPermissionsControllerMixin
+from palace.manager.api.admin.controller.util import required_library_from_request
 from palace.manager.api.controller.circulation_manager import (
     CirculationManagerController,
 )
@@ -16,15 +17,17 @@ from palace.manager.util.problem_detail import ProblemDetail
 
 class FeedController(CirculationManagerController, AdminPermissionsControllerMixin):
     def suppressed(self):
-        self.require_librarian(flask.request.library)
+        library = required_library_from_request(flask.request)
+        self.require_librarian(library)
 
         this_url = url_for("suppressed", _external=True)
-        annotator = AdminAnnotator(self.circulation, flask.request.library)
+        annotator = AdminAnnotator(self.circulation, library)
         pagination = load_pagination_from_request()
         if isinstance(pagination, ProblemDetail):
             return pagination
         opds_feed = AdminFeed.suppressed(
             _db=self._db,
+            library=library,
             title="Hidden Books",
             url=this_url,
             annotator=annotator,

--- a/src/palace/manager/api/admin/controller/util.py
+++ b/src/palace/manager/api/admin/controller/util.py
@@ -1,0 +1,27 @@
+from flask import Request
+
+from palace.manager.api.admin.problem_details import ADMIN_NOT_AUTHORIZED
+from palace.manager.api.problem_details import LIBRARY_NOT_FOUND
+from palace.manager.sqlalchemy.model.admin import Admin
+from palace.manager.sqlalchemy.model.library import Library
+from palace.manager.util.problem_detail import ProblemDetailException
+
+
+def optional_admin_from_request(request: Request) -> Admin | None:
+    return getattr(request, "admin", None)
+
+
+def required_admin_from_request(request: Request) -> Admin:
+    if (admin := optional_admin_from_request(request)) is None:
+        raise ProblemDetailException(ADMIN_NOT_AUTHORIZED)
+    return admin
+
+
+def optional_library_from_request(request: Request) -> Library | None:
+    return getattr(request, "library", None)
+
+
+def required_library_from_request(request: Request) -> Library:
+    if (library := optional_library_from_request(request)) is None:
+        raise ProblemDetailException(LIBRARY_NOT_FOUND)
+    return library

--- a/src/palace/manager/feed/admin.py
+++ b/src/palace/manager/feed/admin.py
@@ -25,8 +25,8 @@ class AdminFeed(OPDSAcquisitionFeed):
         _pagination = pagination or Pagination.default()
 
         q = (
-            _db.query(LicensePool)
-            .join(Work)
+            _db.query(Work)
+            .join(LicensePool)
             .join(Edition)
             .filter(
                 and_(
@@ -35,11 +35,10 @@ class AdminFeed(OPDSAcquisitionFeed):
                     Work.suppressed_for.contains(library),
                 )
             )
-            .order_by(Edition.title)
+            .order_by(Edition.sort_title)
         )
-        pools = _pagination.modify_database_query(_db, q).all()
+        works = _pagination.modify_database_query(_db, q).all()
 
-        works = [pool.work for pool in pools]
         feed = cls(title, url, works, annotator, pagination=_pagination)
         feed.generate_feed()
 
@@ -65,8 +64,7 @@ class AdminFeed(OPDSAcquisitionFeed):
                 rel="first",
             )
 
-        previous_page = _pagination.previous_page
-        if previous_page:
+        if previous_page := _pagination.previous_page:
             feed.add_link(
                 annotator.suppressed_url(previous_page),
                 rel="previous",

--- a/tests/manager/api/admin/controller/test_feed.py
+++ b/tests/manager/api/admin/controller/test_feed.py
@@ -8,11 +8,12 @@ from palace.manager.sqlalchemy.model.admin import AdminRole
 
 class TestFeedController:
     def test_suppressed(self, admin_librarian_fixture):
+        library = admin_librarian_fixture.ctrl.library
+
         suppressed_work = admin_librarian_fixture.ctrl.db.work(
             with_open_access_download=True
         )
-        suppressed_work.license_pools[0].suppressed = True
-
+        suppressed_work.suppressed_for.append(library)
         unsuppressed_work = admin_librarian_fixture.ctrl.db.work()
 
         with (


### PR DESCRIPTION
## Description

Changes the feed of suppressed books to include only books suppressed at the library level for the designated library.

## Motivation and Context

Since we've changed book un/suppression to work on a per-library basis, the feed of suppressed books needs to work that way, too.

[Jira [PP-1462](https://ebce-lyrasis.atlassian.net/browse/PP-1462)]

## How Has This Been Tested?

- Functionality manually tested in local environment.
- Tests passing in local environment.
- CI tests for associated branch pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1462]: https://ebce-lyrasis.atlassian.net/browse/PP-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ