### PR TITLE
Update batch sizes for overdrive monitors (PP-1717)

### DIFF
--- a/src/palace/manager/api/overdrive.py
+++ b/src/palace/manager/api/overdrive.py
@@ -2128,6 +2128,7 @@ class OverdriveCollectionReaper(IdentifierSweepMonitor):
 
     SERVICE_NAME = "Overdrive Collection Reaper"
     PROTOCOL = OverdriveAPI.label()
+    DEFAULT_BATCH_SIZE = 10
 
     def __init__(self, _db, collection, api_class=OverdriveAPI):
         super().__init__(_db, collection)
@@ -2179,7 +2180,7 @@ class OverdriveFormatSweep(IdentifierSweepMonitor):
     """
 
     SERVICE_NAME = "Overdrive Format Sweep"
-    DEFAULT_BATCH_SIZE = 25
+    DEFAULT_BATCH_SIZE = 10
     PROTOCOL = OverdriveAPI.label()
 
     def __init__(self, _db, collection, api_class=OverdriveAPI):


### PR DESCRIPTION
## Description

This lowers the size of the batch of work being done by `OverdriveCollectionReaper` and `OverdriveFormatSweep`. Previously `OverdriveCollectionReaper` defaulted to 100 and `OverdriveFormatSweep` defaulted to 25. Since each item of the batch takes one (or multiple) OD API requests, that means these batches can take a significant amount of time. We only commit a transaction at the end of a batch, so lock conflicts can block for a significant amount of time. This should ease those conflicts.

## Motivation and Context

The lock conflicts can impact web workers, if they need a lock on the same row being updated by the script. This can cause timeouts, or even deadlocks like in the case of PP-1717.

## How Has This Been Tested?

- Local testing

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
