### PR TITLE
OPDS2 + ODL Handle case where no licenses are available (PP-1716)

### DIFF
--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -266,9 +266,7 @@ class OPDS2WithODLApi(
                 f"status code {response.status_code}. Expected 2XX. Response headers: {header_string}. "
                 f"Response content: {response_string}."
             )
-            raise RemoteIntegrationException(
-                url, "License Status Document request failed."
-            ) from e
+            raise
         try:
             status_doc = json.loads(response.content)
         except ValueError as e:
@@ -424,7 +422,29 @@ class OPDS2WithODLApi(
             raise NoAvailableCopies()
         loan, ignore = license.loan_to(patron)
 
-        doc = self.get_license_status_document(loan)
+        try:
+            doc = self.get_license_status_document(loan)
+        except BadResponseException as e:
+            _db.delete(loan)
+            response = e.response
+            # DeMarque sends "application/api-problem+json", but the ODL spect says we should
+            # expect "application/problem+json", so we need to check for both.
+            if response.headers.get("Content-Type") in [
+                "application/api-problem+json",
+                "application/problem+json",
+            ]:
+                try:
+                    json_response = response.json()
+                except ValueError:
+                    json_response = {}
+
+                if (
+                    json_response.get("type")
+                    == "http://opds-spec.org/odl/error/checkout/unavailable"
+                ):
+                    raise NoAvailableCopies()
+            raise
+
         status = doc.get("status")
 
         if status not in [self.READY_STATUS, self.ACTIVE_STATUS]:

--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -427,7 +427,7 @@ class OPDS2WithODLApi(
         except BadResponseException as e:
             _db.delete(loan)
             response = e.response
-            # DeMarque sends "application/api-problem+json", but the ODL spect says we should
+            # DeMarque sends "application/api-problem+json", but the ODL spec says we should
             # expect "application/problem+json", so we need to check for both.
             if response.headers.get("Content-Type") in [
                 "application/api-problem+json",

--- a/tests/files/odl/unavailable.json
+++ b/tests/files/odl/unavailable.json
@@ -1,0 +1,1 @@
+{"type":"http://opds-spec.org/odl/error/checkout/unavailable","title":"the license has reached its concurrent checkouts limit","detail":"all 1 of 1 concurrent loans exceeded","status":400}


### PR DESCRIPTION
## Description

Handle the case where we think there are available licenses, but when we reach out to the content provider, it turns out there are no licenses available.

## Motivation and Context

This was found as part of release testing in PP-1716.

## How Has This Been Tested?

- New unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
