### PR TITLE
Use PG 16 in our CI workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ docker restart opensearch
 #### Docker
 
 ```sh
-docker run -d --name pg -e POSTGRES_USER=palace -e POSTGRES_PASSWORD=test -e POSTGRES_DB=circ -p 5432:5432 postgres:12
+docker run -d --name pg -e POSTGRES_USER=palace -e POSTGRES_PASSWORD=test -e POSTGRES_DB=circ -p 5432:5432 postgres:16
 ```
 
 You can run `psql` in the container using the command

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       target: scripts
 
   pg:
-    image: "postgres:12"
+    image: "postgres:16"
     environment:
       POSTGRES_USER: palace
       POSTGRES_PASSWORD: test

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ allowlist_externals =
     coverage
 
 [docker:db-circ]
-image = postgres:12
+image = postgres:16
 environment =
     POSTGRES_USER=palace
     POSTGRES_PASSWORD=test


### PR DESCRIPTION
## Description

Since we are updating all our environments to use PG 16 instead of PG 12, we should also update the docker image we are using for PG in CI.

## Motivation and Context

Making sure our CI workflows match what we have deployed.

## How Has This Been Tested?

- Running CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
