### PR TITLE
More realistic MockSessionMaker

### DIFF
--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -1275,8 +1275,14 @@ class MockSessionMaker:
     def __init__(self, session: Session):
         self._session = session
 
+    @contextmanager
     def __call__(self) -> Session:
-        return self._session
+        subtransaction = self._session.begin_nested()
+        try:
+            yield self._session
+        finally:
+            if subtransaction.is_active:
+                subtransaction.rollback()
 
     @contextmanager
     def begin(self) -> Generator[Session]:

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -1276,7 +1276,7 @@ class MockSessionMaker:
         self._session = session
 
     @contextmanager
-    def __call__(self) -> Session:
+    def __call__(self) -> Generator[Session]:
         subtransaction = self._session.begin_nested()
         try:
             yield self._session


### PR DESCRIPTION
## Description

Updates the behavior of `MockSessionMaker.__call__` to more accurately reflect what a real session maker object does.

## Motivation and Context

Within a Celery task if you do:
```python
with task.session() as session:
   ...
```

It will automatically open and close the session for you, but you are on your own to remember to commit if you need to. Previously this data was still available after the fixture ran, so it looked to tests like it was committed. However now it won't be unless its explicitly committed, which is more accurate and should help catch mistakes.

## How Has This Been Tested?

- Tested in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
