### PR TITLE
Add type hints for util.HTTP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ module = [
     "palace.manager.util.authentication_for_opds",
     "palace.manager.util.base64",
     "palace.manager.util.cache",
+    "palace.manager.util.http",
     "palace.manager.util.log",
     "palace.manager.util.migration.*",
     "palace.manager.util.notifications",

--- a/src/palace/manager/core/selftest.py
+++ b/src/palace/manager/core/selftest.py
@@ -11,10 +11,10 @@ from typing import Any, ParamSpec, TypeVar
 
 from sqlalchemy.orm import Session
 
+from palace.manager.core.exceptions import IntegrationException
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
 from palace.manager.util.datetime_helpers import utc_now
-from palace.manager.util.http import IntegrationException
 from palace.manager.util.log import LoggerMixin
 from palace.manager.util.opds_writer import AtomFeed
 

--- a/tests/manager/api/metadata/test_nyt.py
+++ b/tests/manager/api/metadata/test_nyt.py
@@ -12,12 +12,12 @@ from palace.manager.api.metadata.nyt import (
     NYTBestSellerListTitle,
 )
 from palace.manager.core.config import CannotLoadConfiguration
+from palace.manager.core.exceptions import IntegrationException
 from palace.manager.integration.goals import Goals
 from palace.manager.service.integration_registry.metadata import MetadataRegistry
 from palace.manager.sqlalchemy.model.contributor import Contributor
 from palace.manager.sqlalchemy.model.customlist import CustomListEntry
 from palace.manager.sqlalchemy.model.edition import Edition
-from palace.manager.util.http import IntegrationException
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.files import FilesFixture
 

--- a/tests/manager/api/test_authenticator.py
+++ b/tests/manager/api/test_authenticator.py
@@ -52,6 +52,7 @@ from palace.manager.api.problem_details import (
 from palace.manager.api.simple_authentication import SimpleAuthenticationProvider
 from palace.manager.api.sip import SIP2AuthenticationProvider
 from palace.manager.api.util.patron import PatronUtility
+from palace.manager.core.exceptions import IntegrationException
 from palace.manager.core.user_profile import ProfileController
 from palace.manager.integration.goals import Goals
 from palace.manager.service.analytics.analytics import Analytics
@@ -67,7 +68,7 @@ from palace.manager.sqlalchemy.model.library import Library, LibraryLogo
 from palace.manager.sqlalchemy.model.patron import Patron
 from palace.manager.util.authentication_for_opds import AuthenticationForOPDSDocument
 from palace.manager.util.datetime_helpers import utc_now
-from palace.manager.util.http import IntegrationException, RemoteIntegrationException
+from palace.manager.util.http import RemoteIntegrationException
 from palace.manager.util.opds_writer import OPDSFeed
 from palace.manager.util.problem_detail import ProblemDetail
 from tests.fixtures.announcements import AnnouncementFixture

--- a/tests/manager/core/test_selftest.py
+++ b/tests/manager/core/test_selftest.py
@@ -12,11 +12,11 @@ from unittest.mock import MagicMock, create_autospec
 from pytest import MonkeyPatch
 from sqlalchemy.orm import Session
 
+from palace.manager.core.exceptions import IntegrationException
 from palace.manager.core.selftest import HasSelfTests, SelfTestResult
 from palace.manager.integration.goals import Goals
 from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
 from palace.manager.util.datetime_helpers import utc_now
-from palace.manager.util.http import IntegrationException
 from tests.fixtures.database import DatabaseTransactionFixture
 
 


### PR DESCRIPTION
## Description

- Adds type hints for `util.HTTP`, and adds it to the list of files that are covered by strict type checking.
- Removes the unused encoding parameter.
- Adds a `BearerAuth` helper class for doing Bearer token authentication.

## Motivation and Context

I broke this work off from the work I was doing in https://github.com/ThePalaceProject/circulation/pull/1960, since that PR needs some rework before it can be merged and these changes were more general, and I should be ready to be merged now.

## How Has This Been Tested?

- Tested locally
- Unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
