### PR TITLE
[PP-1511] Update Palace Marketplace Feed domain.

### DIFF
--- a/alembic/versions/20240729_6dd3c1a568b6_update_palace_marketplace_domain.py
+++ b/alembic/versions/20240729_6dd3c1a568b6_update_palace_marketplace_domain.py
@@ -1,0 +1,43 @@
+"""Update Palace Marketplace domain.
+
+Revision ID: 6dd3c1a568b6
+Revises: 7ba553f3f80d
+Create Date: 2024-07-29 21:06:20.670391+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6dd3c1a568b6"
+down_revision = "7ba553f3f80d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    find_and_replace_within_external_account_id(
+        "market.feedbooks.com", "market.thepalaceproject.org"
+    )
+
+
+def find_and_replace_within_external_account_id(find_value: str, replace_value: str):
+    conn = op.get_bind()
+    integration_configurations = conn.execute(
+        f"SELECT id, settings->>'external_account_id' "
+        f"FROM integration_configurations "
+        f"WHERE settings->>'external_account_id' LIKE '%%{find_value}%%'"
+    ).all()
+    for integration_configuration in integration_configurations:
+        external_account_id: str = integration_configuration.external_account_id
+        new_external_account_id = external_account_id.replace(find_value, replace_value)
+        conn.execute(
+            f"""UPDATE integration_configurations
+            SET settings = settings || '{"external_account_id": "{new_external_account_id}"}'
+            WHERE id = {integration_configuration.id}"""
+        )
+
+
+def downgrade() -> None:
+    find_and_replace_within_external_account_id(
+        "market.thepalaceproject.org", "market.feedbooks.com"
+    )


### PR DESCRIPTION
## Description

This PR includes a database migration that replaces all integration_configuration.settings['external_account_id'] values containing "market.feedbooks.com" with "market.thepalaceproject.org"
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1511

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I confirmed that ./docker/ci/test_migrations.sh passed locally.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
