### PR TITLE
Remove deprecated heartbeat endpoint 🧹 

### DIFF
--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -582,18 +582,6 @@ def application_version():
     return app.manager.version.version()
 
 
-# TODO: This route is deprecated and should be removed in a
-#       future release of the code, it has been left here for
-#       one release to ease any deployment issues.
-@app.route("/heartbeat")
-def heartbeat():
-    version_info = application_version()
-    version_info["WARNING"] = (
-        "The /heartbeat endpoint is deprecated. Please use /version.json instead."
-    )
-    return version_info
-
-
 @app.route("/healthcheck.html")
 def health_check():
     return Response("", 200)


### PR DESCRIPTION
## Description

Remove the heartbeat endpoint that was deprecated back in https://github.com/ThePalaceProject/circulation/pull/765. Its not being used anymore, but its still hanging around 👻.

## Motivation and Context

Noticed this while working on something else, so I figured I'd make a PR to 🧹 it up.

## How Has This Been Tested?

- Running test in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
