### PR TITLE
Make library configuration selection predictable for patron auth integration self-tests.

### DIFF
--- a/src/palace/manager/api/admin/controller/patron_auth_services.py
+++ b/src/palace/manager/api/admin/controller/patron_auth_services.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 import flask
 from flask import Response
@@ -189,6 +189,11 @@ class PatronAuthServicesController(
     def get_library_configuration(
         integration: IntegrationConfiguration,
     ) -> IntegrationLibraryConfiguration | None:
-        if not integration.library_configurations:
+        """Find the first library (lowest id) associated with this service."""
+        if not (library_configurations := integration.library_configurations):
             return None
-        return integration.library_configurations[0]
+        # We sort by library id to ensure that the result is predictable.
+        # We cast the library id to `int`, since mypy doesn't understand the relationship.
+        return sorted(
+            library_configurations, key=lambda config: cast(int, config.library_id)
+        )[0]


### PR DESCRIPTION
## Description

Of the libraries associated with a given patron authentication integration, always pick the one with the lowest `id` for a given patron authentication integration self-test.

## Motivation and Context

Ran into this issue while trying to test [PP-1648](https://ebce-lyrasis.atlassian.net/browse/PP-1648). After setting the configuration for the current library, the order would change and a new library would be used for the self-test. Because 
`IntegrationConfiguration.library_configurations` doesn't return the `IntegrationLibraryConfiguration`s in a predicable order, the self-test wasn't always running against the expected library. 

## How Has This Been Tested?

- Manually tested locally.
- [CI tests for branch](https://github.com/ThePalaceProject/circulation/actions/runs/10853865216) pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.


[PP-1648]: https://ebce-lyrasis.atlassian.net/browse/PP-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ