### PR TITLE
Return problem detail when LCP fulfillment fails (PP-1641)

### DIFF
--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -567,7 +567,9 @@ class OPDS2WithODLApi(
         if content_link is None or content_type is None:
             raise CannotFulfill()
 
-        return FetchFulfillment(content_link, content_type)
+        return FetchFulfillment(
+            content_link, content_type, allowed_response_codes=["2xx"]
+        )
 
     def _bearer_token_fulfill(
         self, loan: Loan, delivery_mechanism: LicensePoolDeliveryMechanism

--- a/tests/manager/api/odl/test_api.py
+++ b/tests/manager/api/odl/test_api.py
@@ -894,6 +894,7 @@ class TestOPDS2WithODLApi:
         assert isinstance(fulfillment, FetchFulfillment)
         assert correct_link == fulfillment.content_link
         assert correct_type == fulfillment.content_type
+        assert ["2xx"] == fulfillment.allowed_response_codes
 
     def test_fulfill_open_access(
         self,


### PR DESCRIPTION
## Description

If LCP fulfillment request does not return a status in the 2xx range, raise a `ProblemDetailException`, which will be returned to the clients.

## Motivation and Context

We've seen a number of times recently when LCP fulfillment fails, and the CM just blindly passes along whatever the LCP API gives us, which confuses the apps. Instead in this PR if we get an unexpected status code, we turn that into a problem detail, and log the issue. This should give a better user experience and let us track down the problems from our logs. 

This PR is only a couple lines, but it took a lot of refactoring in https://github.com/ThePalaceProject/circulation/pull/2034 and https://github.com/ThePalaceProject/circulation/pull/2035 to get here.

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
