### PR TITLE
Allow restriction to multiple patron locations. (PP-1648)

### DIFF
--- a/src/palace/manager/api/authentication/base.py
+++ b/src/palace/manager/api/authentication/base.py
@@ -167,6 +167,7 @@ class PatronData:
 
     def __init__(
         self,
+        *,
         permanent_id=None,
         authorization_identifier=None,
         username=None,

--- a/src/palace/manager/api/authentication/basic.py
+++ b/src/palace/manager/api/authentication/basic.py
@@ -52,7 +52,7 @@ class LibraryIdentifierRestriction(Enum):
     LIST = "list"
 
 
-class LibraryIdenfitierRestrictionFields(Enum):
+class LibraryIdenfitierRestrictionField(Enum):
     BARCODE = "barcode"
     PATRON_LIBRARY = "patron location"
 
@@ -228,8 +228,8 @@ class BasicAuthProviderLibrarySettings(AuthProviderLibrarySettings):
             "values here. This value is not used if <em>Library Identifier Restriction Type</em> "
             "is set to 'No restriction'.",
             options={
-                LibraryIdenfitierRestrictionFields.BARCODE: "Barcode",
-                LibraryIdenfitierRestrictionFields.PATRON_LIBRARY: "Patron Location",
+                LibraryIdenfitierRestrictionField.BARCODE: "Barcode",
+                LibraryIdenfitierRestrictionField.PATRON_LIBRARY: "Patron Location",
             },
         ),
     )
@@ -765,8 +765,8 @@ class BasicAuthenticationProvider(
         self, patrondata: PatronData
     ) -> tuple[PatronData, str | None]:
         supported_fields = {
-            LibraryIdenfitierRestrictionFields.BARCODE.value: patrondata.authorization_identifier,
-            LibraryIdenfitierRestrictionFields.PATRON_LIBRARY.value: patrondata.library_identifier,
+            LibraryIdenfitierRestrictionField.BARCODE.value: patrondata.authorization_identifier,
+            LibraryIdenfitierRestrictionField.PATRON_LIBRARY.value: patrondata.library_identifier,
         }
         library_verification_field = self.library_identifier_field.lower()
         if library_verification_field in supported_fields:

--- a/src/palace/manager/api/authentication/basic.py
+++ b/src/palace/manager/api/authentication/basic.py
@@ -745,7 +745,7 @@ class BasicAuthenticationProvider(
             case [_, _restriction, _] if not _restriction:
                 pass
             case [_, _, _value] if _value is None or _value == "":
-                failure_reason = "No value in field."
+                failure_reason = "No value in field"
             case [LibraryIdentifierRestriction.REGEX, *_]:
                 if not (_pattern := cast(Pattern, restriction)).search(value):
                     failure_reason = f"{value!r} does not match regular expression {_pattern.pattern!r}"

--- a/src/palace/manager/api/authentication/basic.py
+++ b/src/palace/manager/api/authentication/basic.py
@@ -825,12 +825,12 @@ class BasicAuthenticationProvider(
             return patrondata
 
         patrondata, field_value = self.get_library_identifier_field_data(patrondata)
-        isValid, reason = self._restriction_matches(
+        is_valid, reason = self._restriction_matches(
             field_value,
             self.library_identifier_restriction_criteria,
             self.library_identifier_restriction_type,
         )
-        if not isValid:
+        if not is_valid:
             raise ProblemDetailException(
                 PATRON_OF_ANOTHER_LIBRARY.with_debug(
                     f"{self.library_identifier_field!r} does not match library restriction: {reason}."

--- a/src/palace/manager/api/sip/__init__.py
+++ b/src/palace/manager/api/sip/__init__.py
@@ -195,19 +195,6 @@ class SIP2LibrarySettings(BasicAuthProviderLibrarySettings):
             description="A specific identifier for the library or branch, if used in patron authentication",
         ),
     )
-    # Used with SIP2, when it is available in the patron information response.
-    patron_location_restriction: str | None = FormField(
-        None,
-        form=ConfigurationFormItem(
-            label="Patron Location Restriction",
-            description=(
-                "A code for the library or branch, which, when specified, "
-                "must exactly match the permanent location for the patron."
-                "<br>If an ILS does not return a location for its patrons, specifying "
-                "a value here will always result in authentication failure."
-            ),
-        ),
-    )
 
 
 class SIP2AuthenticationProvider(
@@ -257,7 +244,6 @@ class SIP2AuthenticationProvider(
         self.ssl_verification = settings.ssl_verification
         self.dialect = settings.ils
         self.institution_id = library_settings.institution_id
-        self.patron_location_restriction = library_settings.patron_location_restriction
         self._client = client
 
         # Check if patrons should be blocked based on SIP status
@@ -349,41 +335,7 @@ class SIP2AuthenticationProvider(
             # passing it on.
             password = None
         info = self.patron_information(username, password)
-        self._enforce_patron_location_restriction(info)
         return self.info_to_patrondata(info)
-
-    def _location_mismatch_message(
-        self, patron_location: str | None, library_restriction: str | None = None
-    ) -> str:
-        library_restriction = library_restriction or self.patron_location_restriction
-        patron_location = (
-            f"'{patron_location}'" if patron_location is not None else "(missing)"
-        )
-        return (
-            f"Patron location ({patron_location}) does not match "
-            f"library location restriction ('{library_restriction}')."
-        )
-
-    def _enforce_patron_location_restriction(
-        self, info: dict[str, Any] | ProblemDetail
-    ) -> None:
-        """Raise an exception if patron location does not match the restriction.
-
-        If a location restriction is specified for the library against which the
-        patron is attempting to authenticate, then the authentication will fail
-        if either (1) the patron does not have an associated location or (2) the
-        patron's location does not exactly match the one configured.
-        """
-        if (
-            not isinstance(info, ProblemDetail)
-            and self.patron_location_restriction is not None
-            and self.patron_location_restriction != info.get("permanent_location")
-        ):
-            raise ProblemDetailException(
-                PATRON_OF_ANOTHER_LIBRARY.with_debug(
-                    self._location_mismatch_message(info.get("permanent_location"))
-                )
-            )
 
     def _run_self_tests(self, _db):
         def makeConnection(sip):

--- a/src/palace/manager/api/sip/__init__.py
+++ b/src/palace/manager/api/sip/__init__.py
@@ -465,6 +465,8 @@ class SIP2AuthenticationProvider(
             patrondata.email_address = info["email_address"]
         if "personal_name" in info:
             patrondata.personal_name = info["personal_name"]
+        if "permanent_location" in info:
+            patrondata.library_identifier = info["permanent_location"]
         if "fee_amount" in info:
             fines = info["fee_amount"]
         else:

--- a/tests/manager/api/sip/test_authentication_provider.py
+++ b/tests/manager/api/sip/test_authentication_provider.py
@@ -11,7 +11,7 @@ from palace.manager.api.authentication.base import PatronData
 from palace.manager.api.authentication.basic import (
     BasicAuthProviderLibrarySettings,
     Keyboards,
-    LibraryIdenfitierRestrictionFields,
+    LibraryIdenfitierRestrictionField,
     LibraryIdentifierRestriction,
 )
 from palace.manager.api.problem_details import (
@@ -351,7 +351,7 @@ class TestSIP2AuthenticationProvider:
         library_restriction = "TestLoc"
         library_settings = create_library_settings(
             library_identifier_restriction_type=LibraryIdentifierRestriction.STRING,
-            library_identifier_field=LibraryIdenfitierRestrictionFields.PATRON_LIBRARY.value,
+            library_identifier_field=LibraryIdenfitierRestrictionField.PATRON_LIBRARY.value,
             library_identifier_restriction_criteria=library_restriction,
         )
         provider = create_provider(library_settings=library_settings)
@@ -361,6 +361,7 @@ class TestSIP2AuthenticationProvider:
         client.queue_response(self.evergreen_patron_with_location)
         client.queue_response(self.end_session_response)
         patrondata = provider.remote_authenticate("user", "pass")
+        assert isinstance(patrondata, PatronData)
         patrondata = provider.enforce_library_identifier_restriction(patrondata)
         assert isinstance(patrondata, PatronData)
         assert "Patron Name" == patrondata.personal_name
@@ -369,6 +370,7 @@ class TestSIP2AuthenticationProvider:
         client.queue_response(self.evergreen_patron_wo_location)
         client.queue_response(self.end_session_response)
         patrondata = provider.remote_authenticate("user", "pass")
+        assert isinstance(patrondata, PatronData)
         with pytest.raises(ProblemDetailException) as exc:
             provider.enforce_library_identifier_restriction(patrondata)
         assert exc.value.problem_detail == PATRON_OF_ANOTHER_LIBRARY.with_debug(
@@ -379,6 +381,7 @@ class TestSIP2AuthenticationProvider:
         client.queue_response(self.evergreen_patron_with_wrong_loc)
         client.queue_response(self.end_session_response)
         patrondata = provider.remote_authenticate("user", "pass")
+        assert isinstance(patrondata, PatronData)
         with pytest.raises(ProblemDetailException) as exc:
             provider.enforce_library_identifier_restriction(patrondata)
         assert exc.value.problem_detail == PATRON_OF_ANOTHER_LIBRARY.with_debug(

--- a/tests/manager/api/sip/test_authentication_provider.py
+++ b/tests/manager/api/sip/test_authentication_provider.py
@@ -11,6 +11,8 @@ from palace.manager.api.authentication.base import PatronData
 from palace.manager.api.authentication.basic import (
     BasicAuthProviderLibrarySettings,
     Keyboards,
+    LibraryIdenfitierRestrictionFields,
+    LibraryIdentifierRestriction,
 )
 from palace.manager.api.problem_details import (
     INVALID_CREDENTIALS,
@@ -348,7 +350,9 @@ class TestSIP2AuthenticationProvider:
         # This patron authentication library instance is configured with "TestLoc".
         library_restriction = "TestLoc"
         library_settings = create_library_settings(
-            patron_location_restriction=library_restriction
+            library_identifier_restriction_type=LibraryIdentifierRestriction.STRING,
+            library_identifier_field=LibraryIdenfitierRestrictionFields.PATRON_LIBRARY.value,
+            library_identifier_restriction_criteria=library_restriction,
         )
         provider = create_provider(library_settings=library_settings)
         client = cast(MockSIPClient, provider.client)
@@ -357,29 +361,28 @@ class TestSIP2AuthenticationProvider:
         client.queue_response(self.evergreen_patron_with_location)
         client.queue_response(self.end_session_response)
         patrondata = provider.remote_authenticate("user", "pass")
+        patrondata = provider.enforce_library_identifier_restriction(patrondata)
         assert isinstance(patrondata, PatronData)
         assert "Patron Name" == patrondata.personal_name
 
         # This patron does NOT have an associated location.
         client.queue_response(self.evergreen_patron_wo_location)
         client.queue_response(self.end_session_response)
+        patrondata = provider.remote_authenticate("user", "pass")
         with pytest.raises(ProblemDetailException) as exc:
-            provider.remote_authenticate("user", "pass")
-        debug_message = provider._location_mismatch_message(None, library_restriction)
+            provider.enforce_library_identifier_restriction(patrondata)
         assert exc.value.problem_detail == PATRON_OF_ANOTHER_LIBRARY.with_debug(
-            debug_message
+            "'patron location' does not match library restriction: No value in field."
         )
 
         # This patron has the WRONG location.
         client.queue_response(self.evergreen_patron_with_wrong_loc)
         client.queue_response(self.end_session_response)
+        patrondata = provider.remote_authenticate("user", "pass")
         with pytest.raises(ProblemDetailException) as exc:
-            provider.remote_authenticate("user", "pass")
-        debug_message = provider._location_mismatch_message(
-            "OtherLoc", library_restriction
-        )
+            provider.enforce_library_identifier_restriction(patrondata)
         assert exc.value.problem_detail == PATRON_OF_ANOTHER_LIBRARY.with_debug(
-            debug_message
+            "'patron location' does not match library restriction: 'OtherLoc' does not exactly match 'TestLoc'."
         )
 
     def test_encoding(

--- a/tests/manager/api/test_authenticator.py
+++ b/tests/manager/api/test_authenticator.py
@@ -1784,7 +1784,8 @@ class TestBasicAuthenticationProvider:
         identifier: str,
         expected_success: bool,
     ):
-        def assert_pd_debug(debug_message: str, field_name: str) -> None:
+        def assert_pd_debug(debug_message: str | None, field_name: str) -> None:
+            assert debug_message is not None
             assert debug_message.startswith(
                 f"'{field_name}' does not match library restriction: "
             )


### PR DESCRIPTION
## Description

Support more than a single patron location when restricting which patrons can be associated with a given library.

This PR does this by adding an additional Library Identifier Field, "Patron Location", to the fields that can be used to restrict library membership.

Note:
Setting this PR as draft for now, since I still need to remove the recently added single-valued patron location restriction and add/update some more tests, but would be happy to get an initial review on the approach here.

## Motivation and Context

Some libraries have multiple locations, so we need a mechanism to support those.

[Jira [PP-1648](https://ebce-lyrasis.atlassian.net/browse/PP-1648)]

## How Has This Been Tested?

- Manually tested locally.
- Fixed existing tests.
- [CI tests pass for associated](https://github.com/ThePalaceProject/circulation/actions/runs/10801475003) branch.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1648]: https://ebce-lyrasis.atlassian.net/browse/PP-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ