### PR TITLE
JSONFormatter use getfqdn

### DIFF
--- a/src/palace/manager/service/logging/log.py
+++ b/src/palace/manager/service/logging/log.py
@@ -35,11 +35,7 @@ except ImportError:
 class JSONFormatter(logging.Formatter):
     def __init__(self) -> None:
         super().__init__()
-        hostname = socket.gethostname()
-        fqdn = socket.getfqdn()
-        if len(fqdn) > len(hostname):
-            hostname = fqdn
-        self.hostname = hostname
+        self.hostname = socket.getfqdn()
         self.main_thread_id = threading.main_thread().ident
 
     def format(self, record: logging.LogRecord) -> str:


### PR DESCRIPTION
## Description

Use `getfqdn` always, since it falls back to `gethostname`.

See `python docs`:
> Return a fully qualified domain name for name. If name is omitted or empty, it is interpreted as the local host. ... In case no fully qualified domain name is available and name was provided, it is returned unchanged. If name was empty or equal to '0.0.0.0', the hostname from [gethostname()](https://docs.python.org/3/library/socket.html#socket.gethostname) is returned.

## Motivation and Context

This constantly causes noise in the coverage of our test runs, because sometimes this if is hit and sometimes it isn't. Depending on the CI workers the tests run on.

## How Has This Been Tested?

- Tested that this makes no difference in our production environment. Both `getfqdn` and `gethostname` always return the same thing.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
