### PR TITLE
Update mypy configuration for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,11 @@ warn_unused_ignores = true
 # silences those errors, but only for the tests module.
 # See discussion here:
 # https://github.com/python/mypy/issues/2427
-disable_error_code = "method-assign"
+disable_error_code = "method-assign, union-attr"
 module = "tests.*"
+# Mypy seems to have issues in the test code where it thinks code is unreachable
+# when it is not. So we disable this warning for the tests module.
+warn_unreachable = false
 
 [[tool.mypy.overrides]]
 # This override is the equivalent of running mypy with the --strict flag.

--- a/tests/manager/api/controller/test_profile.py
+++ b/tests/manager/api/controller/test_profile.py
@@ -91,11 +91,11 @@ class TestProfileController:
             assert request_patron.synchronize_annotations is True
 
             # The other patron is unaffected.
-            assert profile_fixture.other_patron.synchronize_annotations is False  # type: ignore[unreachable]
+            assert profile_fixture.other_patron.synchronize_annotations is False
 
         # Now we can create an annotation for the patron who enabled
         # annotation sync.
-        get_one_or_create(  # type: ignore[unreachable]
+        get_one_or_create(
             profile_fixture.db.session,
             Annotation,
             patron=request_patron,

--- a/tests/manager/api/test_authenticator.py
+++ b/tests/manager/api/test_authenticator.py
@@ -1549,7 +1549,7 @@ class TestBasicAuthenticationProvider:
             assert isinstance(patron, Patron)
             assert patron.external_type == "xyz"
         else:
-            assert patron is expected  # type: ignore[unreachable]
+            assert patron is expected
 
     def test_update_patron_metadata(
         self, db: DatabaseTransactionFixture, mock_basic: MockBasicFixture
@@ -1572,7 +1572,7 @@ class TestBasicAuthenticationProvider:
         # .neighborhood was not stored in .cached_neighborhood.  In
         # this case, it must be cheap to get .neighborhood every time,
         # and it's better not to store information we can get cheaply.
-        assert "Little Homeworld" == patron.neighborhood  # type: ignore[unreachable]
+        assert "Little Homeworld" == patron.neighborhood
         assert patron.cached_neighborhood is None
 
     def test_update_patron_metadata_noop_if_no_remote_metadata(

--- a/tests/manager/api/test_axis.py
+++ b/tests/manager/api/test_axis.py
@@ -1883,7 +1883,7 @@ class TestAxis360Fulfillment:
         # document.
         assert fulfillment.content_type == DeliveryMechanism.FINDAWAY_DRM
         assert fulfillment.content is not None
-        assert isinstance(fulfillment.content, str)  # type: ignore[unreachable]
+        assert isinstance(fulfillment.content, str)
 
         # The manifest document combines information from the
         # fulfillment document and the metadata document.

--- a/tests/manager/api/test_routes.py
+++ b/tests/manager/api/test_routes.py
@@ -85,7 +85,7 @@ class TestIndex:
 
     def test_authentication_document(self, fixture: RouteTestFixture):
         url = "/authentication_document"
-        fixture.assert_request_calls(url, fixture.controller.authentication_document)  # type: ignore[union-attr]
+        fixture.assert_request_calls(url, fixture.controller.authentication_document)
 
 
 class TestOPDSFeed:
@@ -99,7 +99,7 @@ class TestOPDSFeed:
     def test_acquisition_groups(self, fixture: RouteTestFixture):
         # An incoming lane identifier is passed in to the groups()
         # method.
-        method = fixture.controller.groups  # type: ignore[union-attr]
+        method = fixture.controller.groups
         fixture.assert_request_calls("/groups", method, None)
         fixture.assert_request_calls(
             "/groups/<lane_identifier>", method, "<lane_identifier>"
@@ -109,28 +109,28 @@ class TestOPDSFeed:
         # An incoming lane identifier is passed in to the feed()
         # method.
         url = "/feed"
-        fixture.assert_request_calls(url, fixture.controller.feed, None)  # type: ignore[union-attr]
+        fixture.assert_request_calls(url, fixture.controller.feed, None)
         url = "/feed/<lane_identifier>"
-        fixture.assert_request_calls(url, fixture.controller.feed, "<lane_identifier>")  # type: ignore[union-attr]
+        fixture.assert_request_calls(url, fixture.controller.feed, "<lane_identifier>")
 
     def test_navigation_feed(self, fixture: RouteTestFixture):
         # An incoming lane identifier is passed in to the navigation_feed()
         # method.
         url = "/navigation"
-        fixture.assert_request_calls(url, fixture.controller.navigation, None)  # type: ignore[union-attr]
+        fixture.assert_request_calls(url, fixture.controller.navigation, None)
         url = "/navigation/<lane_identifier>"
         fixture.assert_request_calls(
-            url, fixture.controller.navigation, "<lane_identifier>"  # type: ignore[union-attr]
+            url, fixture.controller.navigation, "<lane_identifier>"
         )
 
     def test_crawlable_library_feed(self, fixture: RouteTestFixture):
         url = "/crawlable"
-        fixture.assert_request_calls(url, fixture.controller.crawlable_library_feed)  # type: ignore[union-attr]
+        fixture.assert_request_calls(url, fixture.controller.crawlable_library_feed)
 
     def test_crawlable_list_feed(self, fixture: RouteTestFixture):
         url = "/lists/<list_name>/crawlable"
         fixture.assert_request_calls(
-            url, fixture.controller.crawlable_list_feed, "<list_name>"  # type: ignore[union-attr]
+            url, fixture.controller.crawlable_list_feed, "<list_name>"
         )
 
     def test_crawlable_collection_feed(self, fixture: RouteTestFixture):
@@ -143,21 +143,21 @@ class TestOPDSFeed:
 
     def test_lane_search(self, fixture: RouteTestFixture):
         url = "/search"
-        fixture.assert_request_calls(url, fixture.controller.search, None)  # type: ignore[union-attr]
+        fixture.assert_request_calls(url, fixture.controller.search, None)
 
         url = "/search/<lane_identifier>"
         fixture.assert_request_calls(
-            url, fixture.controller.search, "<lane_identifier>"  # type: ignore[union-attr]
+            url, fixture.controller.search, "<lane_identifier>"
         )
 
     def test_qa_feed(self, fixture: RouteTestFixture):
         url = "/feed/qa"
-        fixture.assert_authenticated_request_calls(url, fixture.controller.qa_feed)  # type: ignore[union-attr]
+        fixture.assert_authenticated_request_calls(url, fixture.controller.qa_feed)
 
     def test_qa_series_feed(self, fixture: RouteTestFixture):
         url = "/feed/qa/series"
         fixture.assert_authenticated_request_calls(
-            url, fixture.controller.qa_series_feed  # type: ignore[union-attr]
+            url, fixture.controller.qa_series_feed
         )
 
 
@@ -171,7 +171,7 @@ class TestMARCRecord:
 
     def test_marc_page(self, fixture: RouteTestFixture):
         url = "/marc"
-        fixture.assert_request_calls(url, fixture.controller.download_page)  # type: ignore[union-attr]
+        fixture.assert_request_calls(url, fixture.controller.download_page)
 
 
 class TestProfileController:
@@ -186,7 +186,7 @@ class TestProfileController:
         url = "/patrons/me"
         fixture.assert_authenticated_request_calls(
             url,
-            fixture.controller.protocol,  # type: ignore[union-attr]
+            fixture.controller.protocol,
         )
 
 
@@ -202,7 +202,7 @@ class TestLoansController:
         url = "/loans"
         fixture.assert_authenticated_request_calls(
             url,
-            fixture.controller.sync,  # type: ignore[union-attr]
+            fixture.controller.sync,
         )
         fixture.assert_supported_methods(url, "GET", "HEAD")
 
@@ -210,7 +210,7 @@ class TestLoansController:
         url = "/works/<identifier_type>/<identifier>/borrow"
         fixture.assert_request_calls_method_using_identifier(
             url,
-            fixture.controller.borrow,  # type: ignore[union-attr]
+            fixture.controller.borrow,
             "<identifier_type>",
             "<identifier>",
             None,
@@ -221,7 +221,7 @@ class TestLoansController:
         url = "/works/<identifier_type>/<identifier>/borrow/<mechanism_id>"
         fixture.assert_request_calls_method_using_identifier(
             url,
-            fixture.controller.borrow,  # type: ignore[union-attr]
+            fixture.controller.borrow,
             "<identifier_type>",
             "<identifier>",
             "<mechanism_id>",
@@ -235,18 +235,18 @@ class TestLoansController:
         # open-access titles.
         url = "/works/<license_pool_id>/fulfill"
         fixture.assert_request_calls(
-            url, fixture.controller.fulfill, "<license_pool_id>", None  # type: ignore[union-attr]
+            url, fixture.controller.fulfill, "<license_pool_id>", None
         )
 
         url = "/works/<license_pool_id>/fulfill/<mechanism_id>"
         fixture.assert_request_calls(
-            url, fixture.controller.fulfill, "<license_pool_id>", "<mechanism_id>"  # type: ignore[union-attr]
+            url, fixture.controller.fulfill, "<license_pool_id>", "<mechanism_id>"
         )
 
     def test_revoke_loan_or_hold(self, fixture: RouteTestFixture):
         url = "/loans/<license_pool_id>/revoke"
         fixture.assert_authenticated_request_calls(
-            url, fixture.controller.revoke, "<license_pool_id>"  # type: ignore[union-attr]
+            url, fixture.controller.revoke, "<license_pool_id>"
         )
 
         fixture.assert_supported_methods(url, "GET", "PUT")
@@ -255,7 +255,7 @@ class TestLoansController:
         url = "/loans/<identifier_type>/<identifier>"
         fixture.assert_request_calls_method_using_identifier(
             url,
-            fixture.controller.detail,  # type: ignore[union-attr]
+            fixture.controller.detail,
             "<identifier_type>",
             "<identifier>",
             authenticated=True,
@@ -273,13 +273,13 @@ class TestAnnotationsController:
 
     def test_annotations(self, fixture: RouteTestFixture):
         url = "/annotations/"
-        fixture.assert_authenticated_request_calls(url, fixture.controller.container)  # type: ignore[union-attr]
+        fixture.assert_authenticated_request_calls(url, fixture.controller.container)
         fixture.assert_supported_methods(url, "HEAD", "GET", "POST")
 
     def test_annotation_detail(self, fixture: RouteTestFixture):
         url = "/annotations/<annotation_id>"
         fixture.assert_authenticated_request_calls(
-            url, fixture.controller.detail, "<annotation_id>"  # type: ignore[union-attr]
+            url, fixture.controller.detail, "<annotation_id>"
         )
         fixture.assert_supported_methods(url, "HEAD", "GET", "DELETE")
 
@@ -287,7 +287,7 @@ class TestAnnotationsController:
         url = "/annotations/<identifier_type>/<identifier>"
         fixture.assert_request_calls_method_using_identifier(
             url,
-            fixture.controller.container_for_work,  # type: ignore[union-attr]
+            fixture.controller.container_for_work,
             "<identifier_type>",
             "<identifier>",
             authenticated=True,
@@ -305,7 +305,7 @@ class TestURNLookupController:
 
     def test_work(self, fixture: RouteTestFixture):
         url = "/works"
-        fixture.assert_request_calls(url, fixture.controller.work_lookup, "work")  # type: ignore[union-attr]
+        fixture.assert_request_calls(url, fixture.controller.work_lookup, "work")
 
 
 class TestWorkController:
@@ -319,14 +319,14 @@ class TestWorkController:
     def test_contributor(self, fixture: RouteTestFixture):
         url = "/works/contributor/<contributor_name>"
         fixture.assert_request_calls(
-            url, fixture.controller.contributor, "<contributor_name>", None, None  # type: ignore[union-attr]
+            url, fixture.controller.contributor, "<contributor_name>", None, None
         )
 
     def test_contributor_language(self, fixture: RouteTestFixture):
         url = "/works/contributor/<contributor_name>/<languages>"
         fixture.assert_request_calls(
             url,
-            fixture.controller.contributor,  # type: ignore[union-attr]
+            fixture.controller.contributor,
             "<contributor_name>",
             "<languages>",
             None,
@@ -336,7 +336,7 @@ class TestWorkController:
         url = "/works/contributor/<contributor_name>/<languages>/<audiences>"
         fixture.assert_request_calls(
             url,
-            fixture.controller.contributor,  # type: ignore[union-attr]
+            fixture.controller.contributor,
             "<contributor_name>",
             "<languages>",
             "<audiences>",
@@ -345,20 +345,20 @@ class TestWorkController:
     def test_series(self, fixture: RouteTestFixture):
         url = "/works/series/<series_name>"
         fixture.assert_request_calls(
-            url, fixture.controller.series, "<series_name>", None, None  # type: ignore[union-attr]
+            url, fixture.controller.series, "<series_name>", None, None
         )
 
     def test_series_language(self, fixture: RouteTestFixture):
         url = "/works/series/<series_name>/<languages>"
         fixture.assert_request_calls(
-            url, fixture.controller.series, "<series_name>", "<languages>", None  # type: ignore[union-attr]
+            url, fixture.controller.series, "<series_name>", "<languages>", None
         )
 
     def test_series_language_audience(self, fixture: RouteTestFixture):
         url = "/works/series/<series_name>/<languages>/<audiences>"
         fixture.assert_request_calls(
             url,
-            fixture.controller.series,  # type: ignore[union-attr]
+            fixture.controller.series,
             "<series_name>",
             "<languages>",
             "<audiences>",
@@ -367,19 +367,19 @@ class TestWorkController:
     def test_permalink(self, fixture: RouteTestFixture):
         url = "/works/<identifier_type>/<identifier>"
         fixture.assert_request_calls_method_using_identifier(
-            url, fixture.controller.permalink, "<identifier_type>", "<identifier>"  # type: ignore[union-attr]
+            url, fixture.controller.permalink, "<identifier_type>", "<identifier>"
         )
 
     def test_recommendations(self, fixture: RouteTestFixture):
         url = "/works/<identifier_type>/<identifier>/recommendations"
         fixture.assert_request_calls_method_using_identifier(
-            url, fixture.controller.recommendations, "<identifier_type>", "<identifier>"  # type: ignore[union-attr]
+            url, fixture.controller.recommendations, "<identifier_type>", "<identifier>"
         )
 
     def test_related_books(self, fixture: RouteTestFixture):
         url = "/works/<identifier_type>/<identifier>/related_books"
         fixture.assert_request_calls_method_using_identifier(
-            url, fixture.controller.related, "<identifier_type>", "<identifier>"  # type: ignore[union-attr]
+            url, fixture.controller.related, "<identifier_type>", "<identifier>"
         )
 
 
@@ -398,7 +398,7 @@ class TestAnalyticsController:
         # unauthenticated.
         fixture.assert_request_calls_method_using_identifier(
             url,
-            fixture.controller.track_event,  # type: ignore[union-attr]
+            fixture.controller.track_event,
             "<identifier_type>",
             "<identifier>",
             "<event_type>",
@@ -417,14 +417,16 @@ class TestODLNotificationController:
 
     def test_odl_notify_deprecated(self, fixture: RouteTestFixture):
         url = "/odl_notify/<loan_id>"
-        fixture.assert_request_calls(url, fixture.controller.notify_deprecated, "<loan_id>")  # type: ignore[union-attr]
+        fixture.assert_request_calls(
+            url, fixture.controller.notify_deprecated, "<loan_id>"
+        )
         fixture.assert_supported_methods(url, "GET", "POST")
 
     def test_odl_notify(self, fixture: RouteTestFixture):
         url = "/odl/notify/<patron_identifier>/<license_identifier>"
         fixture.assert_request_calls(
             url,
-            fixture.controller.notify,  # type: ignore[union-attr]
+            fixture.controller.notify,
             "<patron_identifier>",
             "<license_identifier>",
             http_method="POST",
@@ -442,7 +444,7 @@ class TestApplicationVersionController:
 
     def test_heartbeat(self, fixture: RouteTestFixture):
         url = "/version.json"
-        fixture.assert_request_calls(url, fixture.controller.version)  # type: ignore[union-attr]
+        fixture.assert_request_calls(url, fixture.controller.version)
 
 
 class TestHealthCheck:

--- a/tests/manager/api/test_selftest.py
+++ b/tests/manager/api/test_selftest.py
@@ -88,7 +88,7 @@ class TestHasPatronSelfTests:
             with pytest.raises(test_patron_lookup_exception) as excinfo:
                 test_patron_lookup_method(db.default_library())
         assert not isinstance(result_patron, (Patron, ProblemDetail))
-        assert expected_message == excinfo.value.message  # type: ignore
+        assert expected_message == excinfo.value.message
         assert excinfo.value.detail is None
 
     def test_default_patrons(

--- a/tests/manager/marc/test_uploader.py
+++ b/tests/manager/marc/test_uploader.py
@@ -64,10 +64,10 @@ class TestMarcUploadManager:
             assert uploader.locked is True
 
             # The lock is also reflected in the uploads object
-            assert marc_upload_manager_fixture.uploads.locked(by_us=True) is True  # type: ignore[unreachable]
+            assert marc_upload_manager_fixture.uploads.locked(by_us=True) is True
 
         # The lock is released after the context manager exits
-        assert uploader.locked is False  # type: ignore[unreachable]
+        assert uploader.locked is False
         assert marc_upload_manager_fixture.uploads.locked(by_us=True) is False
 
         # If an exception occurs, the lock is deleted and the exception is raised by calling

--- a/tests/manager/service/logging/test_configuration.py
+++ b/tests/manager/service/logging/test_configuration.py
@@ -35,7 +35,7 @@ def test_cloudwatch_region_valid() -> None:
 class TestLogLevel:
     def test_level_string(self) -> None:
         assert LogLevel.debug == "DEBUG"
-        assert LogLevel.info == "INFO"  # type: ignore[unreachable]
+        assert LogLevel.info == "INFO"
         assert LogLevel.warning == "WARNING"
         assert LogLevel.error == "ERROR"
 

--- a/tests/manager/sqlalchemy/model/test_licensing.py
+++ b/tests/manager/sqlalchemy/model/test_licensing.py
@@ -719,7 +719,7 @@ class TestLicensePool:
         assert work.last_update_time is not None
 
         # Updating availability also modified work.last_update_time.
-        assert (utc_now() - work.last_update_time) < datetime.timedelta(seconds=2)  # type: ignore[unreachable]
+        assert (utc_now() - work.last_update_time) < datetime.timedelta(seconds=2)
 
     def test_update_availability_does_nothing_if_given_no_data(
         self, db: DatabaseTransactionFixture

--- a/tests/manager/sqlalchemy/model/test_work.py
+++ b/tests/manager/sqlalchemy/model/test_work.py
@@ -278,7 +278,7 @@ class TestWork:
         assert work.last_update_time is not None
         # The last update time has been set.
         # Updating availability also modified work.last_update_time.
-        assert (utc_now() - work.last_update_time) < datetime.timedelta(seconds=2)  # type: ignore[unreachable]
+        assert (utc_now() - work.last_update_time) < datetime.timedelta(seconds=2)
 
         # The index has not been updated.
         assert [] == external_search_fake_fixture.service.documents_all()


### PR DESCRIPTION
## Description

Update mypy configuration for our tests to:
- Disable `union-attr` check
- Disable `warn-unreachable`

## Motivation and Context

Both of these flags don't provide a lot of value in our tests, and cause us to have to add a bunch of ignore comments, so just disabling them seems like a better option.

## How Has This Been Tested?

- Mypy / tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
