### PR TITLE
[PP-1456] Add loan count column to audio book playback time reports.

### DIFF
--- a/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
+++ b/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
@@ -32,7 +32,7 @@ def upgrade() -> None:
     )
 
     op.create_unique_constraint(
-        "unique_playtime_entry_with_loan_identifier",
+        "unique_playtime_entry",
         "playtime_entries",
         [
             "tracking_id",
@@ -55,7 +55,7 @@ def upgrade() -> None:
     )
 
     op.create_unique_constraint(
-        "unique_playtime_summary_with_loan_identifier",
+        "unique_playtime_summary",
         "playtime_summaries",
         [
             "timestamp",
@@ -68,11 +68,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    session = Session(bind=op.get_bind())
-    conn = session.connection()
-
     op.drop_constraint(
-        "unique_playtime_entry_with_loan_identifier",
+        "unique_playtime_entry",
         "playtime_entries",
         type_="unique",
     )
@@ -92,7 +89,7 @@ def downgrade() -> None:
     )
 
     op.drop_constraint(
-        "unique_playtime_summary_with_loan_identifier",
+        "unique_playtime_summary",
         "playtime_summaries",
         type_="unique",
     )

--- a/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
+++ b/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
@@ -30,7 +30,30 @@ def upgrade() -> None:
         sa.Column("loan_identifier", sa.String(length=40), nullable=False, default=""),
     )
 
+    op.drop_index("unique_playtime_summary", "playtime_summaries")
+
+    op.create_unique_constraint(
+        "unique_playtime_summary",
+        "playtime_summaries",
+        [
+            "timestamp",
+            "identifier_str",
+            "collection_name",
+            "library_name",
+            "loan_identifier",
+        ],
+    )
+
 
 def downgrade() -> None:
     op.drop_column("playtime_entries", "loan_identifier")
+
+    op.drop_index("unique_playtime_summary", "playtime_summaries")
+
     op.drop_column("playtime_summaries", "loan_identifier")
+
+    op.create_unique_constraint(
+        "unique_playtime_summary",
+        "playtime_summaries",
+        ["timestamp", "identifier_str", "collection_name", "library_name"],
+    )

--- a/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
+++ b/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
@@ -30,7 +30,7 @@ def upgrade() -> None:
         sa.Column("loan_identifier", sa.String(length=40), nullable=False, default=""),
     )
 
-    op.drop_index("unique_playtime_summary", "playtime_summaries")
+    op.drop_constraint("unique_playtime_summary", "playtime_summaries", type_="unique")
 
     op.create_unique_constraint(
         "unique_playtime_summary",
@@ -48,7 +48,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_column("playtime_entries", "loan_identifier")
 
-    op.drop_index("unique_playtime_summary", "playtime_summaries")
+    op.drop_constraint("unique_playtime_summary", "playtime_summaries", type_="unique")
 
     op.drop_column("playtime_summaries", "loan_identifier")
 

--- a/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
+++ b/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
@@ -1,0 +1,102 @@
+"""Add loan_identifier column to playtime tables.
+
+Revision ID: 7a2fcaac8b63
+Revises: 7ba553f3f80d
+Create Date: 2024-08-21 23:23:48.085451+00:00
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.orm.session import Session
+
+# revision identifiers, used by Alembic.
+revision = "7a2fcaac8b63"
+down_revision = "7ba553f3f80d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    session = Session(bind=op.get_bind())
+    conn = session.connection()
+
+    op.add_column(
+        "playtime_entries",
+        sa.Column("loan_identifier", sa.String(length=50), nullable=False, default=""),
+    )
+
+    op.drop_constraint(
+        "unique_playtime_entry",
+        "playtime_entries",
+    )
+
+    op.create_unique_constraint(
+        "unique_playtime_entry",
+        "playtime_entries",
+        [
+            "tracking_id",
+            "identifier_str",
+            "collection_name",
+            "library_name",
+            "loan_identifier",
+        ],
+    )
+
+    op.add_column(
+        "playtime_summaries",
+        sa.Column("loan_identifier", sa.String(length=50), nullable=False, default=""),
+    )
+
+    op.drop_constraint(
+        "unique_playtime_summary",
+        "playtime_summaries",
+    )
+
+    op.create_unique_constraint(
+        "unique_playtime_summary",
+        "playtime_summaries",
+        [
+            "timestamp",
+            "identifier_str",
+            "collection_name",
+            "library_name",
+            "loan_identifier",
+        ],
+    )
+
+
+def downgrade() -> None:
+    session = Session(bind=op.get_bind())
+    conn = session.connection()
+
+    op.drop_constraint(
+        "unique_playtime_entry",
+        "playtime_entries",
+    )
+
+    op.drop_column("playtime_entries", "loan_identifier")
+
+    op.create_unique_constraint(
+        "unique_playtime_entry",
+        "playtime_entries",
+        [
+            "tracking_id",
+            "timestamp",
+            "identifier_str",
+            "collection_name",
+            "library_name",
+        ],
+    )
+
+    op.drop_constraint(
+        "unique_playtime_summary",
+        "playtime_summaries",
+    )
+
+    op.drop_column("playtime_summaries", "loan_identifier")
+
+    op.create_unique_constraint(
+        "unique_playtime_summary",
+        "playtime_summaries",
+        ["timestamp", "identifier_str", "collection_name", "library_name"],
+    )

--- a/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
+++ b/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
@@ -22,82 +22,15 @@ def upgrade() -> None:
 
     op.add_column(
         "playtime_entries",
-        sa.Column("loan_identifier", sa.String(length=50), nullable=False, default=""),
-    )
-
-    op.drop_constraint(
-        "unique_playtime_entry",
-        "playtime_entries",
-        type_="unique",
-    )
-
-    op.create_unique_constraint(
-        "unique_playtime_entry",
-        "playtime_entries",
-        [
-            "tracking_id",
-            "identifier_str",
-            "collection_name",
-            "library_name",
-            "loan_identifier",
-        ],
+        sa.Column("loan_identifier", sa.String(length=40), nullable=False, default=""),
     )
 
     op.add_column(
         "playtime_summaries",
-        sa.Column("loan_identifier", sa.String(length=50), nullable=False, default=""),
-    )
-
-    op.drop_constraint(
-        "unique_playtime_summary",
-        "playtime_summaries",
-        type_="unique",
-    )
-
-    op.create_unique_constraint(
-        "unique_playtime_summary",
-        "playtime_summaries",
-        [
-            "timestamp",
-            "identifier_str",
-            "collection_name",
-            "library_name",
-            "loan_identifier",
-        ],
+        sa.Column("loan_identifier", sa.String(length=40), nullable=False, default=""),
     )
 
 
 def downgrade() -> None:
-    op.drop_constraint(
-        "unique_playtime_entry",
-        "playtime_entries",
-        type_="unique",
-    )
-
     op.drop_column("playtime_entries", "loan_identifier")
-
-    op.create_unique_constraint(
-        "unique_playtime_entry",
-        "playtime_entries",
-        [
-            "tracking_id",
-            "timestamp",
-            "identifier_str",
-            "collection_name",
-            "library_name",
-        ],
-    )
-
-    op.drop_constraint(
-        "unique_playtime_summary",
-        "playtime_summaries",
-        type_="unique",
-    )
-
     op.drop_column("playtime_summaries", "loan_identifier")
-
-    op.create_unique_constraint(
-        "unique_playtime_summary",
-        "playtime_summaries",
-        ["timestamp", "identifier_str", "collection_name", "library_name"],
-    )

--- a/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
+++ b/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
@@ -28,10 +28,11 @@ def upgrade() -> None:
     op.drop_constraint(
         "unique_playtime_entry",
         "playtime_entries",
+        type_="unique",
     )
 
     op.create_unique_constraint(
-        "unique_playtime_entry",
+        "unique_playtime_entry_with_loan_identifier",
         "playtime_entries",
         [
             "tracking_id",
@@ -50,10 +51,11 @@ def upgrade() -> None:
     op.drop_constraint(
         "unique_playtime_summary",
         "playtime_summaries",
+        type_="unique",
     )
 
     op.create_unique_constraint(
-        "unique_playtime_summary",
+        "unique_playtime_summary_with_loan_identifier",
         "playtime_summaries",
         [
             "timestamp",
@@ -70,8 +72,9 @@ def downgrade() -> None:
     conn = session.connection()
 
     op.drop_constraint(
-        "unique_playtime_entry",
+        "unique_playtime_entry_with_loan_identifier",
         "playtime_entries",
+        type_="unique",
     )
 
     op.drop_column("playtime_entries", "loan_identifier")
@@ -89,8 +92,9 @@ def downgrade() -> None:
     )
 
     op.drop_constraint(
-        "unique_playtime_summary",
+        "unique_playtime_summary_with_loan_identifier",
         "playtime_summaries",
+        type_="unique",
     )
 
     op.drop_column("playtime_summaries", "loan_identifier")

--- a/src/palace/manager/api/controller/playtime_entries.py
+++ b/src/palace/manager/api/controller/playtime_entries.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from datetime import timedelta
 
 import flask
@@ -24,12 +25,18 @@ from palace.manager.sqlalchemy.model.licensing import LicensePool
 from palace.manager.sqlalchemy.model.patron import Loan
 from palace.manager.sqlalchemy.util import get_one
 
+MISSING_LOAN_IDENTIFIER = "LOAN_NOT_FOUND"
+
 
 def resolve_loan_identifier(loan: Loan | None) -> str:
     def sha1(msg):
         return
 
-    return sha1(f"loan: {loan.id}") if loan else "no-loan-found"
+    return (
+        hashlib.sha1(f"loan: {loan.id}".encode()).hexdigest()
+        if loan
+        else MISSING_LOAN_IDENTIFIER
+    )
 
 
 class PlaytimeEntriesController(CirculationManagerController):

--- a/src/palace/manager/api/controller/playtime_entries.py
+++ b/src/palace/manager/api/controller/playtime_entries.py
@@ -72,7 +72,7 @@ class PlaytimeEntriesController(CirculationManagerController):
             .order_by(Loan.start.desc())
         ).first()
 
-        loan_identifier = self.resolve_loan_identifier(
+        loan_identifier = resolve_loan_identifier(
             loan=loan, patron=flask.request.patron
         )
 

--- a/src/palace/manager/core/query/playtime_entries.py
+++ b/src/palace/manager/core/query/playtime_entries.py
@@ -28,6 +28,7 @@ class PlaytimeEntries:
         collection: Collection,
         library: Library,
         data: PlaytimeEntriesPost,
+        loan_identifier: str,
     ) -> tuple[list, PlaytimeEntriesPostSummary]:
         """Insert into the database playtime entries from a request"""
         responses = []
@@ -59,6 +60,7 @@ class PlaytimeEntries:
                         library_name=library.name,
                         timestamp=entry.during_minute,
                         total_seconds_played=entry.seconds_played,
+                        loan_identfier=loan_identifier,
                     )
             except IntegrityError as ex:
                 logging.getLogger("Time Tracking").error(

--- a/src/palace/manager/core/query/playtime_entries.py
+++ b/src/palace/manager/core/query/playtime_entries.py
@@ -60,7 +60,7 @@ class PlaytimeEntries:
                         library_name=library.name,
                         timestamp=entry.during_minute,
                         total_seconds_played=entry.seconds_played,
-                        loan_identfier=loan_identifier,
+                        loan_identifier=loan_identifier,
                     )
             except IntegrityError as ex:
                 logging.getLogger("Time Tracking").error(

--- a/src/palace/manager/scripts/playtime_entries.py
+++ b/src/palace/manager/scripts/playtime_entries.py
@@ -272,7 +272,7 @@ class PlaytimeEntriesEmailReportsScript(Script):
         )
         combined_sq = combined.subquery()
 
-        query4 = self._db.query(
+        return self._db.query(
             combined_sq.c.identifier_str,
             combined_sq.c.collection_name,
             combined_sq.c.library_name,
@@ -285,8 +285,6 @@ class PlaytimeEntriesEmailReportsScript(Script):
             combined_sq.c.library_name,
             combined_sq.c.identifier_str,
         )
-        results = query4.all()
-        return results
 
 
 def _produce_report(writer: Writer, date_label, records=None) -> None:

--- a/src/palace/manager/sqlalchemy/model/time_tracking.py
+++ b/src/palace/manager/sqlalchemy/model/time_tracking.py
@@ -142,6 +142,7 @@ class PlaytimeSummary(Base):
             "identifier_str",
             "collection_name",
             "library_name",
+            "loan_identifier",
             name="unique_playtime_summary",
         ),
     )

--- a/src/palace/manager/sqlalchemy/model/time_tracking.py
+++ b/src/palace/manager/sqlalchemy/model/time_tracking.py
@@ -143,6 +143,7 @@ class PlaytimeSummary(Base):
             "identifier_str",
             "collection_name",
             "library_name",
+            "loan_identifier",
             name="unique_playtime_summary",
         ),
     )

--- a/src/palace/manager/sqlalchemy/model/time_tracking.py
+++ b/src/palace/manager/sqlalchemy/model/time_tracking.py
@@ -74,12 +74,15 @@ class PlaytimeEntry(Base):
     collection: Mapped[Collection] = relationship("Collection", uselist=False)
     library: Mapped[Library] = relationship("Library", uselist=False)
 
+    loan_identifier = Column(String(50), nullable=False)
+
     __table_args__ = (
         UniqueConstraint(
             "tracking_id",
             "identifier_str",
             "collection_name",
             "library_name",
+            "loan_identifier",
             name="unique_playtime_entry",
         ),
     )
@@ -128,6 +131,7 @@ class PlaytimeSummary(Base):
 
     title = Column(String)
     isbn = Column(String)
+    loan_identifier = Column(String(50), nullable=False)
 
     identifier: Mapped[Identifier] = relationship("Identifier", uselist=False)
     collection: Mapped[Collection] = relationship("Collection", uselist=False)
@@ -155,6 +159,7 @@ class PlaytimeSummary(Base):
         identifier_str: str,
         collection_name: str,
         library_name: str | None,
+        loan_identifier: str,
     ) -> PlaytimeSummary:
         """Add playtime (in seconds) to it's associated minute-level summary record."""
         # Update each label with its current value, if its foreign key is present.
@@ -178,6 +183,7 @@ class PlaytimeSummary(Base):
             "collection_name": None if collection else collection_name,
             "library_id": library.id if library else None,
             "library_name": None if library else library_name,
+            "loan_identifier": loan_identifier,
         }
         lookup_keys = {k: v for k, v in _potential_lookup_keys.items() if v is not None}
         additional_columns = {

--- a/src/palace/manager/sqlalchemy/model/time_tracking.py
+++ b/src/palace/manager/sqlalchemy/model/time_tracking.py
@@ -74,7 +74,7 @@ class PlaytimeEntry(Base):
     collection: Mapped[Collection] = relationship("Collection", uselist=False)
     library: Mapped[Library] = relationship("Library", uselist=False)
 
-    loan_identifier = Column(String(50), nullable=False)
+    loan_identifier = Column(String(40), nullable=False)
 
     __table_args__ = (
         UniqueConstraint(
@@ -82,7 +82,6 @@ class PlaytimeEntry(Base):
             "identifier_str",
             "collection_name",
             "library_name",
-            "loan_identifier",
             name="unique_playtime_entry",
         ),
     )
@@ -131,7 +130,7 @@ class PlaytimeSummary(Base):
 
     title = Column(String)
     isbn = Column(String)
-    loan_identifier = Column(String(50), nullable=False)
+    loan_identifier = Column(String(40), nullable=False)
 
     identifier: Mapped[Identifier] = relationship("Identifier", uselist=False)
     collection: Mapped[Collection] = relationship("Collection", uselist=False)
@@ -143,7 +142,6 @@ class PlaytimeSummary(Base):
             "identifier_str",
             "collection_name",
             "library_name",
-            "loan_identifier",
             name="unique_playtime_summary",
         ),
     )

--- a/tests/manager/api/controller/test_playtime_entries.py
+++ b/tests/manager/api/controller/test_playtime_entries.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import flask
 from sqlalchemy.exc import IntegrityError
 
+from palace.manager.api.controller.playtime_entries import resolve_loan_identifier
 from palace.manager.sqlalchemy.model.time_tracking import PlaytimeEntry
 from palace.manager.sqlalchemy.util import get_one
 from palace.manager.util.datetime_helpers import utc_now
@@ -91,6 +92,7 @@ class TestPlaytimeEntriesController:
             assert entry.library == db.default_library()
             assert entry.total_seconds_played == 17
             assert entry.timestamp.isoformat() == date_string(hour=12, minute=1)
+            assert entry.loan_identifier
 
             # The very old entry does not get recorded
             assert None == get_one(
@@ -114,6 +116,8 @@ class TestPlaytimeEntriesController:
         )
         patron = db.patron()
 
+        loan_identifier = resolve_loan_identifier(loan=None, patron=patron)
+
         db.session.add(
             PlaytimeEntry(
                 tracking_id="tracking-id-0",
@@ -125,6 +129,7 @@ class TestPlaytimeEntriesController:
                 identifier_str=identifier.urn,
                 collection_name=collection.name,
                 library_name=library.name,
+                loan_identifier=loan_identifier,
             )
         )
 

--- a/tests/manager/api/controller/test_playtime_entries.py
+++ b/tests/manager/api/controller/test_playtime_entries.py
@@ -3,7 +3,6 @@ import hashlib
 from unittest.mock import patch
 
 import flask
-from isodate import parse_datetime
 from sqlalchemy.exc import IntegrityError
 
 from palace.manager.api.controller.playtime_entries import (
@@ -42,7 +41,7 @@ class TestPlaytimeEntriesController:
         patron = db.patron()
 
         loan_exists_date_str = date_string(hour=12, minute=0)
-        inscope_loan_start = parse_datetime(loan_exists_date_str)
+        inscope_loan_start = datetime.datetime.fromisoformat(loan_exists_date_str)
         inscope_loan_end = inscope_loan_start + datetime.timedelta(days=14)
 
         loan, _ = pool.loan_to(

--- a/tests/manager/api/controller/test_playtime_entries.py
+++ b/tests/manager/api/controller/test_playtime_entries.py
@@ -106,7 +106,7 @@ class TestPlaytimeEntriesController:
         identifier = db.identifier()
         collection = db.default_collection()
         library = db.default_library()
-
+        patron = db.patron()
         # Attach the identifier to the collection
         pool = db.licensepool(
             db.edition(
@@ -114,9 +114,8 @@ class TestPlaytimeEntriesController:
             ),
             collection=collection,
         )
-        patron = db.patron()
 
-        loan_identifier = resolve_loan_identifier(loan=None, patron=patron)
+        loan_identifier = resolve_loan_identifier(loan=None)
 
         db.session.add(
             PlaytimeEntry(

--- a/tests/manager/scripts/test_playtime_entries.py
+++ b/tests/manager/scripts/test_playtime_entries.py
@@ -10,6 +10,7 @@ import pytz
 from freezegun import freeze_time
 from sqlalchemy.sql.expression import and_, null
 
+from palace.manager.api.controller.playtime_entries import resolve_loan_identifier
 from palace.manager.api.model.time_tracking import PlaytimeTimeEntry
 from palace.manager.core.config import Configuration
 from palace.manager.core.equivalents_coverage import (
@@ -33,6 +34,7 @@ def create_playtime_entries(
     identifier: Identifier,
     collection: Collection,
     library: Library,
+    loan_identifier: str,
     *entries: PlaytimeTimeEntry,
 ) -> list[PlaytimeEntry]:
     all_inserted = []
@@ -47,6 +49,7 @@ def create_playtime_entries(
             identifier_str=identifier.urn,
             collection_name=collection.name,
             library_name=library.name,
+            loan_identifier=loan_identifier,
         )
         db.session.add(inserted)
         all_inserted.append(inserted)
@@ -83,12 +86,16 @@ class TestPlaytimeEntriesSummationScript:
         )
         collection2 = db.collection(name=c2_old_name)
         library2 = db.library(name=l2_old_name)
-
+        loan_identifier, loan_identifier2, loan_identifier3, loan_identifier4 = (
+            resolve_loan_identifier(db.patron(external_identifier=str(x)), None)
+            for x in range(0, 4)
+        )
         entries = create_playtime_entries(
             db,
             identifier,
             collection,
             library,
+            loan_identifier,
             P(id="0", during_minute=dk(m=0), seconds_played=30),
             P(id="1", during_minute=dk(m=0), seconds_played=30),
             P(id="2", during_minute=dk(m=0), seconds_played=30),
@@ -99,6 +106,7 @@ class TestPlaytimeEntriesSummationScript:
             identifier2,
             collection,
             library,
+            loan_identifier2,
             P(id="0", during_minute=dk(m=0), seconds_played=30),
             P(id="1", during_minute=dk(m=0), seconds_played=30),
             P(id="2", during_minute=dk(m=0), seconds_played=30),
@@ -113,6 +121,7 @@ class TestPlaytimeEntriesSummationScript:
             identifier2,
             collection2,
             library,
+            loan_identifier3,
             P(id="0", during_minute=dk(m=0), seconds_played=30),
             P(id="1", during_minute=dk(m=1), seconds_played=40),
         )
@@ -123,6 +132,7 @@ class TestPlaytimeEntriesSummationScript:
             identifier2,
             collection2,
             library2,
+            loan_identifier4,
             P(id="0", during_minute=dk(m=0), seconds_played=30),
             P(id="1", during_minute=dk(m=0), seconds_played=40),
             P(id="2", during_minute=dk(m=0), seconds_played=30),
@@ -134,6 +144,7 @@ class TestPlaytimeEntriesSummationScript:
             identifier2,
             collection,
             library,
+            loan_identifier2,
             P(id="5", during_minute=utc_now(), seconds_played=30),
         )
 
@@ -143,6 +154,7 @@ class TestPlaytimeEntriesSummationScript:
             identifier2,
             collection,
             library,
+            loan_identifier2,
             P(id="6", during_minute=dk(m=10), seconds_played=30),
         )
         processed_entry.processed = True
@@ -214,6 +226,7 @@ class TestPlaytimeEntriesSummationScript:
         assert id1time.identifier_str == identifier.urn
         assert id1time.collection_name == collection.name
         assert id1time.library_name == library.name
+        assert id1time.loan_identifier == loan_identifier
         assert id1time.timestamp == dk()
 
         assert id2time1.identifier == identifier2
@@ -223,6 +236,8 @@ class TestPlaytimeEntriesSummationScript:
         assert id2time1.identifier_str == id2_new_urn
         assert id2time1.collection_name == collection.name
         assert id2time1.library_name == library.name
+        assert id2time1.loan_identifier == loan_identifier2
+
         assert id2time1.timestamp == dk()
 
         assert id2time2.identifier == identifier2
@@ -231,6 +246,7 @@ class TestPlaytimeEntriesSummationScript:
         assert id2time2.identifier_str == id2_new_urn
         assert id2time2.collection_name == collection.name
         assert id2time2.library_name == library.name
+        assert id2time2.loan_identifier == loan_identifier2
         assert id2time2.total_seconds_played == 30
         assert id2time2.timestamp == dk(m=1)
 
@@ -240,6 +256,7 @@ class TestPlaytimeEntriesSummationScript:
         assert id2col2time.identifier_str == id2_new_urn
         assert id2col2time.collection_name == c2_new_name
         assert id2col2time.library_name == library.name
+        assert id2col2time.loan_identifier == loan_identifier3
         assert id2col2time.total_seconds_played == 30
         assert id2col2time.timestamp == dk()
 
@@ -249,6 +266,7 @@ class TestPlaytimeEntriesSummationScript:
         assert id2col2time1.identifier_str == id2_new_urn
         assert id2col2time1.collection_name == c2_new_name
         assert id2col2time1.library_name == library.name
+        assert id2col2time1.loan_identifier == loan_identifier3
         assert id2col2time1.total_seconds_played == 40
         assert id2col2time1.timestamp == dk(m=1)
 
@@ -258,6 +276,7 @@ class TestPlaytimeEntriesSummationScript:
         assert id2c2l2time.identifier_str == id2_new_urn
         assert id2c2l2time.collection_name == c2_new_name
         assert id2c2l2time.library_name == l2_new_name
+        assert id2c2l2time.loan_identifier == loan_identifier4
         assert id2c2l2time.total_seconds_played == 100
         assert id2c2l2time.timestamp == dk()
 
@@ -267,11 +286,13 @@ class TestPlaytimeEntriesSummationScript:
         identifier = db.identifier()
         collection = db.default_collection()
         library = db.default_library()
+        loan_identifier = resolve_loan_identifier(db.patron(), None)
         entries = create_playtime_entries(
             db,
             identifier,
             collection,
             library,
+            loan_identifier,
             P(id="0", during_minute=dk(m=0), seconds_played=30),
             P(id="1", during_minute=dk(m=0), seconds_played=30),
             P(id="2", during_minute=dk(m=0), seconds_played=30),
@@ -341,6 +362,8 @@ class TestPlaytimeEntriesSummationScript:
         c2 = db.collection(name=c2_name)
         l1 = db.library(name=l1_name)
         l2 = db.library(name=l2_name)
+        loan1_id = "loan1"
+        loan2_id = "loan2"
 
         P = PlaytimeTimeEntry
         dk = date2k
@@ -351,6 +374,7 @@ class TestPlaytimeEntriesSummationScript:
             id1,
             c1,
             l1,
+            loan1_id,
             P(id="0", during_minute=dk(m=0), seconds_played=30),
             P(id="1", during_minute=dk(m=0), seconds_played=30),
         )
@@ -359,6 +383,7 @@ class TestPlaytimeEntriesSummationScript:
             id2,
             c2,
             l2,
+            loan2_id,
             P(id="2", during_minute=dk(m=0), seconds_played=12),
             P(id="3", during_minute=dk(m=0), seconds_played=17),
         )
@@ -389,6 +414,7 @@ class TestPlaytimeEntriesSummationScript:
         assert b1sum1.identifier_id == id1.id
         assert b1sum1.collection_id == c1.id
         assert b1sum1.library_id == l1.id
+        assert b1sum1.loan_identifier == loan1_id
 
         assert b2sum1.total_seconds_played == 29
         assert b2sum1.identifier_str == id2_urn
@@ -397,6 +423,7 @@ class TestPlaytimeEntriesSummationScript:
         assert b2sum1.identifier_id == id2.id
         assert b2sum1.collection_id == c2.id
         assert b2sum1.library_id == l2.id
+        assert b2sum1.loan_identifier == loan2_id
 
         # Add some new client playtime entries.
         book1_round2 = create_playtime_entries(
@@ -404,6 +431,7 @@ class TestPlaytimeEntriesSummationScript:
             id1,
             c1,
             l1,
+            loan1_id,
             P(id="4", during_minute=dk(m=0), seconds_played=30),
             P(id="5", during_minute=dk(m=0), seconds_played=30),
         )
@@ -412,6 +440,7 @@ class TestPlaytimeEntriesSummationScript:
             id2,
             c2,
             l2,
+            loan2_id,
             P(id="6", during_minute=dk(m=0), seconds_played=22),
             P(id="7", during_minute=dk(m=0), seconds_played=46),
         )
@@ -456,6 +485,7 @@ class TestPlaytimeEntriesSummationScript:
         assert b1sum1.identifier_id is None
         assert b1sum1.collection_id is None
         assert b1sum1.library_id is None
+        assert b1sum1.loan_identifier == loan1_id
 
         assert b2sum1.total_seconds_played == 97
         assert b2sum1.identifier_str == id2_urn
@@ -464,6 +494,7 @@ class TestPlaytimeEntriesSummationScript:
         assert b2sum1.identifier_id is None
         assert b2sum1.collection_id is None
         assert b2sum1.library_id is None
+        assert b2sum1.loan_identifier == loan2_id
 
 
 def date1m(days) -> date:
@@ -483,6 +514,7 @@ def playtime(
     library: Library,
     timestamp: datetime,
     total_seconds: int,
+    loan_identifier: str,
 ):
     return PlaytimeSummary.add(
         session,
@@ -494,6 +526,7 @@ def playtime(
         identifier_str=identifier.urn,
         collection_name=collection.name,
         library_name=library.name,
+        loan_identifier=loan_identifier,
     )
 
 
@@ -510,6 +543,19 @@ class TestPlaytimeEntriesEmailReportsScript:
         identifier2 = edition.primary_identifier
         collection2 = db.collection()
         library2 = db.library()
+
+        def create_loan_identifier(patron_id: str) -> str:
+            patron = db.patron(external_identifier=patron_id)
+            return resolve_loan_identifier(patron=patron, loan=None)
+
+        loan_identifiers = [create_loan_identifier(str(x)) for x in range(1, 6)]
+        (
+            loan_identifier,
+            loan_identifier2,
+            loan_identifier3,
+            loan_identifier4,
+            loan_identifier5,
+        ) = loan_identifiers
 
         isbn_ids: dict[str, Identifier] = {
             "i1": db.identifier(
@@ -533,23 +579,49 @@ class TestPlaytimeEntriesEmailReportsScript:
         # We're using the RecursiveEquivalencyCache, so must refresh it.
         EquivalentIdentifiersCoverageProvider(db.session).run()
 
-        playtime(db.session, identifier, collection, library, dt1m(3), 1)
-        playtime(db.session, identifier, collection, library, dt1m(31), 2)
         playtime(
-            db.session, identifier, collection, library, dt1m(-31), 60
+            db.session, identifier, collection, library, dt1m(3), 1, loan_identifier
+        )
+        playtime(
+            db.session, identifier, collection, library, dt1m(31), 2, loan_identifier
+        )
+        playtime(
+            db.session, identifier, collection, library, dt1m(-31), 60, loan_identifier
         )  # out of range: prior to the beginning of the default reporting period
         playtime(
-            db.session, identifier, collection, library, dt1m(95), 60
+            db.session,
+            identifier,
+            collection,
+            library,
+            dt1m(95),
+            60,
+            loan_identifier,
         )  # out of range: future
-        playtime(db.session, identifier2, collection, library, dt1m(3), 5)
-        playtime(db.session, identifier2, collection, library, dt1m(4), 6)
+        playtime(
+            db.session, identifier2, collection, library, dt1m(3), 5, loan_identifier2
+        )
+        playtime(
+            db.session, identifier2, collection, library, dt1m(4), 6, loan_identifier2
+        )
 
         # Collection2
-        playtime(db.session, identifier, collection2, library, dt1m(3), 100)
+        playtime(
+            db.session, identifier, collection2, library, dt1m(3), 100, loan_identifier3
+        )
         # library2
-        playtime(db.session, identifier, collection, library2, dt1m(3), 200)
+        playtime(
+            db.session, identifier, collection, library2, dt1m(3), 200, loan_identifier4
+        )
         # collection2 library2
-        playtime(db.session, identifier, collection2, library2, dt1m(3), 300)
+        playtime(
+            db.session,
+            identifier,
+            collection2,
+            library2,
+            dt1m(3),
+            300,
+            loan_identifier5,
+        )
 
         reporting_name = "test cm"
         with (
@@ -584,6 +656,7 @@ class TestPlaytimeEntriesEmailReportsScript:
                     "library",
                     "title",
                     "total seconds",
+                    "loan count",
                 )
             ),
             call(
@@ -595,6 +668,7 @@ class TestPlaytimeEntriesEmailReportsScript:
                     library2.name,
                     None,
                     300,
+                    1,
                 )
             ),
             call(
@@ -606,6 +680,7 @@ class TestPlaytimeEntriesEmailReportsScript:
                     library.name,
                     None,
                     100,
+                    1,
                 )
             ),
             call(
@@ -617,6 +692,7 @@ class TestPlaytimeEntriesEmailReportsScript:
                     library2.name,
                     None,
                     200,
+                    1,
                 )
             ),
             call(
@@ -627,6 +703,7 @@ class TestPlaytimeEntriesEmailReportsScript:
                     collection.name,
                     library.name,
                     None,
+                    3,
                     1,
                 )
             ),  # Identifier without edition
@@ -639,10 +716,13 @@ class TestPlaytimeEntriesEmailReportsScript:
                     library.name,
                     edition.title,
                     11,
+                    1,
                 )
             ),  # Identifier with edition
         ]
 
+        # verify the number of unique loans
+        assert len(loan_identifiers) == sum([x.args[0][7] for x in call_args[1:]])
         assert services_email_fixture.mock_emailer.send.call_count == 1
         assert services_email_fixture.mock_emailer.send.call_args == call(
             subject=f"{reporting_name}: Playtime Summaries {cutoff} - {until}",
@@ -659,7 +739,16 @@ class TestPlaytimeEntriesEmailReportsScript:
         identifier = db.identifier()
         collection = db.default_collection()
         library = db.default_library()
-        _ = playtime(db.session, identifier, collection, library, dt1m(20), 1)
+        loan_id = "loan-id"
+        _ = playtime(
+            db.session,
+            identifier,
+            collection,
+            library,
+            dt1m(20),
+            1,
+            loan_id,
+        )
 
         with patch("palace.manager.scripts.playtime_entries.os.environ", new={}):
             script = PlaytimeEntriesEmailReportsScript(db.session)

--- a/tests/manager/sqlalchemy/model/test_time_tracking.py
+++ b/tests/manager/sqlalchemy/model/test_time_tracking.py
@@ -143,7 +143,7 @@ class TestPlaytimeEntries:
                 loan_identifier=loan_id,
             )
         assert (
-            f"Key (tracking_id, identifier_str, collection_name, library_name, loan_identifier)=(tracking-id-0, {identifier.urn}, {collection.name}, {library.name}, {loan_id}) already exists"
+            f"Key (tracking_id, identifier_str, collection_name, library_name)=(tracking-id-0, {identifier.urn}, {collection.name}, {library.name}) already exists"
             in raised.exconly()
         )
 
@@ -185,7 +185,7 @@ class TestPlaytimeSummaries:
                 loan_identifier=loan_id,
             )
         assert (
-            f'Key ("timestamp", identifier_str, collection_name, library_name, loan_identifier)=(2000-01-01 12:00:00+00, {identifier.urn}, {collection.name}, {library.name}, {loan_id}) already exists'
+            f'Key ("timestamp", identifier_str, collection_name, library_name)=(2000-01-01 12:00:00+00, {identifier.urn}, {collection.name}, {library.name}) already exists'
             in raised.exconly()
         )
 

--- a/tests/manager/sqlalchemy/model/test_time_tracking.py
+++ b/tests/manager/sqlalchemy/model/test_time_tracking.py
@@ -185,7 +185,7 @@ class TestPlaytimeSummaries:
                 loan_identifier=loan_id,
             )
         assert (
-            f'Key ("timestamp", identifier_str, collection_name, library_name)=(2000-01-01 12:00:00+00, {identifier.urn}, {collection.name}, {library.name}) already exists'
+            f'Key ("timestamp", identifier_str, collection_name, library_name, loan_identifier)=(2000-01-01 12:00:00+00, {identifier.urn}, {collection.name}, {library.name}, {loan_id}) already exists'
             in raised.exconly()
         )
 


### PR DESCRIPTION
## Description

As the title indicates, this PR adds a loan count column to the audio book playback time reports.

When playback time data comes in through the API,  the code attempts to resolve the loan associated with the audio book and patron.  If the loan cannot be found (ie because it was purged) we use the user's patron id.  Then we create a sha1 of the loan or patron ID in order to uniquely identify the loan.

Then on the reporting side, we perform a count of the unique loans within the time range and join that count to the seconds summation query.

The default value for the loan_identifier is an empty string.  Since we don't have a way of associating loans or patrons with existing playtime records, I don't see a good way of counting old playtime entries and summaries.  Once the start date of the reporting window passes the date of the release of this update to production the loan counting will be correct.
Before that, it will be one loan per unique isbn, collection, library.
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1456
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Updated the existing tests and added addition assertions.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
