### PR TITLE
Remove deprecated ODL notify endpoint 🧹 

### DIFF
--- a/src/palace/manager/api/controller/odl_notification.py
+++ b/src/palace/manager/api/controller/odl_notification.py
@@ -21,7 +21,6 @@ from palace.manager.service.integration_registry.license_providers import (
 from palace.manager.sqlalchemy.model.credential import Credential
 from palace.manager.sqlalchemy.model.licensing import License
 from palace.manager.sqlalchemy.model.patron import Loan, Patron
-from palace.manager.sqlalchemy.util import get_one
 from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.log import LoggerMixin
 from palace.manager.util.problem_detail import ProblemDetailException
@@ -61,12 +60,6 @@ class ODLNotificationController(LoggerMixin):
         self, patron_identifier: str | None, license_identifier: str | None
     ) -> Response:
         loan = self._get_loan(patron_identifier, license_identifier)
-        return self._process_notification(loan)
-
-    # TODO: This method is deprecated and should be removed once all the loans
-    #   created using the old endpoint have expired.
-    def notify_deprecated(self, loan_id: int) -> Response:
-        loan = get_one(self.db, Loan, id=loan_id)
         return self._process_notification(loan)
 
     def _process_notification(self, loan: Loan | None) -> Response:

--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -572,16 +572,6 @@ def saml_callback():
     )
 
 
-# TODO: This is a deprecated route that will be removed in a future release of the code,
-#       its left here for now to provide a dummy endpoint for existing ODL loans. All
-#       new loans will use the new endpoint.
-@library_route("/odl_notify/<loan_id>", methods=["GET", "POST"])
-@has_library
-@raises_problem_detail
-def odl_notify(loan_id) -> Response:
-    return app.manager.odl_notification_controller.notify_deprecated(loan_id)
-
-
 # Loan notifications for OPDS + ODL distributors
 @library_route("/odl/notify/<patron_identifier>/<license_identifier>", methods=["POST"])
 @has_library

--- a/tests/manager/api/controller/test_odl_notify.py
+++ b/tests/manager/api/controller/test_odl_notify.py
@@ -167,27 +167,6 @@ class TestODLNotificationController:
 
         assert loan.end == utc_now()
 
-    @freeze_time()
-    def test_notify_deprecated(
-        self,
-        flask_app_fixture: FlaskAppFixture,
-        odl_fixture: ODLFixture,
-    ) -> None:
-        loan = odl_fixture.create_loan()
-        assert loan.end != utc_now()
-        status_doc = odl_fixture.loan_status_document("revoked")
-        with flask_app_fixture.test_request_context(
-            "/",
-            method="POST",
-            data=status_doc.model_dump_json(),
-            library=odl_fixture.library,
-        ):
-            assert loan.id is not None
-            response = odl_fixture.controller.notify_deprecated(loan.id)
-            assert response.status_code == 204
-
-        assert loan.end == utc_now()
-
     def test_notify_errors(
         self,
         db: DatabaseTransactionFixture,

--- a/tests/manager/api/test_routes.py
+++ b/tests/manager/api/test_routes.py
@@ -415,13 +415,6 @@ class TestODLNotificationController:
         route_test.set_controller_name(self.CONTROLLER_NAME)
         return route_test
 
-    def test_odl_notify_deprecated(self, fixture: RouteTestFixture):
-        url = "/odl_notify/<loan_id>"
-        fixture.assert_request_calls(
-            url, fixture.controller.notify_deprecated, "<loan_id>"
-        )
-        fixture.assert_supported_methods(url, "GET", "POST")
-
     def test_odl_notify(self, fixture: RouteTestFixture):
         url = "/odl/notify/<patron_identifier>/<license_identifier>"
         fixture.assert_request_calls(


### PR DESCRIPTION
## Description

🚨 This one shouldn't be merged until https://github.com/ThePalaceProject/circulation/pull/2117 is in a release and has been rolled out, so that the old endpoint stays active until all the old loans expire. I'll leave this in draft until then, just wanted to get a PR ready so we don't forget to remove it.

This PR removes the `odl_notify` endpoint that was deprecated in https://github.com/ThePalaceProject/circulation/pull/2117

## Motivation and Context

Cleanup 🧹 

## How Has This Been Tested?

- Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
