### PR TITLE
Fix broken playtime entries test.

### DIFF
--- a/src/palace/manager/scripts/playtime_entries.py
+++ b/src/palace/manager/scripts/playtime_entries.py
@@ -238,7 +238,12 @@ class PlaytimeEntriesEmailReportsScript(Script):
                 sql_max(coalesce(PlaytimeSummary.title, "")).label("title2"),
                 count(distinct(PlaytimeSummary.loan_identifier)).label("loan_count"),
             )
-            .where(PlaytimeSummary.timestamp.between(start, until))
+            .where(
+                and_(
+                    PlaytimeSummary.timestamp >= start,
+                    PlaytimeSummary.timestamp < until,
+                )
+            )
             .group_by(
                 PlaytimeSummary.identifier_str,
                 PlaytimeSummary.collection_name,
@@ -257,7 +262,12 @@ class PlaytimeEntriesEmailReportsScript(Script):
                 coalesce(PlaytimeSummary.title, "").label("title"),
                 sum(PlaytimeSummary.total_seconds_played).label("total_seconds_played"),
             )
-            .where(PlaytimeSummary.timestamp.between(start, until))
+            .where(
+                and_(
+                    PlaytimeSummary.timestamp >= start,
+                    PlaytimeSummary.timestamp < until,
+                )
+            )
             .group_by(
                 PlaytimeSummary.identifier_str,
                 PlaytimeSummary.collection_name,

--- a/tests/manager/scripts/test_playtime_entries.py
+++ b/tests/manager/scripts/test_playtime_entries.py
@@ -584,9 +584,9 @@ class TestPlaytimeEntriesEmailReportsScript:
         playtime(
             db.session, identifier, collection, library, dt1m(4), 2, loan_identifier
         )
-        # one month + 32 days ago : in the future and therefore out of range.
+        # out of range: after end of default reporting period
         playtime(
-            db.session, identifier, collection, library, dt1m(32), 3, loan_identifier
+            db.session, identifier, collection, library, dt1m(31), 6, loan_identifier
         )
         playtime(
             db.session, identifier, collection, library, dt1m(-31), 60, loan_identifier

--- a/tests/manager/scripts/test_playtime_entries.py
+++ b/tests/manager/scripts/test_playtime_entries.py
@@ -576,11 +576,13 @@ class TestPlaytimeEntriesEmailReportsScript:
         # We're using the RecursiveEquivalencyCache, so must refresh it.
         EquivalentIdentifiersCoverageProvider(db.session).run()
 
+        # one month + 3 days ago
         playtime(
             db.session, identifier, collection, library, dt1m(3), 1, loan_identifier
         )
+        # one month + 4 days ago
         playtime(
-            db.session, identifier, collection, library, dt1m(31), 2, loan_identifier
+            db.session, identifier, collection, library, dt1m(4), 2, loan_identifier
         )
         playtime(
             db.session, identifier, collection, library, dt1m(-31), 60, loan_identifier

--- a/tests/manager/scripts/test_playtime_entries.py
+++ b/tests/manager/scripts/test_playtime_entries.py
@@ -576,13 +576,17 @@ class TestPlaytimeEntriesEmailReportsScript:
         # We're using the RecursiveEquivalencyCache, so must refresh it.
         EquivalentIdentifiersCoverageProvider(db.session).run()
 
-        # one month + 3 days ago
+        # one month + 3 days ago : in scope
         playtime(
             db.session, identifier, collection, library, dt1m(3), 1, loan_identifier
         )
-        # one month + 4 days ago
+        # one month + 4 days ago : in scope  should be added
         playtime(
             db.session, identifier, collection, library, dt1m(4), 2, loan_identifier
+        )
+        # one month + 32 days ago : in the future and therefore out of range.
+        playtime(
+            db.session, identifier, collection, library, dt1m(32), 3, loan_identifier
         )
         playtime(
             db.session, identifier, collection, library, dt1m(-31), 60, loan_identifier


### PR DESCRIPTION
## Description
This update fixes a broken test.  The test started failing due to a date addition issue that was interacting badly with the current month.  I changed it to ensure that the playtime entry in question is always in scope.
<!--- Describe your changes -->

## Motivation and Context
Build was broken.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
