### PR TITLE
Remove call to expire_all in ODL code

### DIFF
--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -769,8 +769,6 @@ class OPDS2WithODLApi(
                 days=default_reservation_period
             )
 
-        _db.expire_all()
-
     def _update_hold_position(self, holdinfo: HoldInfo, pool: LicensePool) -> None:
         _db = Session.object_session(pool)
         loans_count = (

--- a/tests/manager/api/odl/test_api.py
+++ b/tests/manager/api/odl/test_api.py
@@ -160,6 +160,8 @@ class TestOPDS2WithODLApi:
 
         # Do the same, patron1 checkout and test patron hold
         pool = work2.active_license_pool()
+        db.session.expire_all()
+
         assert pool is not None
         response = opds2_with_odl_api_fixture.checkout(patron=patron1, pool=pool)
         assert (


### PR DESCRIPTION
## Description

Move the call to `expire_all` into the test code.

## Motivation and Context

I noticed this while working on https://github.com/ThePalaceProject/circulation/pull/2074. I was wondering if you considered this approach @dbernstein of putting this call into the tests instead of the main codebase. Generally, I think, mucking about with the session should be avoided as much as we can.

I left this in draft because I wanted to get your feedback on it @dbernstein, in case there is some pitfall here that I might be falling into.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
