### PR TITLE
[PP-1589] Always block expired cards for Sirsidynix Horizon regardles…

### DIFF
--- a/tests/manager/api/test_sirsidynix_auth_provider.py
+++ b/tests/manager/api/test_sirsidynix_auth_provider.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 from copy import deepcopy
 from dataclasses import dataclass
@@ -214,7 +213,7 @@ class TestSirsiDynixAuthenticationProvider:
         assert patrondata.library_identifier == "testtype"
 
     @pytest.mark.parametrize(
-        "patron_data, patron_status_block, block_reason",
+        "patron_data, patron_blocks_enforced, block_reason",
         [
             (
                 None,
@@ -233,43 +232,6 @@ class TestSirsiDynixAuthenticationProvider:
             ),
             (
                 {"fields": {"hasMaxDaysWithFines": True}},
-                False,
-                PatronData.NO_VALUE,
-            ),
-            (
-                {"fields": {"privilegeExpiresDate": "1900-01-01"}},
-                True,
-                SirsiBlockReasons.EXPIRED,
-            ),
-            (
-                {"fields": {"privilegeExpiresDate": "1900-01-01"}},
-                False,
-                SirsiBlockReasons.EXPIRED,
-            ),
-            (
-                {"fields": {"privilegeExpiresDate": "19000101"}},
-                False,
-                SirsiBlockReasons.EXPIRED,
-            ),
-            (
-                {
-                    "fields": {
-                        "privilegeExpiresDate": (
-                            datetime.datetime.now() - datetime.timedelta(days=1)
-                        ).isoformat()
-                    }
-                },
-                False,
-                SirsiBlockReasons.EXPIRED,
-            ),
-            (
-                {
-                    "fields": {
-                        "privilegeExpiresDate": (
-                            datetime.datetime.now() + datetime.timedelta(days=1)
-                        ).isoformat()
-                    }
-                },
                 False,
                 PatronData.NO_VALUE,
             ),
@@ -304,10 +266,12 @@ class TestSirsiDynixAuthenticationProvider:
         self,
         sirsi_auth_fixture: SirsiAuthFixture,
         patron_data: dict[Any, Any],
-        patron_status_block: bool,
+        patron_blocks_enforced: bool,
         block_reason: str,
     ):
-        settings = sirsi_auth_fixture.settings(patron_status_block=patron_status_block)
+        settings = sirsi_auth_fixture.settings(
+            patron_blocks_enforced=patron_blocks_enforced
+        )
         provider = sirsi_auth_fixture.provider(settings=settings)
         provider_mock = sirsi_auth_fixture.provider_mocked_api(provider)
         if patron_data:

--- a/tests/manager/api/test_sirsidynix_auth_provider.py
+++ b/tests/manager/api/test_sirsidynix_auth_provider.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 from copy import deepcopy
 from dataclasses import dataclass
@@ -212,30 +213,105 @@ class TestSirsiDynixAuthenticationProvider:
         assert patrondata.block_reason == PatronData.NO_VALUE
         assert patrondata.library_identifier == "testtype"
 
-    def test_remote_patron_lookup_unblocked_user_with_blocks_ignored(
-        self, sirsi_auth_fixture: SirsiAuthFixture
+    @pytest.mark.parametrize(
+        "patron_data, patron_status_block, block_reason",
+        [
+            (
+                None,
+                False,
+                PatronData.NO_VALUE,
+            ),
+            (
+                None,
+                True,
+                PatronData.NO_VALUE,
+            ),
+            (
+                {"fields": {"hasMaxDaysWithFines": True}},
+                True,
+                PatronData.EXCESSIVE_FINES,
+            ),
+            (
+                {"fields": {"hasMaxDaysWithFines": True}},
+                False,
+                PatronData.NO_VALUE,
+            ),
+            (
+                {"fields": {"privilegeExpiresDate": "1900-01-01"}},
+                True,
+                SirsiBlockReasons.EXPIRED,
+            ),
+            (
+                {"fields": {"privilegeExpiresDate": "1900-01-01"}},
+                False,
+                SirsiBlockReasons.EXPIRED,
+            ),
+            (
+                {"fields": {"privilegeExpiresDate": "19000101"}},
+                False,
+                SirsiBlockReasons.EXPIRED,
+            ),
+            (
+                {
+                    "fields": {
+                        "privilegeExpiresDate": (
+                            datetime.datetime.now() - datetime.timedelta(days=1)
+                        ).isoformat()
+                    }
+                },
+                False,
+                SirsiBlockReasons.EXPIRED,
+            ),
+            (
+                {
+                    "fields": {
+                        "privilegeExpiresDate": (
+                            datetime.datetime.now() + datetime.timedelta(days=1)
+                        ).isoformat()
+                    }
+                },
+                False,
+                PatronData.NO_VALUE,
+            ),
+            (
+                {"fields": {"privilegeExpiresDate": "9999-01-01"}},
+                True,
+                PatronData.NO_VALUE,
+            ),
+            (
+                {"fields": {"expired": True}},
+                True,
+                SirsiBlockReasons.EXPIRED,
+            ),
+            (
+                {"fields": {"expired": True}},
+                False,
+                SirsiBlockReasons.EXPIRED,
+            ),
+            (
+                {"fields": {"expired": False}},
+                True,
+                PatronData.NO_VALUE,
+            ),
+            (
+                {"fields": {"expired": False}},
+                False,
+                PatronData.NO_VALUE,
+            ),
+        ],
+    )
+    def test_remote_patron_lookup_blocks(
+        self,
+        sirsi_auth_fixture: SirsiAuthFixture,
+        patron_data: dict[Any, Any],
+        patron_status_block: bool,
+        block_reason: str,
     ):
-        settings = sirsi_auth_fixture.settings(patron_status_block=False)
+        settings = sirsi_auth_fixture.settings(patron_status_block=patron_status_block)
         provider = sirsi_auth_fixture.provider(settings=settings)
         provider_mock = sirsi_auth_fixture.provider_mocked_api(provider)
-        patrondata = provider_mock.provider.remote_patron_lookup(
-            SirsiDynixPatronData(permanent_id="xxxx", session_token="xxx")
-        )
-
-        assert provider_mock.api_read_patron_data.call_count == 1
-        assert provider_mock.api_patron_status_info.call_count == 0
-        assert isinstance(patrondata, PatronData)
-        assert patrondata.personal_name == "Test User"
-        assert patrondata.block_reason == PatronData.NO_VALUE
-
-    def test_remote_patron_lookup_blocked_user_with_blocks_enabled(
-        self, sirsi_auth_fixture: SirsiAuthFixture
-    ):
-        """Tests that remote patron block status is called when blocks are enabled."""
-        patron_info = {"fields": {"hasMaxDaysWithFines": True}}
-        provider_mock = sirsi_auth_fixture.provider_mocked_api(
-            patron_status_info=patron_info
-        )
+        if patron_data:
+            provider_mock.api_patron_status_info.return_value = patron_data
 
         patrondata = provider_mock.provider.remote_patron_lookup(
             SirsiDynixPatronData(permanent_id="xxxx", session_token="xxx")
@@ -245,28 +321,7 @@ class TestSirsiDynixAuthenticationProvider:
         assert provider_mock.api_patron_status_info.call_count == 1
         assert isinstance(patrondata, PatronData)
         assert patrondata.personal_name == "Test User"
-        assert patrondata.block_reason == PatronData.EXCESSIVE_FINES
-
-    def test_remote_patron_lookup_blocked_user_with_blocks_ignored(
-        self, sirsi_auth_fixture: SirsiAuthFixture
-    ):
-        """ "Test that patron block status is not called when blocks are ignored."""
-        settings = sirsi_auth_fixture.settings(patron_status_block=False)
-        provider = sirsi_auth_fixture.provider(settings=settings)
-        provider_mock = sirsi_auth_fixture.provider_mocked_api(provider)
-        provider_mock.api_patron_status_info.return_value = {
-            "fields": {"hasMaxDaysWithFines": True}
-        }
-
-        patrondata = provider_mock.provider.remote_patron_lookup(
-            SirsiDynixPatronData(permanent_id="xxxx", session_token="xxx")
-        )
-
-        assert provider_mock.api_read_patron_data.call_count == 1
-        assert provider_mock.api_patron_status_info.call_count == 0
-        assert isinstance(patrondata, PatronData)
-        assert patrondata.personal_name == "Test User"
-        assert patrondata.block_reason == PatronData.NO_VALUE
+        assert patrondata.block_reason == block_reason
 
     def test_remote_patron_lookup_bad_patrondata(
         self, sirsi_auth_fixture: SirsiAuthFixture


### PR DESCRIPTION
…s of ignore blocks flag

## Description

This update ensures that when the sirsidynix api indicates a patron is expired, the user will be blocked from performing checkout operations even if patron blocks are ignored for the sirsi auth provider.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1589
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
New unit tests created.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
