### PR TITLE
Refactor LoanInfo and HoldInfo to be dataclasses (PP-1728)

### DIFF
--- a/alembic/versions/20241015_1938277e993f_remove_hold_external_identifier.py
+++ b/alembic/versions/20241015_1938277e993f_remove_hold_external_identifier.py
@@ -1,0 +1,33 @@
+"""Remove Hold.external_identifier
+
+Revision ID: 1938277e993f
+Revises: 87901a6323d6
+Create Date: 2024-10-15 19:47:55.697280+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1938277e993f"
+down_revision = "87901a6323d6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("holds_external_identifier_key", "holds", type_="unique")
+    op.drop_column("holds", "external_identifier")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "holds",
+        sa.Column(
+            "external_identifier", sa.VARCHAR(), autoincrement=False, nullable=True
+        ),
+    )
+    op.create_unique_constraint(
+        "holds_external_identifier_key", "holds", ["external_identifier"]
+    )

--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -522,7 +522,6 @@ class Axis360API(
         hold_info = HoldInfo.from_license_pool(
             licensepool,
             start_date=utc_now(),
-            end_date=None,
             hold_position=hold_position,
         )
         return hold_info
@@ -1464,8 +1463,8 @@ class CheckoutResponseParser(XMLResponseParser[datetime.datetime | None]):
     def process_one(
         self, e: _Element, namespaces: dict[str, str] | None
     ) -> datetime.datetime | None:
-        """Either turn the given document into a LoanInfo
-        object, or raise an appropriate exception.
+        """Either turn the given document into a datetime representing the
+        loan's expiration date, or raise an appropriate exception.
         """
         self.raise_exception_on_error(e, namespaces)
 
@@ -1615,7 +1614,6 @@ class AvailabilityResponseParser(XMLResponseParser[Union[LoanInfo, HoldInfo]]):
                 collection_id=self.collection_id,
                 identifier_type=self.id_type,
                 identifier=axis_identifier,
-                start_date=None,
                 end_date=end_date,
                 hold_position=0,
             )
@@ -1627,8 +1625,6 @@ class AvailabilityResponseParser(XMLResponseParser[Union[LoanInfo, HoldInfo]]):
                 collection_id=self.collection_id,
                 identifier_type=self.id_type,
                 identifier=axis_identifier,
-                start_date=None,
-                end_date=None,
                 hold_position=position,
             )
         return info

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -338,7 +338,7 @@ class LoanAndHoldInfoMixin:
         return pool
 
 
-@dataclasses.dataclass(frozen=True, kw_only=True)
+@dataclasses.dataclass(kw_only=True)
 class LoanInfo(LoanAndHoldInfoMixin):
     """A record of a loan."""
 

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -14,6 +14,7 @@ from flask_babel import lazy_gettext as _
 from pydantic import PositiveInt
 from sqlalchemy import select
 from sqlalchemy.orm import Session
+from typing_extensions import Self
 
 from palace.manager.api.circulation_exceptions import (
     AlreadyCheckedOut,
@@ -35,6 +36,7 @@ from palace.manager.api.circulation_exceptions import (
     PatronLoanLimitReached,
 )
 from palace.manager.api.util.patron import PatronUtility
+from palace.manager.core.exceptions import PalaceValueError
 from palace.manager.integration.base import HasLibraryIntegrationConfiguration
 from palace.manager.integration.settings import (
     BaseSettings,
@@ -97,31 +99,6 @@ class CirculationInfo:
         self.data_source_name = data_source_name
         self.identifier_type = identifier_type
         self.identifier = identifier
-
-    def collection(self, _db: Session) -> Collection | None:
-        """Find the Collection to which this object belongs."""
-        if self.collection_id is None:
-            return None
-        return Collection.by_id(_db, self.collection_id)
-
-    def license_pool(self, _db: Session) -> LicensePool:
-        """Find the LicensePool model object corresponding to this object."""
-        collection = self.collection(_db)
-        pool, is_new = LicensePool.for_foreign_id(
-            _db,
-            self.data_source_name,
-            self.identifier_type,
-            self.identifier,
-            collection=collection,
-        )
-        return pool
-
-    def fd(self, d: datetime.datetime | None) -> str | None:
-        # Stupid method to format a date
-        if not d:
-            return None
-        else:
-            return datetime.datetime.strftime(d, "%Y/%m/%d %H:%M:%S")
 
 
 class DeliveryMechanismInfo(CirculationInfo):
@@ -334,53 +311,111 @@ class FetchFulfillment(UrlFulfillment, LoggerMixin):
         )
 
 
-class LoanInfo(CirculationInfo):
+class LoanAndHoldInfoMixin:
+    collection_id: int
+    identifier_type: str
+    identifier: str
+
+    def collection(self, _db: Session) -> Collection:
+        """Find the Collection to which this object belongs."""
+        collection = Collection.by_id(_db, self.collection_id)
+        if collection is None:
+            raise PalaceValueError(
+                f"collection_id {self.collection_id} could not be found."
+            )
+        return collection
+
+    def license_pool(self, _db: Session) -> LicensePool:
+        """Find the LicensePool model object corresponding to this object."""
+        collection = self.collection(_db)
+        pool, is_new = LicensePool.for_foreign_id(
+            _db,
+            collection.data_source,
+            self.identifier_type,
+            self.identifier,
+            collection=collection,
+        )
+        return pool
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class LoanInfo(LoanAndHoldInfoMixin):
     """A record of a loan."""
 
-    def __init__(
-        self,
-        collection: Collection | int,
-        data_source_name: str | DataSource | None,
-        identifier_type: str | None,
-        identifier: str | None,
-        start_date: datetime.datetime | None,
+    collection_id: int
+    identifier_type: str
+    identifier: str
+    start_date: datetime.datetime | None = None
+    end_date: datetime.datetime | None
+    fulfillment: Fulfillment | None = None
+    external_identifier: str | None = None
+    locked_to: DeliveryMechanismInfo | None = None
+
+    @classmethod
+    def from_license_pool(
+        cls,
+        license_pool: LicensePool,
+        *,
+        start_date: datetime.datetime | None = None,
         end_date: datetime.datetime | None,
         fulfillment: Fulfillment | None = None,
         external_identifier: str | None = None,
         locked_to: DeliveryMechanismInfo | None = None,
-    ):
-        """Constructor.
-
-        :param start_date: A datetime reflecting when the patron borrowed the book.
-        :param end_date: A datetime reflecting when the checked-out book is due.
-        :param fulfillment: A Fulfillment object representing an
-            active attempt to fulfill the loan.
-        :param locked_to: A DeliveryMechanismInfo object representing the
-            delivery mechanism to which this loan is 'locked'.
-        """
-        super().__init__(collection, data_source_name, identifier_type, identifier)
-        self.start_date = start_date
-        self.end_date = end_date
-        self.fulfillment = fulfillment
-        self.locked_to = locked_to
-        self.external_identifier = external_identifier
+    ) -> Self:
+        collection_id = license_pool.collection_id
+        assert collection_id is not None
+        identifier_type = license_pool.identifier.type
+        assert identifier_type is not None
+        identifier = license_pool.identifier.identifier
+        assert identifier is not None
+        return cls(
+            collection_id=collection_id,
+            identifier_type=identifier_type,
+            identifier=identifier,
+            start_date=start_date,
+            end_date=end_date,
+            fulfillment=fulfillment,
+            external_identifier=external_identifier,
+            locked_to=locked_to,
+        )
 
     def __repr__(self) -> str:
         if self.fulfillment:
             fulfillment = " Fulfilled by: " + repr(self.fulfillment)
         else:
             fulfillment = ""
-        f = "%Y/%m/%d"
         return "<LoanInfo for {}/{}, start={} end={}>{}".format(
             self.identifier_type,
             self.identifier,
-            self.fd(self.start_date),
-            self.fd(self.end_date),
+            self.start_date.isoformat() if self.start_date else self.start_date,
+            self.end_date.isoformat() if self.end_date else self.end_date,
             fulfillment,
         )
 
+    def create_or_update(
+        self, patron: Patron, license_pool: LicensePool | None = None
+    ) -> tuple[Loan, bool]:
+        session = Session.object_session(patron)
+        license_pool = license_pool or self.license_pool(session)
+        loan, is_new = license_pool.loan_to(
+            patron,
+            start=self.start_date,
+            end=self.end_date,
+            fulfillment=self.fulfillment,
+            external_identifier=self.external_identifier,
+        )
+        if self.locked_to:
+            # The loan source is letting us know that the loan is
+            # locked to a specific delivery mechanism. Even if
+            # this is the first we've heard of this loan,
+            # it may have been created in another app or through
+            # a library-website integration.
+            self.locked_to.apply(loan)
+        return loan, is_new
 
-class HoldInfo(CirculationInfo):
+
+@dataclasses.dataclass(kw_only=True)
+class HoldInfo(LoanAndHoldInfoMixin):
     """A record of a hold.
 
     :param identifier_type: Ex. Identifier.BIBLIOTHECA_ID.
@@ -392,30 +427,56 @@ class HoldInfo(CirculationInfo):
         default to be passed is None, which is equivalent to "first in line".
     """
 
-    def __init__(
-        self,
-        collection: Collection | int,
-        data_source_name: str | DataSource | None,
-        identifier_type: str | None,
-        identifier: str | None,
+    collection_id: int
+    identifier_type: str
+    identifier: str
+    start_date: datetime.datetime | None
+    end_date: datetime.datetime | None
+    hold_position: int | None
+
+    @classmethod
+    def from_license_pool(
+        cls,
+        license_pool: LicensePool,
+        *,
         start_date: datetime.datetime | None,
         end_date: datetime.datetime | None,
         hold_position: int | None,
-        external_identifier: str | None = None,
-    ):
-        super().__init__(collection, data_source_name, identifier_type, identifier)
-        self.start_date = start_date
-        self.end_date = end_date
-        self.hold_position = hold_position
-        self.external_identifier = external_identifier
+    ) -> Self:
+        collection_id = license_pool.collection_id
+        assert collection_id is not None
+        identifier_type = license_pool.identifier.type
+        assert identifier_type is not None
+        identifier = license_pool.identifier.identifier
+        assert identifier is not None
+        return cls(
+            collection_id=collection_id,
+            identifier_type=identifier_type,
+            identifier=identifier,
+            start_date=start_date,
+            end_date=end_date,
+            hold_position=hold_position,
+        )
 
     def __repr__(self) -> str:
         return "<HoldInfo for {}/{}, start={} end={}, position={}>".format(
             self.identifier_type,
             self.identifier,
-            self.fd(self.start_date),
-            self.fd(self.end_date),
+            self.start_date.isoformat() if self.start_date else self.start_date,
+            self.end_date.isoformat() if self.end_date else self.end_date,
             self.hold_position,
+        )
+
+    def create_or_update(
+        self, patron: Patron, license_pool: LicensePool | None = None
+    ) -> tuple[Hold, bool]:
+        session = Session.object_session(patron)
+        license_pool = license_pool or self.license_pool(session)
+        return license_pool.on_hold_to(  # type: ignore[no-any-return]
+            patron,
+            start=self.start_date,
+            end=self.end_date,
+            position=self.hold_position,
         )
 
 
@@ -746,31 +807,7 @@ class PatronActivityCirculationAPI(
     ) -> None:
         # Update the local loans and to match the remote loans
         for identifier, loan in remote_loans.items():
-            pool = loan.license_pool(self._db)
-            start = loan.start_date
-            end = loan.end_date
-
-            if identifier in local_loans:
-                # We already have the Loan object, we don't need to look
-                # it up again.
-                local_loan = local_loans[identifier]
-
-                # But maybe the remote's opinions as to the loan's
-                # start or end date have changed.
-                if start:
-                    local_loan.start = start
-                if end:
-                    local_loan.end = end
-            else:
-                local_loan, _ = pool.loan_to(patron, start, end)
-
-            if loan.locked_to:
-                # The loan source is letting us know that the loan is
-                # locked to a specific delivery mechanism. Even if
-                # this is the first we've heard of this loan,
-                # it may have been created in another app or through
-                # a library-website integration.
-                loan.locked_to.apply(local_loan)
+            loan.create_or_update(patron)
 
         loans_to_delete = [
             local_loans[i] for i in local_loans.keys() - remote_loans.keys()
@@ -785,21 +822,7 @@ class PatronActivityCirculationAPI(
     ) -> None:
         # Update the local holds to match the remote holds
         for identifier, hold in remote_holds.items():
-            pool = hold.license_pool(self._db)
-            start = hold.start_date
-            end = hold.end_date
-            position = hold.hold_position
-
-            if identifier in local_holds:
-                # We already have the Hold object, we don't need to look
-                # it up again.
-                local_hold = local_holds[identifier]
-
-                # But maybe the remote's opinions as to the hold's
-                # start or end date have changed.
-                local_hold.update(start, end, position)
-            else:
-                local_hold, _ = pool.on_hold_to(patron, start, end, position)
+            hold.create_or_update(patron)
 
         holds_to_delete = [
             local_holds[i] for i in local_holds.keys() - remote_holds.keys()
@@ -1026,14 +1049,14 @@ class CirculationAPI(LoggerMixin):
         # available -- someone else may have checked it in since we
         # last looked.
         try:
-            loan_info = api.checkout(
+            checkout_result = api.checkout(
                 patron, pin, licensepool, delivery_mechanism=delivery_mechanism  # type: ignore[arg-type]
             )
 
-            if isinstance(loan_info, HoldInfo):
+            if isinstance(checkout_result, HoldInfo):
                 # If the API couldn't give us a loan, it may have given us
                 # a hold instead of raising an exception.
-                hold_info = loan_info
+                hold_info = checkout_result
                 loan_info = None
             else:
                 # We asked the API to create a loan and it gave us a
@@ -1045,30 +1068,26 @@ class CirculationAPI(LoggerMixin):
                 # API does something unusual like return LoanInfo instead
                 # of raising AlreadyCheckedOut.
                 new_loan = True
+                loan_info = checkout_result
+                hold_info = None
         except AlreadyCheckedOut:
             # This is good, but we didn't get the real loan info.
             # Just fake it.
-            identifier = licensepool.identifier
-            loan_info = LoanInfo(
-                licensepool.collection,
-                licensepool.data_source,
-                identifier.type,
-                identifier.identifier,
+            loan_info = LoanInfo.from_license_pool(
+                licensepool,
                 start_date=None,
                 end_date=now + datetime.timedelta(hours=1),
+                external_identifier=(
+                    existing_loan.external_identifier if existing_loan else None
+                ),
             )
-            if existing_loan:
-                loan_info.external_identifier = existing_loan.external_identifier
         except AlreadyOnHold:
             # We're trying to check out a book that we already have on hold.
-            hold_info = HoldInfo(
-                licensepool.collection,
-                licensepool.data_source,
-                licensepool.identifier.type,
-                licensepool.identifier.identifier,
-                None,
-                None,
-                None,
+            hold_info = HoldInfo.from_license_pool(
+                licensepool,
+                start_date=None,
+                end_date=None,
+                hold_position=None,
             )
         except NoAvailableCopies:
             if existing_loan:
@@ -1104,12 +1123,7 @@ class CirculationAPI(LoggerMixin):
             # We successfully secured a loan.  Now create it in our
             # database.
             __transaction = self._db.begin_nested()
-            loan, new_loan_record = licensepool.loan_to(
-                patron,
-                start=loan_info.start_date or now,
-                end=loan_info.end_date,
-                external_identifier=loan_info.external_identifier,
-            )
+            loan, new_loan_record = loan_info.create_or_update(patron, licensepool)
 
             if must_set_delivery_mechanism:
                 loan.fulfillment = delivery_mechanism
@@ -1144,14 +1158,11 @@ class CirculationAPI(LoggerMixin):
                     patron, pin, licensepool, hold_notification_email
                 )
             except AlreadyOnHold as e:
-                hold_info = HoldInfo(
-                    licensepool.collection,
-                    licensepool.data_source,
-                    licensepool.identifier.type,
-                    licensepool.identifier.identifier,
-                    None,
-                    None,
-                    None,
+                hold_info = HoldInfo.from_license_pool(
+                    licensepool,
+                    start_date=None,
+                    end_date=None,
+                    hold_position=None,
                 )
             except CurrentlyAvailable:
                 if loan_exception:
@@ -1172,13 +1183,7 @@ class CirculationAPI(LoggerMixin):
         # It's pretty rare that we'd go from having a loan for a book
         # to needing to put it on hold, but we do check for that case.
         __transaction = self._db.begin_nested()
-        hold, is_new = licensepool.on_hold_to(
-            patron,
-            hold_info.start_date or now,
-            hold_info.end_date,
-            hold_info.hold_position,
-            hold_info.external_identifier,
-        )
+        hold, is_new = hold_info.create_or_update(patron, licensepool)
 
         if hold and is_new:
             # Send out an analytics event to record the fact that

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -430,8 +430,8 @@ class HoldInfo(LoanAndHoldInfoMixin):
     collection_id: int
     identifier_type: str
     identifier: str
-    start_date: datetime.datetime | None
-    end_date: datetime.datetime | None
+    start_date: datetime.datetime | None = None
+    end_date: datetime.datetime | None = None
     hold_position: int | None
 
     @classmethod
@@ -439,8 +439,8 @@ class HoldInfo(LoanAndHoldInfoMixin):
         cls,
         license_pool: LicensePool,
         *,
-        start_date: datetime.datetime | None,
-        end_date: datetime.datetime | None,
+        start_date: datetime.datetime | None = None,
+        end_date: datetime.datetime | None = None,
         hold_position: int | None,
     ) -> Self:
         collection_id = license_pool.collection_id
@@ -1085,8 +1085,6 @@ class CirculationAPI(LoggerMixin):
             # We're trying to check out a book that we already have on hold.
             hold_info = HoldInfo.from_license_pool(
                 licensepool,
-                start_date=None,
-                end_date=None,
                 hold_position=None,
             )
         except NoAvailableCopies:
@@ -1160,8 +1158,6 @@ class CirculationAPI(LoggerMixin):
             except AlreadyOnHold as e:
                 hold_info = HoldInfo.from_license_pool(
                     licensepool,
-                    start_date=None,
-                    end_date=None,
                     hold_position=None,
                 )
             except CurrentlyAvailable:

--- a/src/palace/manager/api/enki.py
+++ b/src/palace/manager/api/enki.py
@@ -428,14 +428,9 @@ class EnkiAPI(
         expires = self._epoch_to_struct(due_date)
 
         # Create the loan info.
-        loan = LoanInfo(
-            licensepool.collection,
-            licensepool.data_source.name,
-            licensepool.identifier.type,
-            licensepool.identifier.identifier,
-            None,
-            expires,
-            None,
+        loan = LoanInfo.from_license_pool(
+            licensepool,
+            end_date=expires,
         )
         return loan
 
@@ -572,16 +567,14 @@ class EnkiAPI(
         enki_id = checkout_data["id"]
         start_date = self._epoch_to_struct(checkout_data["checkoutdate"])
         end_date = self._epoch_to_struct(checkout_data["duedate"])
-        if self.collection is None:
-            raise ValueError("Collection is None")
+        if self.collection_id is None:
+            raise ValueError("Collection_id is None")
         return LoanInfo(
-            self.collection,
-            DataSource.ENKI,
-            Identifier.ENKI_ID,
-            enki_id,
+            collection_id=self.collection_id,
+            identifier_type=Identifier.ENKI_ID,
+            identifier=enki_id,
             start_date=start_date,
             end_date=end_date,
-            fulfillment=None,
         )
 
     def parse_patron_holds(self, hold_data: Mapping[str, Any]) -> HoldInfo | None:

--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -293,13 +293,10 @@ class OPDS2WithODLApi(
             loan_end = loan_obj.end
             external_identifier = loan_obj.external_identifier
 
-        return LoanInfo(
-            licensepool.collection,
-            licensepool.data_source.name,
-            licensepool.identifier.type,
-            licensepool.identifier.identifier,
-            loan_start,
-            loan_end,
+        return LoanInfo.from_license_pool(
+            licensepool,
+            start_date=loan_start,
+            end_date=loan_end,
             external_identifier=external_identifier,
         )
 
@@ -615,14 +612,11 @@ class OPDS2WithODLApi(
 
     def _update_hold_data(self, hold: Hold) -> None:
         pool: LicensePool = hold.license_pool
-        holdinfo = HoldInfo(
-            pool.collection,
-            pool.data_source.name,
-            pool.identifier.type,
-            pool.identifier.identifier,
-            hold.start,
-            hold.end,
-            hold.position,
+        holdinfo = HoldInfo.from_license_pool(
+            pool,
+            start_date=hold.start,
+            end_date=hold.end,
+            hold_position=hold.position,
         )
         library = hold.patron.library
         self._update_hold_end_date(holdinfo, pool, library=library)
@@ -805,14 +799,11 @@ class OPDS2WithODLApi(
             else 0
         )
         licensepool.patrons_in_hold_queue = patrons_in_hold_queue + 1
-        holdinfo = HoldInfo(
-            licensepool.collection,
-            licensepool.data_source.name,
-            licensepool.identifier.type,
-            licensepool.identifier.identifier,
-            utc_now(),
-            None,
-            0,
+        holdinfo = HoldInfo.from_license_pool(
+            licensepool,
+            start_date=utc_now(),
+            end_date=None,
+            hold_position=0,
         )
         library = patron.library
         self._update_hold_end_date(holdinfo, licensepool, library=library)
@@ -884,22 +875,16 @@ class OPDS2WithODLApi(
                 remaining_holds.append(hold)
 
         return [
-            LoanInfo(
-                loan.license_pool.collection,
-                loan.license_pool.data_source.name,
-                loan.license_pool.identifier.type,
-                loan.license_pool.identifier.identifier,
-                loan.start,
-                loan.end,
+            LoanInfo.from_license_pool(
+                loan.license_pool,
+                start_date=loan.start,
+                end_date=loan.end,
                 external_identifier=loan.external_identifier,
             )
             for loan in loans
         ] + [
-            HoldInfo(
-                hold.license_pool.collection,
-                hold.license_pool.data_source.name,
-                hold.license_pool.identifier.type,
-                hold.license_pool.identifier.identifier,
+            HoldInfo.from_license_pool(
+                hold.license_pool,
                 start_date=hold.start,
                 end_date=hold.end,
                 hold_position=hold.position,

--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -802,7 +802,6 @@ class OPDS2WithODLApi(
         holdinfo = HoldInfo.from_license_pool(
             licensepool,
             start_date=utc_now(),
-            end_date=None,
             hold_position=0,
         )
         library = patron.library

--- a/src/palace/manager/api/opds_for_distributors.py
+++ b/src/palace/manager/api/opds_for_distributors.py
@@ -275,11 +275,8 @@ class OPDSForDistributorsAPI(
         delivery_mechanism: LicensePoolDeliveryMechanism,
     ) -> LoanInfo:
         now = utc_now()
-        return LoanInfo(
-            licensepool.collection,
-            licensepool.data_source.name,
-            licensepool.identifier.type,
-            licensepool.identifier.identifier,
+        return LoanInfo.from_license_pool(
+            licensepool,
             start_date=now,
             end_date=None,
         )

--- a/src/palace/manager/api/overdrive.py
+++ b/src/palace/manager/api/overdrive.py
@@ -1633,7 +1633,6 @@ class OverdriveAPI(
             return HoldInfo.from_license_pool(
                 licensepool,
                 start_date=start_date,
-                end_date=None,
                 hold_position=position,
             )
 

--- a/src/palace/manager/core/opds_import.py
+++ b/src/palace/manager/core/opds_import.py
@@ -344,7 +344,7 @@ class BaseOPDSAPI(
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
     ) -> LoanInfo:
-        return LoanInfo(licensepool.collection, None, None, None, None, None)
+        return LoanInfo.from_license_pool(licensepool, end_date=None)
 
     def can_fulfill_without_loan(
         self,

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -1053,6 +1053,10 @@ class LicensePool(Base):
             loan.fulfillment = fulfillment
         if external_identifier:
             loan.external_identifier = external_identifier
+        if start:
+            loan.start = start
+        if end:
+            loan.end = end
         return loan, is_new
 
     def on_hold_to(
@@ -1061,7 +1065,6 @@ class LicensePool(Base):
         start=None,
         end=None,
         position=None,
-        external_identifier=None,
     ):
         _db = Session.object_session(patron)
         if not patron.library.settings.allow_holds:
@@ -1069,8 +1072,6 @@ class LicensePool(Base):
         start = start or utc_now()
         hold, new = get_one_or_create(_db, Hold, patron=patron, license_pool=self)
         hold.update(start, end, position)
-        if external_identifier:
-            hold.external_identifier = external_identifier
         return hold, new
 
     def best_available_license(self) -> License | None:

--- a/src/palace/manager/sqlalchemy/model/patron.py
+++ b/src/palace/manager/sqlalchemy/model/patron.py
@@ -567,7 +567,6 @@ class Hold(Base, LoanAndHoldMixin):
     start = Column(DateTime(timezone=True), index=True)
     end = Column(DateTime(timezone=True), index=True)
     position = Column(Integer, index=True)
-    external_identifier = Column(Unicode, unique=True, nullable=True)
     patron_last_notified = Column(DateTime, nullable=True)
 
     patron: Mapped[Patron] = relationship(

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -271,13 +271,10 @@ class TestLoanController:
         pool = work.license_pools[0]
         loan_fixture.manager.d_circulation.queue_checkout(
             pool,
-            LoanInfo(
-                pool.collection,
-                pool.data_source.name,
-                pool.identifier.type,
-                pool.identifier.identifier,
-                utc_now(),
-                utc_now() + datetime.timedelta(seconds=3600),
+            LoanInfo.from_license_pool(
+                pool,
+                start_date=utc_now(),
+                end_date=utc_now() + datetime.timedelta(seconds=3600),
             ),
         )
 
@@ -494,13 +491,10 @@ class TestLoanController:
             loan_fixture.manager.loans.authenticated_patron_from_request()
             loan_fixture.manager.d_circulation.queue_checkout(
                 pool,
-                LoanInfo(
-                    pool.collection,
-                    pool.data_source.name,
-                    pool.identifier.type,
-                    pool.identifier.identifier,
-                    utc_now(),
-                    utc_now() + datetime.timedelta(seconds=3600),
+                LoanInfo.from_license_pool(
+                    pool,
+                    start_date=utc_now(),
+                    end_date=utc_now() + datetime.timedelta(seconds=3600),
                 ),
             )
             with patch(
@@ -673,14 +667,11 @@ class TestLoanController:
             loan_fixture.manager.d_circulation.queue_checkout(pool, NoAvailableCopies())
             loan_fixture.manager.d_circulation.queue_hold(
                 pool,
-                HoldInfo(
-                    pool.collection,
-                    pool.data_source.name,
-                    pool.identifier.type,
-                    pool.identifier.identifier,
-                    utc_now(),
-                    utc_now() + datetime.timedelta(seconds=3600),
-                    1,
+                HoldInfo.from_license_pool(
+                    pool,
+                    start_date=utc_now(),
+                    end_date=utc_now() + datetime.timedelta(seconds=3600),
+                    hold_position=1,
                 ),
             )
             response = loan_fixture.manager.loans.borrow(
@@ -739,14 +730,11 @@ class TestLoanController:
             loan_fixture.manager.d_circulation.queue_checkout(pool, AlreadyOnHold())
             loan_fixture.manager.d_circulation.queue_hold(
                 pool,
-                HoldInfo(
-                    pool.collection,
-                    pool.data_source.name,
-                    pool.identifier.type,
-                    pool.identifier.identifier,
-                    utc_now(),
-                    utc_now() + datetime.timedelta(seconds=3600),
-                    1,
+                HoldInfo.from_license_pool(
+                    pool,
+                    start_date=utc_now(),
+                    end_date=utc_now() + datetime.timedelta(seconds=3600),
+                    hold_position=1,
                 ),
             )
             response = loan_fixture.manager.loans.borrow(
@@ -1347,13 +1335,10 @@ class TestLoanController:
             patron.fines = Decimal("0.49")
             loan_fixture.manager.d_circulation.queue_checkout(
                 pool,
-                LoanInfo(
-                    pool.collection,
-                    pool.data_source.name,
-                    pool.identifier.type,
-                    pool.identifier.identifier,
-                    utc_now(),
-                    utc_now() + datetime.timedelta(seconds=3600),
+                LoanInfo.from_license_pool(
+                    pool,
+                    start_date=utc_now(),
+                    end_date=utc_now() + datetime.timedelta(seconds=3600),
                 ),
             )
             response = loan_fixture.manager.loans.borrow(
@@ -1706,13 +1691,10 @@ class TestLoanController:
                 )
                 license_pool = work.license_pools[0]
 
-                loan_info = LoanInfo(
-                    license_pool.collection,
-                    license_pool.data_source.name,
-                    license_pool.identifier.type,
-                    license_pool.identifier.identifier,
-                    loan_start,
-                    loan_end,
+                loan_info = LoanInfo.from_license_pool(
+                    license_pool,
+                    start_date=loan_start,
+                    end_date=loan_end,
                 )
 
                 return license_pool, loan_info

--- a/tests/manager/api/controller/test_work.py
+++ b/tests/manager/api/controller/test_work.py
@@ -423,13 +423,10 @@ class TestWorkController:
             pool = work.license_pools[0]
             [delivery_mechanism] = pool.delivery_mechanisms
 
-            loan_info = LoanInfo(
-                pool.collection,
-                pool.data_source.name,
-                pool.identifier.type,
-                pool.identifier.identifier,
-                utc_now(),
-                utc_now() + datetime.timedelta(seconds=3600),
+            loan_info = LoanInfo.from_license_pool(
+                pool,
+                start_date=utc_now(),
+                end_date=utc_now() + datetime.timedelta(seconds=3600),
             )
             work_fixture.manager.d_circulation.queue_checkout(pool, loan_info)
 

--- a/tests/manager/api/test_bibliotheca.py
+++ b/tests/manager/api/test_bibliotheca.py
@@ -820,7 +820,6 @@ class TestPatronCirculationParser:
 
         # This is the book on reserve.
         assert collection.id == h1.collection_id
-        assert DataSource.BIBLIOTHECA == h1.data_source_name
         assert "9wd8" == h1.identifier
         expect_hold_start = datetime_utc(2015, 5, 25, 17, 5, 34)
         expect_hold_end = datetime_utc(2015, 5, 27, 17, 5, 34)
@@ -831,7 +830,6 @@ class TestPatronCirculationParser:
         # This is the book on hold.
         assert "d4o8r9" == h2.identifier
         assert collection.id == h2.collection_id
-        assert DataSource.BIBLIOTHECA == h2.data_source_name
         expect_hold_start = datetime_utc(2015, 3, 24, 15, 6, 56)
         expect_hold_end = datetime_utc(2015, 3, 24, 15, 7, 51)
         assert expect_hold_start == h2.start_date

--- a/tests/manager/api/test_circulationapi.py
+++ b/tests/manager/api/test_circulationapi.py
@@ -264,8 +264,6 @@ class TestCirculationAPI:
         circulation_api.remote.queue_checkout(NoAvailableCopies())
         holdinfo = HoldInfo.from_license_pool(
             circulation_api.pool,
-            start_date=None,
-            end_date=None,
             hold_position=10,
         )
         circulation_api.remote.queue_hold(holdinfo)
@@ -286,8 +284,6 @@ class TestCirculationAPI:
         # an error.
         holdinfo = HoldInfo.from_license_pool(
             circulation_api.pool,
-            start_date=None,
-            end_date=None,
             hold_position=10,
         )
         circulation_api.remote.queue_checkout(holdinfo)
@@ -311,8 +307,6 @@ class TestCirculationAPI:
         # Attempting to place a hold will succeed.
         holdinfo = HoldInfo.from_license_pool(
             circulation_api.pool,
-            start_date=None,
-            end_date=None,
             hold_position=10,
         )
         circulation_api.remote.queue_hold(holdinfo)
@@ -355,8 +349,6 @@ class TestCirculationAPI:
         circulation_api.remote.queue_checkout(NoAvailableCopies())
         holdinfo = HoldInfo.from_license_pool(
             circulation_api.pool,
-            start_date=None,
-            end_date=None,
             hold_position=10,
         )
         circulation_api.remote.queue_hold(holdinfo)

--- a/tests/manager/api/test_circulationapi.py
+++ b/tests/manager/api/test_circulationapi.py
@@ -8,7 +8,9 @@ from unittest.mock import MagicMock, create_autospec
 import flask
 import pytest
 from flask import Flask
+from freezegun import freeze_time
 
+from palace.manager.api.bibliotheca import BibliothecaAPI
 from palace.manager.api.circulation import (
     BaseCirculationAPI,
     CirculationAPI,
@@ -114,13 +116,10 @@ class TestCirculationAPI:
 
     def test_borrow_sends_analytics_event(self, circulation_api: CirculationAPIFixture):
         now = utc_now()
-        loaninfo = LoanInfo(
-            circulation_api.pool.collection,
-            circulation_api.pool.data_source,
-            circulation_api.pool.identifier.type,
-            circulation_api.pool.identifier.identifier,
-            now,
-            now + timedelta(seconds=3600),
+        loaninfo = LoanInfo.from_license_pool(
+            circulation_api.pool,
+            start_date=now,
+            end_date=now + timedelta(seconds=3600),
             external_identifier=circulation_api.db.fresh_str(),
         )
         circulation_api.remote.queue_checkout(loaninfo)
@@ -165,6 +164,7 @@ class TestCirculationAPI:
         loan, hold, is_new = self.borrow(circulation_api)
         assert 3 == circulation_api.analytics.count
 
+    @freeze_time()
     def test_attempt_borrow_with_existing_remote_loan(
         self, circulation_api: CirculationAPIFixture
     ):
@@ -187,8 +187,8 @@ class TestCirculationAPI:
         # but didn't give us any useful information on when that loan
         # was created. We've faked it with values that should be okay
         # until the next sync.
-        assert abs((loan.start - now).seconds) < 2
-        assert 3600 == (loan.end - loan.start).seconds
+        assert (loan.start - now).seconds == 0
+        assert (loan.end - loan.start).seconds == 3600
 
     def test_attempt_borrow_with_existing_remote_hold(
         self, circulation_api: CirculationAPIFixture
@@ -262,14 +262,11 @@ class TestCirculationAPI:
     ):
         # We want to borrow this book but there are no copies.
         circulation_api.remote.queue_checkout(NoAvailableCopies())
-        holdinfo = HoldInfo(
-            circulation_api.pool.collection,
-            circulation_api.pool.data_source,
-            circulation_api.identifier.type,
-            circulation_api.identifier.identifier,
-            None,
-            None,
-            10,
+        holdinfo = HoldInfo.from_license_pool(
+            circulation_api.pool,
+            start_date=None,
+            end_date=None,
+            hold_position=10,
         )
         circulation_api.remote.queue_hold(holdinfo)
 
@@ -287,14 +284,11 @@ class TestCirculationAPI:
         # There are no available copies, but the remote API
         # places a hold for us right away instead of raising
         # an error.
-        holdinfo = HoldInfo(
-            circulation_api.pool.collection,
-            circulation_api.pool.data_source,
-            circulation_api.identifier.type,
-            circulation_api.identifier.identifier,
-            None,
-            None,
-            10,
+        holdinfo = HoldInfo.from_license_pool(
+            circulation_api.pool,
+            start_date=None,
+            end_date=None,
+            hold_position=10,
         )
         circulation_api.remote.queue_checkout(holdinfo)
 
@@ -315,14 +309,11 @@ class TestCirculationAPI:
 
         # But the point is moot because the book isn't even available.
         # Attempting to place a hold will succeed.
-        holdinfo = HoldInfo(
-            circulation_api.pool.collection,
-            circulation_api.pool.data_source,
-            circulation_api.identifier.type,
-            circulation_api.identifier.identifier,
-            None,
-            None,
-            10,
+        holdinfo = HoldInfo.from_license_pool(
+            circulation_api.pool,
+            start_date=None,
+            end_date=None,
+            hold_position=10,
         )
         circulation_api.remote.queue_hold(holdinfo)
 
@@ -362,14 +353,11 @@ class TestCirculationAPI:
 
     def test_hold_sends_analytics_event(self, circulation_api: CirculationAPIFixture):
         circulation_api.remote.queue_checkout(NoAvailableCopies())
-        holdinfo = HoldInfo(
-            circulation_api.pool.collection,
-            circulation_api.pool.data_source,
-            circulation_api.identifier.type,
-            circulation_api.identifier.identifier,
-            None,
-            None,
-            10,
+        holdinfo = HoldInfo.from_license_pool(
+            circulation_api.pool,
+            start_date=None,
+            end_date=None,
+            hold_position=10,
         )
         circulation_api.remote.queue_hold(holdinfo)
 
@@ -401,13 +389,10 @@ class TestCirculationAPI:
         # We use local time here, rather than UTC time, because we use
         # local time when checking for expired cards in authorization_is_active.
         now = datetime.datetime.now()
-        loaninfo = LoanInfo(
-            circulation_api.pool.collection,
-            circulation_api.pool.data_source,
-            circulation_api.pool.identifier.type,
-            circulation_api.pool.identifier.identifier,
-            now,
-            now + timedelta(seconds=3600),
+        loaninfo = LoanInfo.from_license_pool(
+            circulation_api.pool,
+            start_date=now,
+            end_date=now + timedelta(seconds=3600),
         )
         circulation_api.remote.queue_checkout(loaninfo)
 
@@ -424,13 +409,10 @@ class TestCirculationAPI:
     ):
         # This checkout would succeed...
         now = utc_now()
-        loaninfo = LoanInfo(
-            circulation_api.pool.collection,
-            circulation_api.pool.data_source,
-            circulation_api.pool.identifier.type,
-            circulation_api.pool.identifier.identifier,
-            now,
-            now + timedelta(seconds=3600),
+        loaninfo = LoanInfo.from_license_pool(
+            circulation_api.pool,
+            start_date=now,
+            end_date=now + timedelta(seconds=3600),
         )
         circulation_api.remote.queue_checkout(loaninfo)
 
@@ -457,13 +439,10 @@ class TestCirculationAPI:
     def test_borrow_with_block_fails(self, circulation_api: CirculationAPIFixture):
         # This checkout would succeed...
         now = utc_now()
-        loaninfo = LoanInfo(
-            circulation_api.pool.collection,
-            circulation_api.pool.data_source,
-            circulation_api.pool.identifier.type,
-            circulation_api.pool.identifier.identifier,
-            now,
-            now + timedelta(seconds=3600),
+        loaninfo = LoanInfo.from_license_pool(
+            circulation_api.pool,
+            start_date=now,
+            end_date=now + timedelta(seconds=3600),
         )
         circulation_api.remote.queue_checkout(loaninfo)
 
@@ -787,14 +766,11 @@ class TestCirculationAPI:
         library_fixture.settings(circulation_api.patron.library).hold_limit = 2
         circulation_api.remote.queue_checkout(NoAvailableCopies())
         now = utc_now()
-        holdinfo = HoldInfo(
-            circulation_api.pool.collection,
-            circulation_api.pool.data_source,
-            circulation_api.pool.identifier.type,
-            circulation_api.pool.identifier.identifier,
-            now,
-            now + timedelta(seconds=3600),
-            10,
+        holdinfo = HoldInfo.from_license_pool(
+            circulation_api.pool,
+            start_date=now,
+            end_date=now + timedelta(seconds=3600),
+            hold_position=10,
         )
         circulation_api.remote.queue_hold(holdinfo)
         loan, hold, is_new = self.borrow(circulation_api)
@@ -1060,7 +1036,7 @@ class PatronActivityCirculationAPIFixture:
     def __init__(self, db: DatabaseTransactionFixture) -> None:
         self.db = db
         self.patron = db.patron()
-        self.collection = db.collection()
+        self.collection = db.collection(protocol=BibliothecaAPI)
         edition, self.pool = db.edition(
             data_source_name=DataSource.BIBLIOTHECA,
             identifier_type=Identifier.BIBLIOTHECA_ID,
@@ -1191,13 +1167,10 @@ class TestPatronActivityCirculationAPI:
         # But the remote thinks the loan runs from today until two
         # weeks from today.
         patron_activity_circulation_api.api.add_remote_loan(
-            LoanInfo(
-                patron_activity_circulation_api.pool.collection,
-                patron_activity_circulation_api.pool.data_source,
-                patron_activity_circulation_api.identifier.type,
-                patron_activity_circulation_api.identifier.identifier,
-                patron_activity_circulation_api.now,
-                patron_activity_circulation_api.in_two_weeks,
+            LoanInfo.from_license_pool(
+                patron_activity_circulation_api.pool,
+                start_date=patron_activity_circulation_api.now,
+                end_date=patron_activity_circulation_api.in_two_weeks,
             )
         )
 
@@ -1215,14 +1188,11 @@ class TestPatronActivityCirculationAPI:
         hold.position = 10
 
         patron_activity_circulation_api.api.add_remote_hold(
-            HoldInfo(
-                pool2.collection,
-                pool2.data_source,
-                pool2.identifier.type,
-                pool2.identifier.identifier,
-                patron_activity_circulation_api.now,
-                patron_activity_circulation_api.in_two_weeks,
-                0,
+            HoldInfo.from_license_pool(
+                pool2,
+                start_date=patron_activity_circulation_api.now,
+                end_date=patron_activity_circulation_api.in_two_weeks,
+                hold_position=0,
             )
         )
         patron_activity_circulation_api.sync_patron_activity()
@@ -1246,15 +1216,14 @@ class TestPatronActivityCirculationAPI:
         mechanism = DeliveryMechanismInfo(
             Representation.TEXT_HTML_MEDIA_TYPE, DeliveryMechanism.NO_DRM
         )
-        pool = db.licensepool(None)
+        data_source = db.default_collection().data_source
+        assert data_source is not None
+        pool = db.licensepool(None, data_source_name=data_source.name)
         patron_activity_circulation_api.api.add_remote_loan(
-            LoanInfo(
-                pool.collection,
-                pool.data_source.name,
-                pool.identifier.type,
-                pool.identifier.identifier,
-                utc_now(),
-                None,
+            LoanInfo.from_license_pool(
+                pool,
+                start_date=utc_now(),
+                end_date=None,
                 locked_to=mechanism,
             )
         )

--- a/tests/manager/api/test_enki.py
+++ b/tests/manager/api/test_enki.py
@@ -403,7 +403,6 @@ class TestEnkiAPI:
         loan = enki_test_fixture.api.parse_patron_loans(
             result["result"]["checkedOutItems"][0]
         )
-        assert loan.data_source_name == DataSource.ENKI
         assert loan.identifier_type == Identifier.ENKI_ID
         assert loan.identifier == "2"
         assert loan.start_date == datetime_utc(2017, 8, 23, 19, 31, 58, 0)
@@ -416,7 +415,6 @@ class TestEnkiAPI:
         loan = enki_test_fixture.api.parse_patron_loans(
             result["result"]["checkedOutItems"][0]
         )
-        assert loan.data_source_name == DataSource.ENKI
         assert loan.identifier_type == Identifier.ENKI_ID
         assert loan.identifier == "3334"
         assert loan.start_date == datetime_utc(2017, 8, 23, 19, 42, 35, 0)
@@ -603,7 +601,6 @@ class TestEnkiAPI:
         # The result is a single LoanInfo.
         assert isinstance(loan, LoanInfo)
         assert Identifier.ENKI_ID == loan.identifier_type
-        assert DataSource.ENKI == loan.data_source_name
         assert "231" == loan.identifier
         assert enki_test_fixture.collection == loan.collection(db.session)
         assert datetime_utc(2017, 8, 15, 14, 56, 51) == loan.start_date

--- a/tests/manager/api/test_opds_for_distributors.py
+++ b/tests/manager/api/test_opds_for_distributors.py
@@ -421,7 +421,6 @@ class TestOPDSForDistributorsAPI:
             patron, "1234", pool, MagicMock()
         )
         assert opds_dist_api_fixture.collection.id == loan_info.collection_id
-        assert data_source.name == loan_info.data_source_name
         assert Identifier.URI == loan_info.identifier_type
         assert pool.identifier.identifier == loan_info.identifier
 

--- a/tests/manager/api/test_overdrive.py
+++ b/tests/manager/api/test_overdrive.py
@@ -866,7 +866,6 @@ class TestOverdriveAPI:
         # The return value is a LoanInfo object with all relevant info.
         assert isinstance(loan, LoanInfo)
         assert pool.collection.id == loan.collection_id
-        assert pool.data_source.name == loan.data_source_name
         assert identifier.type == loan.identifier_type
         assert identifier.identifier == loan.identifier
         assert None == loan.start_date
@@ -995,7 +994,6 @@ class TestOverdriveAPI:
         # And a LoanInfo was created with all relevant information.
         assert isinstance(loan, LoanInfo)
         assert pool.collection.id == loan.collection_id
-        assert pool.data_source.name == loan.data_source_name
         assert identifier.type == loan.identifier_type
         assert identifier.identifier == loan.identifier
         assert None == loan.start_date
@@ -1177,7 +1175,6 @@ class TestOverdriveAPI:
         def assert_correct_holdinfo(x):
             assert isinstance(x, HoldInfo)
             assert licensepool.collection == x.collection(db.session)
-            assert licensepool.data_source.name == x.data_source_name
             assert identifier.identifier == x.identifier
             assert identifier.type == x.identifier_type
             assert datetime_utc(2015, 3, 26, 11, 30, 29) == x.start_date

--- a/tests/manager/celery/tasks/test_patron_activity.py
+++ b/tests/manager/celery/tasks/test_patron_activity.py
@@ -187,8 +187,6 @@ class TestSyncPatronActivity:
             HoldInfo.from_license_pool(
                 hold_pool,
                 hold_position=1,
-                start_date=None,
-                end_date=None,
             )
         )
 

--- a/tests/manager/celery/tasks/test_patron_activity.py
+++ b/tests/manager/celery/tasks/test_patron_activity.py
@@ -166,25 +166,26 @@ class TestSyncPatronActivity:
     def test_success(
         self, sync_task_fixture: SyncTaskFixture, db: DatabaseTransactionFixture
     ):
-        loan_pool = db.licensepool(None, collection=sync_task_fixture.collection)
-        hold_pool = db.licensepool(None, collection=sync_task_fixture.collection)
+        collection = sync_task_fixture.collection
+        assert collection.data_source is not None
+        data_source_name = collection.data_source.name
+        loan_pool = db.licensepool(
+            None, collection=collection, data_source_name=data_source_name
+        )
+        hold_pool = db.licensepool(
+            None, collection=collection, data_source_name=data_source_name
+        )
 
         sync_task_fixture.mock_collection_api.add_remote_loan(
-            LoanInfo(
-                collection=sync_task_fixture.collection,
-                data_source_name=loan_pool.data_source,
-                identifier_type=loan_pool.identifier.type,
-                identifier=loan_pool.identifier.identifier,
+            LoanInfo.from_license_pool(
+                loan_pool,
                 start_date=None,
                 end_date=None,
             )
         )
         sync_task_fixture.mock_collection_api.add_remote_hold(
-            HoldInfo(
-                collection=sync_task_fixture.collection,
-                data_source_name=hold_pool.data_source,
-                identifier_type=hold_pool.identifier.type,
-                identifier=hold_pool.identifier.identifier,
+            HoldInfo.from_license_pool(
+                hold_pool,
                 hold_position=1,
                 start_date=None,
                 end_date=None,

--- a/tests/manager/celery/tasks/test_patron_activity.py
+++ b/tests/manager/celery/tasks/test_patron_activity.py
@@ -179,7 +179,6 @@ class TestSyncPatronActivity:
         sync_task_fixture.mock_collection_api.add_remote_loan(
             LoanInfo.from_license_pool(
                 loan_pool,
-                start_date=None,
                 end_date=None,
             )
         )

--- a/tests/manager/core/test_opds_import.py
+++ b/tests/manager/core/test_opds_import.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import random
 from functools import partial
 from io import StringIO
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests_mock
@@ -2123,10 +2123,6 @@ class TestOPDSAPI:
     def test_checkout(self, opds_api_fixture: OPDSAPIFixture) -> None:
         # Make sure checkout returns a LoanInfo object with the correct
         # collection id.
-        mock_collection_property = PropertyMock(
-            return_value=opds_api_fixture.collection
-        )
-        type(opds_api_fixture.mock_licensepool).collection = mock_collection_property
         delivery_mechanism = MagicMock(spec=LicensePoolDeliveryMechanism)
         loan = opds_api_fixture.api.checkout(
             opds_api_fixture.mock_patron,
@@ -2135,8 +2131,7 @@ class TestOPDSAPI:
             delivery_mechanism,
         )
         assert isinstance(loan, LoanInfo)
-        assert mock_collection_property.call_count == 1
-        assert loan.collection_id == opds_api_fixture.collection.id
+        assert loan.collection_id == opds_api_fixture.mock_licensepool.collection_id
 
     def test_can_fulfill_without_loan(self, opds_api_fixture: OPDSAPIFixture) -> None:
         # This should always return True.

--- a/tests/manager/sqlalchemy/model/test_licensing.py
+++ b/tests/manager/sqlalchemy/model/test_licensing.py
@@ -1174,13 +1174,11 @@ class TestLicensePool:
 
         fulfillment = pool.delivery_mechanisms[0]
         position = 99
-        external_identifier = db.fresh_str()
         hold, is_new = pool.on_hold_to(
             patron,
             start=yesterday,
             end=tomorrow,
             position=position,
-            external_identifier=external_identifier,
         )
 
         assert is_new is True
@@ -1190,7 +1188,6 @@ class TestLicensePool:
         assert yesterday == hold.start
         assert tomorrow == hold.end
         assert position == hold.position
-        assert external_identifier == hold.external_identifier
 
         # 'Creating' a hold that already exists returns the existing hold.
         hold2, is_new = pool.on_hold_to(
@@ -1198,7 +1195,6 @@ class TestLicensePool:
             start=yesterday,
             end=tomorrow,
             position=position,
-            external_identifier=external_identifier,
         )
         assert is_new is False
         assert hold == hold2


### PR DESCRIPTION
## Description

Refactor `LoanInfo` and `HoldInfo` to be simple dataclasses, and move the logic for creating and updating loans and holds from a `LoanInfo` or `HoldInfo` into a method called `create_or_update`.

In the process, I removed the `Hold.external_identifier` column, which appears to be unused.

## Motivation and Context

Needed to modify how `LoanInfo` and `HoldInfo` are used as part of PP-1728, this refactor makes that work easier, but I thought it would be easier to understand as a separate PR.

## How Has This Been Tested?

- Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
