### PR TITLE
Fix bug generating OPDS2 ODL notification URL

### DIFF
--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -159,7 +159,7 @@ class OPDS2WithODLApi(
     def _notification_url(
         short_name: str | None, patron_id: str, license_id: str
     ) -> str:
-        """Get the notification URL that should be passed in the ODL checkout link
+        """Get the notification URL that should be passed in the ODL checkout link.
 
         This is broken out into a separate function to make it easier to override
         in tests.

--- a/tests/manager/api/odl/test_api.py
+++ b/tests/manager/api/odl/test_api.py
@@ -51,6 +51,7 @@ from palace.manager.util.http import BadResponseException, RemoteIntegrationExce
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.files import OPDSFilesFixture
 from tests.fixtures.odl import OPDS2WithODLApiFixture
+from tests.mocks.odl import MockOPDS2WithODLApi
 
 
 class TestOPDS2WithODLApi:
@@ -426,19 +427,31 @@ class TestOPDS2WithODLApi:
         patron_id = str(uuid.uuid4())
         license_id = str(uuid.uuid4())
 
+        def get_path(path: str) -> str:
+            return urlparse(path).path
+
         # Import the app so we can setup a request context to verify that we can correctly generate
         # notification url via url_for.
         from palace.manager.api.app import app
 
+        # Test that we generated the expected URL
         with app.test_request_context():
             notification_url = OPDS2WithODLApi._notification_url(
                 short_name, patron_id, license_id
             )
 
         assert (
-            urlparse(notification_url).path
+            get_path(notification_url)
             == f"/{short_name}/odl/notify/{patron_id}/{license_id}"
         )
+
+        # Test that our mock generates the same URL
+        with app.test_request_context():
+            assert get_path(
+                OPDS2WithODLApi._notification_url(short_name, patron_id, license_id)
+            ) == get_path(
+                MockOPDS2WithODLApi._notification_url(short_name, patron_id, license_id)
+            )
 
     def test_checkout_success(
         self,

--- a/tests/manager/api/odl/test_api.py
+++ b/tests/manager/api/odl/test_api.py
@@ -430,11 +430,15 @@ class TestOPDS2WithODLApi:
         # notification url via url_for.
         from palace.manager.api.app import app
 
-        with app.test_request_context(base_url="https://cm"):
-            assert (
-                OPDS2WithODLApi._notification_url(short_name, patron_id, license_id)
-                == f"https://cm/{short_name}/odl/notify/{patron_id}/{license_id}"
+        with app.test_request_context():
+            notification_url = OPDS2WithODLApi._notification_url(
+                short_name, patron_id, license_id
             )
+
+        assert (
+            urlparse(notification_url).path
+            == f"/{short_name}/odl/notify/{patron_id}/{license_id}"
+        )
 
     def test_checkout_success(
         self,

--- a/tests/mocks/odl.py
+++ b/tests/mocks/odl.py
@@ -37,12 +37,16 @@ class MockOPDS2WithODLApi(OPDS2WithODLApi):
             token="new_token", expires=utc_now() + self.refresh_token_timedelta
         )
 
-    def _url_for(self, *args: Any, **kwargs: Any) -> str:
-        del kwargs["_external"]
-        return "http://{}?{}".format(
-            "/".join(args),
-            "&".join([f"{key}={val}" for key, val in list(kwargs.items())]),
-        )
+    @staticmethod
+    def _notification_url(
+        short_name: str | None, patron_id: str, license_id: str
+    ) -> str:
+        """Get the notification URL that should be passed in the ODL checkout link
+
+        This is broken out into a separate function to make it easier to override
+        in tests.
+        """
+        return f"https://cm/{short_name}/notification/{patron_id}/{license_id}"
 
     def _basic_auth_request(
         self,

--- a/tests/mocks/odl.py
+++ b/tests/mocks/odl.py
@@ -41,12 +41,7 @@ class MockOPDS2WithODLApi(OPDS2WithODLApi):
     def _notification_url(
         short_name: str | None, patron_id: str, license_id: str
     ) -> str:
-        """Get the notification URL that should be passed in the ODL checkout link
-
-        This is broken out into a separate function to make it easier to override
-        in tests.
-        """
-        return f"https://cm/{short_name}/notification/{patron_id}/{license_id}"
+        return f"https://cm/{short_name}/odl/notify/{patron_id}/{license_id}"
 
     def _basic_auth_request(
         self,


### PR DESCRIPTION
## Description

Fix parameters passed to `url_for` to generate the URL for the OPDS2 + ODL notification endpoint. Previously I was passing `patron_id` and `license_id`, but the actual parameters were `patron_identifier` and `license_identifier`.

I did a little bit of light refactoring as well so I could add a better test, where we test the actual URL generation.

## Motivation and Context

Testing the changes from https://github.com/ThePalaceProject/circulation/pull/2117 

## How Has This Been Tested?

- Running tests CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
