### PR TITLE
Fix get_one_or_create IntegrityError handler (PP-1838)

### DIFF
--- a/src/palace/manager/api/overdrive.py
+++ b/src/palace/manager/api/overdrive.py
@@ -904,7 +904,7 @@ class OverdriveAPI(
             return response
 
     def get_patron_credential(
-        self, patron: Patron, pin: str | None, is_fulfillment=False
+        self, patron: Patron, pin: str | None, is_fulfillment: bool = False
     ) -> Credential:
         """Create an OAuth token for the given patron.
 
@@ -913,7 +913,7 @@ class OverdriveAPI(
         :param is_fulfillment: Boolean indicating whether we need a fulfillment credential.
         """
 
-        def refresh(credential):
+        def refresh(credential: Credential) -> Credential:
             return self.refresh_patron_access_token(
                 credential, patron, pin, is_fulfillment=is_fulfillment
             )

--- a/src/palace/manager/sqlalchemy/model/credential.py
+++ b/src/palace/manager/sqlalchemy/model/credential.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import datetime
 import uuid
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import Mapped, relationship
@@ -120,15 +121,15 @@ class Credential(Base):
     @classmethod
     def lookup(
         cls,
-        _db,
-        data_source,
-        token_type,
-        patron,
-        refresher_method,
-        allow_persistent_token=False,
-        allow_empty_token=False,
-        collection=None,
-        force_refresh=False,
+        _db: Session,
+        data_source: DataSource | str,
+        token_type: str,
+        patron: Patron | None,
+        refresher_method: Callable[[Credential], Any] | None,
+        allow_persistent_token: bool = False,
+        allow_empty_token: bool = False,
+        collection: Collection | None = None,
+        force_refresh: bool = False,
     ) -> Credential:
         from palace.manager.sqlalchemy.model.datasource import DataSource
 

--- a/tests/manager/sqlalchemy/test_util.py
+++ b/tests/manager/sqlalchemy/test_util.py
@@ -90,7 +90,7 @@ class TestDatabaseInterface:
         assert not is_new
         assert isinstance(credential_existing, Credential)
         assert credential_existing == credential
-        assert "INTEGRITY ERRROR" in caplog.text
+        assert "INTEGRITY ERROR" in caplog.text
 
 
 class TestNumericRangeConversion:

--- a/tests/manager/sqlalchemy/test_util.py
+++ b/tests/manager/sqlalchemy/test_util.py
@@ -1,8 +1,15 @@
+import functools
+from unittest.mock import patch
+
 import pytest
 from psycopg2.extras import NumericRange
 from sqlalchemy import not_
 from sqlalchemy.orm.exc import MultipleResultsFound
 
+from palace.manager.service.logging.configuration import LogLevel
+from palace.manager.sqlalchemy import util
+from palace.manager.sqlalchemy.model.credential import Credential
+from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.sqlalchemy.util import (
     get_one,
@@ -44,6 +51,46 @@ class TestDatabaseInterface:
         constraint = not_(Edition.title.in_(titles))
         result = get_one(db.session, Edition, constraint=constraint)
         assert None == result
+
+    def test_get_one_or_create(
+        self, db: DatabaseTransactionFixture, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        data_source = DataSource.lookup(db.session, "Test", autocreate=True)
+        patron = db.patron()
+        collection = db.collection()
+
+        get_one_or_create = functools.partial(
+            util.get_one_or_create,
+            db.session,
+            Credential,
+            data_source=data_source,
+            type="Test token",
+            patron=patron,
+            collection=collection,
+        )
+
+        # If it doesn't exist... the function will create it
+        credential, is_new = get_one_or_create()
+        assert is_new
+        assert isinstance(credential, Credential)
+
+        # If it already exists, that gets returned instead
+        credential_existing, is_new = get_one_or_create()
+        assert not is_new
+        assert isinstance(credential_existing, Credential)
+        assert credential_existing == credential
+
+        # If there is a race condition, and an IntegrityError happens
+        # it will be handled, an error message logged, and the existing
+        # object returned
+        caplog.clear()
+        caplog.set_level(LogLevel.debug)
+        with patch.object(util, "get_one", return_value=None):
+            credential_existing, is_new = get_one_or_create()
+        assert not is_new
+        assert isinstance(credential_existing, Credential)
+        assert credential_existing == credential
+        assert "INTEGRITY ERRROR" in caplog.text
 
 
 class TestNumericRangeConversion:


### PR DESCRIPTION
## Description

Fix an issue with the Exception handler for an `IntegrityError` in the `get_one_or_create` function. 

If one of the parameters for this function is a sqlalchemy class, then the logging function can cause a `PendingRollbackError`, since the rollback is happening after the log message. 

Update the function to use db.begin_nested() as a context manager, and write a test for this case. 

I added type hints to a couple related functions while I was debugging this before i narrowed in on exactly the cause. These hints are included in this PR. They aren't really related to this fix, but they seem harmless to come in with this one. I can break them out to separate PR if desired.
 
## Motivation and Context

We are seeing a number of `PendingRollbackError` happening via the `patron_activity.sync_patron_activity` celery task. 282 in the last week. Trying to clean up these errors that are causing tasks to fail, so we can add alerts for failed celery tasks.

## How Has This Been Tested?

- Added test for this case
- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
