### PR TITLE
[PP-1556] Fix broken time tracking summary script.

### DIFF
--- a/src/palace/manager/sqlalchemy/model/time_tracking.py
+++ b/src/palace/manager/sqlalchemy/model/time_tracking.py
@@ -21,7 +21,7 @@ from palace.manager.sqlalchemy.model.identifier import (
     Identifier,
     RecursiveEquivalencyCache,
 )
-from palace.manager.sqlalchemy.util import get_one, get_one_or_create
+from palace.manager.sqlalchemy.util import get_one_or_create
 from palace.manager.util.datetime_helpers import minute_timestamp
 
 if TYPE_CHECKING:
@@ -228,7 +228,11 @@ def _title_for_identifier(identifier: Identifier | None) -> str | None:
     if identifier is None:
         return None
     db = Session.object_session(identifier)
-    if edition := get_one(db, Edition, primary_identifier_id=identifier.id):
+    if (
+        edition := db.query(Edition)
+        .filter(Edition.primary_identifier == identifier)
+        .first()
+    ):
         return edition.title
     return None
 

--- a/tests/manager/sqlalchemy/model/test_time_tracking.py
+++ b/tests/manager/sqlalchemy/model/test_time_tracking.py
@@ -11,6 +11,7 @@ from palace.manager.sqlalchemy.model.time_tracking import (
     PlaytimeEntry,
     PlaytimeSummary,
     _isbn_for_identifier,
+    _title_for_identifier,
 )
 from palace.manager.sqlalchemy.util import create
 from palace.manager.util.datetime_helpers import utc_now
@@ -295,3 +296,24 @@ class TestHelpers:
         result = _isbn_for_identifier(test_identifier)
         # Assert
         assert result == expected_isbn
+
+    def test__title_for_identifier_multiple_editions(
+        self,
+        db: DatabaseTransactionFixture,
+    ):
+        identifier = db.identifier()
+        test_title = "test title"
+        e1 = db.edition(title=test_title)
+        e2 = db.edition(title=test_title, data_source_name="another datasource")
+        e1.primary_identifier = identifier
+        e2.primary_identifier = identifier
+        assert e1.id != e2.id
+        result = _title_for_identifier(identifier)
+        assert result == test_title
+
+    def test__title_for_identifier_no_edition(
+        self,
+        db: DatabaseTransactionFixture,
+    ):
+        identifier = db.identifier()
+        assert not _title_for_identifier(identifier)


### PR DESCRIPTION
## Description

Since it is possible for multiple editions to be returned  when looking up an edition by primary identifier (ie when there are multiple collections with overlapping contents on the same CM), we should grab the first result rather than expecting one and only one result.
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1556
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
