### PR TITLE
[PP-1544] Do not specify target age on interest level classifier for …

### DIFF
--- a/src/palace/manager/core/classifier/age.py
+++ b/src/palace/manager/core/classifier/age.py
@@ -156,8 +156,6 @@ class InterestLevelClassifier(Classifier):
             return cls.range_tuple(5, 8)
         if identifier in ("mg+", "mg"):
             return cls.range_tuple(9, 13)
-        if identifier == "ug":
-            return cls.range_tuple(14, 17)
         return None
 
 

--- a/tests/manager/core/classifiers/test_age.py
+++ b/tests/manager/core/classifiers/test_age.py
@@ -179,4 +179,4 @@ class TestInterestLevelClassifier:
         assert (5, 8) == f("lg")
         assert (9, 13) == f("mg")
         assert (9, 13) == f("mg+")
-        assert (14, 17) == f("ug")
+        assert f("ug") is None


### PR DESCRIPTION
…"UG" interest level

## Description
This update removes the target_age classification on the InterestLevelClassifier for "UG".   This way downstream classifiers will not use the target_age resolved from an interest level classifier to resolve an audience.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1544

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests updated.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
