### PR TITLE
Ensures that the overdrive new titles script does not fail when cover…

### DIFF
--- a/src/palace/manager/core/coverage.py
+++ b/src/palace/manager/core/coverage.py
@@ -383,7 +383,7 @@ class BaseCoverageProvider:
             transient_failures,
             persistent_failures,
         ), results = self.process_batch_and_handle_results(batch_results)
-
+        self.finalize_batch()
         # Update the running totals so that the service's eventual timestamp
         # will have a useful .achievements.
         progress.successes += successes
@@ -485,9 +485,6 @@ class BaseCoverageProvider:
             persistent_failures,
             num_ignored,
         )
-
-        # Finalize this batch before moving on to the next one.
-        self.finalize_batch()
 
         # For all purposes outside this method, treat an ignored identifier
         # as a transient failure.
@@ -910,6 +907,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         while index < len(need_coverage):
             batch = need_coverage[index : index + self.batch_size]
             (s, t, p), r = self.process_batch_and_handle_results(batch)
+            self.finalize_batch()
             successes += s
             transient_failures += t
             persistent_failures += p

--- a/tests/manager/core/test_coverage.py
+++ b/tests/manager/core/test_coverage.py
@@ -535,9 +535,6 @@ class TestBaseCoverageProvider:
         class MockProvider1(AlwaysSuccessfulCoverageProvider):
             OPERATION = "i succeed"
 
-            def finalize_batch(self):
-                self.finalized = True
-
         success_provider = MockProvider1(db.session)
 
         batch = [i1, i2]
@@ -545,9 +542,6 @@ class TestBaseCoverageProvider:
 
         # Two successes.
         assert (2, 0, 0) == counts
-
-        # finalize_batch() was called.
-        assert True == success_provider.finalized
 
         # Each represented with a CoverageRecord with status='success'
         assert all(isinstance(x, CoverageRecord) for x in successes)

--- a/tests/manager/core/test_coverage.py
+++ b/tests/manager/core/test_coverage.py
@@ -515,6 +515,7 @@ class TestBaseCoverageProvider:
         assert 1 == progress.successes
         assert 2 == progress.transient_failures
         assert 3 == progress.persistent_failures
+        assert provider.finalize_batch_called
 
         assert (
             "Items processed: 6. Successes: 1, transient failures: 2, persistent failures: 3"
@@ -607,6 +608,9 @@ class TestBaseCoverageProvider:
         ]
         assert [CoverageRecord.PERSISTENT_FAILURE] * 2 == [x.status for x in results]
         assert ["i will always fail"] * 2 == [x.operation for x in results]
+
+        assert not success_provider.finalize_batch_called
+        assert not persistent_failure_provider.finalize_batch_called
 
     def test_process_batch(self, db: DatabaseTransactionFixture):
         class Mock(BaseCoverageProvider):
@@ -1150,6 +1154,8 @@ class TestIdentifierCoverageProvider:
         for i in not_to_be_tested:
             assert i not in provider.attempts
 
+        assert provider.finalize_batch_called
+
     def test_run_on_specific_identifiers_respects_cutoff_time(
         self, db: DatabaseTransactionFixture
     ):
@@ -1193,6 +1199,7 @@ class TestIdentifierCoverageProvider:
         # reflect the failure.
         assert records[0] == record
         assert "What did you expect?" == record.exception
+        assert provider.finalize_batch_called
 
     def test_run_never_successful(self, db: DatabaseTransactionFixture):
         """Verify that NeverSuccessfulCoverageProvider works the

--- a/tests/mocks/mock.py
+++ b/tests/mocks/mock.py
@@ -102,10 +102,14 @@ class InstrumentedCoverageProvider(MockCoverageProvider, IdentifierCoverageProvi
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.attempts = []
+        self.finalize_batch_called = False
 
     def process_item(self, item):
         self.attempts.append(item)
         return item
+
+    def finalize_batch(self):
+        self.finalize_batch_called = True
 
 
 class InstrumentedWorkCoverageProvider(MockCoverageProvider, WorkCoverageProvider):


### PR DESCRIPTION
…age records are added.

## Description
The overdrive new titles  and overdrive recent titles monitors are currently broken due to a hidden commit when coverage records are added.   I discovered this issue while fixing https://github.com/ThePalaceProject/circulation/pull/2040
<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1708
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tested this manually to make sure that it is fixed and changed a single unit test that was affected.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
