### PR TITLE
Don't proxy the full response headers (PP-1713)

### DIFF
--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -271,6 +271,14 @@ class RedirectFulfillment(UrlFulfillment):
         )
 
 
+class FetchResponse(Response):
+    """
+    Response object that defaults to no mimetype if none is provided.
+    """
+
+    default_mimetype = None
+
+
 class FetchFulfillment(UrlFulfillment, LoggerMixin):
     """
     Fulfill a loan by fetching a URL and returning the content. This should be
@@ -314,16 +322,16 @@ class FetchFulfillment(UrlFulfillment, LoggerMixin):
             )
             raise
 
-        headers = {}
+        headers = {"Cache-Control": "private"}
 
         if self.content_type:
             headers["Content-Type"] = self.content_type
         elif "Content-Type" in response.headers:
             headers["Content-Type"] = response.headers["Content-Type"]
 
-        headers["Cache-Control"] = "private"
-
-        return Response(response.content, status=response.status_code, headers=headers)
+        return FetchResponse(
+            response.content, status=response.status_code, headers=headers
+        )
 
 
 class LoanInfo(CirculationInfo):

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -314,10 +314,14 @@ class FetchFulfillment(UrlFulfillment, LoggerMixin):
             )
             raise
 
-        headers = dict(response.headers)
+        headers = {}
 
         if self.content_type:
             headers["Content-Type"] = self.content_type
+        elif "Content-Type" in response.headers:
+            headers["Content-Type"] = response.headers["Content-Type"]
+
+        headers["Cache-Control"] = "private"
 
         return Response(response.content, status=response.status_code, headers=headers)
 

--- a/tests/manager/api/test_circulation.py
+++ b/tests/manager/api/test_circulation.py
@@ -55,7 +55,10 @@ class TestFetchFulfillment:
     def test_fetch_fulfillment(self) -> None:
         http = MockHTTPClient()
         http.queue_response(
-            204, content="This is some content.", media_type="application/xyz"
+            204,
+            content="This is some content.",
+            media_type="application/xyz",
+            other_headers={"X-Test": "test"},
         )
         fulfillment = FetchFulfillment("http://some.location", "foo/bar")
         with http.patch():
@@ -68,6 +71,7 @@ class TestFetchFulfillment:
         # Any content type set on the fulfillment, overrides the content type from the request.
         assert response.content_type == "foo/bar"
         assert http.requests == ["http://some.location"]
+        assert "X-Test" not in response.headers
 
         # If no content type is set on the fulfillment, the content type from the request is used.
         http = MockHTTPClient()

--- a/tests/manager/api/test_circulation.py
+++ b/tests/manager/api/test_circulation.py
@@ -87,6 +87,16 @@ class TestFetchFulfillment:
         [(args, kwargs)] = http.requests_args
         assert kwargs["allow_redirects"] is True
 
+        # If the content type is not set on the fulfillment, and the response does not have a content type,
+        # we fall back to no content type.
+        http = MockHTTPClient()
+        http.queue_response(200, content="Other content.")
+        fulfillment = FetchFulfillment("http://some.other.location")
+        with http.patch():
+            response = fulfillment.response()
+        assert isinstance(response, Response)
+        assert response.content_type is None
+
     def test_fetch_fulfillment_include_headers(self) -> None:
         # If include_headers is set, the headers are set when the fetch is made, but
         # not included in the response.


### PR DESCRIPTION
## Description

When we proxy requests through to the client, don't forward the headers from the response. 

## Motivation and Context

This solves an issue we were seeing where the `Content-Encoding` header is set on the request, but since Python requests automatically decodes the transfer encoding, we were mistakenly forwarding on the `Content-Encoding` header, without encoded data. 

I'm open to the suggestion we should just drop the `Content-Encoding` header, instead of not forwarding any headers, but it seemed safer to me to just not pass on any headers, to avoid surprises like this in the future. The only header we pass on is `Content-Type`, if it is set.

JIRA: [PP-1713](https://ebce-lyrasis.atlassian.net/browse/PP-1713)

## How Has This Been Tested?

- Did some local testing to reproduce the problem we were seeing in production

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1713]: https://ebce-lyrasis.atlassian.net/browse/PP-1713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ