### PR TITLE
Race condition in search_indexing task (PP-1840)

### DIFF
--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -145,13 +145,13 @@ def search_indexing(task: Task, batch_size: int = 500) -> None:
         if len(works) > 0:
             index_works.delay(works=works)
 
-        if len(works) == batch_size:
-            # This task is complete, but there are more works waiting to be indexed. Requeue ourselves
-            # to process the next batch.
-            raise task.replace(search_indexing.s(batch_size=batch_size))
+    if len(works) == batch_size:
+        # This task is complete, but there are more works waiting to be indexed. Requeue ourselves
+        # to process the next batch.
+        raise task.replace(search_indexing.s(batch_size=batch_size))
 
-        task.log.info(f"Finished queuing indexing tasks.")
-        return
+    task.log.info(f"Finished queuing indexing tasks.")
+    return
 
 
 @shared_task(queue=QueueNames.default, bind=True, max_retries=4)


### PR DESCRIPTION
## Description

Move the `task.replace` call outside of the `lock` context manager. So the task releases its lock before re-queuing itself.

## Motivation and Context

Previously because the task was holding the lock, while adding itself back to the queue, occasionally another worker would pickup the new task before this task had released the lock, resulting in the task failing.

This is part of the effort to fix celery task failures, so we can setup an alert when tasks fail. In our logs this happened 39 times in the last week. Since this task runs every minute, the doesn't trigger every time, but it does happen often enough that we should fix it.

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
