### PR TITLE
Fix bug with playtime migration with existing data

### DIFF
--- a/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
+++ b/alembic/versions/20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py
@@ -22,12 +22,29 @@ def upgrade() -> None:
 
     op.add_column(
         "playtime_entries",
-        sa.Column("loan_identifier", sa.String(length=40), nullable=False, default=""),
+        sa.Column("loan_identifier", sa.String(length=40), nullable=True, default=""),
     )
 
     op.add_column(
         "playtime_summaries",
-        sa.Column("loan_identifier", sa.String(length=40), nullable=False, default=""),
+        sa.Column("loan_identifier", sa.String(length=40), nullable=True, default=""),
+    )
+
+    # Migrate the existing playtime records before we set the new columns to not nullable.
+    conn.execute("UPDATE playtime_entries SET loan_identifier = ''")
+    conn.execute("UPDATE playtime_summaries SET loan_identifier = ''")
+
+    op.alter_column(
+        "playtime_entries",
+        "loan_identifier",
+        existing_type=sa.String(length=40),
+        nullable=False,
+    )
+    op.alter_column(
+        "playtime_summaries",
+        "loan_identifier",
+        existing_type=sa.String(length=40),
+        nullable=False,
     )
 
     op.drop_constraint("unique_playtime_summary", "playtime_summaries", type_="unique")


### PR DESCRIPTION
## Description

Update the migration so that we add the new columns as nullable, fill them with the default data, then set them to not nullable.

## Motivation and Context

Running `main` against an existing DB today I ran into this issue with the `20240821_7a2fcaac8b63_add_loan_identifier_column_to_playtime_tables.py` migration.

```
{"host": "Syrah.woh.ca", "name": "alembic.runtime.migration", "level": "INFO", "filename": "migration.py", "message": "Running upgrade 7ba553f3f80d -> 7a2fcaac8b63, Add loan_identifier column to playtime tables.", "timestamp": "2024-09-05T14:20:18.621451+00:00", "process": 15725}
Traceback (most recent call last):
  File "/Users/jgreen/.pyenv/versions/circulation/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
    self.dialect.do_execute(
  File "/Users/jgreen/.pyenv/versions/circulation/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.NotNullViolation: column "loan_identifier" contains null values
```

## How Has This Been Tested?

- Tested locally with existing DB

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
