### PR TITLE
[PP-1650] Allows SirsiDynix Horizon Auth Provider users to reset Adob…

### DIFF
--- a/src/palace/manager/api/admin/controller/patron.py
+++ b/src/palace/manager/api/admin/controller/patron.py
@@ -36,7 +36,7 @@ class PatronController(CirculationManagerController, AdminPermissionsControllerM
             )
 
         patron_data = PatronData(authorization_identifier=identifier)
-        complete_patron_data = None
+        remote_patron_data = None
         patron_lookup_providers = list(authenticator.unique_patron_lookup_providers)
 
         if not patron_lookup_providers:
@@ -45,12 +45,12 @@ class PatronController(CirculationManagerController, AdminPermissionsControllerM
             )
 
         for provider in patron_lookup_providers:
-            complete_patron_data = provider.remote_patron_lookup(patron_data)
-            if complete_patron_data:
-                return complete_patron_data
+            remote_patron_data = provider.remote_patron_lookup(patron_data)
+            if remote_patron_data:
+                return remote_patron_data
 
         # If we get here, none of the providers succeeded.
-        if not complete_patron_data:
+        if not remote_patron_data:
             return NO_SUCH_PATRON.detailed(
                 _(
                     "No patron with identifier %(patron_identifier)s was found at your library",

--- a/src/palace/manager/api/sirsidynix_authentication_provider.py
+++ b/src/palace/manager/api/sirsidynix_authentication_provider.py
@@ -193,7 +193,7 @@ class SirsiDynixHorizonAuthenticationProvider(
 
     def remote_patron_lookup(
         self, patron_or_patrondata: Patron | PatronData
-    ) -> None | SirsiDynixPatronData | PatronData:
+    ) -> None | PatronData:
         """Do a remote patron lookup, this method can only look up a patron with a patrondata object
         with a session_token already setup within it.
         This method also checks all the reasons that a patron may be blocked for.
@@ -206,7 +206,7 @@ class SirsiDynixHorizonAuthenticationProvider(
         # if the patron data object is not authenticated just pass it back after ensuring the
         # complete flag is set to False
         if (
-            not hasattr(patron_or_patrondata, "session_token")
+            not isinstance(patron_or_patrondata, SirsiDynixPatronData)
             or patron_or_patrondata.session_token is None
         ):
             patron_or_patrondata.complete = False
@@ -216,7 +216,7 @@ class SirsiDynixHorizonAuthenticationProvider(
         # Pull and parse the basic patron information
         data = self.api_read_patron_data(
             patron_key=patrondata.permanent_id,
-            session_token=patrondata.session_token,  # type: ignore[attr-defined]
+            session_token=patrondata.session_token,
         )
         if not data or "fields" not in data:
             return None
@@ -243,7 +243,7 @@ class SirsiDynixHorizonAuthenticationProvider(
         # Get patron "fines" information
         status = self.api_patron_status_info(
             patron_key=patrondata.permanent_id,
-            session_token=patrondata.session_token,  # type: ignore[attr-defined]
+            session_token=patrondata.session_token,
         )
 
         if not status or "fields" not in status:

--- a/src/palace/manager/api/sirsidynix_authentication_provider.py
+++ b/src/palace/manager/api/sirsidynix_authentication_provider.py
@@ -199,11 +199,20 @@ class SirsiDynixHorizonAuthenticationProvider(
         with a session_token already setup within it.
         This method also checks all the reasons that a patron may be blocked for.
         """
+        # if the patron data object is not authenticated just pass it back after ensuring the
+        # complete flag is set to False
+        if (
+            not hasattr(patron_or_patrondata, "session_token")
+            or patron_or_patrondata.session_token is None
+        ):
+            patron_or_patrondata.complete = False
+            return patron_or_patrondata
+
         # We cannot do a remote lookup without a session token
-        if not isinstance(patron_or_patrondata, SirsiDynixPatronData):
-            return None
-        elif not patron_or_patrondata.session_token:
-            return None
+        # if :
+        #     return None
+        # elif not patron_or_patrondata.session_token:
+        #     return None
 
         patrondata = patron_or_patrondata
         # Pull and parse the basic patron information

--- a/tests/manager/api/admin/controller/test_patron.py
+++ b/tests/manager/api/admin/controller/test_patron.py
@@ -83,6 +83,18 @@ class TestPatronController:
                 == response.detail
             )
 
+        # Authenticator can find patron with this identifier
+        auth_provider = MockAuthenticationProvider(
+            {identifier: {"authorization_identifier": identifier}}
+        )
+        authenticator.unique_patron_lookup_providers.clear()
+        authenticator.unique_patron_lookup_providers.append(auth_provider)
+
+        with patron_controller_fixture.request_context_with_library_and_admin("/"):
+            flask.request.form = form
+            response = m(authenticator)
+            assert identifier == response["authorization_identifier"]
+
     def test_lookup_patron(self, patron_controller_fixture: PatronControllerFixture):
         # Here's a patron.
         patron = patron_controller_fixture.ctrl.db.patron()

--- a/tests/manager/api/test_sirsidynix_auth_provider.py
+++ b/tests/manager/api/test_sirsidynix_auth_provider.py
@@ -288,7 +288,9 @@ class TestSirsiDynixAuthenticationProvider:
         assert patrondata.block_reason == block_reason
 
     def test_remote_patron_lookup_bad_patrondata(
-        self, sirsi_auth_fixture: SirsiAuthFixture
+        self,
+        sirsi_auth_fixture: SirsiAuthFixture,
+        db: DatabaseTransactionFixture,
     ):
         # Test no session token
         provider = sirsi_auth_fixture.provider_mocked_api().provider
@@ -296,11 +298,15 @@ class TestSirsiDynixAuthenticationProvider:
             SirsiDynixPatronData(permanent_id="xxxx", session_token=None)
         )
 
-        assert not patron_data.complete
+        assert patron_data and not patron_data.complete
 
         # Test incorrect patrondata type
         patron_data = provider.remote_patron_lookup(PatronData(permanent_id="xxxx"))
-        assert not patron_data.complete
+        assert patron_data and not patron_data.complete
+
+        # Test remote_patron_lookup with Patron object
+        patron = db.patron()
+        assert provider.remote_patron_lookup(patron) is None
 
     def test_remote_patron_lookup_bad_patron_read_data(
         self, sirsi_auth_fixture: SirsiAuthFixture

--- a/tests/manager/api/test_sirsidynix_auth_provider.py
+++ b/tests/manager/api/test_sirsidynix_auth_provider.py
@@ -292,15 +292,15 @@ class TestSirsiDynixAuthenticationProvider:
     ):
         # Test no session token
         provider = sirsi_auth_fixture.provider_mocked_api().provider
-        assert (
-            provider.remote_patron_lookup(
-                SirsiDynixPatronData(permanent_id="xxxx", session_token=None)
-            )
-            is None
+        patron_data = provider.remote_patron_lookup(
+            SirsiDynixPatronData(permanent_id="xxxx", session_token=None)
         )
 
+        assert not patron_data.complete
+
         # Test incorrect patrondata type
-        assert provider.remote_patron_lookup(PatronData(permanent_id="xxxx")) is None
+        patron_data = provider.remote_patron_lookup(PatronData(permanent_id="xxxx"))
+        assert not patron_data.complete
 
     def test_remote_patron_lookup_bad_patron_read_data(
         self, sirsi_auth_fixture: SirsiAuthFixture


### PR DESCRIPTION
…e IDs.

## Description

This update brings SirsiDynix Horizon Auth Provider in line with other  Auth Providers which do not require users to authenticate before resetting their Adobe IDs. 

When a CM admin tries to reset a patron's the Adobe ID, the CM makes an attempt to verify that the patron exists.   For SIP2 and Millenium Providers, this kind of unauthenticated query is supported   For Kansas, it is not supported so the KansasAuthenticationAPI just quietly passes the patron object back to the caller.   However for SirsiDynix Horizon an authenticated session is required to pull patron information.  

This update therefore allows a Sirsidynix Auth Provider caller to return an incomplete PatronData object rather than no result at all.  In this way, CM admins will be able to reset adobe ids for sirsidynix-using library patrons without needing the patrons credentials.

I moved this PR out of draft mode because I haven't yet heard back from SirsiDynix and I'm not holding my breath.  I doubt that their API supports what we ideally want to be able to do here: namely, to retrieve some minimal user info without having to authenticate.  If it turns out that we can,  I can always put in a new PR to take advantage of pulling patron info without authenticating.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1630
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tests have been updated and coverage improved.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
