### PR TITLE
[PP-1377] Ensure all eligible collections are displayed in report pre…

### DIFF
--- a/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
+++ b/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
@@ -36,7 +36,15 @@ def eligible_integrations(
     def is_eligible(integration: IntegrationConfiguration) -> bool:
         if integration.protocol is None:
             return False
-        settings = registry[integration.protocol].settings_load(integration)
+
+        if integration.collection.parent:
+            parent_integration = integration.collection.parent.integration_configuration
+        else:
+            parent_integration = None
+
+        settings = registry[integration.protocol].settings_load(
+            integration, parent_integration
+        )
         return isinstance(settings, OPDSImporterSettings)
 
     return [integration for integration in integrations if is_eligible(integration)]

--- a/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
+++ b/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
@@ -37,15 +37,8 @@ def eligible_integrations(
         if integration.protocol is None:
             return False
 
-        if integration.collection.parent:
-            parent_integration = integration.collection.parent.integration_configuration
-        else:
-            parent_integration = None
-
-        settings = registry[integration.protocol].settings_load(
-            integration, parent_integration
-        )
-        return isinstance(settings, OPDSImporterSettings)
+        settings_cls = registry[integration.protocol].settings_class()
+        return issubclass(settings_cls, OPDSImporterSettings)
 
     return [integration for integration in integrations if is_eligible(integration)]
 

--- a/src/palace/manager/integration/base.py
+++ b/src/palace/manager/integration/base.py
@@ -102,7 +102,11 @@ class HasIntegrationConfiguration(Generic[SettingsType], ABC):
         ...
 
     @classmethod
-    def settings_load(cls, integration: IntegrationConfiguration) -> SettingsType:
+    def settings_load(
+        cls,
+        integration: IntegrationConfiguration,
+        parent: IntegrationConfiguration | None = None,
+    ) -> SettingsType:
         """
         Load the settings object for this integration from the database.
 

--- a/src/palace/manager/integration/base.py
+++ b/src/palace/manager/integration/base.py
@@ -105,7 +105,6 @@ class HasIntegrationConfiguration(Generic[SettingsType], ABC):
     def settings_load(
         cls,
         integration: IntegrationConfiguration,
-        parent: IntegrationConfiguration | None = None,
     ) -> SettingsType:
         """
         Load the settings object for this integration from the database.


### PR DESCRIPTION
…view.
## Description
This update addresses the bug that was causing the list of collections to be included in the inventory report to fail when the library in question as associated with at least one overdrive advantage account.



<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1377
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tested it manually and added a new test that covers the conditions required to reproduce the bug.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
