### PR TITLE
Refactor OPDS classes to use HTTP.get_with_timeout (PP-1485)

### DIFF
--- a/src/palace/manager/api/opds_for_distributors.py
+++ b/src/palace/manager/api/opds_for_distributors.py
@@ -38,7 +38,7 @@ from palace.manager.sqlalchemy.model.licensing import (
     RightsStatus,
 )
 from palace.manager.sqlalchemy.model.patron import Loan, Patron
-from palace.manager.sqlalchemy.model.resource import HttpResponseTuple, Hyperlink
+from palace.manager.sqlalchemy.model.resource import Hyperlink
 from palace.manager.sqlalchemy.util import get_one
 from palace.manager.util import base64
 from palace.manager.util.datetime_helpers import utc_now
@@ -446,7 +446,7 @@ class OPDSForDistributorsImportMonitor(OPDSImportMonitor):
 
         self.api = OPDSForDistributorsAPI(_db, collection)
 
-    def _get(self, url: str, headers: Mapping[str, str]) -> HttpResponseTuple:
+    def _get(self, url: str, headers: Mapping[str, str]) -> Response:
         """Make a normal HTTP request for an OPDS feed, but add in an
         auth header with the credentials for the collection.
         """

--- a/src/palace/manager/core/opds2_import.py
+++ b/src/palace/manager/core/opds2_import.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Iterable, Mapping
 from datetime import datetime
 from io import BytesIO, StringIO
 from typing import TYPE_CHECKING, Any
@@ -63,11 +63,7 @@ from palace.manager.sqlalchemy.model.licensing import (
     RightsStatus,
 )
 from palace.manager.sqlalchemy.model.patron import Patron
-from palace.manager.sqlalchemy.model.resource import (
-    HttpResponseTuple,
-    Hyperlink,
-    Representation,
-)
+from palace.manager.sqlalchemy.model.resource import Hyperlink, Representation
 from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.http import HTTP, BadResponseException
 from palace.manager.util.opds_writer import OPDSFeed
@@ -282,7 +278,6 @@ class OPDS2Importer(BaseOPDSImporter[OPDS2ImporterSettings]):
         collection: Collection,
         parser: RWPMManifestParser,
         data_source_name: str | None = None,
-        http_get: Callable[..., HttpResponseTuple] | None = None,
     ):
         """Initialize a new instance of OPDS2Importer class.
 
@@ -298,7 +293,7 @@ class OPDS2Importer(BaseOPDSImporter[OPDS2ImporterSettings]):
             NOTE: If `collection` is provided, its .data_source will take precedence over any value provided here.
             This is only for use when you are importing OPDS metadata without any particular Collection in mind.
         """
-        super().__init__(db, collection, data_source_name, http_get)
+        super().__init__(db, collection, data_source_name)
         self._parser = parser
         self.ignored_identifier_types = self.settings.ignored_identifier_types
 

--- a/tests/fixtures/odl.py
+++ b/tests/fixtures/odl.py
@@ -27,6 +27,7 @@ from palace.manager.sqlalchemy.model.patron import Loan, Patron
 from palace.manager.sqlalchemy.model.work import Work
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.files import FilesFixture, OPDS2WithODLFilesFixture
+from tests.mocks.mock import MockRequestsResponse
 from tests.mocks.odl import MockOPDS2WithODLApi
 
 
@@ -265,10 +266,7 @@ class OPDS2WithODLImporterFixture:
         )
 
     def get_response(self, *args: Any, **kwargs: Any) -> Response:
-        resp = Response()
-        resp.status_code = 200
-        resp._content = self.responses.pop(0)
-        return resp
+        return MockRequestsResponse(200, content=self.responses.pop(0))
 
     def queue_response(self, item: LicenseInfoHelper | str | bytes) -> None:
         if isinstance(item, LicenseInfoHelper):

--- a/tests/fixtures/odl.py
+++ b/tests/fixtures/odl.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from jinja2 import Template
+from requests import Response
 
 from palace.manager.api.circulation import LoanInfo
 from palace.manager.api.odl.api import OPDS2WithODLApi
@@ -23,7 +24,6 @@ from palace.manager.sqlalchemy.model.licensing import (
     LicensePoolDeliveryMechanism,
 )
 from palace.manager.sqlalchemy.model.patron import Loan, Patron
-from palace.manager.sqlalchemy.model.resource import HttpResponseTuple
 from palace.manager.sqlalchemy.model.work import Work
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.files import FilesFixture, OPDS2WithODLFilesFixture
@@ -264,8 +264,11 @@ class OPDS2WithODLImporterFixture:
             http_get=self.get_response,
         )
 
-    def get_response(self, *args: Any, **kwargs: Any) -> HttpResponseTuple:
-        return 200, {}, self.responses.pop(0)
+    def get_response(self, *args: Any, **kwargs: Any) -> Response:
+        resp = Response()
+        resp.status_code = 200
+        resp._content = self.responses.pop(0)
+        return resp
 
     def queue_response(self, item: LicenseInfoHelper | str | bytes) -> None:
         if isinstance(item, LicenseInfoHelper):

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -69,7 +69,7 @@ from tests.fixtures.library import LibraryFixture
 from tests.fixtures.redis import RedisFixture
 from tests.fixtures.services import ServicesFixture
 from tests.mocks.circulation import MockPatronActivityCirculationAPI
-from tests.mocks.mock import DummyHTTPClient
+from tests.mocks.mock import MockRepresentationHTTPClient
 
 
 class LoanFixture(CirculationControllerFixture):
@@ -423,7 +423,7 @@ class TestLoanController:
             # external request to obtain the book.
             loan_fixture.pool.open_access = False
 
-            http = DummyHTTPClient()
+            http = MockRepresentationHTTPClient()
 
             fulfillment = FulfillmentInfo(
                 loan_fixture.pool.collection,
@@ -602,7 +602,7 @@ class TestLoanController:
             assert None == loan.fulfillment
 
             # We can still use the other mechanism too.
-            http = DummyHTTPClient()
+            http = MockRepresentationHTTPClient()
             http.queue_response(200, content="I am an ACSM file")
 
             loan_fixture.manager.d_circulation.queue_fulfill(

--- a/tests/manager/api/metadata/test_novelist.py
+++ b/tests/manager/api/metadata/test_novelist.py
@@ -15,7 +15,7 @@ from palace.manager.sqlalchemy.model.resource import HttpResponseTuple
 from palace.manager.util.http import HTTP
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.files import FilesFixture
-from tests.mocks.mock import DummyHTTPClient, MockRequestsResponse
+from tests.mocks.mock import MockRepresentationHTTPClient, MockRequestsResponse
 
 
 class NoveListFilesFixture(FilesFixture):
@@ -216,7 +216,7 @@ class TestNoveListAPI:
 
     def test_lookup(self, novelist_fixture: NoveListFixture):
         # Test the lookup() method.
-        h = DummyHTTPClient()
+        h = MockRepresentationHTTPClient()
         h.queue_response(200, "text/html", content="yay")
 
         novelist = novelist_fixture.novelist

--- a/tests/manager/api/test_enki.py
+++ b/tests/manager/api/test_enki.py
@@ -594,7 +594,7 @@ class TestEnkiAPI:
     def test_patron_activity_failure(self, enki_test_fixture: EnkiTestFixure):
         db = enki_test_fixture.db
         patron = db.patron()
-        enki_test_fixture.api.queue_response(404, "No such patron")
+        enki_test_fixture.api.queue_response(404, content="No such patron")
         collect = lambda: list(enki_test_fixture.api.patron_activity(patron, "pin"))
         pytest.raises(PatronAuthorizationFailedException, collect)
 

--- a/tests/manager/api/test_opds_for_distributors.py
+++ b/tests/manager/api/test_opds_for_distributors.py
@@ -35,6 +35,7 @@ from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.opds_writer import OPDSFeed
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.files import FilesFixture
+from tests.mocks.mock import MockRequestsResponse
 from tests.mocks.opds_for_distributors import MockOPDSForDistributorsAPI
 
 
@@ -728,7 +729,9 @@ class TestOPDSForDistributorsReaperMonitor:
             """An OPDSForDistributorsReaperMonitor that overrides _get."""
 
             def _get(self, url, headers):
-                return (200, {"content-type": OPDSFeed.ACQUISITION_FEED_TYPE}, feed)
+                return MockRequestsResponse(
+                    200, {"content-type": OPDSFeed.ACQUISITION_FEED_TYPE}, feed
+                )
 
         data_source = DataSource.lookup(
             opds_dist_api_fixture.db.session, "Biblioboard", autocreate=True

--- a/tests/manager/sqlalchemy/model/test_resource.py
+++ b/tests/manager/sqlalchemy/model/test_resource.py
@@ -13,7 +13,7 @@ from tests.fixtures.database import (
     TemporaryDirectoryConfigurationFixture,
 )
 from tests.fixtures.files import SampleCoversFixture
-from tests.mocks.mock import DummyHTTPClient, MockRequestsResponse
+from tests.mocks.mock import MockRepresentationHTTPClient, MockRequestsResponse
 
 
 class TestHyperlink:
@@ -289,7 +289,7 @@ class TestRepresentation:
         assert None == representation.unicode_content
 
     def test_presumed_media_type(self, db: DatabaseTransactionFixture):
-        h = DummyHTTPClient()
+        h = MockRepresentationHTTPClient()
 
         # In the absence of a content-type header, the presumed_media_type
         # takes over.
@@ -328,7 +328,7 @@ class TestRepresentation:
         assert "text/plain" == representation.media_type
 
     def test_404_creates_cachable_representation(self, db: DatabaseTransactionFixture):
-        h = DummyHTTPClient()
+        h = MockRepresentationHTTPClient()
         h.queue_response(404)
 
         url = db.fresh_url()
@@ -340,7 +340,7 @@ class TestRepresentation:
         assert representation == representation2
 
     def test_302_creates_cachable_representation(self, db: DatabaseTransactionFixture):
-        h = DummyHTTPClient()
+        h = MockRepresentationHTTPClient()
         h.queue_response(302)
 
         url = db.fresh_url()
@@ -354,7 +354,7 @@ class TestRepresentation:
     def test_500_creates_uncachable_representation(
         self, db: DatabaseTransactionFixture
     ):
-        h = DummyHTTPClient()
+        h = MockRepresentationHTTPClient()
         h.queue_response(500)
         url = db.fresh_url()
         representation, cached = Representation.get(db.session, url, do_get=h.do_get)
@@ -367,7 +367,7 @@ class TestRepresentation:
     def test_response_reviewer_impacts_representation(
         self, db: DatabaseTransactionFixture
     ):
-        h = DummyHTTPClient()
+        h = MockRepresentationHTTPClient()
         h.queue_response(200, media_type="text/html")
 
         def reviewer(response):
@@ -496,7 +496,7 @@ class TestRepresentation:
         assert "cover.png" == filename
 
     def test_cautious_http_get(self):
-        h = DummyHTTPClient()
+        h = MockRepresentationHTTPClient()
         h.queue_response(200, content="yay")
 
         # If the domain is obviously safe, the GET request goes through,
@@ -660,7 +660,7 @@ class TestRepresentation:
 
         normalizer = Normalizer()
 
-        h = DummyHTTPClient()
+        h = MockRepresentationHTTPClient()
         h.queue_response(200, content="yay")
         original_url = "http://url/?sid=12345"
 


### PR DESCRIPTION
## Description

This removes one layer of abstraction from our HTTP calls and does some refactoring in the tests.

## Motivation and Context

This is some setup for the work in PP-1485.

## How Has This Been Tested?

Ran tests locally.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
