### PR TITLE
Add user agent to logs

### DIFF
--- a/src/palace/manager/service/logging/log.py
+++ b/src/palace/manager/service/logging/log.py
@@ -97,6 +97,8 @@ class JSONFormatter(logging.Formatter):
             }
             if flask_request.query_string:
                 data["request"]["query"] = flask_request.query_string.decode()
+            if user_agent := flask_request.headers.get("User-Agent"):
+                data["request"]["user_agent"] = user_agent
 
         # If we are running in uwsgi context, we include the worker id in the log
         if uwsgi:

--- a/tests/manager/service/logging/test_log.py
+++ b/tests/manager/service/logging/test_log.py
@@ -182,9 +182,10 @@ class TestJSONFormatter:
             assert request["method"] == "GET"
             assert "host" in request
             assert "query" not in request
+            assert "user-agent" not in request
 
         with flask_app_fixture.test_request_context(
-            "/test?query=string&foo=bar", method="POST"
+            "/test?query=string&foo=bar", method="POST", headers={"User-Agent": "UA"}
         ):
             data = json.loads(formatter.format(record))
             assert "request" in data
@@ -192,6 +193,7 @@ class TestJSONFormatter:
             assert request["path"] == "/test"
             assert request["method"] == "POST"
             assert request["query"] == "query=string&foo=bar"
+            assert request["user_agent"] == "UA"
 
         # If flask is not installed, the request data is not included in the log.
         with patch("palace.manager.service.logging.log.flask_request", None):


### PR DESCRIPTION
## Description

If we are logging in the context of a flask request, include the user agent in the logs.

## Motivation and Context

When troubleshooting with the logs, there has been a couple times where it would have been helpful to know what user agent triggered a particular log line.

## How Has This Been Tested?

- Added unit test

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
