### PR TITLE
Fix RunCollectionMonitorScript PG application name

### DIFF
--- a/src/palace/manager/scripts/monitor.py
+++ b/src/palace/manager/scripts/monitor.py
@@ -100,7 +100,7 @@ class RunCollectionMonitorScript(RunMultipleMonitorsScript, CollectionArgumentsS
     @property
     def _db(self) -> Session:
         if not hasattr(self, "_session"):
-            self._session = production_session(self.monitor_class.__class__)
+            self._session = production_session(self.monitor_class)
         return self._session
 
     def __init__(self, monitor_class, _db=None, cmd_args=None, **kwargs):


### PR DESCRIPTION
## Description

Update the class that we pass into `production_session` to use `self.monitor_class` instead of `self.monitor_class.__class__`.

## Motivation and Context

When I added this in https://github.com/ThePalaceProject/circulation/pull/2062, I mistakenly thought `self.monitor_class` was an instance.

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
