### PR TITLE
Fix bug in HTTP._request_with_timeout when headers are None (PP-1582)

### DIFF
--- a/src/palace/manager/util/http.py
+++ b/src/palace/manager/util/http.py
@@ -261,29 +261,29 @@ class HTTP(LoggerMixin):
         )
         backoff_factor: float = float(kwargs.pop("backoff_factor", 1.0))
 
-        # Unicode data can't be sent over the wire. Convert it
-        # to UTF-8.
+        # Unicode data can't be sent over the wire. Convert it to UTF-8.
         if "data" in kwargs and isinstance(kwargs["data"], str):
             kwdata: str = kwargs["data"]
             kwargs["data"] = kwdata.encode("utf8")
 
-        headers = kwargs.get("headers", {})
         # Set a user-agent if not already present
-        if "User-Agent" not in headers:
-            version = (
-                manager.__version__
-                if manager.__version__
-                else cls.DEFAULT_USER_AGENT_VERSION
-            )
-            headers["User-Agent"] = f"Palace Manager/{version}"
-        new_headers = {}
-        for k, v in list(headers.items()):
-            if isinstance(k, str):
-                k = k.encode("utf8")
-            if isinstance(v, str):
-                v = v.encode("utf8")
-            new_headers[k] = v
-        kwargs["headers"] = new_headers
+        version = (
+            manager.__version__
+            if manager.__version__
+            else cls.DEFAULT_USER_AGENT_VERSION
+        )
+        ua_header = {"User-Agent": f"Palace Manager/{version}"}
+        headers = ua_header | (kwargs.get("headers") or {})
+
+        # Make sure headers are encoded as utf-8
+        kwargs["headers"] = {
+            k.encode()
+            if isinstance(k, str)
+            else k: v.encode()
+            if isinstance(v, str)
+            else v
+            for k, v in headers.items()
+        }
 
         try:
             if verbose:

--- a/tests/manager/util/test_http.py
+++ b/tests/manager/util/test_http.py
@@ -97,6 +97,26 @@ class TestHTTP:
         assert HTTP._request_with_timeout("/", request.fake_request).status_code == 201
         assert request.agent == b"Palace Manager/1.x.x"
 
+        # User agent is still set if headers are None
+        assert (
+            HTTP._request_with_timeout(
+                "/", request.fake_request, headers=None
+            ).status_code
+            == 201
+        )
+        assert request.agent == b"Palace Manager/1.x.x"
+
+        # The headers are not modified if they are passed into the function
+        original_headers = {"header": "value"}
+        assert (
+            HTTP._request_with_timeout(
+                "/", request.fake_request, headers=original_headers
+            ).status_code
+            == 201
+        )
+        assert request.agent == b"Palace Manager/1.x.x"
+        assert original_headers == {"header": "value"}
+
     def test_request_with_timeout_failure(self):
         def immediately_timeout(*args, **kwargs):
             raise requests.exceptions.Timeout("I give up")


### PR DESCRIPTION
## Description

`HTTP._request_with_timeout` was failing when `None` was passed in as a headers value. The function was also modifying the passed in headers dict, which might be unexpected by the caller. This PR fixes both of those issues and adds tests for them. 

## Motivation and Context

The code in https://github.com/ThePalaceProject/circulation/pull/1960 was calling `HTTP._request_with_timeout` causing an exception.

## How Has This Been Tested?

- Tested locally
- Tested with unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
