### PR TITLE
Remove unused Overdrive credentials from the database

### DIFF
--- a/alembic/versions/20240916_87901a6323d6_remove_unused_overdrive_credentials.py
+++ b/alembic/versions/20240916_87901a6323d6_remove_unused_overdrive_credentials.py
@@ -5,6 +5,7 @@ Revises: 350a29bf0ff0
 Create Date: 2024-09-16 19:54:56.986491+00:00
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/alembic/versions/20240916_87901a6323d6_remove_unused_overdrive_credentials.py
+++ b/alembic/versions/20240916_87901a6323d6_remove_unused_overdrive_credentials.py
@@ -1,0 +1,27 @@
+"""Remove unused Overdrive credentials
+
+Revision ID: 87901a6323d6
+Revises: 350a29bf0ff0
+Create Date: 2024-09-16 19:54:56.986491+00:00
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "87901a6323d6"
+down_revision = "350a29bf0ff0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Clean out the old unused credential objects, so they are not hanging around and causing confusion
+    # in the future.
+    op.execute(
+        "DELETE from credentials WHERE type is NULL and patron_id is NULL and data_source_id in "
+        "(SELECT id from datasources where name = 'Overdrive')"
+    )
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Description

Small follow up to https://github.com/ThePalaceProject/circulation/pull/2060 to delete the credentials from the database that we stopped using in that PR.

🚨 This is ready for a code review, but it shouldn't get merged until https://github.com/ThePalaceProject/circulation/pull/2060 is in a release. I'll keep it in draft until then. 

## Motivation and Context

🧹 cleanup

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
