### PR TITLE
Refactor s3 multipart uploads (PP-1472)

### DIFF
--- a/src/palace/manager/service/storage/s3.py
+++ b/src/palace/manager/service/storage/s3.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import sys
+from functools import cached_property
 from io import BytesIO
 from string import Formatter
 from types import TracebackType
@@ -20,7 +21,6 @@ else:
 
 if TYPE_CHECKING:
     from mypy_boto3_s3 import S3Client
-    from mypy_boto3_s3.type_defs import CreateMultipartUploadOutputTypeDef
 
 
 @dataclasses.dataclass
@@ -32,33 +32,22 @@ class MultipartS3UploadPart:
 class MultipartS3ContextManager(LoggerMixin):
     def __init__(
         self,
-        client: S3Client,
-        bucket: str,
+        service: S3Service,
         key: str,
-        url: str,
         media_type: str | None = None,
     ) -> None:
-        self.client = client
+        self._service = service
         self.key = key
-        self.bucket = bucket
-        self.part_number = 1
         self.parts: list[MultipartS3UploadPart] = []
         self.media_type = media_type
-        self.upload: CreateMultipartUploadOutputTypeDef | None = None
         self.upload_id: str | None = None
         self._complete = False
-        self._url = url
         self._exception: BaseException | None = None
 
     def __enter__(self) -> Self:
-        params = {
-            "Bucket": self.bucket,
-            "Key": self.key,
-        }
-        if self.media_type is not None:
-            params["ContentType"] = self.media_type
-        self.upload = self.client.create_multipart_upload(**params)  # type: ignore[arg-type]
-        self.upload_id = self.upload["UploadId"]
+        if self.upload_id is not None:
+            raise RuntimeError("Upload already in progress.")
+        self.upload_id = self._service.multipart_create(self.key, self.media_type)
         return self
 
     def __exit__(
@@ -82,18 +71,10 @@ class MultipartS3ContextManager(LoggerMixin):
         if self.complete or self.exception or self.upload_id is None:
             raise RuntimeError("Upload already complete or aborted.")
 
-        self.log.info(
-            f"Uploading part {self.part_number} of {self.key} to {self.bucket}"
+        result = self._service.multipart_upload(
+            self.key, self.upload_id, len(self.parts) + 1, content
         )
-        result = self.client.upload_part(
-            Body=content,
-            Bucket=self.bucket,
-            Key=self.key,
-            PartNumber=self.part_number,
-            UploadId=self.upload_id,
-        )
-        self.parts.append(MultipartS3UploadPart(result["ETag"], self.part_number))
-        self.part_number += 1
+        self.parts.append(result)
 
     def _upload_complete(self) -> None:
         if not self.parts:
@@ -102,28 +83,19 @@ class MultipartS3ContextManager(LoggerMixin):
         elif self.upload_id is None:
             raise RuntimeError("Upload ID not set.")
         else:
-            self.client.complete_multipart_upload(
-                Bucket=self.bucket,
-                Key=self.key,
-                UploadId=self.upload_id,
-                MultipartUpload=dict(Parts=[dataclasses.asdict(part) for part in self.parts]),  # type: ignore[misc]
-            )
+            self._service.multipart_complete(self.key, self.upload_id, self.parts)
             self._complete = True
 
     def _upload_abort(self) -> None:
-        self.log.info(f"Aborting upload of {self.key}.")
-        if self.upload_id is not None:
-            self.client.abort_multipart_upload(
-                Bucket=self.bucket,
-                Key=self.key,
-                UploadId=self.upload_id,
-            )
-        else:
+        if self.upload_id is None:
             self.log.error("Upload ID not set, unable to abort.")
+            return
 
-    @property
+        self._service.multipart_abort(self.key, self.upload_id)
+
+    @cached_property
     def url(self) -> str:
-        return self._url
+        return self._service.generate_url(self.key)
 
     @property
     def complete(self) -> bool:
@@ -225,7 +197,48 @@ class S3Service(LoggerMixin):
     def multipart(
         self, key: str, content_type: str | None = None
     ) -> MultipartS3ContextManager:
-        url = self.generate_url(key)
-        return MultipartS3ContextManager(
-            self.client, self.bucket, key, url, content_type
+        return MultipartS3ContextManager(self, key, content_type)
+
+    def multipart_create(self, key: str, content_type: str | None = None) -> str:
+        params = {
+            "Bucket": self.bucket,
+            "Key": key,
+        }
+        if content_type is not None:
+            params["ContentType"] = content_type
+        upload = self.client.create_multipart_upload(**params)  # type: ignore[arg-type]
+        return upload["UploadId"]
+
+    def multipart_upload(
+        self, key: str, upload_id: str, part_number: int, content: bytes
+    ) -> MultipartS3UploadPart:
+        self.log.info(f"Uploading part {part_number} of {key} to {self.bucket}")
+        result = self.client.upload_part(
+            Body=content,
+            Bucket=self.bucket,
+            Key=key,
+            PartNumber=part_number,
+            UploadId=upload_id,
+        )
+        return MultipartS3UploadPart(result["ETag"], part_number)
+
+    def multipart_complete(
+        self, key: str, upload_id: str, parts: list[MultipartS3UploadPart]
+    ) -> None:
+        self.log.info(
+            f"Completing multipart upload of {key} to {self.bucket} ({len(parts)} parts)."
+        )
+        self.client.complete_multipart_upload(
+            Bucket=self.bucket,
+            Key=key,
+            UploadId=upload_id,
+            MultipartUpload=dict(Parts=[dataclasses.asdict(part) for part in parts]),  # type: ignore[misc]
+        )
+
+    def multipart_abort(self, key: str, upload_id: str) -> None:
+        self.log.info(f"Aborting multipart upload of {key} to {self.bucket}.")
+        self.client.abort_multipart_upload(
+            Bucket=self.bucket,
+            Key=key,
+            UploadId=upload_id,
         )

--- a/tests/fixtures/s3.py
+++ b/tests/fixtures/s3.py
@@ -106,6 +106,7 @@ class S3ServiceProtocol(Protocol):
 class S3ServiceFixture:
     def __init__(self):
         self.mock_s3_client = MagicMock()
+        self.mock_s3_client.upload_part = MagicMock(return_value={"ETag": "xyz"})
         self.region = "region"
         self.url_template = "https://{region}.test.com/{bucket}/{key}"
         self.bucket = "bucket"

--- a/tests/manager/service/storage/test_s3.py
+++ b/tests/manager/service/storage/test_s3.py
@@ -209,8 +209,8 @@ class TestS3Service:
 
             assert len(upload.parts) == 2
             [part1, part2] = upload.parts
-            assert part1.PartNumber == 1
-            assert part2.PartNumber == 2
+            assert part1.part_number == 1
+            assert part2.part_number == 2
 
             s3_service_fixture.mock_s3_client.complete_multipart_upload.assert_not_called()
 

--- a/tests/manager/service/storage/test_s3.py
+++ b/tests/manager/service/storage/test_s3.py
@@ -186,10 +186,14 @@ class TestS3Service:
     def test_multipart_upload(self, s3_service_fixture: S3ServiceFixture):
         service = s3_service_fixture.service()
 
-        # Successful upload
-        with service.multipart(key="key") as upload:
-            assert upload.client == s3_service_fixture.mock_s3_client
-            assert upload.bucket == s3_service_fixture.bucket
+        with (ctx := service.multipart(key="key")) as upload:
+            # You are not allowed to nest the multipart upload context manager.
+            with pytest.raises(RuntimeError):
+                with ctx:
+                    pass
+
+            # Successful upload
+            assert upload._service == service
             assert upload.key == "key"
             assert upload.parts == []
 


### PR DESCRIPTION
## Description

Refactor multipart s3 uploads, so that the context manager is just a wrapper around logic in the main S3Service class. 

## Motivation and Context

In PP-1472, I need to do multipart s3 uploads outside of a context manager. The way this functionality was previously implemented this was impossible. This PR just moves the logic around so the functions are accessible outside of a context manager.

## How Has This Been Tested?

- Running units tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
