### PR TITLE
Pp 1755 fix overdrive sweep transaction errors

### DIFF
--- a/src/palace/manager/core/monitor.py
+++ b/src/palace/manager/core/monitor.py
@@ -5,6 +5,7 @@ import logging
 import traceback
 from typing import TYPE_CHECKING
 
+from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm import defer
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 from sqlalchemy.sql.expression import and_, or_
@@ -516,6 +517,7 @@ class SweepMonitor(CollectionMonitor):
         retry=(
             retry_if_exception_type(StaleDataError)
             | retry_if_exception_type(ObjectDeletedError)
+            | retry_if_exception_type(InvalidRequestError)
         ),
         stop=stop_after_attempt(MAXIMUM_BATCH_RETRIES),
         wait=wait_exponential(multiplier=1, min=1, max=60),

--- a/tests/manager/core/test_monitor.py
+++ b/tests/manager/core/test_monitor.py
@@ -2,6 +2,7 @@ import datetime
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 
 from palace.manager.api.bibliotheca import BibliothecaAPI
@@ -700,6 +701,8 @@ class TestSweepMonitor:
                     raise StaleDataError("stale data")
                 elif self.process_item_invocation_count == 2:
                     raise ObjectDeletedError({}, "object deleted")
+                elif self.process_item_invocation_count == 3:
+                    raise InvalidRequestError("invalid request")
                 else:
                     super().process_item(item)
 
@@ -707,7 +710,7 @@ class TestSweepMonitor:
         timestamp = monitor.timestamp()
         monitor.run()
         # we expect that process should have been called 3 times total
-        assert monitor.process_item_invocation_count == 3
+        assert monitor.process_item_invocation_count == 4
         # there shouldn't be an exception saved since it ultimately succeeded.
         assert timestamp.exception is None
         assert "Records processed: 1." == timestamp.achievements


### PR DESCRIPTION
## Description

This update adds another error (InvalidRequestError)  to look for in the retry logic of the monitor.    I don't fully understand why this error is getting generated while the overdrive format sweep.  According to the error message associated with the error, a transaction is being closed inside a context manager.  How or why that is happening is unclear but it appears to be an error that can be recovered from with a retry.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1755
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Manually tested with an overdrive collection that was previously failing.  
Updated unit test for the monitor.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
