### PR TITLE
Add a configuration to enable a debug faulthandler (PP-1717)

### DIFF
--- a/src/palace/manager/service/logging/configuration.py
+++ b/src/palace/manager/service/logging/configuration.py
@@ -6,7 +6,7 @@ from enum import auto
 from typing import Any
 
 import boto3
-from pydantic import PositiveInt, validator
+from pydantic import NonNegativeInt, PositiveInt, validator
 from watchtower import DEFAULT_LOG_STREAM_NAME
 
 from palace.manager.service.configuration.service_configuration import (
@@ -72,6 +72,11 @@ class LogLevel(StrEnum):
 class LoggingConfiguration(ServiceConfiguration):
     level: LogLevel = LogLevel.info
     verbose_level: LogLevel = LogLevel.warning
+
+    # This config is useful when debugging, it will print a traceback to stderr
+    # at the specified interval (in seconds). It should not be enabled in normal
+    # production operation. The default value of 0 disables this feature.
+    debug_traceback_interval: NonNegativeInt = 0
 
     cloudwatch_enabled: bool = False
     cloudwatch_region: str | None = None

--- a/src/palace/manager/service/logging/container.py
+++ b/src/palace/manager/service/logging/container.py
@@ -8,6 +8,7 @@ from dependency_injector import providers
 from dependency_injector.containers import DeclarativeContainer
 from dependency_injector.providers import Provider, Singleton
 
+from palace.manager.service.logging.debug_traceback import setup_debug_traceback
 from palace.manager.service.logging.log import (
     JSONFormatter,
     create_cloudwatch_handler,
@@ -53,4 +54,9 @@ class Logging(DeclarativeContainer):
         stream=stream_handler,
         cloudwatch_enabled=config.cloudwatch_enabled,
         cloudwatch_callable=cloudwatch_handler.provider,
+    )
+
+    debug_traceback = providers.Resource(
+        setup_debug_traceback,
+        interval=config.debug_traceback_interval,
     )

--- a/src/palace/manager/service/logging/debug_traceback.py
+++ b/src/palace/manager/service/logging/debug_traceback.py
@@ -1,0 +1,12 @@
+import faulthandler
+
+
+def setup_debug_traceback(interval: int) -> None:
+    """
+    Sets up the faulthandler module to dump a traceback to stderr at the specified interval.
+
+    :param interval: The interval (in seconds) at which to dump the traceback. If 0, the feature is disabled.
+    """
+
+    if interval > 0:
+        faulthandler.dump_traceback_later(interval, repeat=True)

--- a/src/palace/manager/service/logging/debug_traceback.py
+++ b/src/palace/manager/service/logging/debug_traceback.py
@@ -1,12 +1,12 @@
 import faulthandler
 
 
-def setup_debug_traceback(interval: int) -> None:
+def setup_debug_traceback(interval: int | None) -> None:
     """
     Sets up the faulthandler module to dump a traceback to stderr at the specified interval.
 
     :param interval: The interval (in seconds) at which to dump the traceback. If 0, the feature is disabled.
     """
 
-    if interval > 0:
+    if interval is not None and interval > 0:
         faulthandler.dump_traceback_later(interval, repeat=True)

--- a/tests/manager/service/logging/test_debug_traceback.py
+++ b/tests/manager/service/logging/test_debug_traceback.py
@@ -8,8 +8,10 @@ def test_setup_debug_traceback():
     with patch.object(
         faulthandler, "dump_traceback_later"
     ) as mock_dump_traceback_later:
-        # If the interval is 0, the feature should be disabled.
+        # If the interval is 0 or None, the feature should be disabled.
         setup_debug_traceback(0)
+        mock_dump_traceback_later.assert_not_called()
+        setup_debug_traceback(None)
         mock_dump_traceback_later.assert_not_called()
 
         # Otherwise, we should call dump_traceback_later with the correct arguments.

--- a/tests/manager/service/logging/test_debug_traceback.py
+++ b/tests/manager/service/logging/test_debug_traceback.py
@@ -1,0 +1,17 @@
+import faulthandler
+from unittest.mock import patch
+
+from palace.manager.service.logging.debug_traceback import setup_debug_traceback
+
+
+def test_setup_debug_traceback():
+    with patch.object(
+        faulthandler, "dump_traceback_later"
+    ) as mock_dump_traceback_later:
+        # If the interval is 0, the feature should be disabled.
+        setup_debug_traceback(0)
+        mock_dump_traceback_later.assert_not_called()
+
+        # Otherwise, we should call dump_traceback_later with the correct arguments.
+        setup_debug_traceback(5)
+        mock_dump_traceback_later.assert_called_once_with(5, repeat=True)


### PR DESCRIPTION
## Description

Adds a new env variable `PALACE_LOG_DEBUG_TRACEBACK_INTERVAL`. This option is disabled when it is zero (the default). When it is non-zero it uses the python [faulthandler](https://docs.python.org/3/library/faulthandler.html) module to print stack traces of every thread to stderr every `INTERVAL` seconds.

## Motivation and Context

This is useful to figure out the state of the app when a thread is deadlocked, watching the stack traces after the deadlock occurs gives an idea of what is happening. I though this would be useful to add to the main codebase as it might help assist if / when we get deadlocks happening in environments that are not easily reproduced. This could be enabled with a env var to get a bit of additional information to assist with debugging.

## How Has This Been Tested?

- Tested locally, I was using it to help track down a deadlock in PG.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
