### PR TITLE
[PP-1525] Add support for bypassing user blocks on Sirsidynix Authent…

### DIFF
--- a/src/palace/manager/api/sirsidynix_authentication_provider.py
+++ b/src/palace/manager/api/sirsidynix_authentication_provider.py
@@ -66,7 +66,6 @@ class SirsiDynixHorizonAuthSettings(BasicAuthProviderSettings):
             type=ConfigurationFormItemType.SELECT,
             options={"true": "Yes, block.", "false": "No, do not block."},
         ),
-        alias="patron block status",
     )
 
 

--- a/src/palace/manager/api/sirsidynix_authentication_provider.py
+++ b/src/palace/manager/api/sirsidynix_authentication_provider.py
@@ -165,7 +165,7 @@ class SirsiDynixHorizonAuthenticationProvider(
         self.sirsi_disallowed_suffixes = library_settings.library_disallowed_suffixes
         self.sirsi_library_id = library_settings.library_id
 
-        # Check if patrons should be blocked based on SIP status
+        # Check if patrons should be blocked based on ILS status
         self.patron_status_should_block = settings.patron_status_block
 
     def remote_authenticate(

--- a/src/palace/manager/api/sirsidynix_authentication_provider.py
+++ b/src/palace/manager/api/sirsidynix_authentication_provider.py
@@ -167,10 +167,7 @@ class SirsiDynixHorizonAuthenticationProvider(
         self.sirsi_library_id = library_settings.library_id
 
         # Check if patrons should be blocked based on SIP status
-        if settings.patron_status_block:
-            self.patron_status_should_block = True
-        else:
-            self.patron_status_should_block = False
+        self.patron_status_should_block = settings.patron_status_block
 
     def remote_authenticate(
         self, username: str | None, password: str | None

--- a/src/palace/manager/api/sirsidynix_authentication_provider.py
+++ b/src/palace/manager/api/sirsidynix_authentication_provider.py
@@ -56,6 +56,19 @@ class SirsiDynixHorizonAuthSettings(BasicAuthProviderSettings):
         alias="CLIENT_ID",
     )
 
+    patron_status_block: bool = FormField(
+        True,
+        form=ConfigurationFormItem(
+            label="Patron Status Block",
+            description=(
+                "Block patrons from borrowing based on the status of the ILS's patron block field?"
+            ),
+            type=ConfigurationFormItemType.SELECT,
+            options={"true": "Yes, block.", "false": "No, do not block."},
+        ),
+        alias="patron block status",
+    )
+
 
 class SirsiDynixHorizonAuthLibrarySettings(BasicAuthProviderLibrarySettings):
     library_id: str = FormField(
@@ -153,6 +166,12 @@ class SirsiDynixHorizonAuthenticationProvider(
         self.sirsi_disallowed_suffixes = library_settings.library_disallowed_suffixes
         self.sirsi_library_id = library_settings.library_id
 
+        # Check if patrons should be blocked based on SIP status
+        if settings.patron_status_block:
+            self.patron_status_should_block = True
+        else:
+            self.patron_status_should_block = False
+
     def remote_authenticate(
         self, username: str | None, password: str | None
     ) -> PatronData | None:
@@ -213,38 +232,44 @@ class SirsiDynixHorizonAuthenticationProvider(
                 patrondata.block_reason = SirsiBlockReasons.PATRON_BLOCKED
                 return patrondata
 
-        # Get patron "fines" information
-        status = self.api_patron_status_info(
-            patron_key=patrondata.permanent_id,
-            session_token=patrondata.session_token,
-        )
+        if self.patron_status_should_block:
+            # Get patron "fines" information
+            status = self.api_patron_status_info(
+                patron_key=patrondata.permanent_id,
+                session_token=patrondata.session_token,
+            )
 
-        if not status or "fields" not in status:
-            return None
+            if not status or "fields" not in status:
+                return None
 
-        status_fields: dict = status["fields"]
-        fines = status_fields.get("estimatedFines")
-        if fines is not None:
-            # We ignore currency for now, and assume USD
-            patrondata.fines = float(fines.get("amount", 0))
+            status_fields: dict = status["fields"]
+            fines = status_fields.get("estimatedFines")
+            if fines is not None:
+                # We ignore currency for now, and assume USD
+                patrondata.fines = float(fines.get("amount", 0))
 
-        # Blockable statuses
-        if status_fields.get("hasMaxDaysWithFines") or status_fields.get("hasMaxFines"):
-            patrondata.block_reason = PatronData.EXCESSIVE_FINES
-        elif status_fields.get("hasMaxLostItem"):
-            patrondata.block_reason = PatronData.TOO_MANY_LOST
-        elif status_fields.get("hasMaxOverdueDays") or status_fields.get(
-            "hasMaxOverdueItem"
-        ):
-            patrondata.block_reason = PatronData.TOO_MANY_OVERDUE
-        elif status_fields.get("hasMaxItemsCheckedOut"):
-            patrondata.block_reason = PatronData.TOO_MANY_LOANS
-        elif status_fields.get("expired"):
-            patrondata.block_reason = SirsiBlockReasons.EXPIRED
+            # Blockable statuses
+            if status_fields.get("hasMaxDaysWithFines") or status_fields.get(
+                "hasMaxFines"
+            ):
+                patrondata.block_reason = PatronData.EXCESSIVE_FINES
+            elif status_fields.get("hasMaxLostItem"):
+                patrondata.block_reason = PatronData.TOO_MANY_LOST
+            elif status_fields.get("hasMaxOverdueDays") or status_fields.get(
+                "hasMaxOverdueItem"
+            ):
+                patrondata.block_reason = PatronData.TOO_MANY_OVERDUE
+            elif status_fields.get("hasMaxItemsCheckedOut"):
+                patrondata.block_reason = PatronData.TOO_MANY_LOANS
+            elif status_fields.get("expired"):
+                patrondata.block_reason = SirsiBlockReasons.EXPIRED
 
-        # If previously, the patron was blocked this should unset the value in the DB
-        if patrondata.block_reason is None:
+            # If previously, the patron was blocked this should unset the value in the DB
+            if patrondata.block_reason is None:
+                patrondata.block_reason = PatronData.NO_VALUE
+        else:
             patrondata.block_reason = PatronData.NO_VALUE
+
         return patrondata
 
     ###

--- a/tests/manager/api/test_sirsidynix_auth_provider.py
+++ b/tests/manager/api/test_sirsidynix_auth_provider.py
@@ -80,7 +80,7 @@ class SirsiAuthFixture:
     def provider_mocked_api(
         self,
         provider: SirsiDynixHorizonAuthenticationProvider | None = None,
-        patron_status_info: dict | None = None,
+        patron_status_info: dict[str, Any] | None = None,
     ) -> MockedSirsiApi:
         if provider is None:
             provider = self.provider()


### PR DESCRIPTION
…ication Provider.

## Description

This update adds a setting to the Sirsidynix Horizon Authentication provider for ignoring user blocks due to any block other than an expired card.  By default blocks are respected.

When blocks are ignored, we are skipping the call for patron block information. 
<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1525
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I added three unit tests and verified manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
