### PR TITLE
ODL feed error when license already checked out (PP-1716)

### DIFF
--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -442,6 +442,11 @@ class OPDS2WithODLApi(
                     json_response.get("type")
                     == "http://opds-spec.org/odl/error/checkout/unavailable"
                 ):
+                    # TODO: This would be a good place to do an async availability update, since we know
+                    #   the book is unavailable, when we thought it was available. For now, we know that
+                    #   the license has no checkouts_available, so we do that update.
+                    license.checkouts_available = 0
+                    licensepool.update_availability_from_licenses()
                     raise NoAvailableCopies()
             raise
 


### PR DESCRIPTION
## Description

In https://github.com/ThePalaceProject/circulation/pull/2057 I partially solved this one. We are doing the correct thing raising `NoAvailableCopies`. But then when we try to place a hold, because we didn't update the availability, the we were raising `CurrentlyAvailable`.

## Motivation and Context

JIRA: PP-1716

## How Has This Been Tested?

- Unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
