### PR TITLE
Run autoflake without ignore-init-module-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,6 @@ repos:
         args:
           - --in-place
           - --remove-all-unused-imports
-          - --ignore-init-module-imports
 
   - repo: https://github.com/psf/black
     rev: 24.8.0

--- a/src/palace/manager/api/sip/__init__.py
+++ b/src/palace/manager/api/sip/__init__.py
@@ -13,10 +13,7 @@ from palace.manager.api.authentication.basic import (
     BasicAuthProviderLibrarySettings,
     BasicAuthProviderSettings,
 )
-from palace.manager.api.problem_details import (
-    INVALID_CREDENTIALS,
-    PATRON_OF_ANOTHER_LIBRARY,
-)
+from palace.manager.api.problem_details import INVALID_CREDENTIALS
 from palace.manager.api.sip.client import Sip2Encoding, SIPClient
 from palace.manager.api.sip.dialect import Dialect as Sip2Dialect
 from palace.manager.integration.settings import (
@@ -27,7 +24,7 @@ from palace.manager.integration.settings import (
 from palace.manager.service.analytics.analytics import Analytics
 from palace.manager.sqlalchemy.model.patron import Patron
 from palace.manager.util import MoneyUtility
-from palace.manager.util.problem_detail import ProblemDetail, ProblemDetailException
+from palace.manager.util.problem_detail import ProblemDetail
 
 
 class SIP2Settings(BasicAuthProviderSettings):

--- a/src/palace/manager/sqlalchemy/model/__init__.py
+++ b/src/palace/manager/sqlalchemy/model/__init__.py
@@ -1,3 +1,4 @@
+# autoflake: skip_file
 """
 We rely on all of our sqlalchemy models being listed here, so that we can
 make sure they are all registered with the declarative base.

--- a/src/palace/manager/util/__init__.py
+++ b/src/palace/manager/util/__init__.py
@@ -6,12 +6,10 @@ import re
 import string
 from collections import Counter
 from collections.abc import Generator, Iterable, Sequence
-from typing import Any, SupportsIndex, TypeVar
+from typing import Any, TypeVar
 
 import sqlalchemy
 from money import Money
-from sqlalchemy import distinct, select
-from sqlalchemy.sql.functions import func
 
 import palace.manager.sqlalchemy.flask_sqlalchemy_session
 


### PR DESCRIPTION
## Description

Now that we aren't using star imports for the classifier code we can run [autoflake](https://github.com/PyCQA/autoflake) without the `ignore-init-module-imports` option. This cleaned up some unneeded imports, and will catch future changes.

## Motivation and Context

🧹 

## How Has This Been Tested?

- Running tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
