### PR TITLE
Stop using `flask-pydantic-spec`. (PP-1656)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1470,24 +1470,6 @@ files = [
 Flask = ">=0.9"
 
 [[package]]
-name = "flask-pydantic-spec"
-version = "0.6.0"
-description = "generate OpenAPI document and validate request & response with Python annotations."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "flask_pydantic_spec-0.6.0-py3-none-any.whl", hash = "sha256:480689102eed43900b2164d07af930221a2379253ed06337d280a47224990035"},
-    {file = "flask_pydantic_spec-0.6.0.tar.gz", hash = "sha256:f20d63cba821dfaaa92fa19c1e1975e0acf544ea6a3cc9eb5cbac62a81117790"},
-]
-
-[package.dependencies]
-inflection = ">=0.5.0,<1"
-pydantic = ">=1.2,<2"
-
-[package.extras]
-flask = ["flask"]
-
-[[package]]
 name = "freezegun"
 version = "1.5.1"
 description = "Let your Python tests travel through time"
@@ -2018,17 +2000,6 @@ python-versions = ">=3.5"
 files = [
     {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
     {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
-]
-
-[[package]]
-name = "inflection"
-version = "0.5.1"
-description = "A port of Ruby on Rails inflector to Python"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"},
-    {file = "inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417"},
 ]
 
 [[package]]
@@ -5124,4 +5095,4 @@ lxml = ">=3.8"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4"
-content-hash = "b422e5d0530d0abdcf7714a2983e565f263f247622fc8a5ce018c0b6c63465b3"
+content-hash = "516641d4707fd026e58036e379fd66853dc84e4af7620e5ce6eb0f2cfe872fcb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,6 @@ module = [
     "feedparser",
     "firebase_admin.*",
     "flask_babel",
-    "flask_pydantic_spec.*",
     "fuzzywuzzy",
     "google.auth",
     "greenlet",
@@ -234,7 +233,6 @@ firebase-admin = "^6.0.1"
 Flask = "^3.0"
 Flask-Babel = "^4.0"
 Flask-Cors = "4.0.1"
-flask-pydantic-spec = "^0.6.0"
 fuzzywuzzy = "0.18.0"  # fuzzywuzzy is for author name manipulations
 html-sanitizer = "^2.1.0"
 isbnlib = "^3.10.14"

--- a/src/palace/manager/api/admin/controller/custom_lists.py
+++ b/src/palace/manager/api/admin/controller/custom_lists.py
@@ -7,7 +7,6 @@ from datetime import datetime
 import flask
 from flask import Response, url_for
 from flask_babel import lazy_gettext as _
-from flask_pydantic_spec.flask_backend import Context
 from pydantic import BaseModel
 
 from palace.manager.api.admin.controller.base import AdminPermissionsControllerMixin
@@ -38,6 +37,7 @@ from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.model.licensing import LicensePool
 from palace.manager.sqlalchemy.model.work import Work
 from palace.manager.sqlalchemy.util import create, get_one
+from palace.manager.util.flask_util import parse_multi_dict
 from palace.manager.util.problem_detail import ProblemDetail, ProblemDetailException
 
 
@@ -98,27 +98,21 @@ class CustomListsController(
             return dict(custom_lists=custom_lists)
 
         if flask.request.method == "POST":
-            ctx: Context = flask.request.context.body  # type: ignore
+            list_ = self.CustomListPostRequest.parse_obj(
+                parse_multi_dict(flask.request.form)
+            )
             return self._create_or_update_list(
                 library,
-                ctx.name,
-                ctx.entries,
-                ctx.collections,
-                id=ctx.id,
-                auto_update=ctx.auto_update,
-                auto_update_facets=ctx.auto_update_facets,
-                auto_update_query=ctx.auto_update_query,
+                list_.name,
+                list_.entries,
+                list_.collections,
+                id=list_.id,
+                auto_update=list_.auto_update,
+                auto_update_facets=list_.auto_update_facets,
+                auto_update_query=list_.auto_update_query,
             )
 
         return None
-
-    def _getJSONFromRequest(self, values: str | None) -> list:
-        if values:
-            return_values = json.loads(values)
-        else:
-            return_values = []
-
-        return return_values
 
     def _get_work_from_urn(self, library: Library, urn: str | None) -> Work | None:
         identifier, ignore = Identifier.parse_urn(self._db, urn)
@@ -365,17 +359,19 @@ class CustomListsController(
             )
 
         elif flask.request.method == "POST":
-            ctx: Context = flask.request.context.body  # type: ignore
+            list_ = self.CustomListPostRequest.parse_obj(
+                parse_multi_dict(flask.request.form)
+            )
             return self._create_or_update_list(
                 library,
-                ctx.name,
-                ctx.entries,
-                ctx.collections,
-                deleted_entries=ctx.deletedEntries,
+                list_.name,
+                list_.entries,
+                list_.collections,
+                deleted_entries=list_.deletedEntries,
                 id=list_id,
-                auto_update=ctx.auto_update,
-                auto_update_query=ctx.auto_update_query,
-                auto_update_facets=ctx.auto_update_facets,
+                auto_update=list_.auto_update,
+                auto_update_query=list_.auto_update_query,
+                auto_update_facets=list_.auto_update_facets,
             )
 
         elif flask.request.method == "DELETE":

--- a/src/palace/manager/api/app.py
+++ b/src/palace/manager/api/app.py
@@ -3,7 +3,6 @@ import logging
 import flask_babel
 from flask import request
 from flask_babel import Babel
-from flask_pydantic_spec import FlaskPydanticSpec
 from sqlalchemy.orm import Session
 
 from palace.manager.api.admin.controller import setup_admin_controllers
@@ -38,12 +37,6 @@ app.config["BABEL_DEFAULT_LOCALE"] = LanguageCodes.three_to_two[
 ]
 app.config["BABEL_TRANSLATION_DIRECTORIES"] = "../translations"
 babel = Babel(app, locale_selector=get_locale)
-
-# The autodoc spec, can be accessed at "/apidoc/swagger"
-api_spec = FlaskPydanticSpec(
-    "Palace Manager", mode="strict", title="Palace Manager API"
-)
-api_spec.register(app)
 
 # We use URIs as identifiers throughout the application, meaning that
 # we never want werkzeug's merge_slashes feature.

--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -3,14 +3,8 @@ from functools import update_wrapper, wraps
 import flask
 from flask import Response, make_response, request
 from flask_cors.core import get_cors_options, set_cors_headers
-from flask_pydantic_spec import Response as SpecResponse
 
-from palace.manager.api.app import api_spec, app
-from palace.manager.api.model.patron_auth import PatronAuthAccessToken
-from palace.manager.api.model.time_tracking import (
-    PlaytimeEntriesPost,
-    PlaytimeEntriesPostResponse,
-)
+from palace.manager.api.app import app
 from palace.manager.core.app_server import compressible, returns_problem_detail
 from palace.manager.sqlalchemy.hassessioncache import HasSessionCache
 from palace.manager.util.problem_detail import ProblemDetail
@@ -362,7 +356,6 @@ def delete_patron_devices():
 
 
 @library_dir_route("/patrons/me/token", methods=["POST"])
-@api_spec.validate(resp=SpecResponse(HTTP_200=PatronAuthAccessToken), tags=["patron"])
 @has_library
 @requires_auth
 @returns_problem_detail
@@ -540,11 +533,6 @@ def track_analytics_event(identifier_type, identifier, event_type):
 )
 @has_library
 @requires_auth
-@api_spec.validate(
-    resp=SpecResponse(HTTP_200=PlaytimeEntriesPostResponse),
-    body=PlaytimeEntriesPost,
-    tags=["analytics"],
-)
 @returns_problem_detail
 def track_playtime_events(collection_id, identifier_type, identifier):
     """The actual response type is 207, but due to a bug in flask-pydantic-spec we must document it as a 200"""

--- a/src/palace/manager/core/app_server.py
+++ b/src/palace/manager/core/app_server.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 import flask
 from flask import Response, make_response, url_for
-from flask_pydantic_spec import FlaskPydanticSpec
 from psycopg2 import OperationalError
 from werkzeug.exceptions import HTTPException
 
@@ -80,24 +79,7 @@ def load_pagination_from_request(
     return base_class.from_request(get_arg, default_size, **kwargs)
 
 
-def ensure_pydantic_after_problem_detail(func):
-    """We must ensure the problem_detail decorators are always placed below the
-    `spec.validate` decorator because the `spec.validate` decorator will always expect a
-    tuple or dict-like response, not a ProblemDetail like response.
-    The problem_detail decorators will convert the ProblemDetail before the response gets validated.
-    """
-    spec = getattr(func, "_decorator", None)
-    if spec and isinstance(spec, FlaskPydanticSpec):
-        raise RuntimeError(
-            "FlaskPydanticSpec MUST be decorated above the problem_detail decorator"
-            + ", else problem details will throw errors during response validation"
-            + f": {func}"
-        )
-
-
 def returns_problem_detail(f):
-    ensure_pydantic_after_problem_detail(f)
-
     @wraps(f)
     def decorated(*args, **kwargs):
         v = f(*args, **kwargs)

--- a/tests/mocks/flask.py
+++ b/tests/mocks/flask.py
@@ -1,19 +1,20 @@
-from flask_pydantic_spec.flask_backend import Context
-from flask_pydantic_spec.utils import parse_multi_dict
+from pydantic import BaseModel
+from werkzeug.datastructures import MultiDict
+
+from palace.manager.util.flask_util import parse_multi_dict
 
 
-def add_request_context(request, model, form=None) -> None:
-    """Add a flask pydantic model into the request context
-    :param model: The pydantic model
+def add_request_context(
+    request, model: type[BaseModel], form: MultiDict | None = None
+) -> None:
+    """Add form data into the request context.
+
+    Before doing so, we verify that it can be parsed into the Pydantic model.
+
+    :param model: A pydantic model
     :param form: A form multidict
-    TODO:
-    - query params
-    - json post requests
     """
-    body = None
-    query = None
-    if form is not None:
-        request.form = form
-        body = model.parse_obj(parse_multi_dict(form))
 
-    request.context = Context(query, body, None, None)
+    if form is not None:
+        model.parse_obj(parse_multi_dict(form))
+        request.form = form


### PR DESCRIPTION
## Description

Stop using `flask-pydantic-spec`.

## Motivation and Context

The `flask-pydantic-spec` package does not appear to be actively maintained and it is blocking an upgrade to Pydantic V2.

[Jira [PP-1656](https://ebce-lyrasis.atlassian.net/browse/PP-1656)]

## How Has This Been Tested?

- Some local manual testing. 
- All tests pass locally.
- [CI for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/10586537299) passes.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.

[PP-1656]: https://ebce-lyrasis.atlassian.net/browse/PP-1656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ