### PR TITLE
Fix uwsgi log file permissions (PP-1667)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,7 +74,10 @@ COPY docker/services/nginx /etc/nginx/
 # Setup uwsgi
 COPY docker/services/uwsgi /etc/
 RUN mkdir -p /var/log/uwsgi && \
-    chown -RHh simplified:simplified /var/log/uwsgi && \
+    chown root:adm /var/log/uwsgi && \
+    touch /var/log/uwsgi/uwsgi.log && \
+    chown simplified:adm /var/log/uwsgi/uwsgi.log && \
+    chmod 644 /var/log/uwsgi/uwsgi.log && \
     mkdir /var/run/uwsgi && \
     chown simplified:simplified /var/run/uwsgi
 

--- a/docker/services/logrotate/logrotate.d/celery.conf
+++ b/docker/services/logrotate/logrotate.d/celery.conf
@@ -2,7 +2,7 @@
     missingok
     daily
     create 0660 simplified adm
-    rotate 30
+    rotate 13
     compress
     delaycompress
     notifempty

--- a/docker/services/logrotate/logrotate.d/simplified.conf
+++ b/docker/services/logrotate/logrotate.d/simplified.conf
@@ -1,7 +1,6 @@
 /var/log/simplified/*.log {
     missingok
     daily
-    create 0700 root root
     rotate 13
     copytruncate
     compress
@@ -13,8 +12,7 @@
 /var/log/uwsgi/*.log {
     missingok
     daily
-    create 0660 simplified adm
-    rotate 30
+    rotate 13
     copytruncate
     compress
     delaycompress

--- a/docker/services/uwsgi/uwsgi.d/40_log.ini
+++ b/docker/services/uwsgi/uwsgi.d/40_log.ini
@@ -1,5 +1,4 @@
 [uwsgi]
 log-format = [uwsgi] %(var.HTTP_X_FORWARDED_FOR) (%(addr)) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs) process=%(pid) worker=%(wid)
-logfile-chmod = 644
 logger = stdio:
 logger = file:/var/log/uwsgi/uwsgi.log


### PR DESCRIPTION
## Description

Updates our docker build to make sure that:
- `/var/log/uwsgi` 
  - owned by root:adm
- `/var/log/uwsgi/uwsgi.log` 
  - owned by simplified:adm
  - has 644 permissions, so cloudwatchd can read and upload the files

## Motivation and Context

I'm not sure when this got broken, but I realized when trying to work on PP-1667 this morning that we were not geting logs uploaded from staging, and then I went looking and all recently deployed CMs are in the same state.

Since `/var/log` is mounted as a volume, this will fix things for any new CM, but existing ones will to have their permissions updated. I'm planning to make a follow up PR to do this.

## How Has This Been Tested?

- Ran a `docker compose up` locally, and checked things have the correct permissions

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
