### PR TITLE
Fixes hidden book feed link errors. (PP-1498)

### DIFF
--- a/src/palace/manager/api/admin/controller/feed.py
+++ b/src/palace/manager/api/admin/controller/feed.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import flask
-from flask import url_for
 
 from palace.manager.api.admin.controller.base import AdminPermissionsControllerMixin
 from palace.manager.api.admin.controller.util import required_library_from_request
@@ -20,16 +19,13 @@ class FeedController(CirculationManagerController, AdminPermissionsControllerMix
         library = required_library_from_request(flask.request)
         self.require_librarian(library)
 
-        this_url = url_for("suppressed", _external=True)
         annotator = AdminAnnotator(self.circulation, library)
         pagination = load_pagination_from_request()
         if isinstance(pagination, ProblemDetail):
             return pagination
         opds_feed = AdminFeed.suppressed(
             _db=self._db,
-            library=library,
             title="Hidden Books",
-            url=this_url,
             annotator=annotator,
             pagination=pagination,
         )

--- a/src/palace/manager/feed/annotator/admin.py
+++ b/src/palace/manager/feed/annotator/admin.py
@@ -93,9 +93,17 @@ class AdminAnnotator(LibraryAnnotator):
             )
         )
 
-    def suppressed_url(self, pagination: Pagination) -> str:
+    def suppressed_url(self, **kwargs) -> str:
+        return self.url_for(
+            "suppressed",
+            library_short_name=self.library.short_name,
+            _external=True,
+            **kwargs,
+        )
+
+    def suppressed_url_with_pagination(self, pagination: Pagination) -> str:
         kwargs = dict(list(pagination.items()))
-        return self.url_for("suppressed", _external=True, **kwargs)
+        return self.suppressed_url(**kwargs)
 
     def annotate_feed(self, feed: FeedData) -> None:
         # Add a 'search' link.

--- a/src/palace/manager/feed/annotator/admin.py
+++ b/src/palace/manager/feed/annotator/admin.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Any
 
 from palace.manager.api.circulation import CirculationAPI
 from palace.manager.feed.annotator.circulation import LibraryAnnotator
@@ -93,7 +94,7 @@ class AdminAnnotator(LibraryAnnotator):
             )
         )
 
-    def suppressed_url(self, **kwargs) -> str:
+    def suppressed_url(self, **kwargs: dict[str, Any]) -> str:
         return self.url_for(
             "suppressed",
             library_short_name=self.library.short_name,


### PR DESCRIPTION
## Description

Corrects crawlable feed navigation links for the hidden/suppressed books feed:
- Removes `rel="up"` link.
- Makes `rel="start" link the canonical link for the feed.
- Removes `rel="next"` link when the next page would have no content.
- Ensures that all links have the correct route for our API.

## Motivation and Context

While doing QA for PP-1462, I noticed odd behavior for this endpoint when the logged in admin did not have privileges for the default library.

[Jira [PP-1498](https://ebce-lyrasis.atlassian.net/browse/PP-1498)]

## How Has This Been Tested?

- Manually tested locally via Postman and with Admin UI client.
- All tests pass locally.
- [CI tests pass](https://github.com/ThePalaceProject/circulation/actions/runs/10011548465).

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1498]: https://ebce-lyrasis.atlassian.net/browse/PP-1498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ