### PR TITLE
Handle StaleDataError for ODLNotificationController

### DIFF
--- a/src/palace/manager/api/controller/odl_notification.py
+++ b/src/palace/manager/api/controller/odl_notification.py
@@ -5,7 +5,7 @@ from flask import Response
 from flask_babel import lazy_gettext as _
 from pydantic import ValidationError
 from sqlalchemy import select
-from sqlalchemy.orm import Session, object_session
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import StaleDataError
 
 from palace.manager.api.odl.api import OPDS2WithODLApi
@@ -102,9 +102,8 @@ class ODLNotificationController(LoggerMixin):
             #   Once we move the OPDS2WithODL scripts to celery this should be possible.
             #   For now we just mark the loan as expired.
             if not status_doc.active:
-                session = object_session(loan)
                 try:
-                    with session.begin_nested():
+                    with self.db.begin_nested():
                         loan.end = utc_now()
                 except StaleDataError:
                     # This can happen if this callback happened while we were returning this

--- a/src/palace/manager/api/controller/odl_notification.py
+++ b/src/palace/manager/api/controller/odl_notification.py
@@ -5,7 +5,8 @@ from flask import Response
 from flask_babel import lazy_gettext as _
 from pydantic import ValidationError
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, object_session
+from sqlalchemy.orm.exc import StaleDataError
 
 from palace.manager.api.odl.api import OPDS2WithODLApi
 from palace.manager.api.problem_details import (
@@ -101,6 +102,15 @@ class ODLNotificationController(LoggerMixin):
             #   Once we move the OPDS2WithODL scripts to celery this should be possible.
             #   For now we just mark the loan as expired.
             if not status_doc.active:
-                loan.end = utc_now()
+                session = object_session(loan)
+                try:
+                    with session.begin_nested():
+                        loan.end = utc_now()
+                except StaleDataError:
+                    # This can happen if this callback happened while we were returning this
+                    # item. We can fetch the loan, but it's deleted by the time we go to do
+                    # the update. This is not a problem, as we were just marking the loan as
+                    # completed anyway so we just continue.
+                    ...
 
         return Response(status=204)

--- a/tests/manager/api/controller/test_odl_notify.py
+++ b/tests/manager/api/controller/test_odl_notify.py
@@ -1,11 +1,10 @@
-from unittest.mock import PropertyMock, create_autospec, patch
+from unittest.mock import PropertyMock, create_autospec
 
 import pytest
 from flask import Response
 from freezegun import freeze_time
 from sqlalchemy.orm.exc import StaleDataError
 
-from palace.manager.api.controller import odl_notification
 from palace.manager.api.controller.odl_notification import ODLNotificationController
 from palace.manager.api.odl.api import OPDS2WithODLApi
 from palace.manager.api.problem_details import (
@@ -266,14 +265,11 @@ class TestODLNotificationController:
         mock_loan.license_pool.collection.integration_configuration.protocol = (
             db.protocol_string(Goals.LICENSE_GOAL, OPDS2WithODLApi)
         )
-        with (
-            flask_app_fixture.test_request_context(
-                "/",
-                method="POST",
-                library=odl_fixture.library,
-                data=odl_fixture.loan_status_document("revoked").model_dump_json(),
-            ),
-            patch.object(odl_notification, "object_session"),
+        with flask_app_fixture.test_request_context(
+            "/",
+            method="POST",
+            library=odl_fixture.library,
+            data=odl_fixture.loan_status_document("revoked").model_dump_json(),
         ):
             response = odl_fixture.controller._process_notification(mock_loan)
         assert response.status_code == 204

--- a/tests/manager/api/controller/test_odl_notify.py
+++ b/tests/manager/api/controller/test_odl_notify.py
@@ -1,7 +1,11 @@
+from unittest.mock import PropertyMock, create_autospec, patch
+
 import pytest
 from flask import Response
 from freezegun import freeze_time
+from sqlalchemy.orm.exc import StaleDataError
 
+from palace.manager.api.controller import odl_notification
 from palace.manager.api.controller.odl_notification import ODLNotificationController
 from palace.manager.api.odl.api import OPDS2WithODLApi
 from palace.manager.api.problem_details import (
@@ -9,6 +13,7 @@ from palace.manager.api.problem_details import (
     NO_ACTIVE_LOAN,
 )
 from palace.manager.core.problem_details import INVALID_INPUT
+from palace.manager.integration.goals import Goals
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.licensing import License
 from palace.manager.sqlalchemy.model.patron import Loan, Patron
@@ -249,3 +254,26 @@ class TestODLNotificationController:
             odl_fixture.controller.notify(
                 odl_fixture.patron_identifier, NON_EXISTENT_LICENSE_IDENTIFIER
             )
+
+    def test__process_notification_already_deleted(
+        self,
+        odl_fixture: ODLFixture,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ) -> None:
+        mock_loan = create_autospec(Loan)
+        type(mock_loan).end = PropertyMock(side_effect=StaleDataError())
+        mock_loan.license_pool.collection.integration_configuration.protocol = (
+            db.protocol_string(Goals.LICENSE_GOAL, OPDS2WithODLApi)
+        )
+        with (
+            flask_app_fixture.test_request_context(
+                "/",
+                method="POST",
+                library=odl_fixture.library,
+                data=odl_fixture.loan_status_document("revoked").model_dump_json(),
+            ),
+            patch.object(odl_notification, "object_session"),
+        ):
+            response = odl_fixture.controller._process_notification(mock_loan)
+        assert response.status_code == 204


### PR DESCRIPTION
## Description

Catch `StaleDataError` when processing ODL update. This can happen when a loan gets deleted by another process while the ODL notification controller is running. This has the possiblity of happening when we are locally deleting the loan for a returned book, and also receive a callback from the LCP server.

## Motivation and Context

Handle a fairly rare race condition with the `ODLNotificationController`.  I've seen it happen in my testing a couple of times, but not every time.

## How Has This Been Tested?

- Running tests locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
