### PR TITLE
[PP-1551] Ensure EPUB is always first preview link when present as an…

### DIFF
--- a/src/palace/manager/feed/annotator/base.py
+++ b/src/palace/manager/feed/annotator/base.py
@@ -258,17 +258,6 @@ class Annotator(ToFeedEntry):
             return -1
         elif link_1_type != epub_type and link_2_type == epub_type:
             return 1
-        elif link_1_type > link_2_type:
-            return 1
-        elif link_1_type < link_2_type:
-            return -1
-        elif link1.href and link2.href:
-            if link1.href > link2.href:
-                return 1
-            elif link1.href < link2.href:
-                return -1
-            else:
-                return 0
         else:
             return 0
 

--- a/src/palace/manager/feed/annotator/base.py
+++ b/src/palace/manager/feed/annotator/base.py
@@ -20,6 +20,7 @@ from palace.manager.feed.types import (
     WorkEntryData,
 )
 from palace.manager.feed.util import strftime
+from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.classification import Subject
 from palace.manager.sqlalchemy.model.contributor import Contribution, Contributor
 from palace.manager.sqlalchemy.model.datasource import DataSource
@@ -244,18 +245,30 @@ class ToFeedEntry:
 
 
 class Annotator(ToFeedEntry):
-    @classmethod
-    def _sample_link_comparator(cls, link1: Link, link2: Link):
-        link_1_type = link1.type.lower()
-        link_2_type = link2.type.lower()
-        if "/epub" in link_1_type and "/epub" not in link_2_type:
+    @staticmethod
+    def _sample_link_comparator(link1: Link, link2: Link) -> int:
+        link_1_type = link1.type
+        link_2_type = link2.type
+        assert link_1_type
+        assert link_2_type
+
+        epub_type = MediaTypes.EPUB_MEDIA_TYPE
+
+        if link_1_type == epub_type and link_2_type != epub_type:
             return -1
-        elif "/epub" in link_2_type and "/epub" not in link_1_type:
+        elif link_1_type != epub_type and link_2_type == epub_type:
             return 1
         elif link_1_type > link_2_type:
             return 1
         elif link_1_type < link_2_type:
             return -1
+        elif link1.href and link2.href:
+            if link1.href > link2.href:
+                return 1
+            elif link1.href < link2.href:
+                return -1
+            else:
+                return 0
         else:
             return 0
 

--- a/tests/manager/feed/test_annotators.py
+++ b/tests/manager/feed/test_annotators.py
@@ -432,9 +432,10 @@ class TestAnnotator:
             return link
 
         create_sample_link(MediaTypes.PDF_MEDIA_TYPE, "http://pdf")
-        create_sample_link(MediaTypes.EPUB_MEDIA_TYPE, "http://epub")
+        create_sample_link(MediaTypes.EPUB_MEDIA_TYPE, "http://epub-b")
         create_sample_link(MediaTypes.TEXT_HTML_MEDIA_TYPE, "http://html")
         create_sample_link(MediaTypes.APPLICATION_JSON_MEDIA_TYPE, "http://json")
+        create_sample_link(MediaTypes.EPUB_MEDIA_TYPE, "http://epub-a")
 
         edition.cover_full_url = "http://coverurl.jpg"
         edition.cover_thumbnail_url = "http://thumburl.gif"
@@ -485,9 +486,12 @@ class TestAnnotator:
         # other links
         other_links = data.other_links
         assert other_links[0].type == MediaTypes.EPUB_MEDIA_TYPE
-        assert other_links[1].type == MediaTypes.APPLICATION_JSON_MEDIA_TYPE
-        assert other_links[2].type == MediaTypes.PDF_MEDIA_TYPE
-        assert other_links[3].type == MediaTypes.TEXT_HTML_MEDIA_TYPE
+        assert other_links[0].href.startswith("http://epub-a")
+        assert other_links[1].type == MediaTypes.EPUB_MEDIA_TYPE
+        assert other_links[1].href.startswith("http://epub-b")
+        assert other_links[2].type == MediaTypes.APPLICATION_JSON_MEDIA_TYPE
+        assert other_links[3].type == MediaTypes.PDF_MEDIA_TYPE
+        assert other_links[4].type == MediaTypes.TEXT_HTML_MEDIA_TYPE
 
 
 class CirculationManagerAnnotatorFixture:
@@ -730,24 +734,31 @@ class TestCirculationManagerAnnotator:
         assert "2017-01-01" in entry.get("updated")
 
     def test_sample_link_sort(self):
-        epub_link = Link(rel=None, href=None, type="application/epub+zip")
-        html_link = Link(rel=None, href=None, type="text/html")
-        pdf_link = Link(rel=None, href=None, type="application/pdf")
-        kepub_link = Link(rel=None, href=None, type="z-application/kepub+zip")
+        epub_link_a = Link(rel=None, href="a", type=MediaTypes.EPUB_MEDIA_TYPE)
+        epub_link_b = Link(rel=None, href="b", type=MediaTypes.EPUB_MEDIA_TYPE)
+        html_link = Link(rel=None, href="a", type=MediaTypes.TEXT_HTML_MEDIA_TYPE)
+        pdf_link = Link(rel=None, href="a", type=MediaTypes.PDF_MEDIA_TYPE)
+        kepub_link = Link(rel=None, href="a", type="application/kepub+zip")
 
-        sorted_order = [epub_link, pdf_link, html_link, kepub_link]
+        expected_sorted_order = [
+            epub_link_a,
+            epub_link_b,
+            kepub_link,
+            pdf_link,
+            html_link,
+        ]
 
-        test_1 = sorted_order.copy()
+        test_1 = expected_sorted_order.copy()
         test_1.sort(key=cmp_to_key(Annotator._sample_link_comparator))
 
-        assert test_1 == sorted_order
+        assert test_1 == expected_sorted_order
 
-        test_2 = [kepub_link, html_link, pdf_link, epub_link]
+        test_2 = [kepub_link, html_link, pdf_link, epub_link_b, epub_link_a]
         test_2.sort(key=cmp_to_key(Annotator._sample_link_comparator))
 
-        assert test_2 == sorted_order
+        assert test_2 == expected_sorted_order
 
-        test_3 = [epub_link, pdf_link, kepub_link, html_link]
+        test_3 = [epub_link_b, epub_link_a, pdf_link, kepub_link, html_link]
         test_3.sort(key=cmp_to_key(Annotator._sample_link_comparator))
 
-        assert test_3 == sorted_order
+        assert test_3 == expected_sorted_order

--- a/tests/manager/feed/test_annotators.py
+++ b/tests/manager/feed/test_annotators.py
@@ -486,12 +486,10 @@ class TestAnnotator:
         # other links
         other_links = data.other_links
         assert other_links[0].type == MediaTypes.EPUB_MEDIA_TYPE
-        assert other_links[0].href.startswith("http://epub-a")
         assert other_links[1].type == MediaTypes.EPUB_MEDIA_TYPE
-        assert other_links[1].href.startswith("http://epub-b")
-        assert other_links[2].type == MediaTypes.APPLICATION_JSON_MEDIA_TYPE
-        assert other_links[3].type == MediaTypes.PDF_MEDIA_TYPE
-        assert other_links[4].type == MediaTypes.TEXT_HTML_MEDIA_TYPE
+        assert other_links[2].type != MediaTypes.EPUB_MEDIA_TYPE
+        assert other_links[3].type != MediaTypes.EPUB_MEDIA_TYPE
+        assert other_links[4].type != MediaTypes.EPUB_MEDIA_TYPE
 
 
 class CirculationManagerAnnotatorFixture:
@@ -748,17 +746,21 @@ class TestCirculationManagerAnnotator:
             html_link,
         ]
 
+        def test_expected_order(result, expected):
+            assert result[0].type == expected[0].type
+            assert result[1].type == expected[1].type
+            assert result[2].type != MediaTypes.EPUB_MEDIA_TYPE
+            assert result[3].type != MediaTypes.EPUB_MEDIA_TYPE
+            assert result[4].type != MediaTypes.EPUB_MEDIA_TYPE
+
         test_1 = expected_sorted_order.copy()
         test_1.sort(key=cmp_to_key(Annotator._sample_link_comparator))
-
-        assert test_1 == expected_sorted_order
+        test_expected_order(test_1, expected_sorted_order)
 
         test_2 = [kepub_link, html_link, pdf_link, epub_link_b, epub_link_a]
         test_2.sort(key=cmp_to_key(Annotator._sample_link_comparator))
-
-        assert test_2 == expected_sorted_order
+        test_expected_order(test_2, expected_sorted_order)
 
         test_3 = [epub_link_b, epub_link_a, pdf_link, kepub_link, html_link]
         test_3.sort(key=cmp_to_key(Annotator._sample_link_comparator))
-
-        assert test_3 == expected_sorted_order
+        test_expected_order(test_3, expected_sorted_order)


### PR DESCRIPTION
… option.

## Description
This update ensures that the sample links are sorted such that EPUB, if present, will appear at the top of the list.

If the media type contains `/epub` the link will appear first in the list of sample urls. Otherwise the media type will be sorted alphabetically.

<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1551
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Two new unit tests added.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
