### PR TITLE
[PP-1491] Introduce retries to prevent ObjectDeletedError

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4513,6 +4513,21 @@ files = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "8.5.0"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tenacity-8.5.0-py3-none-any.whl", hash = "sha256:b594c2a5945830c267ce6b79a166228323ed52718f30302c1359836112346687"},
+    {file = "tenacity-8.5.0.tar.gz", hash = "sha256:8bc6c0c8a09b31e6cad13c47afbed1a567518250a9a171418582ed8d9c20ca78"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
 name = "textblob"
 version = "0.18.0.post0"
 description = "Simple, Pythonic text processing. Sentiment analysis, part-of-speech tagging, noun phrase parsing, and more."
@@ -5110,4 +5125,4 @@ lxml = ">=3.8"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "aa461668bf6a95b7d04dbac571f106eb8592d59645aa2ceee5861de083f68e42"
+content-hash = "39323fbde8794efd15913489d40fb87e698a8fe64284e30517da57b03efda304"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,6 +268,7 @@ redis = "^5.0.5"
 redmail = "^0.6.0"
 requests = "^2.29"
 sqlalchemy = {version = "^1.4", extras = ["mypy"]}
+tenacity = "^8.5.0"
 textblob = "0.18.0.post0"
 types-pyopenssl = "^24.0.0.20240130"
 types-pyyaml = "^6.0.12.9"

--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -780,6 +780,7 @@ class Axis360CirculationMonitor(CollectionMonitor, TimelineMonitor):
         count = 0
         for bibliographic, circulation in self.api.recent_activity(start):
             self.process_book(bibliographic, circulation)
+            self._db.commit()
             count += 1
         progress.achievements = "Modified titles: %d." % count
 
@@ -796,7 +797,6 @@ class Axis360CirculationMonitor(CollectionMonitor, TimelineMonitor):
         self, bibliographic: Metadata, circulation: CirculationData
     ) -> tuple[Edition, LicensePool]:
         tx = self._db.begin_nested()
-
         try:
             edition, new_edition, license_pool, new_license_pool = self.api.update_book(
                 bibliographic, circulation

--- a/src/palace/manager/core/monitor.py
+++ b/src/palace/manager/core/monitor.py
@@ -480,7 +480,7 @@ class SweepMonitor(CollectionMonitor):
         # last _successful_ batch.
         run_started_at = utc_now()
         timestamp.start = run_started_at
-
+        self._db.commit()
         total_processed = 0
         while True:
             old_offset = offset
@@ -514,9 +514,27 @@ class SweepMonitor(CollectionMonitor):
         # update.
         return TimestampData(counter=offset, achievements=achievements)
 
+    @retry(
+        retry=(
+            retry_if_exception_type(StaleDataError)
+            | retry_if_exception_type(ObjectDeletedError)
+        ),
+        stop=stop_after_attempt(MAXIMUM_BATCH_RETRIES),
+        wait=wait_exponential(multiplier=1, min=1, max=60),
+        reraise=True,
+    )
     def process_batch(self, offset):
         """Process one batch of work."""
         offset = offset or 0
+
+        if self._db.dirty:
+            # If an update failed on a previous attempt due to stale or missing data, the session should be dirty.
+            # Therefore, we should roll it back before trying again.
+            # I've put the rollback here rather than in a @retry before_sleep hook because I could neither
+            # figure out how to cleanly reference the db session from within class or module  level method on
+            # the one hand, nor pass an instance method reference to the hook.
+            self._db.rollback()
+
         items = self.fetch_batch(offset).all()
         if items:
             self.process_items(items)
@@ -529,15 +547,6 @@ class SweepMonitor(CollectionMonitor):
             # are done with the sweep. Reset the counter.
             return 0, 0
 
-    @retry(
-        retry=(
-            retry_if_exception_type(StaleDataError)
-            | retry_if_exception_type(ObjectDeletedError)
-        ),
-        stop=stop_after_attempt(MAXIMUM_BATCH_RETRIES),
-        wait=wait_exponential(multiplier=1, min=1, max=60),
-        reraise=True,
-    )
     def process_items(self, items):
         """Process a list of items."""
         for item in items:

--- a/tests/manager/api/test_axis.py
+++ b/tests/manager/api/test_axis.py
@@ -1008,13 +1008,9 @@ class TestCirculationMonitor:
             identifier_type=Identifier.AXIS_360_ID,
             identifier_id="0003642860",
         )
-
-        axis360.db.session.commit()
-
         licensepool, _ = get_one_or_create(
             axis360.db.session, LicensePool, id=licensepool.id
         )
-
         # We start off with availability information based on the
         # default for test data.
         assert 1 == licensepool.licenses_owned
@@ -1023,15 +1019,12 @@ class TestCirculationMonitor:
             type=licensepool.identifier.type,
             identifier=licensepool.identifier.identifier,
         )
-
         metadata = Metadata(DataSource.AXIS_360, primary_identifier=identifier)
-
         monitor = Axis360CirculationMonitor(
             axis360.db.session,
             axis360.collection,
             api_class=MockAxis360API,
         )
-
         edition, licensepool = monitor.process_book(metadata, axis360.AVAILABILITY_DATA)
 
         # Now we have information based on the CirculationData.

--- a/tests/manager/api/test_overdrive.py
+++ b/tests/manager/api/test_overdrive.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 from requests import Response
-from sqlalchemy.orm.exc import StaleDataError
+from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 
 from palace.manager.api.circulation import (
     CirculationAPI,
@@ -3034,8 +3034,10 @@ class TestOverdriveCirculationMonitor:
                 current_count = current_count + 1
                 self.tries[str(book_id)] = current_count
 
-                if current_count < 2:
+                if current_count < 1:
                     raise StaleDataError("Ouch!")
+                elif current_count < 2:
+                    raise ObjectDeletedError({}, "Ouch Deleted!")
 
                 pool, is_new, is_changed = self.licensepools.pop(0)
                 self.update_licensepool_calls.append((book_id, pool))

--- a/tests/manager/api/test_overdrive.py
+++ b/tests/manager/api/test_overdrive.py
@@ -3100,7 +3100,7 @@ class TestOverdriveCirculationMonitor:
                 current_count = self.tries.get(str(book_id)) or 0
                 current_count = current_count + 1
                 self.tries[str(book_id)] = current_count
-                raise StaleDataError("Ouch!")
+                raise Exception("Generic exception that will cause bypass retries")
 
         class MockAnalytics(Analytics):
             def __init__(self):
@@ -3115,6 +3115,7 @@ class TestOverdriveCirculationMonitor:
             api_class=MockAPI,
             analytics=MockAnalytics(),
         )
+
         api = monitor.api
 
         # A MockAnalytics object was created and is ready to receive analytics
@@ -3134,10 +3135,64 @@ class TestOverdriveCirculationMonitor:
         cutoff = object()
         monitor.catch_up_from(start, cutoff, progress)
 
-        assert api.tries["1"] == 3
-        assert api.tries["2"] == 3
-        assert api.tries["3"] == 3
+        assert api.tries["1"] == 1
+        assert api.tries["2"] == 1
+        assert api.tries["3"] == 1
         assert progress.is_failure
+
+    def test_retries_for_retryable_errors(
+        self, overdrive_api_fixture: OverdriveAPIFixture
+    ):
+        """If  individual books fail due to retryable conditions, confirm success"""
+        db = overdrive_api_fixture.db
+        book1 = 1
+        book2 = 2
+
+        class MockAPI:
+            tries: dict[str, int] = {}
+
+            def __init__(self, *ignore, **kwignore):
+                self.licensepools = []
+                self.update_licensepool_calls = []
+
+            def recently_changed_ids(self, start, cutoff):
+                return [book1, book2]
+
+            def update_licensepool(self, book_id):
+                current_count = self.tries.get(str(book_id)) or 0
+                current_count = current_count + 1
+                self.tries[str(book_id)] = current_count
+                if book_id == 1:
+                    if current_count == 1:
+                        raise StaleDataError("stale data")
+                elif book_id == 2:
+                    if current_count == 1:
+                        raise ObjectDeletedError({}, "object deleted")
+
+                return None, None, False
+
+        monitor = OverdriveCirculationMonitor(
+            db.session,
+            overdrive_api_fixture.collection,
+            api_class=MockAPI,
+        )
+
+        api = monitor.api
+
+        lp1 = db.licensepool(None)
+        lp1.last_checked = utc_now()
+        lp2 = db.licensepool(None)
+        api.licensepools.append((lp1, True, True))
+        api.licensepools.append((lp2, False, False))
+
+        progress = TimestampData()
+        start = object()
+        cutoff = object()
+        monitor.catch_up_from(start, cutoff, progress)
+
+        for b in [book1, book2]:
+            assert api.tries[str(b)] == 2
+        assert not progress.is_failure
 
 
 class TestNewTitlesOverdriveCollectionMonitor:

--- a/tests/manager/core/test_monitor.py
+++ b/tests/manager/core/test_monitor.py
@@ -696,19 +696,12 @@ class TestSweepMonitor:
 
             def process_item(self, item):
                 self.process_item_invocation_count += 1
-                if (
-                    self.process_item_invocation_count
-                    % SweepMonitor.MAXIMUM_BATCH_RETRIES
-                    == 1
-                ):
+                if self.process_item_invocation_count == 1:
                     raise StaleDataError("stale data")
-                if (
-                    self.process_item_invocation_count
-                    % SweepMonitor.MAXIMUM_BATCH_RETRIES
-                    == 2
-                ):
+                elif self.process_item_invocation_count == 2:
                     raise ObjectDeletedError({}, "object deleted")
-                super().process_item(item)
+                else:
+                    super().process_item(item)
 
         monitor = FailOnFirstTwoCallsSucceedOnThird(db.session)
         timestamp = monitor.timestamp()

--- a/tests/manager/core/test_monitor.py
+++ b/tests/manager/core/test_monitor.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 
 from palace.manager.api.bibliotheca import BibliothecaAPI
 from palace.manager.api.overdrive import OverdriveAPI
@@ -680,6 +681,44 @@ class TestSweepMonitor:
 
         # cleanup() is only called when the sweep completes successfully.
         assert [] == monitor.cleanup_called
+
+    def test_retries(
+        self,
+        db: DatabaseTransactionFixture,
+        sweep_monitor_fixture: SweepMonitorFixture,
+    ):
+        identifier = db.identifier()
+
+        class FailOnFirstTwoCallsSucceedOnThird(MockSweepMonitor):
+            def __init__(self, _db, **kwargs):
+                super().__init__(_db, **kwargs)
+                self.process_item_invocation_count = 0
+
+            def process_item(self, item):
+                self.process_item_invocation_count += 1
+                if (
+                    self.process_item_invocation_count
+                    % SweepMonitor.MAXIMUM_BATCH_RETRIES
+                    == 1
+                ):
+                    raise StaleDataError("stale data")
+                if (
+                    self.process_item_invocation_count
+                    % SweepMonitor.MAXIMUM_BATCH_RETRIES
+                    == 2
+                ):
+                    raise ObjectDeletedError({}, "object deleted")
+                super().process_item(item)
+
+        monitor = FailOnFirstTwoCallsSucceedOnThird(db.session)
+        timestamp = monitor.timestamp()
+        monitor.run()
+        # we expect that process should have been called 3 times total
+        assert monitor.process_item_invocation_count == 3
+        # there shouldn't be an exception saved since it ultimately succeeded.
+        assert timestamp.exception is None
+        assert "Records processed: 1." == timestamp.achievements
+        assert [identifier] == monitor.processed
 
 
 class TestIdentifierSweepMonitor:


### PR DESCRIPTION
## Description
This update attempts to solve the problem of occasional monitor failures due to stale data.  I believe the problem arises when two different scripts are updating rows at the same time.   Because the SweepMonitor processes updates in batches of 50-100 books,  a change can be made by one of the circulation monitors to a database resource that is in a member of a batch that has been retrieved from the database but not yet modified.  This can results in both a StaleDataError (not observed but possible) or an ObjectDeletedError (observed).

The following monitors that were showing the behavior:  OverdriveFormatSweep, AxisCollectionReaper, and the Axis360CirculationMonitor.

This update adds retry functionality to the SweepMonitor (and all of its subclasses not overriding `process_batch`).
The retrier will try a maximum of 10 times, each time exponentially backing off until the sleep time hits 60s.

Similarly I added retry functionality to the Axis360CirculationMonitor with the same retry parameters to the `process_book` and removed the batched `commit` calls since batch the commits complicate the retry logic.


## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1491
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
