### PR TITLE
Feature flag for quicksight. (PP-1724)

### DIFF
--- a/src/palace/manager/api/admin/config.py
+++ b/src/palace/manager/api/admin/config.py
@@ -19,6 +19,10 @@ class AdminClientFeatureFlags(ServiceConfigurationWithLimitedEnvOverride):
         True,
         description="Show inventory reports only for sysadmins.",
     )
+    quicksight_only_for_sysadmins: bool = Field(
+        True,
+        description="Show QuickSight dashboards only for sysadmins.",
+    )
 
     # The following fields CANNOT be overridden by environment variables.
     # Setting `const=True` ensures that the default value is not overridden.

--- a/tests/manager/api/admin/controller/test_view.py
+++ b/tests/manager/api/admin/controller/test_view.py
@@ -191,6 +191,7 @@ class TestViewController:
             assert '"enableAutoList": true' in feature_flags
             assert '"showCircEventsDownload": true' in feature_flags
             assert '"reportsOnlyForSysadmins": true' in feature_flags
+            assert '"quicksightOnlyForSysadmins": true' in feature_flags
 
     def test_feature_flags_overridden(
         self,
@@ -207,6 +208,9 @@ class TestViewController:
         monkeypatch.setenv("PALACE_ADMINUI_FEATURE_ENABLE_AUTO_LIST", "false")
         monkeypatch.setenv("PALACE_ADMINUI_FEATURE_SHOW_CIRC_EVENTS_DOWNLOAD", "false")
         monkeypatch.setenv("PALACE_ADMINUI_FEATURE_REPORTS_ONLY_FOR_SYSADMINS", "false")
+        monkeypatch.setenv(
+            "PALACE_ADMINUI_FEATURE_QUICKSIGHT_ONLY_FOR_SYSADMINS", "false"
+        )
 
         with (
             patch(
@@ -235,3 +239,4 @@ class TestViewController:
             assert '"enableAutoList": true' in feature_flags
             assert '"showCircEventsDownload": true' in feature_flags
             assert '"reportsOnlyForSysadmins": false' in feature_flags
+            assert '"quicksightOnlyForSysadmins": false' in feature_flags


### PR DESCRIPTION
## Description

Adds a feature flag to suppress QuickSight link for non-sysadmins from the Admin UI dashboard statistics page. 

## Motivation and Context

Need to be able to hide QuickSight dashboard until it is ready to launch.

[Jira [PP-1724](https://ebce-lyrasis.atlassian.net/browse/PP-1724)]

## How Has This Been Tested?

- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/10910061515) pass.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1724]: https://ebce-lyrasis.atlassian.net/browse/PP-1724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ