### PR TITLE
Fix uncommitted nested transaction in SweepMonitor (PP-1717)

### DIFF
--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -794,8 +794,7 @@ class Axis360CirculationMonitor(CollectionMonitor, TimelineMonitor):
     def process_book(
         self, bibliographic: Metadata, circulation: CirculationData
     ) -> tuple[Edition, LicensePool]:
-        tx = self._db.begin_nested()
-        try:
+        with self._db.begin_nested():
             edition, new_edition, license_pool, new_license_pool = self.api.update_book(
                 bibliographic, circulation
             )
@@ -807,11 +806,7 @@ class Axis360CirculationMonitor(CollectionMonitor, TimelineMonitor):
                 self.bibliographic_coverage_provider.handle_success(identifier)
                 self.bibliographic_coverage_provider.add_coverage_record_for(identifier)
 
-            tx.commit()
             return edition, license_pool
-        except Exception as e:
-            tx.rollback()
-            raise e
 
 
 class Axis360BibliographicCoverageProvider(BibliographicCoverageProvider):

--- a/src/palace/manager/core/monitor.py
+++ b/src/palace/manager/core/monitor.py
@@ -523,8 +523,7 @@ class SweepMonitor(CollectionMonitor):
     )
     def process_batch(self, offset):
         """Process one batch of work."""
-        tx = self._db.begin_nested()
-        try:
+        with self._db.begin_nested():
             offset = offset or 0
             items = self.fetch_batch(offset).all()
             if items:
@@ -538,9 +537,6 @@ class SweepMonitor(CollectionMonitor):
                 result = (0, 0)
 
             return result
-        except Exception as e:
-            tx.rollback()
-            raise e
 
     def process_items(self, items):
         """Process a list of items."""


### PR DESCRIPTION
## Description

This modifies the `begin_nested` calls added in https://github.com/ThePalaceProject/circulation/pull/1948 to use the context manager form of the statement (see [docs](https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#session-begin-nested)).

This really only makes a difference in `src/palace/manager/core/monitor.py` where the call to `commit()` was missing, but its safer to a nested transaction this way, so I modified the calls everywhere.

## Motivation and Context

One of the nested transactions that got added in https://github.com/ThePalaceProject/circulation/pull/1948 had its call to `commit()` removed in https://github.com/ThePalaceProject/circulation/pull/2040 ([here](https://github.com/ThePalaceProject/circulation/pull/2040/files#diff-07e2f4c1209ece2a7e7a7da0ab2d98c85c169263cbb60d34143b1c56e7124508L543)). This was causing all of the `SweepMonitor` to just commit to the nested transaction when they called `commit()` instead of actually committing the transaction. This effectively means that they were doing all their work in one large transaction, which is why they were deadlocking with each other. 😓 

This is a really good example of why using a context manager is a good idea, instead of doing manual cleanup. That way the call to the nested transactions `commit` could have never gotten deleted.

## How Has This Been Tested?

- Tested on Cerberus
- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
