### PR TITLE
Add freeze_time decorator to test_compressible

### DIFF
--- a/tests/manager/core/test_app_server.py
+++ b/tests/manager/core/test_app_server.py
@@ -9,6 +9,7 @@ import pytest
 from flask import Flask, Response, make_response
 from flask_babel import Babel
 from flask_babel import lazy_gettext as _
+from freezegun import freeze_time
 from psycopg2 import OperationalError
 from pytest import LogCaptureFixture
 
@@ -618,6 +619,7 @@ class TestErrorHandler:
 class TestCompressibleAnnotator:
     """Test the @compressible annotator."""
 
+    @freeze_time()
     def test_compressible(self):
         # Test the @compressible annotator.
         app = Flask(__name__)


### PR DESCRIPTION
## Description

I've seen the `test_compressible` test fail occasionally. Its always one byte off, and I think its because there is a timestamp that is getting compressed, and occasionally we cross a second boundary causing this test to fail.

Add the `freeze_time` decorator so that we don't have to worry about time in this test.

## Motivation and Context

This test is failing right now in main: https://github.com/ThePalaceProject/circulation/actions/runs/10473254405/job/29004736627

## How Has This Been Tested?

- Running tests

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
