### PR TITLE
Fix test_handle_error_problem_error flaky test

### DIFF
--- a/tests/manager/core/test_app_server.py
+++ b/tests/manager/core/test_app_server.py
@@ -574,6 +574,7 @@ class TestErrorHandler:
     def test_handle_error_problem_error(
         self, error_handler_fixture: ErrorHandlerFixture, caplog: LogCaptureFixture
     ):
+        caplog.set_level(LogLevel.warning)
         handler = error_handler_fixture.handler()
         with error_handler_fixture.app.test_request_context("/"):
             try:


### PR DESCRIPTION
## Description

Explicitly set the log level before testing warning in `test_handle_error_problem_error`.

## Motivation and Context

I've seen test_handle_error_problem_error fail several times recently. See the test run here: https://github.com/ThePalaceProject/circulation/actions/runs/10166561526/job/28117018111?pr=1957#step:7:320

## How Has This Been Tested?

- Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
