### PR TITLE
Fix S3 multipart upload bug in MARC integration (PP-1693)

### DIFF
--- a/src/palace/manager/service/redis/models/marc.py
+++ b/src/palace/manager/service/redis/models/marc.py
@@ -298,7 +298,7 @@ class MarcFileUploadSession(RedisJsonLock, JsonPathEscapeMixin, LoggerMixin):
             )
 
         buffer_data: str = self._parse_value_or_raise(results[0])
-        part_number: int = self._parse_value_or_raise(results[1])
+        part_number: int = self._parse_value_or_raise(results[1]) + 1
 
         return part_number, buffer_data
 

--- a/tests/fixtures/s3.py
+++ b/tests/fixtures/s3.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
-from mypy_boto3_s3 import S3Client
 from pydantic import AnyHttpUrl
 
 from palace.manager.service.configuration.service_configuration import (
@@ -138,6 +137,9 @@ class MockS3Service(S3Service):
         self, key: str, upload_id: str, part_number: int, content: bytes
     ) -> MultipartS3UploadPart:
         etag = str(uuid4())
+        if not 1 <= part_number <= 10000:
+            raise ValueError("Part number must be between 1 and 10000")
+
         part = MultipartS3UploadPart(etag=etag, part_number=part_number)
         assert key in self.upload_in_progress
         assert self.upload_in_progress[key].upload_id == upload_id

--- a/tests/manager/service/redis/models/test_marc.py
+++ b/tests/manager/service/redis/models/test_marc.py
@@ -418,7 +418,7 @@ class TestMarcFileUploadSession:
         assert uploads.get_part_num_and_buffer(
             marc_file_upload_session_fixture.mock_upload_key_1
         ) == (
-            0,
+            1,
             marc_file_upload_session_fixture.test_data[
                 marc_file_upload_session_fixture.mock_upload_key_1
             ],
@@ -442,7 +442,7 @@ class TestMarcFileUploadSession:
 
         assert uploads.get_part_num_and_buffer(
             marc_file_upload_session_fixture.mock_upload_key_1
-        ) == (2, "1234567")
+        ) == (3, "1234567")
 
     def test_state(
         self, marc_file_upload_session_fixture: MarcFileUploadSessionFixture


### PR DESCRIPTION
## Description

Fix error on S3 upload seen on Minotaur. 

```
{
  "host": "6e56971b8591",
  "name": "celery.app.trace",
  "level": "ERROR",
  "filename": "trace.py",
  "message": "Task marc.marc_export_collection[482f2b12-98f4-43a3-bfa0-780f90670aac] raised unexpected: ClientError('An error occurred (InvalidArgument) when calling the UploadPart operation: Part number must be an integer between 1 and 10000, inclusive')",
  "timestamp": "2024-09-11T13:19:38.712993+00:00",
  "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/celery/app/trace.py\", line 453, in trace_task\n    R = retval = fun(*args, **kwargs)\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/celery/app/trace.py\", line 736, in __protected_call__\n    return self.run(*args, **kwargs)\n  File \"/var/www/circulation/src/palace/manager/celery/tasks/marc.py\", line 134, in marc_export_collection\n    upload_manager.sync()\n  File \"/var/www/circulation/src/palace/manager/marc/uploader.py\", line 74, in sync\n    self._s3_sync(needs_upload)\n  File \"/var/www/circulation/src/palace/manager/marc/uploader.py\", line 54, in _s3_sync\n    upload_part = self.storage_service.multipart_upload(\n  File \"/var/www/circulation/src/palace/manager/service/storage/s3.py\", line 221, in multipart_upload\n    result = self.client.upload_part(\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/botocore/client.py\", line 569, in _api_call\n    return self._make_api_call(operation_name, kwargs)\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/botocore/client.py\", line 1023, in _make_api_call\n    raise error_class(parsed_response, operation_name)\nbotocore.exceptions.ClientError: An error occurred (InvalidArgument) when calling the UploadPart operation: Part number must be an integer between 1 and 10000, inclusive",
  "process": 124,
  "celery": {
    "request_id": "482f2b12-98f4-43a3-bfa0-780f90670aac",
    "task_name": "marc.marc_export_collection"
  }
}
```

```
ClientError: An error occurred (InvalidArgument) when calling the UploadPart operation: Part number must be an integer between 1 and 10000, inclusive
```

Update part number to be 1 indexed, and update our mocks to catch this error in the future.

## Motivation and Context

S3 requires that multipart upload part numbers be 1 indexed. Minio does not, and neither did our mocks, so this all worked fine locally. 

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
