### PR TITLE
Lower uwsgi web worker timeouts (PP-1717)

### DIFF
--- a/docker/services/nginx/conf.d/circulation.conf
+++ b/docker/services/nginx/conf.d/circulation.conf
@@ -8,7 +8,8 @@ server {
     location / { try_files $uri @circulation; }
     location @circulation {
         include uwsgi_params;
-        uwsgi_read_timeout 120;
+        uwsgi_read_timeout 45;
+        uwsgi_send_timeout 45;
         uwsgi_pass unix:/var/run/uwsgi/uwsgi.sock;
     }
 }

--- a/docker/services/uwsgi/uwsgi.ini
+++ b/docker/services/uwsgi/uwsgi.ini
@@ -5,7 +5,7 @@ die-on-term = true
 # reload if this files changes
 touch-reload = /etc/uwsgi.ini
 
-harakiri = 300
+harakiri = 45
 lazy-apps = true
 buffer-size = 131072
 


### PR DESCRIPTION
## Description

Drop some of our configured timeouts to 45s. Right now the uwsgi harakiri timeout of 5 minutes is excessive. It means that when we do see deadlocks in the web process, a deadlock can easily eat up all our workers. 

Looking at the last 3 weeks of data from our production CMs, the max request time was around 20 seconds, with p99 being more like 15 seconds. So 45 seconds seems like it gives a bit of a safety factor without being excessive.

## Motivation and Context

Try to keep sites from going down if deadlocks happen in the web processes.

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
