### PR TITLE
Fix docker warning annotation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN . env/bin/activate && \
 
 FROM common AS exec
 
-ENV SIMPLIFIED_SCRIPT_NAME ""
+ENV SIMPLIFIED_SCRIPT_NAME=""
 
 VOLUME /var/log
 WORKDIR /home/simplified/circulation/bin


### PR DESCRIPTION
## Description

Recent PRs have had the following warning annotation on them: 

```
GitHub Actions / Push circ-exec

Legacy key/value format with whitespace separator should not be used

LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/
```

This PR should fix that, so we're not seeing that annotation on every PR.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
