### PR TITLE
Update license pools for ODL licenses that are loan + concurrency limited

### DIFF
--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -88,7 +88,9 @@ class LicenseFunctions:
             return 0
         elif self.is_loan_limited:
             if self.terms_concurrency is not None:
-                return min(self.checkouts_left, self.terms_concurrency)
+                # We need a type ignore here because mypy doesn't understand that `is_loan_limited`
+                # implies `checkouts_left` is not None.
+                return min(self.checkouts_left, self.terms_concurrency)  # type: ignore[type-var]
             return self.checkouts_left
         else:
             return self.terms_concurrency

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -87,6 +87,8 @@ class LicenseFunctions:
         if self.is_inactive:
             return 0
         elif self.is_loan_limited:
+            if self.terms_concurrency is not None:
+                return min(self.checkouts_left, self.terms_concurrency)
             return self.checkouts_left
         else:
             return self.terms_concurrency

--- a/tests/manager/api/odl/test_importer.py
+++ b/tests/manager/api/odl/test_importer.py
@@ -144,7 +144,7 @@ class TestOPDS2WithODLImporter:
         assert moby_dick_license_pool.identifier.identifier == "978-3-16-148410-0"
         assert moby_dick_license_pool.identifier.type == "ISBN"
         assert not moby_dick_license_pool.open_access
-        assert 30 == moby_dick_license_pool.licenses_owned
+        assert 10 == moby_dick_license_pool.licenses_owned
         assert 10 == moby_dick_license_pool.licenses_available
 
         assert 2 == len(moby_dick_license_pool.delivery_mechanisms)
@@ -544,7 +544,7 @@ class TestOPDS2WithODLImporter:
 
         assert_moby_dick_pool(
             moby_dick_pool,
-            licenses_owned=30,
+            licenses_owned=10,
             licenses_available=10,
             available_for_borrowing=True,
             license_status=LicenseStatus.available,
@@ -560,7 +560,7 @@ class TestOPDS2WithODLImporter:
 
         assert_huck_finn_pool(
             huck_finn_pool,
-            licenses_owned=30,
+            licenses_owned=10,
             licenses_available=10,
             available_for_borrowing=True,
             license_status=LicenseStatus.available,
@@ -816,7 +816,7 @@ class TestOPDS2WithODLImporter:
         assert len(imported_pool.licenses) == 5
 
         # Make sure that the license statistics are correct and include only active licenses.
-        assert imported_pool.licenses_owned == 41
+        assert imported_pool.licenses_owned == 6
         assert imported_pool.licenses_available == 6
 
         # Correct number of active and inactive licenses
@@ -840,7 +840,7 @@ class TestOPDS2WithODLImporter:
             available=1,
         )
         left = LicenseInfoHelper(
-            license=LicenseHelper(concurrency=2), available=1, left=5
+            license=LicenseHelper(concurrency=2), available=1, left=1
         )
         perpetual = LicenseInfoHelper(license=LicenseHelper(concurrency=1), available=0)
         licenses = [date, left, perpetual]
@@ -862,7 +862,7 @@ class TestOPDS2WithODLImporter:
             [imported_pool] = imported_pools
             assert len(imported_pool.licenses) == 3
             assert imported_pool.licenses_available == 2
-            assert imported_pool.licenses_owned == 7
+            assert imported_pool.licenses_owned == 3
 
             # No licenses are expired
             assert sum(not l.is_inactive for l in imported_pool.licenses) == len(

--- a/tests/manager/sqlalchemy/model/test_licensing.py
+++ b/tests/manager/sqlalchemy/model/test_licensing.py
@@ -295,7 +295,7 @@ class LicenseTestFixture:
             expires=None,
             checkouts_left=4,
             checkouts_available=2,
-            terms_concurrency=3,
+            terms_concurrency=5,
         )
 
         self.time_and_loan_limited = db.license(
@@ -362,7 +362,7 @@ class TestLicense:
             ("perpetual", True, False, False, False, 2, 1),
             ("time_limited", False, True, False, False, 1, 1),
             ("loan_limited", False, False, True, False, 4, 2),
-            ("time_and_loan_limited", False, True, True, False, 52, 1),
+            ("time_and_loan_limited", False, True, True, False, 1, 1),
             ("expired_time_limited", False, True, False, True, 0, 0),
             ("expired_loan_limited", False, False, True, True, 0, 0),
             ("unavailable", True, False, False, True, 0, 0),


### PR DESCRIPTION
## Description

The rest of the code seems to treat `licenses_owned` as the maximum number of concurrent lends that can be expected. We were setting that value to `checkouts_left`, which is the case only if `terms_concurrency` isn't set, otherwise its the minimum of the two values.

## Motivation and Context

JIRA: PP-1728

There are some other issues with holds that I'm planning to address in a follow up PR, but this is a major cause of holds that can't be fulfilled.

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
