### PR TITLE
Fix admin UI setting for Library Identifier Field

### DIFF
--- a/src/palace/manager/api/authentication/basic.py
+++ b/src/palace/manager/api/authentication/basic.py
@@ -217,6 +217,7 @@ class BasicAuthProviderLibrarySettings(AuthProviderLibrarySettings):
         "barcode",
         form=ConfigurationFormItem(
             label="Library Identifier Field",
+            type=ConfigurationFormItemType.SELECT,
             description="This is the field on the patron record that the <em>Library Identifier Restriction "
             "Type</em> is applied to, different patron authentication methods provide different "
             "values here. This value is not used if <em>Library Identifier Restriction Type</em> "


### PR DESCRIPTION
## Description

Adds `ConfigurationFormItemType.SELECT` to the _Library Identifier Field_ form input. 

## Motivation and Context

This field already had `options` set like it was a select value, but because it was missing `ConfigurationFormItemType.SELECT` it wasn't being rendered correctly in the admin UI.

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
