### PR TITLE
Add better bibliotheca error messages (PP-1637)

### DIFF
--- a/src/palace/manager/api/bibliotheca.py
+++ b/src/palace/manager/api/bibliotheca.py
@@ -1003,28 +1003,28 @@ class ErrorParser(BibliothecaParser[BaseProblemDetailException]):
         expected = expected.split(",")
 
         if actual == "CAN_WISH":
-            return NoLicenses(message)
+            return NoLicenses(debug_info=message)
 
         if "CAN_LOAN" in expected and actual == "CAN_HOLD":
-            return NoAvailableCopies(message)
+            return NoAvailableCopies(debug_info=message)
 
         if "CAN_LOAN" in expected and actual == "HOLD":
-            return AlreadyOnHold(message)
+            return AlreadyOnHold(debug_info=message)
 
         if "CAN_LOAN" in expected and actual == "LOAN":
-            return AlreadyCheckedOut(message)
+            return AlreadyCheckedOut(debug_info=message)
 
         if "CAN_HOLD" in expected and actual == "CAN_LOAN":
-            return CurrentlyAvailable(message)
+            return CurrentlyAvailable(debug_info=message)
 
         if "CAN_HOLD" in expected and actual == "HOLD":
-            return AlreadyOnHold(message)
+            return AlreadyOnHold(debug_info=message)
 
         if "CAN_HOLD" in expected:
-            return CannotHold(message)
+            return CannotHold(debug_info=message)
 
         if "CAN_LOAN" in expected:
-            return CannotLoan(message)
+            return CannotLoan(debug_info=message)
 
         return RemoteInitiatedServerError(message, BibliothecaAPI.SERVICE_NAME)
 

--- a/src/palace/manager/api/circulation_exceptions.py
+++ b/src/palace/manager/api/circulation_exceptions.py
@@ -322,11 +322,21 @@ class NoAvailableCopies(CannotLoan):
     copies are already checked out.
     """
 
+    @property
+    def base(self) -> ProblemDetail:
+        return CHECKOUT_FAILED.detailed(detail="No available copies to check out.")
+
 
 class AlreadyCheckedOut(CannotLoan):
     """The patron can't put check this book out because they already have
     it checked out.
     """
+
+    @property
+    def base(self) -> ProblemDetail:
+        return CHECKOUT_FAILED.detailed(
+            detail="You already have this book checked out."
+        )
 
 
 class AlreadyOnHold(CannotHold):
@@ -334,11 +344,21 @@ class AlreadyOnHold(CannotHold):
     it on hold.
     """
 
+    @property
+    def base(self) -> ProblemDetail:
+        return HOLD_FAILED.detailed(detail="You already have this book on hold.")
+
 
 class NotCheckedOut(CannotReturn):
     """The patron can't return this book because they don't
     have it checked out in the first place.
     """
+
+    @property
+    def base(self) -> ProblemDetail:
+        return COULD_NOT_MIRROR_TO_REMOTE.detailed(
+            title="Unable to return", detail="You don't have this book checked out."
+        )
 
 
 class NotOnHold(CannotReleaseHold):
@@ -349,6 +369,10 @@ class NotOnHold(CannotReleaseHold):
 
 class CurrentlyAvailable(CannotHold):
     """The patron can't put this book on hold because it's available now."""
+
+    @property
+    def base(self) -> ProblemDetail:
+        return HOLD_FAILED.detailed(detail="Cannot place a hold on an available title.")
 
 
 class HoldOnUnlimitedAccess(CannotHold):

--- a/src/palace/manager/api/circulation_exceptions.py
+++ b/src/palace/manager/api/circulation_exceptions.py
@@ -324,7 +324,7 @@ class NoAvailableCopies(CannotLoan):
 
     @property
     def base(self) -> ProblemDetail:
-        return CHECKOUT_FAILED.detailed(detail="No available copies to check out.")
+        return CHECKOUT_FAILED.detailed(detail="No copies available to check out.")
 
 
 class AlreadyCheckedOut(CannotLoan):

--- a/tests/manager/api/test_bibliotheca.py
+++ b/tests/manager/api/test_bibliotheca.py
@@ -858,48 +858,68 @@ class TestErrorParser:
     )
 
     @pytest.mark.parametrize(
-        "incoming_message, error_class",
+        "incoming_message, error_class, message, debug_message",
         [
             (
                 "Patron cannot loan more than 12 documents",
                 PatronLoanLimitReached,
+                "Patron cannot loan more than 12 documents",
+                None,
             ),
             (
                 "Patron cannot have more than 15 holds",
                 PatronHoldLimitReached,
+                "Patron cannot have more than 15 holds",
+                None,
             ),
             (
                 "the patron document status was CAN_WISH and not one of CAN_LOAN,RESERVATION",
                 NoLicenses,
+                "The library currently has no licenses for this book.",
+                "the patron document status was CAN_WISH and not one of CAN_LOAN,RESERVATION",
             ),
             (
                 "the patron document status was CAN_HOLD and not one of CAN_LOAN,RESERVATION",
                 NoAvailableCopies,
+                "No available copies to check out.",
+                "the patron document status was CAN_HOLD and not one of CAN_LOAN,RESERVATION",
             ),
             (
                 "the patron document status was LOAN and not one of CAN_LOAN,RESERVATION",
                 AlreadyCheckedOut,
+                "You already have this book checked out.",
+                "the patron document status was LOAN and not one of CAN_LOAN,RESERVATION",
             ),
             (
                 "The patron has no eBooks checked out",
                 NotCheckedOut,
+                "The patron has no eBooks checked out",
+                None,
             ),
             (
                 "the patron document status was CAN_LOAN and not one of CAN_HOLD",
                 CurrentlyAvailable,
+                "Cannot place a hold on an available title.",
+                "the patron document status was CAN_LOAN and not one of CAN_HOLD",
             ),
             (
                 "the patron document status was HOLD and not one of CAN_HOLD",
                 AlreadyOnHold,
+                "You already have this book on hold.",
+                "the patron document status was HOLD and not one of CAN_HOLD",
             ),
             (
                 "The patron does not have the book on hold",
                 NotOnHold,
+                "The patron does not have the book on hold",
+                None,
             ),
             # This is such a weird case we don't have a special exception for it.
             (
                 "the patron document status was LOAN and not one of CAN_HOLD",
                 CannotHold,
+                "Could not place hold (reason unknown).",
+                "the patron document status was LOAN and not one of CAN_HOLD",
             ),
         ],
     )
@@ -907,13 +927,16 @@ class TestErrorParser:
         self,
         incoming_message: str,
         error_class: type[CirculationException],
+        message: str,
+        debug_message: str | None,
     ):
         document = self.BIBLIOTHECA_ERROR_RESPONSE_BODY_TEMPLATE.format(
             message=incoming_message
         )
         error = ErrorParser().process_first(document)
         assert error.__class__ is error_class
-        assert incoming_message == str(error)
+        assert error.problem_detail.detail == message
+        assert error.problem_detail.debug_message == debug_message
 
     @pytest.mark.parametrize(
         "incoming_message, incoming_message_from_file, error_string",

--- a/tests/manager/api/test_bibliotheca.py
+++ b/tests/manager/api/test_bibliotheca.py
@@ -881,7 +881,7 @@ class TestErrorParser:
             (
                 "the patron document status was CAN_HOLD and not one of CAN_LOAN,RESERVATION",
                 NoAvailableCopies,
-                "No available copies to check out.",
+                "No copies available to check out.",
                 "the patron document status was CAN_HOLD and not one of CAN_LOAN,RESERVATION",
             ),
             (


### PR DESCRIPTION
## Description

Previously the error message would have been: `the patron document status was LOAN and not one of CAN_LOAN,RESERVATION`. After these changes the error message will be: `No copies available to check out`, which isn't ideal, but it still a better user experience.

## Motivation and Context

See JIRA: PP-1637

## How Has This Been Tested?

- Unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
