### PR TITLE
Fix issues caused by differences between redis and elasticache (PP-1693)

### DIFF
--- a/src/palace/manager/service/redis/escape.py
+++ b/src/palace/manager/service/redis/escape.py
@@ -70,11 +70,10 @@ class JsonPathEscapeMixin:
                     )
                 unescaped.append(self._REVERSE_MAPPING[char])
                 in_escape = False
+            elif char == self._ESCAPE_CHAR:
+                in_escape = True
             else:
-                if char == self._ESCAPE_CHAR:
-                    in_escape = True
-                else:
-                    unescaped.append(char)
+                unescaped.append(char)
 
         if in_escape:
             raise PalaceValueError("Unterminated escape sequence.")

--- a/src/palace/manager/service/redis/escape.py
+++ b/src/palace/manager/service/redis/escape.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+from functools import cached_property
+
+from palace.manager.core.exceptions import PalaceValueError
+
+
+class JsonPathEscapeMixin:
+    r"""
+    Mixin to provide methods for escaping and unescaping JsonPaths for use in Redis / ElastiCache.
+
+    This is necessary because some characters in object keys are not handled well by AWS ElastiCache,
+    and other characters seem problematic in Redis.
+
+    This mixin provides methods to escape and unescape these characters, so that they can be used in
+    object keys, and the keys can be queried via JSONPath without issue.
+
+    In ElastiCache when ~ is used in a key, the key is never updated, despite returning a success. And
+    when a / is used in a key, the key is interpreted as a nested path, nesting a new key for every
+    slash in the path. This is not the behavior we want, so we need to escape these characters.
+
+    In Redis, the \ character is used as an escape character, and the " character is used to denote
+    the end of a string for the JSONPath. This means that these characters need to be escaped as well.
+
+    Characters are escaped by prefixing them with a backtick character, followed by a single character
+    from _MAPPING that represents the escaped character. The backtick character itself is escaped by
+    prefixing it with another backtick character.
+    """
+
+    _ESCAPE_CHAR = "`"
+
+    _MAPPING = {
+        "/": "s",
+        "\\": "b",
+        '"': "'",
+        "~": "t",
+    }
+
+    @cached_property
+    def _FORWARD_MAPPING(self) -> dict[str, str]:
+        mapping = {k: "".join((self._ESCAPE_CHAR, v)) for k, v in self._MAPPING.items()}
+        mapping[self._ESCAPE_CHAR] = "".join((self._ESCAPE_CHAR, self._ESCAPE_CHAR))
+        return mapping
+
+    @cached_property
+    def _REVERSE_MAPPING(self) -> dict[str, str]:
+        mapping = {v: k for k, v in self._MAPPING.items()}
+        mapping[self._ESCAPE_CHAR] = self._ESCAPE_CHAR
+        return mapping
+
+    def _escape_path(self, path: str, elasticache: bool = False) -> str:
+        escaped = "".join([self._FORWARD_MAPPING.get(c, c) for c in path])
+        if elasticache:
+            # As well as the simple escaping we have defined here, for ElastiCache we need to fully
+            # escape the path as if it were a JSON string. So we call json.dumps to do this. We
+            # strip the leading and trailing quotes from the result, as we only want the escaped
+            # string, not the quotes.
+            escaped = json.dumps(escaped)[1:-1]
+        return escaped
+
+    def _unescape_path(self, path: str) -> str:
+        in_escape = False
+        unescaped = []
+        for char in path:
+            if in_escape:
+                if char not in self._REVERSE_MAPPING:
+                    raise PalaceValueError(
+                        f"Invalid escape sequence '{self._ESCAPE_CHAR}{char}'"
+                    )
+                unescaped.append(self._REVERSE_MAPPING[char])
+                in_escape = False
+            else:
+                if char == self._ESCAPE_CHAR:
+                    in_escape = True
+                else:
+                    unescaped.append(char)
+
+        if in_escape:
+            raise PalaceValueError("Unterminated escape sequence.")
+
+        return "".join(unescaped)

--- a/src/palace/manager/service/redis/models/lock.py
+++ b/src/palace/manager/service/redis/models/lock.py
@@ -382,8 +382,8 @@ class RedisJsonLock(BaseRedisLock, ABC):
         This function validates that all the results of the pipeline are successful,
         and not a ResponseError.
 
-        NOTE: The AWS ElastiCache implementation returns slightly different results then Redis.
-        In redis, unsuccessful results when a key is not found are `None`, but in AWS they are
+        NOTE: The AWS ElastiCache implementation returns slightly different results than Redis.
+        In Redis, unsuccessful results when a key is not found are `None`, but in AWS they are
         returned as a `ResponseError`, so we are careful to check for both in this function.
         """
         return all(r and not isinstance(r, ResponseError) for r in results)

--- a/src/palace/manager/service/redis/models/marc.py
+++ b/src/palace/manager/service/redis/models/marc.py
@@ -9,9 +9,9 @@ from functools import cached_property
 from typing import Any
 
 from pydantic import BaseModel
-from redis import ResponseError, WatchError
+from redis import WatchError
 
-from palace.manager.core.exceptions import PalaceValueError
+from palace.manager.service.redis.escape import JsonPathEscapeMixin
 from palace.manager.service.redis.models.lock import LockError, RedisJsonLock
 from palace.manager.service.redis.redis import Pipeline, Redis
 from palace.manager.service.storage.s3 import MultipartS3UploadPart
@@ -41,85 +41,7 @@ class MarcFileUploadState(StrEnum):
     UPLOADING = auto()
 
 
-class PathEscapeMixin:
-    """
-    Mixin to provide methods for escaping and unescaping paths for use in redis.
-
-    This is necessary because it seems like there is a bug in the AWS elasticache implementation
-    of JSONPATH where slashes or tilde character within a string literal used as a key cause issues.
-    This bug is not present in the open source redis implementation, which does the sane thing, not
-    requiring any special escaping.
-
-    Hopefully at some point AWS will fix these issues, and we can drop this mixin, so I tried to
-    encapsulate the logic for this here.
-
-    In AWS when a tilde is used in a key, the key is never updated, despite returning a success. And
-    when a slash is used in a key, the key is interpreted as a nested path, nesting a new key for every
-    slash in the path. This is not the behavior we want, so we need to escape these characters.
-
-    We can test if this is fixed in the future by running the test suite against AWS elasticache with
-    this mixin removed. If the tests pass, then it can be removed.
-
-    Characters are escaped by prefixing them with a backtick character, followed by a single character
-    from _MAPPING that represents the escaped character. The backtick character itself is escaped by
-    prefixing it with another backtick character.
-    """
-
-    _ESCAPE_CHAR = "`"
-
-    _MAPPING = {
-        "/": "s",
-        "~": "t",
-    }
-
-    @cached_property
-    def _FORWARD_MAPPING(self) -> dict[str, str]:
-        mapping = {k: "".join((self._ESCAPE_CHAR, v)) for k, v in self._MAPPING.items()}
-        mapping[self._ESCAPE_CHAR] = "".join((self._ESCAPE_CHAR, self._ESCAPE_CHAR))
-        return mapping
-
-    @cached_property
-    def _REVERSE_MAPPING(self) -> dict[str, str]:
-        mapping = {v: k for k, v in self._MAPPING.items()}
-        mapping[self._ESCAPE_CHAR] = self._ESCAPE_CHAR
-        return mapping
-
-    def _escape_path(self, path: str) -> str:
-        escaped = json.dumps("".join([self._FORWARD_MAPPING.get(c, c) for c in path]))
-        return escaped[1:-1]
-
-    def _unescape_path(self, path: str) -> str:
-        # Normal redis paths are always double-quoted, so we can use json.loads to unescape them.
-        # This does not happen in the AWS elasticache implementation, so we need to handle it manually,
-        # so that we can support both implementations.
-        try:
-            path = json.loads(f'"{path}"')
-        except json.JSONDecodeError:
-            pass
-
-        in_escape = False
-        unescaped = []
-        for char in path:
-            if in_escape:
-                if char not in self._REVERSE_MAPPING:
-                    raise PalaceValueError(
-                        f"Invalid escape sequence '{self._ESCAPE_CHAR}{char}'"
-                    )
-                unescaped.append(self._REVERSE_MAPPING[char])
-                in_escape = False
-            else:
-                if char == self._ESCAPE_CHAR:
-                    in_escape = True
-                else:
-                    unescaped.append(char)
-
-        if in_escape:
-            raise PalaceValueError("Unterminated escape sequence.")
-
-        return "".join(unescaped)
-
-
-class MarcFileUploadSession(RedisJsonLock, PathEscapeMixin, LoggerMixin):
+class MarcFileUploadSession(RedisJsonLock, JsonPathEscapeMixin, LoggerMixin):
     """
     This class is used as a lock for the Celery MARC export task, to ensure that only one
     task can upload MARC files for a given collection at a time. It increments an update
@@ -185,7 +107,7 @@ class MarcFileUploadSession(RedisJsonLock, PathEscapeMixin, LoggerMixin):
         return MarcFileUpload(buffer=buffer_data).dict(exclude_none=True)
 
     def _upload_path(self, upload_key: str) -> str:
-        upload_key = self._escape_path(upload_key)
+        upload_key = self._escape_path(upload_key, self._redis_client.elasticache)
         return f'{self._uploads_json_key}["{upload_key}"]'
 
     def _buffer_path(self, upload_key: str) -> str:
@@ -255,18 +177,6 @@ class MarcFileUploadSession(RedisJsonLock, PathEscapeMixin, LoggerMixin):
 
         return pipe_results[:-3]
 
-    @staticmethod
-    def _validate_results(results: list[Any]) -> bool:
-        """
-        This function validates that all the results of the pipeline are successful,
-        and not a ResponseError.
-
-        NOTE: The AWS elasticache implementation returns slightly different results then redis.
-        In redis, unsuccessful results when a key is not found are `None`, but in AWS they are
-        returned as a `ResponseError`, which is why we are checking for both in this function.
-        """
-        return all(r and not isinstance(r, ResponseError) for r in results)
-
     def append_buffers(self, data: Mapping[str, str]) -> dict[str, int]:
         if not data:
             return {}
@@ -295,7 +205,7 @@ class MarcFileUploadSession(RedisJsonLock, PathEscapeMixin, LoggerMixin):
 
             pipe_results = self._execute_pipeline(pipe, len(data))
 
-        if not self._validate_results(pipe_results):
+        if not self._validate_pipeline_results(pipe_results):
             raise MarcFileUploadSessionError("Failed to append buffers.")
 
         return {
@@ -317,7 +227,7 @@ class MarcFileUploadSession(RedisJsonLock, PathEscapeMixin, LoggerMixin):
             )
             pipe_results = self._execute_pipeline(pipe, 1)
 
-        if not self._validate_results(pipe_results):
+        if not self._validate_pipeline_results(pipe_results):
             raise MarcFileUploadSessionError("Failed to add part and clear buffer.")
 
     def set_upload_id(self, key: str, upload_id: str) -> None:
@@ -330,7 +240,7 @@ class MarcFileUploadSession(RedisJsonLock, PathEscapeMixin, LoggerMixin):
             )
             pipe_results = self._execute_pipeline(pipe, 1)
 
-        if not self._validate_results(pipe_results):
+        if not self._validate_pipeline_results(pipe_results):
             raise MarcFileUploadSessionError("Failed to set upload ID.")
 
     def clear_uploads(self) -> None:
@@ -338,7 +248,7 @@ class MarcFileUploadSession(RedisJsonLock, PathEscapeMixin, LoggerMixin):
             pipe.json().clear(self.key, self._uploads_json_key)
             pipe_results = self._execute_pipeline(pipe, 1)
 
-        if not self._validate_results(pipe_results):
+        if not self._validate_pipeline_results(pipe_results):
             raise MarcFileUploadSessionError("Failed to clear uploads.")
 
     def _get_specific(
@@ -382,7 +292,7 @@ class MarcFileUploadSession(RedisJsonLock, PathEscapeMixin, LoggerMixin):
             pipe.json().get(self.key, self._buffer_path(key))
             pipe.json().arrlen(self.key, self._parts_path(key))
             results = pipe.execute(raise_on_error=False)
-        if not self._validate_results(results):
+        if not self._validate_pipeline_results(results):
             raise MarcFileUploadSessionError(
                 "Failed to get part number and buffer data."
             )

--- a/src/palace/manager/service/redis/models/marc.py
+++ b/src/palace/manager/service/redis/models/marc.py
@@ -273,12 +273,10 @@ class MarcFileUploadSession(RedisJsonLock, PathEscapeMixin, LoggerMixin):
 
         set_results = {}
         with self._pipeline(begin_transaction=False) as pipe:
-            existing_uploads: list[str] = [
-                self._unescape_path(r)
-                for r in self._parse_value_or_raise(
-                    pipe.json().objkeys(self.key, self._uploads_json_key)
-                )
-            ]
+            existing_uploads: list[str] = self._parse_value_or_raise(
+                pipe.json().objkeys(self.key, self._uploads_json_key)
+            )
+            existing_uploads = [self._unescape_path(p) for p in existing_uploads]
             pipe.multi()
             for key, value in data.items():
                 if value == "":

--- a/src/palace/manager/service/redis/models/marc.py
+++ b/src/palace/manager/service/redis/models/marc.py
@@ -11,6 +11,7 @@ from typing import Any
 from pydantic import BaseModel
 from redis import ResponseError, WatchError
 
+from palace.manager.core.exceptions import PalaceValueError
 from palace.manager.service.redis.models.lock import LockError, RedisJsonLock
 from palace.manager.service.redis.redis import Pipeline, Redis
 from palace.manager.service.storage.s3 import MultipartS3UploadPart
@@ -40,7 +41,85 @@ class MarcFileUploadState(StrEnum):
     UPLOADING = auto()
 
 
-class MarcFileUploadSession(RedisJsonLock, LoggerMixin):
+class PathEscapeMixin:
+    """
+    Mixin to provide methods for escaping and unescaping paths for use in redis.
+
+    This is necessary because it seems like there is a bug in the AWS elasticache implementation
+    of JSONPATH where slashes or tilde character within a string literal used as a key cause issues.
+    This bug is not present in the open source redis implementation, which does the sane thing, not
+    requiring any special escaping.
+
+    Hopefully at some point AWS will fix these issues, and we can drop this mixin, so I tried to
+    encapsulate the logic for this here.
+
+    In AWS when a tilde is used in a key, the key is never updated, despite returning a success. And
+    when a slash is used in a key, the key is interpreted as a nested path, nesting a new key for every
+    slash in the path. This is not the behavior we want, so we need to escape these characters.
+
+    We can test if this is fixed in the future by running the test suite against AWS elasticache with
+    this mixin removed. If the tests pass, then it can be removed.
+
+    Characters are escaped by prefixing them with a backtick character, followed by a single character
+    from _MAPPING that represents the escaped character. The backtick character itself is escaped by
+    prefixing it with another backtick character.
+    """
+
+    _ESCAPE_CHAR = "`"
+
+    _MAPPING = {
+        "/": "s",
+        "~": "t",
+    }
+
+    @cached_property
+    def _FORWARD_MAPPING(self) -> dict[str, str]:
+        mapping = {k: "".join((self._ESCAPE_CHAR, v)) for k, v in self._MAPPING.items()}
+        mapping[self._ESCAPE_CHAR] = "".join((self._ESCAPE_CHAR, self._ESCAPE_CHAR))
+        return mapping
+
+    @cached_property
+    def _REVERSE_MAPPING(self) -> dict[str, str]:
+        mapping = {v: k for k, v in self._MAPPING.items()}
+        mapping[self._ESCAPE_CHAR] = self._ESCAPE_CHAR
+        return mapping
+
+    def _escape_path(self, path: str) -> str:
+        escaped = json.dumps("".join([self._FORWARD_MAPPING.get(c, c) for c in path]))
+        return escaped[1:-1]
+
+    def _unescape_path(self, path: str) -> str:
+        # Normal redis paths are always double-quoted, so we can use json.loads to unescape them.
+        # This does not happen in the AWS elasticache implementation, so we need to handle it manually,
+        # so that we can support both implementations.
+        try:
+            path = json.loads(f'"{path}"')
+        except json.JSONDecodeError:
+            pass
+
+        in_escape = False
+        unescaped = []
+        for char in path:
+            if in_escape:
+                if char not in self._REVERSE_MAPPING:
+                    raise PalaceValueError(
+                        f"Invalid escape sequence '{self._ESCAPE_CHAR}{char}'"
+                    )
+                unescaped.append(self._REVERSE_MAPPING[char])
+                in_escape = False
+            else:
+                if char == self._ESCAPE_CHAR:
+                    in_escape = True
+                else:
+                    unescaped.append(char)
+
+        if in_escape:
+            raise PalaceValueError("Unterminated escape sequence.")
+
+        return "".join(unescaped)
+
+
+class MarcFileUploadSession(RedisJsonLock, PathEscapeMixin, LoggerMixin):
     """
     This class is used as a lock for the Celery MARC export task, to ensure that only one
     task can upload MARC files for a given collection at a time. It increments an update
@@ -106,7 +185,8 @@ class MarcFileUploadSession(RedisJsonLock, LoggerMixin):
         return MarcFileUpload(buffer=buffer_data).dict(exclude_none=True)
 
     def _upload_path(self, upload_key: str) -> str:
-        return f"{self._uploads_json_key}['{upload_key}']"
+        upload_key = self._escape_path(upload_key)
+        return f'{self._uploads_json_key}["{upload_key}"]'
 
     def _buffer_path(self, upload_key: str) -> str:
         upload_path = self._upload_path(upload_key)
@@ -166,7 +246,7 @@ class MarcFileUploadSession(RedisJsonLock, LoggerMixin):
         pipe.json().numincrby(self.key, self._update_number_json_key, updates)
         pipe.pexpire(self.key, self._lock_timeout_ms)
         try:
-            pipe_results = pipe.execute()
+            pipe_results = pipe.execute(raise_on_error=False)
         except WatchError as e:
             raise MarcFileUploadSessionError(
                 "Failed to update buffers. Another process is modifying the buffers."
@@ -175,15 +255,30 @@ class MarcFileUploadSession(RedisJsonLock, LoggerMixin):
 
         return pipe_results[:-3]
 
+    @staticmethod
+    def _validate_results(results: list[Any]) -> bool:
+        """
+        This function validates that all the results of the pipeline are successful,
+        and not a ResponseError.
+
+        NOTE: The AWS elasticache implementation returns slightly different results then redis.
+        In redis, unsuccessful results when a key is not found are `None`, but in AWS they are
+        returned as a `ResponseError`, which is why we are checking for both in this function.
+        """
+        return all(r and not isinstance(r, ResponseError) for r in results)
+
     def append_buffers(self, data: Mapping[str, str]) -> dict[str, int]:
         if not data:
             return {}
 
         set_results = {}
         with self._pipeline(begin_transaction=False) as pipe:
-            existing_uploads: list[str] = self._parse_value_or_raise(
-                pipe.json().objkeys(self.key, self._uploads_json_key)
-            )
+            existing_uploads: list[str] = [
+                self._unescape_path(r)
+                for r in self._parse_value_or_raise(
+                    pipe.json().objkeys(self.key, self._uploads_json_key)
+                )
+            ]
             pipe.multi()
             for key, value in data.items():
                 if value == "":
@@ -193,16 +288,17 @@ class MarcFileUploadSession(RedisJsonLock, LoggerMixin):
                         self.key, path=self._buffer_path(key), value=value
                     )
                 else:
+                    path = self._upload_path(key)
                     pipe.json().set(
                         self.key,
-                        path=self._upload_path(key),
+                        path=path,
                         obj=self._upload_initial_value(value),
                     )
                     set_results[key] = len(value)
 
             pipe_results = self._execute_pipeline(pipe, len(data))
 
-        if not all(pipe_results):
+        if not self._validate_results(pipe_results):
             raise MarcFileUploadSessionError("Failed to append buffers.")
 
         return {
@@ -224,7 +320,7 @@ class MarcFileUploadSession(RedisJsonLock, LoggerMixin):
             )
             pipe_results = self._execute_pipeline(pipe, 1)
 
-        if not all(pipe_results):
+        if not self._validate_results(pipe_results):
             raise MarcFileUploadSessionError("Failed to add part and clear buffer.")
 
     def set_upload_id(self, key: str, upload_id: str) -> None:
@@ -237,7 +333,7 @@ class MarcFileUploadSession(RedisJsonLock, LoggerMixin):
             )
             pipe_results = self._execute_pipeline(pipe, 1)
 
-        if not all(pipe_results):
+        if not self._validate_results(pipe_results):
             raise MarcFileUploadSessionError("Failed to set upload ID.")
 
     def clear_uploads(self) -> None:
@@ -245,7 +341,7 @@ class MarcFileUploadSession(RedisJsonLock, LoggerMixin):
             pipe.json().clear(self.key, self._uploads_json_key)
             pipe_results = self._execute_pipeline(pipe, 1)
 
-        if not all(pipe_results):
+        if not self._validate_results(pipe_results):
             raise MarcFileUploadSessionError("Failed to clear uploads.")
 
     def _get_specific(
@@ -269,7 +365,7 @@ class MarcFileUploadSession(RedisJsonLock, LoggerMixin):
         if results is None:
             return {}
 
-        return results
+        return {self._unescape_path(k): v for k, v in results.items()}
 
     def get(self, keys: str | Sequence[str] | None = None) -> dict[str, MarcFileUpload]:
         if keys is None:
@@ -285,15 +381,14 @@ class MarcFileUploadSession(RedisJsonLock, LoggerMixin):
         return self._get_specific(keys, self._upload_id_path)
 
     def get_part_num_and_buffer(self, key: str) -> tuple[int, str]:
-        try:
-            with self._redis_client.pipeline() as pipe:
-                pipe.json().get(self.key, self._buffer_path(key))
-                pipe.json().arrlen(self.key, self._parts_path(key))
-                results = pipe.execute()
-        except ResponseError as e:
+        with self._redis_client.pipeline() as pipe:
+            pipe.json().get(self.key, self._buffer_path(key))
+            pipe.json().arrlen(self.key, self._parts_path(key))
+            results = pipe.execute(raise_on_error=False)
+        if not self._validate_results(results):
             raise MarcFileUploadSessionError(
                 "Failed to get part number and buffer data."
-            ) from e
+            )
 
         buffer_data: str = self._parse_value_or_raise(results[0])
         part_number: int = self._parse_value_or_raise(results[1])

--- a/src/palace/manager/service/redis/models/marc.py
+++ b/src/palace/manager/service/redis/models/marc.py
@@ -288,10 +288,9 @@ class MarcFileUploadSession(RedisJsonLock, PathEscapeMixin, LoggerMixin):
                         self.key, path=self._buffer_path(key), value=value
                     )
                 else:
-                    path = self._upload_path(key)
                     pipe.json().set(
                         self.key,
-                        path=path,
+                        path=(self._upload_path(key)),
                         obj=self._upload_initial_value(value),
                     )
                     set_results[key] = len(value)

--- a/tests/manager/service/redis/test_escape.py
+++ b/tests/manager/service/redis/test_escape.py
@@ -1,0 +1,72 @@
+import json
+import re
+import string
+
+import pytest
+
+from palace.manager.core.exceptions import PalaceValueError
+from palace.manager.service.redis.escape import JsonPathEscapeMixin
+
+
+class TestPathEscapeMixin:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "",
+            "test",
+            string.printable,
+            "test/test1/?$xyz.abc",
+            "`",
+            "```",
+            "/~`\\",
+            "`\\~/``/",
+            "a",
+            "/",
+            "~",
+            " ",
+            '"',
+            "💣ü",
+        ],
+    )
+    def test_escape_path(self, path: str) -> None:
+        # Test a round trip
+        escaper = JsonPathEscapeMixin()
+        escaped = escaper._escape_path(path)
+        unescaped = escaper._unescape_path(escaped)
+        assert unescaped == path
+
+        # Test a round trip with ElastiCache escaping. The json.loads is done implicitly by ElastiCache,
+        # when using these strings in a JsonPath query. We add a json.loads here to simulate that.
+        escaped = escaper._escape_path(path, elasticache=True)
+        unescaped = escaper._unescape_path(json.loads(f'"{escaped}"'))
+        assert unescaped == path
+
+        # Test that we can handle escaping the escaped path multiple times
+        escaped = path
+        for _ in range(10):
+            escaped = escaper._escape_path(escaped)
+
+        unescaped = escaped
+        for _ in range(10):
+            unescaped = escaper._unescape_path(unescaped)
+
+        assert unescaped == path
+
+    def test_unescape(self) -> None:
+        escaper = JsonPathEscapeMixin()
+        assert escaper._unescape_path("") == ""
+
+        with pytest.raises(
+            PalaceValueError, match=re.escape("Invalid escape sequence '`?'")
+        ):
+            escaper._unescape_path("test `?")
+
+        with pytest.raises(
+            PalaceValueError, match=re.escape("Invalid escape sequence '` '")
+        ):
+            escaper._unescape_path("``` test")
+
+        with pytest.raises(
+            PalaceValueError, match=re.escape("Unterminated escape sequence")
+        ):
+            escaper._unescape_path("`")


### PR DESCRIPTION
## Description

Resolves issues surfaced on Minotaur when running against ElastiCache instead of Redis. These issues were around the escaping of characters in object key names. This seems to be handled differently in Redis vs Elasticache. In order to work around this, I ended up creating a scheme where we escaping the problematic characters. 

I don't like this code, or that we are depending on behaviour that is hard to test on CI, but it does fix the issue. If this continues to be an issue, we may either have to rewrite the MARC redis model, so that it doesn't depend on JSON or try to figure out how we can test directly with ElastiCache in CI.

## Motivation and Context

Fix issues that surfaced after deployment to Minotaur.

## How Has This Been Tested?

- Tested against ElastiCache and Redis locally
- Full test with minotaur DB and ElastiCache to make sure we generate marc files

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
