### PR TITLE
Type hint sqlalchemy utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ module = [
     "palace.manager.sqlalchemy.model.integration",
     "palace.manager.sqlalchemy.model.library",
     "palace.manager.sqlalchemy.model.patron",
+    "palace.manager.sqlalchemy.util",
     "palace.manager.util.authentication_for_opds",
     "palace.manager.util.base64",
     "palace.manager.util.cache",

--- a/src/palace/manager/sqlalchemy/model/time_tracking.py
+++ b/src/palace/manager/sqlalchemy/model/time_tracking.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import (
     Boolean,
@@ -185,7 +185,9 @@ class PlaytimeSummary(Base):
             "library_name": None if library else library_name,
             "loan_identifier": loan_identifier,
         }
-        lookup_keys = {k: v for k, v in _potential_lookup_keys.items() if v is not None}
+        lookup_keys: dict[str, Any] = {
+            k: v for k, v in _potential_lookup_keys.items() if v is not None
+        }
         additional_columns = {
             k: v
             for k, v in {

--- a/tests/manager/sqlalchemy/model/test_licensing.py
+++ b/tests/manager/sqlalchemy/model/test_licensing.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 from collections.abc import Callable
+from typing import Any
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
@@ -226,15 +227,15 @@ class TestDeliveryMechanism:
 
         # You can't create two DeliveryMechanisms with the same values
         # for content_type and drm_scheme.
-        with_drm_args = dict(content_type="type1", drm_scheme="scheme1")
-        without_drm_args = dict(content_type="type1", drm_scheme=None)
-        with_drm = create(session, dm, **with_drm_args)
+        with_drm_args: dict[str, Any] = dict(content_type="type1", drm_scheme="scheme1")
+        create(session, dm, **with_drm_args)
         pytest.raises(IntegrityError, create, session, dm, **with_drm_args)
         session.rollback()
 
         # You can't create two DeliveryMechanisms with the same value
         # for content_type and a null value for drm_scheme.
-        without_drm = create(session, dm, **without_drm_args)
+        without_drm_args: dict[str, Any] = dict(content_type="type1", drm_scheme=None)
+        create(session, dm, **without_drm_args)
         pytest.raises(IntegrityError, create, session, dm, **without_drm_args)
         session.rollback()
 


### PR DESCRIPTION
## Description

Small update to finish the type hints in `sqlalchemy/util.py`. Most of whats left couldn't be explicitly hinted, so they had to be set to `Any`, but nice to finish type hinting this file anyway.

## Motivation and Context

I was looking at the file while working on https://github.com/ThePalaceProject/circulation/pull/2086

## How Has This Been Tested?

- Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
