### PR TITLE
Update the fixture for creating collections

### DIFF
--- a/src/palace/manager/api/enki.py
+++ b/src/palace/manager/api/enki.py
@@ -112,7 +112,6 @@ class EnkiAPI(
     HasCollectionSelfTests,
     EnkiConstants,
 ):
-    ENKI_LIBRARY_ID_KEY = "enki_library_id"
     DESCRIPTION = _("Integrate an Enki collection.")
 
     list_endpoint = "ListAPI"

--- a/src/palace/manager/sqlalchemy/model/integration.py
+++ b/src/palace/manager/sqlalchemy/model/integration.py
@@ -130,9 +130,12 @@ class IntegrationConfiguration(Base):
         def process_settings_dict(
             settings_dict: dict[str, Any], indent: int = 0
         ) -> None:
-            secret_keys = ["key", "password", "token"]
+            secret_keys = ["key", "password", "token", "secret"]
             for setting_key, setting_value in sorted(settings_dict.items()):
-                if setting_key in secret_keys and not include_secrets:
+                if (
+                    any(secret_key in setting_key for secret_key in secret_keys)
+                    and not include_secrets
+                ):
                     setting_value = "********"
                 lines.append(" " * indent + f"{setting_key}: {setting_value}")
 

--- a/tests/fixtures/odl.py
+++ b/tests/fixtures/odl.py
@@ -52,26 +52,18 @@ class OPDS2WithODLApiFixture:
     def create_work(self, collection: Collection) -> Work:
         return self.db.work(with_license_pool=True, collection=collection)
 
-    @staticmethod
-    def default_collection_settings() -> dict[str, Any]:
-        return {
-            "username": "a",
-            "password": "b",
-            "external_account_id": "http://odl",
-            Collection.DATA_SOURCE_NAME_SETTING: "Feedbooks",
-        }
-
     def create_collection(self, library: Library) -> Collection:
-        collection, _ = Collection.by_name_and_protocol(
-            self.db.session,
+        return self.db.collection(
             f"Test {OPDS2WithODLApi.__name__} Collection",
-            OPDS2WithODLApi.label(),
+            protocol=OPDS2WithODLApi,
+            library=library,
+            settings=self.db.opds2_odl_settings(
+                username="a",
+                password="b",
+                external_account_id="http://odl",
+                data_source="Feedbooks",
+            ),
         )
-        collection.integration_configuration.settings_dict = (
-            self.default_collection_settings()
-        )
-        collection.libraries.append(library)
-        return collection
 
     def setup_license(
         self,

--- a/tests/manager/api/admin/controller/test_report.py
+++ b/tests/manager/api/admin/controller/test_report.py
@@ -1,6 +1,7 @@
 import logging
 from http import HTTPStatus
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,6 +13,7 @@ from palace.manager.api.admin.model.inventory_report import (
     InventoryReportInfo,
 )
 from palace.manager.api.admin.problem_details import ADMIN_NOT_AUTHORIZED
+from palace.manager.api.circulation import BaseCirculationAPI
 from palace.manager.api.overdrive import OverdriveAPI
 from palace.manager.api.problem_details import LIBRARY_NOT_FOUND
 from palace.manager.core.opds_import import OPDSAPI
@@ -110,8 +112,7 @@ class TestReportController:
         )
 
         collection = db.collection(
-            protocol=OPDSAPI.label(),
-            settings={"data_source": "test", "external_account_id": "http://url"},
+            protocol=OPDSAPI,
         )
         collection.libraries = [library1, library2]
 
@@ -176,8 +177,7 @@ class TestReportController:
         )
 
         collection = db.collection(
-            protocol=OPDSAPI.label(),
-            settings={"data_source": "test", "external_account_id": "http://url"},
+            protocol=OPDSAPI,
         )
         collection.libraries = [library1, library2]
 
@@ -229,13 +229,13 @@ class TestReportController:
         "protocol, settings, parent_settings, expect_collection",
         (
             (
-                OPDSAPI.label(),
+                OPDSAPI,
                 {"data_source": "test", "external_account_id": "http://url"},
                 None,
                 True,
             ),
             (
-                OPDSAPI.label(),
+                OPDSAPI,
                 {
                     "include_in_inventory_report": False,
                     "data_source": "test",
@@ -245,7 +245,7 @@ class TestReportController:
                 False,
             ),
             (
-                OPDSAPI.label(),
+                OPDSAPI,
                 {
                     "include_in_inventory_report": True,
                     "data_source": "test",
@@ -255,7 +255,7 @@ class TestReportController:
                 True,
             ),
             (
-                OverdriveAPI.label(),
+                OverdriveAPI,
                 {
                     "overdrive_website_id": "test",
                     "overdrive_client_key": "test",
@@ -265,7 +265,7 @@ class TestReportController:
                 False,
             ),
             (
-                OverdriveAPI.label(),
+                OverdriveAPI,
                 {"external_account_id": "test"},
                 {
                     "overdrive_website_id": "test",
@@ -281,7 +281,7 @@ class TestReportController:
         report_fixture: ReportControllerFixture,
         db: DatabaseTransactionFixture,
         flask_app_fixture: FlaskAppFixture,
-        protocol: str,
+        protocol: type[BaseCirculationAPI[Any, Any]],
         settings: dict,
         parent_settings: dict,
         expect_collection: bool,

--- a/tests/manager/api/odl/test_reaper.py
+++ b/tests/manager/api/odl/test_reaper.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import datetime
 
 from palace.manager.api.odl.reaper import OPDS2WithODLHoldReaper
-from palace.manager.sqlalchemy.model.collection import Collection
-from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.patron import Hold
 from palace.manager.util.datetime_helpers import utc_now
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -25,11 +23,6 @@ class TestOPDS2WithODLHoldReaper:
         api = opds2_with_odl_api_fixture.api
         pool = license.license_pool
 
-        data_source = DataSource.lookup(db.session, "Feedbooks", autocreate=True)
-        DatabaseTransactionFixture.set_settings(
-            collection.integration_configuration,
-            **{Collection.DATA_SOURCE_NAME_SETTING: data_source.name},
-        )
         reaper = OPDS2WithODLHoldReaper(db.session, collection, api=api)
 
         now = utc_now()

--- a/tests/manager/api/test_circulationapi.py
+++ b/tests/manager/api/test_circulationapi.py
@@ -802,10 +802,7 @@ class TestCirculationAPI:
 
     def test_fulfill_errors(self, circulation_api: CirculationAPIFixture):
         # Here's an open-access title.
-        collection = circulation_api.db.collection(
-            data_source_name="OPDS",
-            external_account_id="http://url/",
-        )
+        collection = circulation_api.db.collection()
         circulation_api.pool.open_access = True
         circulation_api.pool.collection = collection
 

--- a/tests/manager/api/test_lanes.py
+++ b/tests/manager/api/test_lanes.py
@@ -1172,8 +1172,7 @@ class TestJackpotWorkList:
         library = db.default_library()
         overdrive_collection = db.collection(
             "Test Overdrive Collection",
-            protocol=OverdriveAPI.label(),
-            data_source_name=DataSource.OVERDRIVE,
+            protocol=OverdriveAPI,
         )
         overdrive_collection.libraries.append(library)
 
@@ -1181,8 +1180,7 @@ class TestJackpotWorkList:
         # library. It will not be used at all.
         ignored_collection = db.collection(
             "Ignored Collection",
-            protocol=BibliothecaAPI.label(),
-            data_source_name=DataSource.BIBLIOTHECA,
+            protocol=BibliothecaAPI,
         )
 
         # Pass in a JackpotFacets object

--- a/tests/manager/celery/tasks/test_generate_inventory_and_hold_reports.py
+++ b/tests/manager/celery/tasks/test_generate_inventory_and_hold_reports.py
@@ -9,7 +9,7 @@ from unittest.mock import create_autospec
 from pytest import LogCaptureFixture
 from sqlalchemy.orm import sessionmaker
 
-from palace.manager.api.overdrive import OverdriveSettings
+from palace.manager.api.overdrive import OverdriveAPI
 from palace.manager.celery.tasks.generate_inventory_and_hold_reports import (
     GenerateInventoryAndHoldsReportsJob,
     generate_inventory_and_hold_reports,
@@ -66,16 +66,9 @@ def test_job_run(
         "Another Test Collection", "AnotherOpdsDataSource", db, library, False
     )
 
-    od_settings = OverdriveSettings(
-        overdrive_website_id="overdrive_id",
-        overdrive_client_key="client_key",
-        overdrive_client_secret="secret",
-        external_account_id="http://www.overdrive/id",
-    )
     od_collection_not_to_include = db.collection(
+        protocol=OverdriveAPI,
         name="Overdrive Test Collection",
-        data_source_name="Overdrive",
-        settings=od_settings.model_dump(),
     )
 
     od_collection_not_to_include.libraries = [library]
@@ -287,7 +280,7 @@ def create_test_opds_collection(
         external_account_id="http://opds.com",
         data_source=data_source,
     )
-    collection = db.collection(name=collection_name, settings=settings.model_dump())
+    collection = db.collection(name=collection_name, settings=settings)
     collection.libraries = [library]
     return collection
 

--- a/tests/manager/core/test_coverage.py
+++ b/tests/manager/core/test_coverage.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 
+from palace.manager.api.axis import Axis360API
 from palace.manager.api.overdrive import OverdriveAPI
 from palace.manager.core.coverage import (
     BaseCoverageProvider,
@@ -823,7 +824,7 @@ class TestIdentifierCoverageProvider:
     def test_bulk_register_with_collection(self, db: DatabaseTransactionFixture):
         identifier = db.identifier()
         provider = AlwaysSuccessfulCoverageProvider
-        collection = db.collection(data_source_name=DataSource.AXIS_360)
+        collection = db.collection(protocol=Axis360API)
 
         try:
             # If a DataSource or data source name is provided and
@@ -1352,7 +1353,7 @@ class TestCollectionCoverageProvider:
         """Verify that class variables become appropriate instance
         variables.
         """
-        collection = db.collection(protocol=OPDSAPI.label())
+        collection = db.collection(protocol=OPDSAPI)
         provider = AlwaysSuccessfulCollectionCoverageProvider(collection)
         assert provider.DATA_SOURCE_NAME == provider.data_source.name
 
@@ -1367,7 +1368,7 @@ class TestCollectionCoverageProvider:
     def test_collection_protocol_must_match_class_protocol(
         self, db: DatabaseTransactionFixture
     ):
-        collection = db.collection(protocol=OverdriveAPI.label())
+        collection = db.collection(protocol=OverdriveAPI)
         with pytest.raises(ValueError) as excinfo:
             AlwaysSuccessfulCollectionCoverageProvider(collection)
         assert (
@@ -1509,9 +1510,9 @@ class TestCollectionCoverageProvider:
         objects, one for each Collection that implements the
         appropriate protocol.
         """
-        opds1 = db.collection(protocol=OPDSAPI.label())
-        opds2 = db.collection(protocol=OPDSAPI.label())
-        overdrive = db.collection(protocol=OverdriveAPI.label())
+        opds1 = db.collection(protocol=OPDSAPI)
+        opds2 = db.collection(protocol=OPDSAPI)
+        overdrive = db.collection(protocol=OverdriveAPI)
         providers = list(
             AlwaysSuccessfulCollectionCoverageProvider.all(db.session, batch_size=34)
         )
@@ -1783,7 +1784,7 @@ class TestCollectionCoverageProvider:
             PROTOCOL = OverdriveAPI.label()
             IDENTIFIER_TYPES = Identifier.OVERDRIVE_ID
 
-        collection = db.collection(protocol=OverdriveAPI.label())
+        collection = db.collection(protocol=OverdriveAPI)
         provider = OverdriveProvider(collection)
 
         # We get a CoverageFailure if we don't pass in any data at all.

--- a/tests/manager/core/test_monitor.py
+++ b/tests/manager/core/test_monitor.py
@@ -290,8 +290,8 @@ class TestCollectionMonitor:
             PROTOCOL = OverdriveAPI.label()
 
         # Two collections.
-        c1 = db.collection(protocol=OverdriveAPI.label())
-        c2 = db.collection(protocol=BibliothecaAPI.label())
+        c1 = db.collection(protocol=OverdriveAPI)
+        c2 = db.collection(protocol=BibliothecaAPI)
 
         # The NoProtocolMonitor can be instantiated with either one,
         # or with no Collection at all.
@@ -323,7 +323,7 @@ class TestCollectionMonitor:
         o3 = db.collection("o3")
 
         # ...and a Bibliotheca collection.
-        b1 = db.collection(protocol=BibliothecaAPI.label())
+        b1 = db.collection(protocol=BibliothecaAPI)
 
         # o1 just had its Monitor run.
         Timestamp.stamp(

--- a/tests/manager/core/test_opds2_import.py
+++ b/tests/manager/core/test_opds2_import.py
@@ -99,9 +99,11 @@ class OPDS2ImporterFixture:
     def __init__(self, db: DatabaseTransactionFixture) -> None:
         self.transaction = db
         self.collection = db.collection(
-            protocol=OPDS2API.label(),
-            data_source_name="OPDS 2.0 Data Source",
-            external_account_id="http://opds2.example.org/feed",
+            protocol=OPDS2API,
+            settings=db.opds_settings(
+                external_account_id="http://opds2.example.org/feed",
+                data_source="OPDS 2.0 Data Source",
+            ),
         )
         self.library = db.default_library()
         self.collection.libraries.append(self.library)
@@ -711,9 +713,11 @@ class Opds2ApiFixture:
     def __init__(self, db: DatabaseTransactionFixture, mock_http: MagicMock):
         self.patron = db.patron()
         self.collection: Collection = db.collection(
-            protocol=OPDS2API.label(),
-            data_source_name="test",
-            external_account_id="http://opds2.example.org/feed",
+            protocol=OPDS2API,
+            settings=db.opds_settings(
+                external_account_id="http://opds2.example.org/feed",
+                data_source="test",
+            ),
         )
         self.collection.integration_configuration.context = {
             OPDS2API.TOKEN_AUTH_CONFIG_KEY: "http://example.org/token?userName={patron_id}"
@@ -911,9 +915,10 @@ class TestOPDS2ImportMonitor:
         self, db: DatabaseTransactionFixture, content_type: str, exception: bool
     ) -> None:
         collection = db.collection(
-            protocol=OPDS2API.label(),
-            data_source_name="test",
-            external_account_id="http://test.com",
+            protocol=OPDS2API,
+            settings=db.opds_settings(
+                external_account_id="http://opds2.example.org/feed",
+            ),
         )
         monitor = OPDS2ImportMonitor(
             db.session,

--- a/tests/manager/core/test_opds_validate.py
+++ b/tests/manager/core/test_opds_validate.py
@@ -13,7 +13,6 @@ from palace.manager.core.opds_schema import (
     OPDS2SchemaValidation,
     OPDS2WithODLSchemaValidation,
 )
-from palace.manager.sqlalchemy.model.datasource import DataSource
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.files import OPDS2FilesFixture, OPDS2WithODLFilesFixture
 
@@ -36,11 +35,7 @@ class TestOPDS2Validation:
         opds2_files_fixture: OPDS2FilesFixture,
     ):
         collection = db.collection(
-            protocol=OPDS2API.label(),
-            data_source_name=DataSource.FEEDBOOKS,
-            settings={
-                "external_account_id": "http://example.com/feed",
-            },
+            protocol=OPDS2API,
         )
         validator = OPDS2SchemaValidation(
             db.session,
@@ -72,13 +67,7 @@ class TestOPDS2WithODLValidation:
         opds2_with_odl_files_fixture: OPDS2WithODLFilesFixture,
     ):
         collection = db.collection(
-            protocol=OPDS2WithODLApi.label(),
-            data_source_name=DataSource.FEEDBOOKS,
-            settings={
-                "username": "username",
-                "password": "password",
-                "external_account_id": "http://example.com/feed",
-            },
+            protocol=OPDS2WithODLApi,
         )
         validator = OPDS2WithODLSchemaValidation(
             db.session,

--- a/tests/manager/feed/test_loan_and_hold_annotator.py
+++ b/tests/manager/feed/test_loan_and_hold_annotator.py
@@ -213,7 +213,7 @@ class TestLibraryLoanAndHoldAnnotator:
         feed = OPDSAcquisitionFeed("title", "url", [], annotator)
 
         # Annotate time tracking
-        opds_for_distributors = db.collection(protocol=OPDSForDistributorsAPI.label())
+        opds_for_distributors = db.collection(protocol=OPDSForDistributorsAPI)
         opds_for_distributors.libraries.append(library)
         work = db.work(with_license_pool=True, collection=opds_for_distributors)
         work.active_license_pool().should_track_playtime = True

--- a/tests/manager/scripts/test_configuration.py
+++ b/tests/manager/scripts/test_configuration.py
@@ -197,7 +197,7 @@ class TestConfigureCollectionScript:
 
     def test_reconfigure_collection(self, db: DatabaseTransactionFixture):
         # The collection exists.
-        collection = db.collection(name="Collection 1", protocol=OverdriveAPI.label())
+        collection = db.collection(name="Collection 1", protocol=OverdriveAPI)
         script = ConfigureCollectionScript()
         output = StringIO()
 

--- a/tests/manager/scripts/test_informational.py
+++ b/tests/manager/scripts/test_informational.py
@@ -71,8 +71,8 @@ class TestShowCollectionsScript:
         assert "No collections found.\n" == output.getvalue()
 
     def test_with_multiple_collections(self, db: DatabaseTransactionFixture):
-        c1 = db.collection(name="Collection 1", protocol=OverdriveAPI.label())
-        c2 = db.collection(name="Collection 2", protocol=BibliothecaAPI.label())
+        c1 = db.collection(name="Collection 1", protocol=OverdriveAPI)
+        c2 = db.collection(name="Collection 2", protocol=BibliothecaAPI)
 
         # The output of this script is the result of running explain()
         # on both collections.

--- a/tests/manager/scripts/test_monitor.py
+++ b/tests/manager/scripts/test_monitor.py
@@ -172,7 +172,7 @@ class TestRunCollectionMonitorScript:
         o3 = db.collection()
 
         # ...and a Bibliotheca collection.
-        b1 = db.collection(protocol=BibliothecaAPI.label())
+        b1 = db.collection(protocol=BibliothecaAPI)
 
         script = RunCollectionMonitorScript(
             OPDSCollectionMonitor, db.session, cmd_args=[]

--- a/tests/manager/scripts/test_opds_import.py
+++ b/tests/manager/scripts/test_opds_import.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from palace.manager.core.opds_import import OPDSImportMonitor
 from palace.manager.scripts.opds_import import OPDSImportScript
-from palace.manager.sqlalchemy.model.collection import Collection
-from palace.manager.sqlalchemy.model.datasource import DataSource
 from tests.fixtures.database import DatabaseTransactionFixture
 
 
@@ -37,11 +35,8 @@ class MockOPDSImportScript(OPDSImportScript):
 
 class TestOPDSImportScript:
     def test_do_run(self, db: DatabaseTransactionFixture):
-        DatabaseTransactionFixture.set_settings(
-            db.default_collection().integration_configuration,
-            Collection.DATA_SOURCE_NAME_SETTING,
-            DataSource.OA_CONTENT_SERVER,
-        )
+        # Create a collection to use as the default
+        db.default_collection()
 
         script = MockOPDSImportScript(db.session)
         script.do_run([])

--- a/tests/mocks/enki.py
+++ b/tests/mocks/enki.py
@@ -4,36 +4,14 @@ from sqlalchemy.orm import Session
 
 from palace.manager.api.enki import EnkiAPI
 from palace.manager.sqlalchemy.model.collection import Collection
-from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.util.http import HTTP
-from tests.fixtures.database import DatabaseTransactionFixture
 from tests.mocks.mock import MockRequestsResponse
 
 
 class MockEnkiAPI(EnkiAPI):
-    def __init__(
-        self, _db: Session, library: Library, collection: Collection | None = None
-    ) -> None:
+    def __init__(self, _db: Session, collection: Collection) -> None:
         self.responses: list[MockRequestsResponse] = []
         self.requests: list[list[Any]] = []
-
-        if not collection:
-            collection, ignore = Collection.by_name_and_protocol(
-                _db, name="Test Enki Collection", protocol=EnkiAPI.ENKI
-            )
-            assert collection is not None
-            collection.protocol = EnkiAPI.ENKI
-        if collection not in library.collections:
-            collection.libraries.append(library)
-
-        # Set the "Enki library ID" variable between the default library
-        # and this Enki collection.
-        library_config = collection.integration_configuration.for_library(library)
-        assert library_config is not None
-        DatabaseTransactionFixture.set_settings(
-            library_config, **{self.ENKI_LIBRARY_ID_KEY: "c"}
-        )
-        _db.commit()
 
         super().__init__(_db, collection)
 

--- a/tests/mocks/opds_for_distributors.py
+++ b/tests/mocks/opds_for_distributors.py
@@ -1,38 +1,9 @@
-from sqlalchemy.orm import Session
-
 from palace.manager.api.opds_for_distributors import OPDSForDistributorsAPI
-from palace.manager.sqlalchemy.model.collection import Collection
-from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.util.http import HTTP
 from tests.mocks.mock import MockRequestsResponse
 
 
 class MockOPDSForDistributorsAPI(OPDSForDistributorsAPI):
-    @classmethod
-    def mock_collection(
-        self,
-        _db: Session,
-        library: Library,
-        name: str = "Test OPDS For Distributors Collection",
-    ) -> Collection:
-        """Create a mock OPDS For Distributors collection to use in tests.
-
-        :param _db: Database session.
-        :param name: A name for the collection.
-        """
-        collection, _ = Collection.by_name_and_protocol(
-            _db, name=name, protocol=OPDSForDistributorsAPI.label()
-        )
-        collection.integration_configuration.settings_dict = dict(
-            username="a",
-            password="b",
-            data_source="data_source",
-            external_account_id="http://opds",
-        )
-        if library not in collection.libraries:
-            collection.libraries.append(library)
-        return collection
-
     def __init__(self, _db, collection, *args, **kwargs):
         self.responses = []
         self.requests = []


### PR DESCRIPTION
## Description

Update the fixture for creating collections, similar to the integration configuration fixture, so its easy to just pass a class name in as the protocol when creating a collection. Also remove the set_settings function, and replace it with the new collection functionality.

## Motivation and Context

Needed to create a number of collections for testing and getting the protocol names was more difficult then it should have been.

## How Has This Been Tested?

- Tested in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
