### PR TITLE
Refactor BadResponseException (PP-1641)

### DIFF
--- a/src/palace/manager/api/overdrive.py
+++ b/src/palace/manager/api/overdrive.py
@@ -562,10 +562,10 @@ class OverdriveAPI(
         if status_code == 401:
             if exception_on_401:
                 # This is our second try. Give up.
-                raise BadResponseException.from_response(
+                raise BadResponseException(
                     url,
                     "Something's wrong with the Overdrive OAuth Bearer Token!",
-                    (status_code, headers, content),
+                    response,
                 )
             else:
                 # Refresh the token and try again.

--- a/src/palace/manager/util/http.py
+++ b/src/palace/manager/util/http.py
@@ -110,7 +110,6 @@ class BadResponseException(RemoteIntegrationException):
             )
 
         super().__init__(url_or_service, message, debug_message)
-        # to be set to 500, etc.
         self.response = response
 
     @classmethod

--- a/tests/manager/api/odl/test_api.py
+++ b/tests/manager/api/odl/test_api.py
@@ -1813,6 +1813,18 @@ class TestOPDS2WithODLApi:
         assert 6 == opds2_with_odl_api_fixture.pool.licenses_available
         assert 1 == db.session.query(Loan).count()
 
+    def test_update_loan_bad_status(
+        self,
+        db: DatabaseTransactionFixture,
+        opds2_with_odl_api_fixture: OPDS2WithODLApiFixture,
+    ) -> None:
+        status_doc = {
+            "status": "foo",
+        }
+
+        with pytest.raises(RemoteIntegrationException, match="unknown status value"):
+            opds2_with_odl_api_fixture.api.update_loan(MagicMock(), status_doc)
+
     def test_update_loan_removes_loan(
         self,
         db: DatabaseTransactionFixture,

--- a/tests/manager/util/test_http.py
+++ b/tests/manager/util/test_http.py
@@ -394,14 +394,14 @@ class TestRemoteIntegrationException:
 
 
 class TestBadResponseException:
-    def test_from_response(self):
+    def test__init__(self):
         response = MockRequestsResponse(102, content="nonsense")
-        exc = BadResponseException.from_response(
+        exc = BadResponseException(
             "http://url/", "Terrible response, just terrible", response
         )
 
-        # the status code gets set on the exception
-        assert exc.status_code == 102
+        # the response gets set on the exception
+        assert exc.response is response
 
         # Turn the exception into a problem detail document, and it's full
         # of useful information.
@@ -418,7 +418,7 @@ class TestBadResponseException:
         )
         assert problem_detail.status_code == 502
 
-    def test_bad_status_code(object):
+    def test_bad_status_code(self):
         response = MockRequestsResponse(500, content="Internal Server Error!")
         exc = BadResponseException.bad_status_code("http://url/", response)
         doc = exc.problem_detail
@@ -434,11 +434,12 @@ class TestBadResponseException:
         )
 
     def test_problem_detail(self):
+        response = MockRequestsResponse(401, content="You are not authorized!")
         exception = BadResponseException(
             "http://url/",
             "What even is this",
             debug_message="some debug info",
-            status_code=401,
+            response=response,
         )
         document = exception.problem_detail
         assert 502 == document.status_code
@@ -451,7 +452,7 @@ class TestBadResponseException:
             "Bad response from http://url/: What even is this\n\nsome debug info"
             == document.debug_message
         )
-        assert exception.status_code == 401
+        assert exception.response is response
 
 
 class TestRequestTimedOut:

--- a/tests/mocks/odl.py
+++ b/tests/mocks/odl.py
@@ -10,8 +10,7 @@ from palace.manager.api.odl.auth import TokenTuple
 from palace.manager.api.odl.settings import OPDS2AuthType
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.util.datetime_helpers import utc_now
-from palace.manager.util.http import HTTP
-from tests.mocks.mock import MockRequestsResponse
+from tests.mocks.mock import MockHTTPClient
 
 
 class MockOPDS2WithODLApi(OPDS2WithODLApi):
@@ -19,12 +18,11 @@ class MockOPDS2WithODLApi(OPDS2WithODLApi):
         self,
         _db: Session,
         collection: Collection,
+        mock_http_client: MockHTTPClient,
     ) -> None:
         super().__init__(_db, collection)
-        self.responses: list[MockRequestsResponse] = []
-        self.requests: list[
-            tuple[str, Mapping[str, str] | None, Mapping[str, Any]]
-        ] = []
+
+        self.mock_http_client = mock_http_client
         self.mock_auth_type = self.settings.auth_type
         self.refresh_token_calls = 0
         self.refresh_token_timedelta = timedelta(minutes=30)
@@ -39,16 +37,6 @@ class MockOPDS2WithODLApi(OPDS2WithODLApi):
             token="new_token", expires=utc_now() + self.refresh_token_timedelta
         )
 
-    def queue_response(
-        self,
-        status_code: int,
-        headers: dict[str, str] | None = None,
-        content: str | None = None,
-    ):
-        if headers is None:
-            headers = {}
-        self.responses.insert(0, MockRequestsResponse(status_code, headers, content))
-
     def _url_for(self, *args: Any, **kwargs: Any) -> str:
         del kwargs["_external"]
         return "http://{}?{}".format(
@@ -59,6 +47,4 @@ class MockOPDS2WithODLApi(OPDS2WithODLApi):
     def _get(
         self, url: str, headers: Mapping[str, str] | None = None, **kwargs: Any
     ) -> Response:
-        self.requests.append((url, headers, kwargs))
-        response = self.responses.pop()
-        return HTTP._process_response(url, response)
+        return self.mock_http_client.do_get(url, headers=headers, **kwargs)


### PR DESCRIPTION
## Description

Refactor `BadResponseException`, so it has a reference to the response that can be used to deal with the exception.

This required changing a couple references to `RemoteIntegrationException`, where the response wasn't readily available. These exceptions have the same base class, so this should be handled okay.

I updated the OPDS2 + ODL importer to use the new exception, rather then doing its own status code parsing. I also updated mock OPDS2 + ODL importer to use `MockHTTPClient` instead of having its own mock client.

## Motivation and Context

- This work was done as a pre-requisite for the work in https://github.com/ThePalaceProject/circulation/pull/2033. I figured breaking this out to a separate PR would make it easier to review.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
