### PR TITLE
Add a script to clean up old marc file exports (PP-348)

### DIFF
--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -43,6 +43,13 @@ def beat_schedule() -> dict[str, Any]:
                 hour="3,11", minute="0"
             ),  # Run twice a day at 3:00 AM and 11:00 AM
         },
+        "marc_export_cleanup": {
+            "task": "marc.marc_export_cleanup",
+            "schedule": crontab(
+                hour="1",
+                minute="0",
+            ),  # Run every day at 1:00 AM
+        },
     }
 
 

--- a/src/palace/manager/sqlalchemy/model/marcfile.py
+++ b/src/palace/manager/sqlalchemy/model/marcfile.py
@@ -22,7 +22,6 @@ class MarcFile(Base):
 
     # The library should never be null in normal operation, but if a library is deleted, we don't want to lose the
     # record of the MARC file, so we set the library to null.
-    # TODO: We need a job to clean up these records.
     library_id = Column(
         Integer,
         ForeignKey("libraries.id", ondelete="SET NULL"),
@@ -35,7 +34,6 @@ class MarcFile(Base):
 
     # The collection should never be null in normal operation, but similar to the library, if a collection is deleted,
     # we don't want to lose the record of the MARC file, so we set the collection to null.
-    # TODO: We need a job to clean up these records.
     collection_id = Column(
         Integer,
         ForeignKey("collections.id", ondelete="SET NULL"),

--- a/tests/fixtures/s3.py
+++ b/tests/fixtures/s3.py
@@ -105,6 +105,10 @@ class MockS3Service(S3Service):
 
         self.upload_in_progress: dict[str, MockMultipartUpload] = {}
         self.aborted: list[str] = []
+        self.deleted: list[str] = []
+
+    def delete(self, key: str) -> None:
+        self.deleted.append(key)
 
     def store_stream(
         self,

--- a/tests/manager/service/storage/test_s3.py
+++ b/tests/manager/service/storage/test_s3.py
@@ -246,6 +246,8 @@ class TestS3ServiceIntegration:
         bucket_contents = raw_client.list_objects(Bucket=bucket).get("Contents", [])
         assert len(bucket_contents) == 0
 
+        service.delete("key")  # Deleting a non-existent key should not raise an error.
+
     @pytest.mark.parametrize(
         "key, service_name, content, content_type",
         [


### PR DESCRIPTION
## Description

Create a Celery task that runs once a day cleaning up old MARC exports stored in S3. The script leaves the most recent full export and the 12 most recent delta exports. It also cleans up any files for libraries and collections that have been deleted or had their MARC exporter disabled.

## Motivation and Context

The MARC export functionality creates records for libraries and lanes, but never removes any previous exports. So old, useless files are accumulating endlessly, using storage, increasing costs, and worsening user experience.

## How Has This Been Tested?

- Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
