### PR TITLE
Fix flaky test comparison

### DIFF
--- a/tests/manager/api/test_overdrive.py
+++ b/tests/manager/api/test_overdrive.py
@@ -2664,17 +2664,20 @@ class TestSyncBookshelf:
 
         # We have recorded a new DeliveryMechanism associated with
         # each loan.
-        mechanisms = []
-        for loan in loans.values():
-            if loan.fulfillment:
-                mechanism = loan.fulfillment.delivery_mechanism
-                mechanisms.append((mechanism.content_type, mechanism.drm_scheme))
-        assert [
+        mechanisms = {
+            (
+                loan.fulfillment.delivery_mechanism.content_type,
+                loan.fulfillment.delivery_mechanism.drm_scheme,
+            )
+            for loan in loans.values()
+            if loan.fulfillment
+        }
+        assert {
             (Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM),
             (Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM),
             (Representation.PDF_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM),
             (Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM),
-        ] == mechanisms
+        } == mechanisms
 
         # There are no holds.
         assert {} == holds


### PR DESCRIPTION
## Description

It looks like `main` has a failed test right now, due to the comparison order in `test_sync_patron_activity_creates_local_loans` being non-deterministic. This PR updates the test to use a set instead, so that order doesn't matter.

See this test run: https://github.com/ThePalaceProject/circulation/actions/runs/10151142851/job/28069801915

## Motivation and Context

I was looking into why the build failed for `main` and noticed this.

## How Has This Been Tested?

- Ran test locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
