### PR TITLE
Migrate MARC exporter protocol name

### DIFF
--- a/alembic/versions/20240905_350a29bf0ff0_update_existing_marcexporter_protocols.py
+++ b/alembic/versions/20240905_350a29bf0ff0_update_existing_marcexporter_protocols.py
@@ -1,0 +1,29 @@
+"""Update existing MarcExporter protocols
+
+Revision ID: 350a29bf0ff0
+Revises: 7a2fcaac8b63
+Create Date: 2024-09-05 16:04:45.789665+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "350a29bf0ff0"
+down_revision = "7a2fcaac8b63"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Update existing MarcExporter protocols to use the new protocol name
+    op.execute(
+        "UPDATE integration_configurations SET protocol = 'MarcExporter' "
+        "WHERE protocol = 'MARCExporter' and goal = 'CATALOG_GOAL'"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE integration_configurations SET protocol = 'MARCExporter' "
+        "WHERE protocol = 'MarcExporter' and goal = 'CATALOG_GOAL'"
+    )

--- a/src/palace/manager/service/integration_registry/catalog_services.py
+++ b/src/palace/manager/service/integration_registry/catalog_services.py
@@ -14,4 +14,4 @@ class CatalogServicesRegistry(IntegrationRegistry["MarcExporter"]):
         from palace.manager.marc.exporter import MarcExporter
 
         super().__init__(Goals.CATALOG_GOAL)
-        self.register(MarcExporter, aliases=["MARCExporter"])
+        self.register(MarcExporter)


### PR DESCRIPTION
## Description

🚨 This one can get a review, but can't be merged until after a release is cut that contains https://github.com/ThePalaceProject/circulation/pull/2017. I'm going to keep this in draft until then.

This migrates the names of any existing MARC exporter integrations to the new `MarcExporter` name.

## Motivation and Context

Just some housekeeping 🧹, so we know all our databases have the new protocol name in them.

## How Has This Been Tested?

- Tested locally with database containing old intergration configuration.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
