### PR TITLE
Ensure that borrowing privileges are allowed when patron.block_reason…

### DIFF
--- a/tests/manager/api/test_patron_utility.py
+++ b/tests/manager/api/test_patron_utility.py
@@ -122,6 +122,25 @@ class TestPatronUtility:
         patron.block_reason = None
         assert True == PatronUtility.has_borrowing_privileges(patron)
 
+        patron.block_reason = PatronData.NO_VALUE
+        assert True == PatronUtility.has_borrowing_privileges(patron)
+
+    def test_has_borrowing_privileges_when_block_reason_is_set_to_NO_VALUE(
+        self, db: DatabaseTransactionFixture, library_fixture: LibraryFixture
+    ):
+        # Test the has_excess_fines method.
+        library = library_fixture.library()
+        patron = db.patron(library=library)
+        settings = library_fixture.settings(library)
+        patron.fines = 10.0
+        settings.max_outstanding_fines = 9.0
+        patron.block_reason = PatronData.NO_VALUE
+        assert PatronUtility.has_borrowing_privileges(patron) is True
+
+        # if block reason is unset, then deny borrowing privileges when excess fines present.
+        patron.block_reason = None
+        assert PatronUtility.has_borrowing_privileges(patron) is False
+
     def test_has_excess_fines(
         self, db: DatabaseTransactionFixture, library_fixture: LibraryFixture
     ):


### PR DESCRIPTION
… == PatronData.NO_VALUE

## Description

There was some privilege checks outside for the sirsidynix horizon auth provider that I missed on the last round of changes.
This update ensures that `patron.block_reason = NO_VALUE` is  understood to mean do not block even if there are fines.

## Motivation and Context

Follow on ticket for https://ebce-lyrasis.atlassian.net/browse/PP-1589

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
