### PR TITLE
[PP-1509] Add support for default facet

### DIFF
--- a/src/palace/manager/feed/opds.py
+++ b/src/palace/manager/feed/opds.py
@@ -12,10 +12,7 @@ from palace.manager.feed.serializer.opds import (
     OPDS1Version1Serializer,
     OPDS1Version2Serializer,
 )
-from palace.manager.feed.serializer.opds2 import (
-    OPDS2Version1Serializer,
-    OPDS2Version2Serializer,
-)
+from palace.manager.feed.serializer.opds2 import OPDS2Serializer
 from palace.manager.feed.types import FeedData, WorkEntry
 from palace.manager.sqlalchemy.model.lane import FeaturedFacets
 from palace.manager.util.flask_util import OPDSEntryResponse, OPDSFeedResponse
@@ -27,11 +24,9 @@ def get_serializer(
 ) -> SerializerInterface[Any]:
     # Ordering matters for poor matches (eg. */*), so we will keep OPDS1 first
     serializers: dict[str, type[SerializerInterface[Any]]] = {
+        "application/atom+xml; api-version=2": OPDS1Version2Serializer,
         "application/atom+xml": OPDS1Version1Serializer,
-        "application/atom+xml;api-version=2": OPDS1Version2Serializer,
-        "application/opds+json": OPDS2Version1Serializer,
-        "application/opds+json;api-version=1": OPDS2Version1Serializer,
-        "application/opds+json;api-version=2": OPDS2Version2Serializer,
+        "application/opds+json": OPDS2Serializer,
     }
     if mime_types:
         match = mime_types.best_match(

--- a/src/palace/manager/feed/opds.py
+++ b/src/palace/manager/feed/opds.py
@@ -94,7 +94,7 @@ class BaseOPDSFeed(FeedInterface):
             ),
             **response_kwargs,
         )
-        if isinstance(serializer, OPDS2Version1Serializer):
+        if isinstance(serializer, OPDS2Serializer):
             # Only OPDS2 has the same content type for feed and entry
             response.content_type = serializer.content_type()
         return response

--- a/src/palace/manager/feed/serializer/opds.py
+++ b/src/palace/manager/feed/serializer/opds.py
@@ -64,7 +64,7 @@ def is_sort_link(link: Link) -> bool:
     )
 
 
-class OPDS1Serializer(SerializerInterface[etree._Element], OPDSFeed):
+class OPDS1Version1Serializer(SerializerInterface[etree._Element], OPDSFeed):
     """An OPDS 1.2 Atom feed serializer"""
 
     def __init__(self) -> None:
@@ -415,3 +415,11 @@ class OPDS1Serializer(SerializerInterface[etree._Element], OPDSFeed):
         if link.get("activeFacet", False):
             sort_link.add_attributes(dict(activeSort="true"))
         return self._serialize_feed_entry("link", sort_link)
+
+
+class OPDS1Version2Serializer(OPDS1Version1Serializer):
+    """An OPDS 1.2 Atom feed serializer with Palace specific modifications (version 2) to support
+    new IOS and Android client features."""
+
+    def __init__(self) -> None:
+        pass

--- a/src/palace/manager/feed/serializer/opds.py
+++ b/src/palace/manager/feed/serializer/opds.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import abc
 import datetime
 from functools import partial
 from typing import Any, cast
 
 from lxml import etree
+from typing_extensions import override
 
 from palace.manager.core.facets import FacetConstants
 from palace.manager.feed.serializer.base import SerializerInterface
@@ -33,7 +35,7 @@ TAG_MAPPING = {
     "hashed_passphrase": f"{{{OPDSFeed.LCP_NS}}}hashed_passphrase",
 }
 
-ATTRIBUTE_MAPPING = {
+V1_ATTRIBUTE_MAPPING = {
     "vendor": f"{{{OPDSFeed.DRM_NS}}}vendor",
     "scheme": f"{{{OPDSFeed.DRM_NS}}}scheme",
     "username": f"{{{OPDSFeed.SIMPLIFIED_NS}}}username",
@@ -43,8 +45,12 @@ ATTRIBUTE_MAPPING = {
     "facetGroup": f"{{{OPDSFeed.OPDS_NS}}}facetGroup",
     "facetGroupType": f"{{{OPDSFeed.SIMPLIFIED_NS}}}facetGroupType",
     "activeFacet": f"{{{OPDSFeed.OPDS_NS}}}activeFacet",
-    "defaultFacet": f"{{{OPDSFeed.PALACE_PROPS_NS}}}default",
     "ratingValue": f"{{{OPDSFeed.SCHEMA_NS}}}ratingValue",
+}
+
+V2_ATTRIBUTE_MAPPING = {
+    **V1_ATTRIBUTE_MAPPING,
+    "defaultFacet": f"{{{OPDSFeed.PALACE_PROPS_NS}}}default",
     "activeSort": f"{{{OPDSFeed.PALACE_PROPS_NS}}}active-sort",
 }
 
@@ -56,8 +62,8 @@ AUTHOR_MAPPING = {
 }
 
 
-def is_sort_link(link: Link) -> bool:
-    """A until method that determines if the specified link is a sort link"""
+def is_sort_facet(link: Link) -> bool:
+    """A until method that determines if the specified link is part of a sort facet"""
     return (
         hasattr(link, "facetGroup")
         and link.facetGroup
@@ -65,9 +71,7 @@ def is_sort_link(link: Link) -> bool:
     )
 
 
-class OPDS1Version1Serializer(SerializerInterface[etree._Element], OPDSFeed):
-    """An OPDS 1.2 Atom feed serializer"""
-
+class BaseOPDS1Serializer(SerializerInterface[etree._Element], OPDSFeed):
     def __init__(self) -> None:
         pass
 
@@ -80,7 +84,7 @@ class OPDS1Version1Serializer(SerializerInterface[etree._Element], OPDSFeed):
 
     def _attr_name(self, attr_name: str, mapping: dict[str, str] | None = None) -> str:
         if not mapping:
-            mapping = ATTRIBUTE_MAPPING
+            mapping = V1_ATTRIBUTE_MAPPING
         return mapping.get(attr_name, attr_name)
 
     def serialize_feed(
@@ -119,10 +123,10 @@ class OPDS1Version1Serializer(SerializerInterface[etree._Element], OPDSFeed):
                 breadcrumbs.append(self._serialize_feed_entry("link", link))
             serialized.append(breadcrumbs)
 
-        for link in self._serialize_facet_links(feed.facet_links):
+        for link in self._serialize_facet_links(feed):
             serialized.append(link)
 
-        for link in self._serialize_sort_links(feed.facet_links):
+        for link in self._serialize_sort_links(feed):
             serialized.append(link)
 
         etree.indent(serialized)
@@ -313,11 +317,16 @@ class OPDS1Version1Serializer(SerializerInterface[etree._Element], OPDSFeed):
                 if attrib == "text":
                     entry.text = value
                 else:
+                    attribute_mapping = self._get_attribute_mapping()
                     entry.set(
-                        ATTRIBUTE_MAPPING.get(attrib, attrib),
+                        attribute_mapping.get(attrib, attrib),
                         value if value is not None else "",
                     )
         return entry
+
+    @abc.abstractmethod
+    def _get_attribute_mapping(self) -> dict[str, str]:
+        pass
 
     def _serialize_author_tag(self, tag: str, author: Author) -> etree._Element:
         entry: etree._Element = self._tag(tag)
@@ -404,40 +413,75 @@ class OPDS1Version1Serializer(SerializerInterface[etree._Element], OPDSFeed):
     def to_string(cls, element: etree._Element) -> str:
         return cast(str, etree.tostring(element, encoding="unicode"))
 
+    @abc.abstractmethod
     def content_type(self) -> str:
-        return OPDSFeed.ACQUISITION_FEED_TYPE
+        pass
 
-    def _serialize_facet_links(self, facet_links: list[Link]) -> list[Link]:
+    @abc.abstractmethod
+    def _serialize_facet_links(self, feed: FeedData) -> list[Link]:
+        pass
+
+    @abc.abstractmethod
+    def _serialize_sort_links(self, feed: FeedData) -> list[Link]:
+        pass
+
+
+class OPDS1Version1Serializer(BaseOPDS1Serializer):
+    """An OPDS 1.2 Atom feed serializer.  This version of the feed implements sort links as
+    facets rather than using the http://palaceproject.io/terms/rel/sort rel and does not  support
+    the http://palaceproject.io/terms/properties/default property indicating default facets
+    """
+
+    @override
+    def _serialize_facet_links(self, feed: FeedData) -> list[Link]:
         links = []
-        if facet_links:
-            for link in facet_links:
+        if feed.facet_links:
+            for link in feed.facet_links:
                 links.append(self._serialize_feed_entry("link", link))
         return links
 
-    def _serialize_sort_links(self, facet_links: list[Link]) -> list[Link]:
+    @override
+    def _serialize_sort_links(self, feed: FeedData) -> list[Link]:
+        # Since this version of the serializer implements sort links as facets,
+        # we return an empty list of sort links.
         return []
 
+    @override
+    def _get_attribute_mapping(self) -> dict[str, str]:
+        return V1_ATTRIBUTE_MAPPING
 
-class OPDS1Version2Serializer(OPDS1Version1Serializer):
+    @override
+    def content_type(self) -> str:
+        return OPDSFeed.ACQUISITION_FEED_TYPE + "; api-version=1"
+
+
+class OPDS1Version2Serializer(BaseOPDS1Serializer):
     """An OPDS 1.2 Atom feed serializer with Palace specific modifications (version 2) to support
-    new IOS and Android client features."""
+    new IOS and Android client features. Namely, this version of the feed implements sort links as
+    links using the http://palaceproject.io/terms/rel/sort rel.  The active or selected sort link is indicated
+    by the http://palaceproject.io/terms/properties/active-sort property.  Default facets and sort links are
+    inidcated by the http://palaceproject.io/terms/properties/default property.
+    """
 
-    def __init__(self) -> None:
-        pass
-
-    def _serialize_facet_links(self, facet_links: list[Link]) -> list[Link]:
+    @override
+    def _serialize_facet_links(self, feed: FeedData) -> list[Link]:
         links: list[Link] = []
+        facet_links = feed.facet_links
         if facet_links:
             for link in facet_links:
-                if not is_sort_link(link):
+                # serialize all but the sort facets.
+                if not is_sort_facet(link):
                     links.append(self._serialize_feed_entry("link", link))
         return links
 
-    def _serialize_sort_links(self, facet_links: list[Link]) -> list[Link]:
+    @override
+    def _serialize_sort_links(self, feed: FeedData) -> list[Link]:
         links: list[Link] = []
+        facet_links = feed.facet_links
         if facet_links:
-            for link in facet_links:
-                if is_sort_link(link):
+            for link in feed.facet_links:
+                # select only the sort facets for serialization
+                if is_sort_facet(link):
                     links.append(self._serialize_sort_link(link))
         return links
 
@@ -453,3 +497,11 @@ class OPDS1Version2Serializer(OPDS1Version1Serializer):
         sort_link.add_attributes(attributes)
 
         return self._serialize_feed_entry("link", sort_link)
+
+    @override
+    def _get_attribute_mapping(self) -> dict[str, str]:
+        return V2_ATTRIBUTE_MAPPING
+
+    @override
+    def content_type(self) -> str:
+        return OPDSFeed.ACQUISITION_FEED_TYPE + "; api-version=2"

--- a/src/palace/manager/feed/serializer/opds.py
+++ b/src/palace/manager/feed/serializer/opds.py
@@ -43,6 +43,7 @@ ATTRIBUTE_MAPPING = {
     "facetGroup": f"{{{OPDSFeed.OPDS_NS}}}facetGroup",
     "facetGroupType": f"{{{OPDSFeed.SIMPLIFIED_NS}}}facetGroupType",
     "activeFacet": f"{{{OPDSFeed.OPDS_NS}}}activeFacet",
+    "defaultFacet": f"{{{OPDSFeed.PALACE_PROPS_NS}}}default",
     "ratingValue": f"{{{OPDSFeed.SCHEMA_NS}}}ratingValue",
     "activeSort": f"{{{OPDSFeed.PALACE_PROPS_NS}}}active-sort",
 }
@@ -413,7 +414,7 @@ class OPDS1Version1Serializer(SerializerInterface[etree._Element], OPDSFeed):
                 links.append(self._serialize_feed_entry("link", link))
         return links
 
-    def _serialize_sort_links(self, facet_links):
+    def _serialize_sort_links(self, facet_links: list[Link]) -> list[Link]:
         return []
 
 
@@ -437,14 +438,18 @@ class OPDS1Version2Serializer(OPDS1Version1Serializer):
         if facet_links:
             for link in facet_links:
                 if is_sort_link(link):
-                    links.append(self._serialize_sort_link("link", link))
+                    links.append(self._serialize_sort_link(link))
         return links
 
     def _serialize_sort_link(self, link: Link) -> etree._Element:
         sort_link = Link(
             href=link.href, title=link.title, rel=AtomFeed.PALACE_REL_NS + "sort"
         )
+        attributes: dict[str, Any] = dict()
         if link.get("activeFacet", False):
-            sort_link.add_attributes(dict(activeSort="true"))
+            attributes.update(dict(activeSort="true"))
+        if link.get("defaultFacet", False):
+            attributes.update(dict(defaultFacet="true"))
+        sort_link.add_attributes(attributes)
 
         return self._serialize_feed_entry("link", sort_link)

--- a/src/palace/manager/feed/serializer/opds2.py
+++ b/src/palace/manager/feed/serializer/opds2.py
@@ -145,7 +145,7 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]]):
         return publication
 
     def _serialize_link(self, link: Link) -> dict[str, Any]:
-        serialized = {"href": link.href, "rel": link.rel}
+        serialized: dict[str, Any] = {"href": link.href, "rel": link.rel}
         if link.type:
             serialized["type"] = link.type
         if link.title:
@@ -226,7 +226,7 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]]):
     def to_string(cls, data: dict[str, Any]) -> str:
         return json.dumps(data, indent=2)
 
-    def _serialize_feed_links(self, feed: FeedData) -> list[Link]:
+    def _serialize_feed_links(self, feed: FeedData) -> list[dict[str, Any]]:
         links = []
         if feed.links:
             for link in feed.links:

--- a/src/palace/manager/feed/serializer/opds2.py
+++ b/src/palace/manager/feed/serializer/opds2.py
@@ -34,6 +34,7 @@ MARC_CODE_TO_ROLES = {
 
 PALACE_REL_SORT = AtomFeed.PALACE_REL_SORT
 PALACE_PROPERTIES_ACTIVE_SORT = AtomFeed.PALACE_PROPS_NS + "active-sort"
+PALACE_PROPERTIES_DEFAULT = AtomFeed.PALACE_PROPERTIES_DEFAULT
 
 
 class OPDS2Version1Serializer(SerializerInterface[dict[str, Any]]):
@@ -255,6 +256,14 @@ class OPDS2Version2Serializer(OPDS2Version1Serializer):
             "title": link.title,
             "rel": PALACE_REL_SORT,
         }
+
+        properties: dict[str, str] = {}
+
+        sort_link["properties"] = properties
+
         if link.get("activeFacet", False):
-            sort_link["properties"] = {PALACE_PROPERTIES_ACTIVE_SORT: "true"}
+            properties.update({PALACE_PROPERTIES_ACTIVE_SORT: "true"})
+
+        if link.get("defaultFacet", False):
+            properties.update({PALACE_PROPERTIES_DEFAULT: "true"})
         return sort_link

--- a/src/palace/manager/feed/serializer/opds2.py
+++ b/src/palace/manager/feed/serializer/opds2.py
@@ -237,6 +237,8 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]]):
         results = []
         facet_links: dict[str, Any] = defaultdict(lambda: {"metadata": {}, "links": []})
         for link in feed.facet_links:
+            # TODO: When we remove the facet-based sort links [PP-1814],
+            # this check can be removed.
             if not is_sort_facet(link):
                 group = getattr(link, "facetGroup", None)
                 if group:
@@ -249,6 +251,8 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]]):
 
     def _serialize_sort_links(self, feed: FeedData) -> list[dict[str, Any]]:
         sort_links = []
+        # TODO: When we remove the facet-based sort links [PP-1814],
+        # we'll want to pull the sort link data from the feed.sort_links once that is in place.
         if feed.facet_links:
             for link in feed.facet_links:
                 if is_sort_facet(link):

--- a/src/palace/manager/feed/serializer/opds2.py
+++ b/src/palace/manager/feed/serializer/opds2.py
@@ -36,7 +36,7 @@ PALACE_REL_SORT = AtomFeed.PALACE_REL_SORT
 PALACE_PROPERTIES_ACTIVE_SORT = AtomFeed.PALACE_PROPS_NS + "active-sort"
 
 
-class OPDS2Serializer(SerializerInterface[dict[str, Any]]):
+class OPDS2Version1Serializer(SerializerInterface[dict[str, Any]]):
     CONTENT_TYPE = "application/opds+json"
 
     def __init__(self) -> None:
@@ -237,3 +237,10 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]]):
     @classmethod
     def to_string(cls, data: dict[str, Any]) -> str:
         return json.dumps(data, indent=2)
+
+
+class OPDS2Version2Serializer(OPDS2Version1Serializer):
+    CONTENT_TYPE = "application/opds+json"
+
+    def __init__(self) -> None:
+        pass

--- a/src/palace/manager/feed/serializer/opds2.py
+++ b/src/palace/manager/feed/serializer/opds2.py
@@ -249,6 +249,19 @@ class OPDS2Version2Serializer(OPDS2Version1Serializer):
 
         return link_data
 
+    def _serialize_link(self, link: Link) -> dict[str, Any]:
+        serialized = super()._serialize_link(link)
+
+        if link.get("activeFacet", False):
+            serialized["rel"] = "self"
+
+        if link.get("defaultFacet", False):
+            properties: dict[str, Any] = dict()
+            properties.update({PALACE_PROPERTIES_DEFAULT: "true"})
+            serialized["properties"] = properties
+
+        return serialized
+
     @classmethod
     def _serialize_sort_link(cls, link: Link) -> dict[str, Any]:
         sort_link: dict[str, Any] = {

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -98,7 +98,7 @@ class BaseFacets(FacetConstants):
     @property
     def facet_groups(self):
         """Yield a list of 5-tuples
-        (facet group, facet value, new Facets object, selected, default)
+        (facet group, facet value, new Facets object, selected, is_default)
         for use in building OPDS facets.
 
         This does not include the 'entry point' facet group,
@@ -616,7 +616,7 @@ class Facets(FacetsWithEntryPoint):
     @property
     def facet_groups(self):
         """Yield a list of 5-tuples
-        (facet group, facet value, new Facets object, selected, value is default)
+        (facet group, facet value, new Facets object, selected, is_default)
         for use in building OPDS facets.
 
         This does not yield anything for the 'entry point' facet group,

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -615,8 +615,8 @@ class Facets(FacetsWithEntryPoint):
 
     @property
     def facet_groups(self):
-        """Yield a list of 4-tuples
-        (facet group, facet value, new Facets object, selected)
+        """Yield a list of 5-tuples
+        (facet group, facet value, new Facets object, selected, value is default)
         for use in building OPDS facets.
 
         This does not yield anything for the 'entry point' facet group,
@@ -631,9 +631,11 @@ class Facets(FacetsWithEntryPoint):
             collection_name_facets,
         ) = self.enabled_facets
 
-        facet_config = FacetConfig.from_library(self.library)
+        facet_config = FacetConfig.from_library(self.library) if self.library else None
 
         def is_default_facet(facets, facet, facet_group_name) -> bool:
+            if not facet_config:
+                return False
             default_facet = facets.default_facet(facet_config, facet_group_name)
             return default_facet == facet
 

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -97,8 +97,8 @@ class BaseFacets(FacetConstants):
 
     @property
     def facet_groups(self):
-        """Yield a list of 4-tuples
-        (facet group, facet value, new Facets object, selected)
+        """Yield a list of 5-tuples
+        (facet group, facet value, new Facets object, selected, default)
         for use in building OPDS facets.
 
         This does not include the 'entry point' facet group,

--- a/src/palace/manager/util/opds_writer.py
+++ b/src/palace/manager/util/opds_writer.py
@@ -47,6 +47,7 @@ class AtomFeed:
     PALACE_PROPS_NS = "http://palaceproject.io/terms/properties/"
 
     PALACE_REL_SORT = PALACE_REL_NS + "sort"
+    PALACE_PROPERTIES_DEFAULT = PALACE_PROPS_NS + "default"
 
     nsmap = {
         None: ATOM_NS,

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -46,7 +46,7 @@ from palace.manager.api.problem_details import (
 )
 from palace.manager.core.opds_import import OPDSAPI
 from palace.manager.core.problem_details import INTEGRATION_ERROR, INVALID_INPUT
-from palace.manager.feed.serializer.opds2 import OPDS2Version1Serializer
+from palace.manager.feed.serializer.opds2 import OPDS2Serializer
 from palace.manager.service.redis.models.patron_activity import PatronActivity
 from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.collection import Collection
@@ -132,8 +132,8 @@ class OPDSSerializationTestHelper:
             ("default-foo-bar", OPDSFeed.ENTRY_TYPE),
             (AtomFeed.ATOM_TYPE, OPDSFeed.ENTRY_TYPE),
             (
-                OPDS2Version1Serializer.CONTENT_TYPE,
-                OPDS2Version1Serializer.CONTENT_TYPE,
+                OPDS2Serializer.CONTENT_TYPE,
+                OPDS2Serializer.CONTENT_TYPE,
             ),
         ],
     )

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -154,7 +154,7 @@ class OPDSSerializationTestHelper:
         if self.expected_content_type == OPDSFeed.ENTRY_TYPE:
             feed = feedparser.parse(response.get_data())
             [entry] = feed["entries"]
-        elif self.expected_content_type == OPDS2Version1Serializer.CONTENT_TYPE:
+        elif self.expected_content_type == OPDS2Serializer.CONTENT_TYPE:
             entry = response.get_json()
         else:
             assert (

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -46,7 +46,7 @@ from palace.manager.api.problem_details import (
 )
 from palace.manager.core.opds_import import OPDSAPI
 from palace.manager.core.problem_details import INTEGRATION_ERROR, INVALID_INPUT
-from palace.manager.feed.serializer.opds2 import OPDS2Serializer
+from palace.manager.feed.serializer.opds2 import OPDS2Version1Serializer
 from palace.manager.service.redis.models.patron_activity import PatronActivity
 from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.collection import Collection
@@ -131,7 +131,10 @@ class OPDSSerializationTestHelper:
             (None, OPDSFeed.ENTRY_TYPE),
             ("default-foo-bar", OPDSFeed.ENTRY_TYPE),
             (AtomFeed.ATOM_TYPE, OPDSFeed.ENTRY_TYPE),
-            (OPDS2Serializer.CONTENT_TYPE, OPDS2Serializer.CONTENT_TYPE),
+            (
+                OPDS2Version1Serializer.CONTENT_TYPE,
+                OPDS2Version1Serializer.CONTENT_TYPE,
+            ),
         ],
     )
 
@@ -151,7 +154,7 @@ class OPDSSerializationTestHelper:
         if self.expected_content_type == OPDSFeed.ENTRY_TYPE:
             feed = feedparser.parse(response.get_data())
             [entry] = feed["entries"]
-        elif self.expected_content_type == OPDS2Serializer.CONTENT_TYPE:
+        elif self.expected_content_type == OPDS2Version1Serializer.CONTENT_TYPE:
             entry = response.get_json()
         else:
             assert (

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -131,10 +131,7 @@ class OPDSSerializationTestHelper:
             (None, OPDSFeed.ENTRY_TYPE),
             ("default-foo-bar", OPDSFeed.ENTRY_TYPE),
             (AtomFeed.ATOM_TYPE, OPDSFeed.ENTRY_TYPE),
-            (
-                OPDS2Serializer.CONTENT_TYPE,
-                OPDS2Serializer.CONTENT_TYPE,
-            ),
+            (OPDS2Serializer.CONTENT_TYPE, OPDS2Serializer.CONTENT_TYPE),
         ],
     )
 

--- a/tests/manager/api/controller/test_urn_lookup.py
+++ b/tests/manager/api/controller/test_urn_lookup.py
@@ -20,7 +20,9 @@ class TestURNLookupController:
 
             # We got an OPDS feed.
             assert 200 == response.status_code
-            assert OPDSFeed.ACQUISITION_FEED_TYPE == response.headers["Content-Type"]
+            assert response.headers["Content-Type"].startswith(
+                OPDSFeed.ACQUISITION_FEED_TYPE
+            )
 
             # Parse it.
             feed = feedparser.parse(response.data)

--- a/tests/manager/api/controller/test_work.py
+++ b/tests/manager/api/controller/test_work.py
@@ -121,7 +121,9 @@ class TestWorkController:
         with work_fixture.request_context_with_library("/"):
             response = m(contributor, "eng,spa", "Children,Young Adult")
         assert 200 == response.status_code
-        assert OPDSFeed.ACQUISITION_FEED_TYPE == response.headers["Content-Type"]
+        assert response.headers["Content-Type"].startswith(
+            OPDSFeed.ACQUISITION_FEED_TYPE
+        )
         feed = feedparser.parse(response.data)
 
         # The feed is named after the person we looked up.
@@ -673,7 +675,9 @@ class TestWorkController:
                 novelist_api=mock_api,
             )
         assert 200 == response.status_code
-        assert OPDSFeed.ACQUISITION_FEED_TYPE == response.headers["content-type"]
+        assert response.headers["content-type"].startswith(
+            OPDSFeed.ACQUISITION_FEED_TYPE
+        )
         feed = feedparser.parse(response.data)
         assert "Related Books" == feed["feed"]["title"]
 

--- a/tests/manager/core/test_app_server.py
+++ b/tests/manager/core/test_app_server.py
@@ -299,8 +299,8 @@ class TestURNLookupController:
 
                 # We got an OPDS feed that includes an entry for the work.
                 assert 200 == response.status_code
-                assert (
-                    OPDSFeed.ACQUISITION_FEED_TYPE == response.headers["Content-Type"]
+                assert response.headers["Content-Type"].startswith(
+                    OPDSFeed.ACQUISITION_FEED_TYPE
                 )
                 response_data = response.data.decode("utf8")
                 assert identifier.urn in response_data
@@ -340,7 +340,9 @@ class TestURNLookupController:
 
             # We got an OPDS feed that includes an entry for the work.
             assert 200 == response.status_code
-            assert OPDSFeed.ACQUISITION_FEED_TYPE == response.headers["Content-Type"]
+            assert response.headers["Content-Type"].startswith(
+                OPDSFeed.ACQUISITION_FEED_TYPE
+            )
             response_data = response.data.decode("utf8")
             assert identifier.urn in response_data
             assert work.title in response_data

--- a/tests/manager/feed/test_opds2_serializer.py
+++ b/tests/manager/feed/test_opds2_serializer.py
@@ -4,8 +4,7 @@ from palace.manager.feed.serializer.opds2 import (
     PALACE_PROPERTIES_ACTIVE_SORT,
     PALACE_PROPERTIES_DEFAULT,
     PALACE_REL_SORT,
-    OPDS2Version1Serializer,
-    OPDS2Version2Serializer,
+    OPDS2Serializer,
 )
 from palace.manager.feed.types import (
     Acquisition,
@@ -46,7 +45,7 @@ class TestOPDS2Serializer:
             )
         ]
 
-        serialized = OPDS2Version1Serializer().serialize_feed(feed)
+        serialized = OPDS2Serializer().serialize_feed(feed)
         result = json.loads(serialized)
 
         assert result["metadata"]["title"] == "Title"
@@ -91,7 +90,7 @@ class TestOPDS2Serializer:
             duration=10,
         )
 
-        serializer = OPDS2Version1Serializer()
+        serializer = OPDS2Serializer()
 
         entry = serializer.serialize_work_entry(data)
         metadata = entry["metadata"]
@@ -157,7 +156,7 @@ class TestOPDS2Serializer:
             {"vendor": "vendor_name", "clientToken": FeedEntryType(text="token_value")}
         )
 
-        serializer = OPDS2Version1Serializer()
+        serializer = OPDS2Serializer()
         acquisition = Acquisition(
             href="http://acquisition",
             rel="acquisition",
@@ -224,62 +223,17 @@ class TestOPDS2Serializer:
             sort_name="Author,",
             link=Link(href="http://author", rel="contributor", title="Delete me!"),
         )
-        result = OPDS2Version1Serializer()._serialize_contributor(author)
+        result = OPDS2Serializer()._serialize_contributor(author)
         assert result["name"] == "Author"
         assert result["sortAs"] == "Author,"
         assert result["links"] == [{"href": "http://author", "rel": "contributor"}]
 
     def test_serialize_opds_message(self):
-        assert OPDS2Version1Serializer().serialize_opds_message(
+        assert OPDS2Serializer().serialize_opds_message(
             OPDSMessage("URN", 200, "Description")
         ) == dict(urn="URN", description="Description")
 
-    def test_serialize_v1_feed_links(self):
-        feed_data = FeedData()
-
-        # specify a sort link
-        link = Link(href="test1", rel="test_rel1", title="text1")
-        link.add_attributes(
-            dict(facetGroup="Sort by", activeFacet="true", defaultFacet="true")
-        )
-
-        # include a non-sort facet
-        link2 = Link(href="test2", title="text2", rel="test_rel2")
-        link2.add_attributes(
-            dict(facetGroup="test_group", activeFacet="true", defaultFacet="true")
-        )
-
-        feed_data.facet_links.append(link)
-        feed_data.facet_links.append(link2)
-        links = OPDS2Version1Serializer()._serialize_feed_links(feed=feed_data)
-
-        assert links == {
-            "links": [],
-            "facets": [
-                {
-                    "metadata": {"title": "Sort by"},
-                    "links": [
-                        {
-                            "href": "test1",
-                            "rel": "test_rel1",
-                            "title": "text1",
-                        }
-                    ],
-                },
-                {
-                    "metadata": {"title": "test_group"},
-                    "links": [
-                        {
-                            "href": "test2",
-                            "rel": "test_rel2",
-                            "title": "text2",
-                        }
-                    ],
-                },
-            ],
-        }
-
-    def test_serialize_v2_feed_links(self):
+    def test_serialize_feed(self):
         feed_data = FeedData()
 
         # specify a sort link
@@ -296,9 +250,11 @@ class TestOPDS2Serializer:
 
         feed_data.facet_links.append(link)
         feed_data.facet_links.append(link2)
-        links = OPDS2Version2Serializer()._serialize_feed_links(feed=feed_data)
+        links = json.loads(OPDS2Serializer().serialize_feed(feed=feed_data))
 
         assert links == {
+            "publications": [],
+            "metadata": {},
             "links": [
                 {
                     "href": "test",

--- a/tests/manager/feed/test_opds2_serializer.py
+++ b/tests/manager/feed/test_opds2_serializer.py
@@ -2,6 +2,7 @@ import json
 
 from palace.manager.feed.serializer.opds2 import (
     PALACE_PROPERTIES_ACTIVE_SORT,
+    PALACE_PROPERTIES_DEFAULT,
     PALACE_REL_SORT,
     OPDS2Version1Serializer,
     OPDS2Version2Serializer,
@@ -236,7 +237,9 @@ class TestOPDS2Serializer:
     def test_serialize_v2_sort_links(self):
         feed_data = FeedData()
         link = Link(href="test", rel="test_rel", title="text1")
-        link.add_attributes(dict(facetGroup="Sort by", activeFacet="true"))
+        link.add_attributes(
+            dict(facetGroup="Sort by", activeFacet="true", defaultFacet="true")
+        )
         feed_data.facet_links.append(link)
         links = OPDS2Version2Serializer()._serialize_feed_links(feed=feed_data)
 
@@ -246,7 +249,10 @@ class TestOPDS2Serializer:
                     "href": "test",
                     "rel": PALACE_REL_SORT,
                     "title": "text1",
-                    "properties": {PALACE_PROPERTIES_ACTIVE_SORT: "true"},
+                    "properties": {
+                        PALACE_PROPERTIES_ACTIVE_SORT: "true",
+                        PALACE_PROPERTIES_DEFAULT: "true",
+                    },
                 }
             ],
             "facets": [],

--- a/tests/manager/feed/test_opds2_serializer.py
+++ b/tests/manager/feed/test_opds2_serializer.py
@@ -3,7 +3,7 @@ import json
 from palace.manager.feed.serializer.opds2 import (
     PALACE_PROPERTIES_ACTIVE_SORT,
     PALACE_REL_SORT,
-    OPDS2Serializer,
+    OPDS2Version1Serializer,
 )
 from palace.manager.feed.types import (
     Acquisition,
@@ -44,7 +44,7 @@ class TestOPDS2Serializer:
             )
         ]
 
-        serialized = OPDS2Serializer().serialize_feed(feed)
+        serialized = OPDS2Version1Serializer().serialize_feed(feed)
         result = json.loads(serialized)
 
         assert result["metadata"]["title"] == "Title"
@@ -89,7 +89,7 @@ class TestOPDS2Serializer:
             duration=10,
         )
 
-        serializer = OPDS2Serializer()
+        serializer = OPDS2Version1Serializer()
 
         entry = serializer.serialize_work_entry(data)
         metadata = entry["metadata"]
@@ -155,7 +155,7 @@ class TestOPDS2Serializer:
             {"vendor": "vendor_name", "clientToken": FeedEntryType(text="token_value")}
         )
 
-        serializer = OPDS2Serializer()
+        serializer = OPDS2Version1Serializer()
         acquisition = Acquisition(
             href="http://acquisition",
             rel="acquisition",
@@ -222,13 +222,13 @@ class TestOPDS2Serializer:
             sort_name="Author,",
             link=Link(href="http://author", rel="contributor", title="Delete me!"),
         )
-        result = OPDS2Serializer()._serialize_contributor(author)
+        result = OPDS2Version1Serializer()._serialize_contributor(author)
         assert result["name"] == "Author"
         assert result["sortAs"] == "Author,"
         assert result["links"] == [{"href": "http://author", "rel": "contributor"}]
 
     def test_serialize_opds_message(self):
-        assert OPDS2Serializer().serialize_opds_message(
+        assert OPDS2Version1Serializer().serialize_opds_message(
             OPDSMessage("URN", 200, "Description")
         ) == dict(urn="URN", description="Description")
 
@@ -237,7 +237,7 @@ class TestOPDS2Serializer:
         link = Link(href="test", rel="test_rel", title="text1")
         link.add_attributes(dict(facetGroup="Sort by", activeFacet="true"))
         feed_data.facet_links.append(link)
-        links = OPDS2Serializer()._serialize_feed_links(feed=feed_data)
+        links = OPDS2Version1Serializer()._serialize_feed_links(feed=feed_data)
 
         assert links == {
             "links": [

--- a/tests/manager/feed/test_opds2_serializer.py
+++ b/tests/manager/feed/test_opds2_serializer.py
@@ -234,13 +234,23 @@ class TestOPDS2Serializer:
             OPDSMessage("URN", 200, "Description")
         ) == dict(urn="URN", description="Description")
 
-    def test_serialize_v2_sort_links(self):
+    def test_serialize_v2_feed_links(self):
         feed_data = FeedData()
+
+        # specify a sort link
         link = Link(href="test", rel="test_rel", title="text1")
         link.add_attributes(
             dict(facetGroup="Sort by", activeFacet="true", defaultFacet="true")
         )
+
+        # include a non-sort facet
+        link2 = Link(href="test2", rel="test_rel", title="text1")
+        link2.add_attributes(
+            dict(facetGroup="test_group", activeFacet="false", defaultFacet="false")
+        )
+
         feed_data.facet_links.append(link)
+        feed_data.facet_links.append(link2)
         links = OPDS2Version2Serializer()._serialize_feed_links(feed=feed_data)
 
         assert links == {
@@ -255,5 +265,10 @@ class TestOPDS2Serializer:
                     },
                 }
             ],
-            "facets": [],
+            "facets": [
+                {
+                    "metadata": {"title": "test_group"},
+                    "links": [{"href": "test2", "rel": "test_rel", "title": "text1"}],
+                }
+            ],
         }

--- a/tests/manager/feed/test_opds2_serializer.py
+++ b/tests/manager/feed/test_opds2_serializer.py
@@ -233,7 +233,7 @@ class TestOPDS2Serializer:
             OPDSMessage("URN", 200, "Description")
         ) == dict(urn="URN", description="Description")
 
-    def test_serialize_feed(self):
+    def test_serialize_feed_sort_and_facet_links(self):
         feed_data = FeedData()
 
         # specify a sort link

--- a/tests/manager/feed/test_opds2_serializer.py
+++ b/tests/manager/feed/test_opds2_serializer.py
@@ -4,6 +4,7 @@ from palace.manager.feed.serializer.opds2 import (
     PALACE_PROPERTIES_ACTIVE_SORT,
     PALACE_REL_SORT,
     OPDS2Version1Serializer,
+    OPDS2Version2Serializer,
 )
 from palace.manager.feed.types import (
     Acquisition,
@@ -232,12 +233,12 @@ class TestOPDS2Serializer:
             OPDSMessage("URN", 200, "Description")
         ) == dict(urn="URN", description="Description")
 
-    def test_serialize_sort_links(self):
+    def test_serialize_v2_sort_links(self):
         feed_data = FeedData()
         link = Link(href="test", rel="test_rel", title="text1")
         link.add_attributes(dict(facetGroup="Sort by", activeFacet="true"))
         feed_data.facet_links.append(link)
-        links = OPDS2Version1Serializer()._serialize_feed_links(feed=feed_data)
+        links = OPDS2Version2Serializer()._serialize_feed_links(feed=feed_data)
 
         assert links == {
             "links": [

--- a/tests/manager/feed/test_opds2_serializer.py
+++ b/tests/manager/feed/test_opds2_serializer.py
@@ -234,6 +234,51 @@ class TestOPDS2Serializer:
             OPDSMessage("URN", 200, "Description")
         ) == dict(urn="URN", description="Description")
 
+    def test_serialize_v1_feed_links(self):
+        feed_data = FeedData()
+
+        # specify a sort link
+        link = Link(href="test1", rel="test_rel1", title="text1")
+        link.add_attributes(
+            dict(facetGroup="Sort by", activeFacet="true", defaultFacet="true")
+        )
+
+        # include a non-sort facet
+        link2 = Link(href="test2", title="text2", rel="test_rel2")
+        link2.add_attributes(
+            dict(facetGroup="test_group", activeFacet="true", defaultFacet="true")
+        )
+
+        feed_data.facet_links.append(link)
+        feed_data.facet_links.append(link2)
+        links = OPDS2Version1Serializer()._serialize_feed_links(feed=feed_data)
+
+        assert links == {
+            "links": [],
+            "facets": [
+                {
+                    "metadata": {"title": "Sort by"},
+                    "links": [
+                        {
+                            "href": "test1",
+                            "rel": "test_rel1",
+                            "title": "text1",
+                        }
+                    ],
+                },
+                {
+                    "metadata": {"title": "test_group"},
+                    "links": [
+                        {
+                            "href": "test2",
+                            "rel": "test_rel2",
+                            "title": "text2",
+                        }
+                    ],
+                },
+            ],
+        }
+
     def test_serialize_v2_feed_links(self):
         feed_data = FeedData()
 
@@ -244,9 +289,9 @@ class TestOPDS2Serializer:
         )
 
         # include a non-sort facet
-        link2 = Link(href="test2", rel="test_rel", title="text1")
+        link2 = Link(href="test2", title="text2", rel="test_2_rel")
         link2.add_attributes(
-            dict(facetGroup="test_group", activeFacet="false", defaultFacet="false")
+            dict(facetGroup="test_group", activeFacet="true", defaultFacet="true")
         )
 
         feed_data.facet_links.append(link)
@@ -268,7 +313,16 @@ class TestOPDS2Serializer:
             "facets": [
                 {
                     "metadata": {"title": "test_group"},
-                    "links": [{"href": "test2", "rel": "test_rel", "title": "text1"}],
+                    "links": [
+                        {
+                            "href": "test2",
+                            "rel": "self",
+                            "title": "text2",
+                            "properties": {
+                                PALACE_PROPERTIES_DEFAULT: "true",
+                            },
+                        }
+                    ],
                 }
             ],
         }

--- a/tests/manager/feed/test_opds_acquisition_feed.py
+++ b/tests/manager/feed/test_opds_acquisition_feed.py
@@ -861,7 +861,7 @@ class TestOPDSAcquisitionFeed:
         class MockFacets:
             @property
             def facet_groups(self):
-                """Yield a facet group+facet 4-tuple that passes the test we're
+                """Yield a facet group+facet 5-tuple that passes the test we're
                 running (which will be turned into a link), and then a
                 bunch that don't (which will be ignored).
                 """
@@ -872,6 +872,7 @@ class TestOPDSAcquisitionFeed:
                     Facets.COLLECTION_FULL,
                     "try the featured collection instead",
                     True,
+                    False,
                 )
 
                 # Real facet group, nonexistent facet
@@ -880,6 +881,7 @@ class TestOPDSAcquisitionFeed:
                     "no such facet",
                     "this facet does not exist",
                     True,
+                    False,
                 )
 
                 # Nonexistent facet group, real facet
@@ -888,6 +890,7 @@ class TestOPDSAcquisitionFeed:
                     Facets.COLLECTION_FULL,
                     "this facet exists but it's in a nonexistent group",
                     True,
+                    False,
                 )
 
                 # Nonexistent facet group, nonexistent facet
@@ -896,15 +899,16 @@ class TestOPDSAcquisitionFeed:
                     "no such facet",
                     "i just don't know",
                     True,
+                    False,
                 )
 
         class MockFeed(OPDSAcquisitionFeed):
             links = []
 
             @classmethod
-            def facet_link(cls, url, facet_title, group_title, selected):
+            def facet_link(cls, url, facet_title, group_title, selected, is_default):
                 # Return the passed-in objects as is.
-                return (url, facet_title, group_title, selected)
+                return (url, facet_title, group_title, selected, is_default)
 
         annotator = MockAnnotator()
         facets = MockFacets()

--- a/tests/manager/feed/test_opds_acquisition_feed.py
+++ b/tests/manager/feed/test_opds_acquisition_feed.py
@@ -913,17 +913,20 @@ class TestOPDSAcquisitionFeed:
         annotator = MockAnnotator()
         facets = MockFacets()
 
-        # The only 4-tuple yielded by facet_groups was passed on to us.
+        # The only 5-tuple yielded by facet_groups was passed on to us.
         # The link was run through MockAnnotator.facet_url(),
         # and the human-readable titles were found using lookups.
         #
-        # The other three 4-tuples were ignored since we don't know
+        # The other three 5-tuples were ignored since we don't know
         # how to generate human-readable titles for them.
-        [[url, facet, group, selected]] = MockFeed.facet_links(annotator, facets)
+        [[url, facet, group, selected, is_default]] = MockFeed.facet_links(
+            annotator, facets
+        )
         assert "url: try the featured collection instead" == url
         assert Facets.FACET_DISPLAY_TITLES[Facets.COLLECTION_FULL] == facet
         assert Facets.GROUP_DISPLAY_TITLES[Facets.COLLECTION_FACET_GROUP_NAME] == group
-        assert True == selected
+        assert selected
+        assert not is_default
 
     def test_active_loans_for_with_holds(
         self, db: DatabaseTransactionFixture, patch_url_for: PatchedUrlFor

--- a/tests/manager/feed/test_opds_base.py
+++ b/tests/manager/feed/test_opds_base.py
@@ -1,3 +1,4 @@
+import pytest
 from flask import Request
 
 from palace.manager.feed.opds import get_serializer
@@ -5,107 +6,59 @@ from palace.manager.feed.serializer.opds import (
     OPDS1Version1Serializer,
     OPDS1Version2Serializer,
 )
-from palace.manager.feed.serializer.opds2 import (
-    OPDS2Version1Serializer,
-    OPDS2Version2Serializer,
-)
+from palace.manager.feed.serializer.opds2 import OPDS2Serializer
 
 
 class TestBaseOPDSFeed:
-    def test_get_serializer(self):
+
+    @pytest.mark.parametrize(
+        "accept_header, serializer",
+        [
+            # test api-version parameter when specified return the appropriate version
+            ["application/atom+xml;", OPDS1Version1Serializer],
+            ["application/atom+xml;api-version=1", OPDS1Version1Serializer],
+            ["application/atom+xml;api-version=2", OPDS1Version2Serializer],
+            # test exact matches
+            ["application/atom+xml", OPDS1Version1Serializer],
+            ["application/opds+json", OPDS2Serializer],
+            # The q - value should take priority
+            ["application/atom+xml;q=0.8,application/opds+json;q=0.9", OPDS2Serializer],
+            # Multiple additional key-value pairs don't matter
+            [
+                "application/atom+xml;profile=opds-catalog;kind=acquisition;q=0.08, application/opds+json;q=0.9",
+                OPDS2Serializer,
+            ],
+            [
+                "application/atom+xml;profile=opds-catalog;kind=acquisition",
+                OPDS1Version1Serializer,
+            ],
+            # The default q-value should be 1, but opds2 specificity is higher
+            [
+                "application/atom+xml;profile=feed,application/opds+json;q=0.9",
+                OPDS2Serializer,
+            ],
+            # The default q-value should sort above 0.9
+            [
+                "application/opds+json;q=0.9,application/atom+xml",
+                OPDS1Version1Serializer,
+            ],
+            # Same q-values respect order of definition in the code
+            [
+                "application/opds+json;q=0.9,application/atom+xml;q=0.9",
+                OPDS1Version1Serializer,
+            ],
+            # test api-version parameter when specified return the appropriate version
+            ["application/atom+xml;api-version=1", OPDS1Version1Serializer],
+            # complex multi value mimetype
+            [
+                "application/atom+xml;profile=opds-catalog;kind=acquisition;q=0.08, application/opds+json;api-version=2;q=0.84, application/atom+xml;profile=opds-catalog;kind=acquisition;api-version=2;q=0.9",
+                OPDS1Version1Serializer,
+            ],
+            # No valid accept mimetype should default to OPDS1.x
+            ["text/html", OPDS1Version1Serializer],
+        ],
+    )
+    def test_get_serializer1(self, accept_header: str, serializer):
         # The q-value should take priority
-        request = Request.from_values(
-            headers=dict(
-                Accept="application/atom+xml;q=0.8,application/opds+json;q=0.9"
-            )
-        )
-        assert isinstance(
-            get_serializer(request.accept_mimetypes), OPDS2Version1Serializer
-        )
-
-        # Multiple additional key-value pairs don't matter
-        request = Request.from_values(
-            headers=dict(
-                Accept="application/atom+xml;profile=opds-catalog;kind=acquisition;q=0.08, application/opds+json;q=0.9"
-            )
-        )
-        assert isinstance(
-            get_serializer(request.accept_mimetypes), OPDS2Version1Serializer
-        )
-
-        request = Request.from_values(
-            headers=dict(
-                Accept="application/atom+xml;profile=opds-catalog;kind=acquisition"
-            )
-        )
-        assert isinstance(
-            get_serializer(request.accept_mimetypes), OPDS1Version1Serializer
-        )
-
-        # The default q-value should be 1, but opds2 specificity is higher
-        request = Request.from_values(
-            headers=dict(
-                Accept="application/atom+xml;profile=feed,application/opds+json;q=0.9"
-            )
-        )
-        assert isinstance(
-            get_serializer(request.accept_mimetypes), OPDS2Version1Serializer
-        )
-
-        # The default q-value should sort above 0.9
-        request = Request.from_values(
-            headers=dict(Accept="application/opds+json;q=0.9,application/atom+xml")
-        )
-        assert isinstance(
-            get_serializer(request.accept_mimetypes), OPDS1Version1Serializer
-        )
-
-        # Same q-values respect order of definition in the code
-        request = Request.from_values(
-            headers=dict(
-                Accept="application/opds+json;q=0.9,application/atom+xml;q=0.9"
-            )
-        )
-        assert isinstance(
-            get_serializer(request.accept_mimetypes), OPDS1Version1Serializer
-        )
-
-        # test api-version parameter when specified return the appropriate
-        # version
-        request = Request.from_values(
-            headers=dict(Accept="application/atom+xml;api-version=1")
-        )
-
-        assert isinstance(
-            get_serializer(request.accept_mimetypes), OPDS1Version1Serializer
-        )
-
-        request = Request.from_values(
-            headers=dict(Accept="application/atom+xml;api-version=2")
-        )
-
-        assert isinstance(
-            get_serializer(request.accept_mimetypes), OPDS1Version2Serializer
-        )
-
-        request = Request.from_values(
-            headers=dict(Accept="application/opds+json;api-version=1")
-        )
-
-        assert isinstance(
-            get_serializer(request.accept_mimetypes), OPDS2Version1Serializer
-        )
-
-        request = Request.from_values(
-            headers=dict(Accept="application/opds+json;api-version=2")
-        )
-
-        assert isinstance(
-            get_serializer(request.accept_mimetypes), OPDS2Version2Serializer
-        )
-
-        # No valid accept mimetype should default to OPDS1.x
-        request = Request.from_values(headers=dict(Accept="text/html"))
-        assert isinstance(
-            get_serializer(request.accept_mimetypes), OPDS1Version1Serializer
-        )
+        request = Request.from_values(headers=dict(Accept=accept_header))
+        assert isinstance(get_serializer(request.accept_mimetypes), serializer)

--- a/tests/manager/feed/test_opds_base.py
+++ b/tests/manager/feed/test_opds_base.py
@@ -59,6 +59,5 @@ class TestBaseOPDSFeed:
         ],
     )
     def test_get_serializer1(self, accept_header: str, serializer):
-        # The q-value should take priority
         request = Request.from_values(headers=dict(Accept=accept_header))
         assert isinstance(get_serializer(request.accept_mimetypes), serializer)

--- a/tests/manager/feed/test_opds_base.py
+++ b/tests/manager/feed/test_opds_base.py
@@ -1,8 +1,14 @@
 from flask import Request
 
 from palace.manager.feed.opds import get_serializer
-from palace.manager.feed.serializer.opds import OPDS1Serializer
-from palace.manager.feed.serializer.opds2 import OPDS2Serializer
+from palace.manager.feed.serializer.opds import (
+    OPDS1Version1Serializer,
+    OPDS1Version2Serializer,
+)
+from palace.manager.feed.serializer.opds2 import (
+    OPDS2Version1Serializer,
+    OPDS2Version2Serializer,
+)
 
 
 class TestBaseOPDSFeed:
@@ -13,7 +19,9 @@ class TestBaseOPDSFeed:
                 Accept="application/atom+xml;q=0.8,application/opds+json;q=0.9"
             )
         )
-        assert isinstance(get_serializer(request.accept_mimetypes), OPDS2Serializer)
+        assert isinstance(
+            get_serializer(request.accept_mimetypes), OPDS2Version1Serializer
+        )
 
         # Multiple additional key-value pairs don't matter
         request = Request.from_values(
@@ -21,14 +29,18 @@ class TestBaseOPDSFeed:
                 Accept="application/atom+xml;profile=opds-catalog;kind=acquisition;q=0.08, application/opds+json;q=0.9"
             )
         )
-        assert isinstance(get_serializer(request.accept_mimetypes), OPDS2Serializer)
+        assert isinstance(
+            get_serializer(request.accept_mimetypes), OPDS2Version1Serializer
+        )
 
         request = Request.from_values(
             headers=dict(
                 Accept="application/atom+xml;profile=opds-catalog;kind=acquisition"
             )
         )
-        assert isinstance(get_serializer(request.accept_mimetypes), OPDS1Serializer)
+        assert isinstance(
+            get_serializer(request.accept_mimetypes), OPDS1Version1Serializer
+        )
 
         # The default q-value should be 1, but opds2 specificity is higher
         request = Request.from_values(
@@ -36,13 +48,17 @@ class TestBaseOPDSFeed:
                 Accept="application/atom+xml;profile=feed,application/opds+json;q=0.9"
             )
         )
-        assert isinstance(get_serializer(request.accept_mimetypes), OPDS2Serializer)
+        assert isinstance(
+            get_serializer(request.accept_mimetypes), OPDS2Version1Serializer
+        )
 
         # The default q-value should sort above 0.9
         request = Request.from_values(
             headers=dict(Accept="application/opds+json;q=0.9,application/atom+xml")
         )
-        assert isinstance(get_serializer(request.accept_mimetypes), OPDS1Serializer)
+        assert isinstance(
+            get_serializer(request.accept_mimetypes), OPDS1Version1Serializer
+        )
 
         # Same q-values respect order of definition in the code
         request = Request.from_values(
@@ -50,8 +66,46 @@ class TestBaseOPDSFeed:
                 Accept="application/opds+json;q=0.9,application/atom+xml;q=0.9"
             )
         )
-        assert isinstance(get_serializer(request.accept_mimetypes), OPDS1Serializer)
+        assert isinstance(
+            get_serializer(request.accept_mimetypes), OPDS1Version1Serializer
+        )
+
+        # test api-version parameter when specified return the appropriate
+        # version
+        request = Request.from_values(
+            headers=dict(Accept="application/atom+xml;api-version=1")
+        )
+
+        assert isinstance(
+            get_serializer(request.accept_mimetypes), OPDS1Version1Serializer
+        )
+
+        request = Request.from_values(
+            headers=dict(Accept="application/atom+xml;api-version=2")
+        )
+
+        assert isinstance(
+            get_serializer(request.accept_mimetypes), OPDS1Version2Serializer
+        )
+
+        request = Request.from_values(
+            headers=dict(Accept="application/opds+json;api-version=1")
+        )
+
+        assert isinstance(
+            get_serializer(request.accept_mimetypes), OPDS2Version1Serializer
+        )
+
+        request = Request.from_values(
+            headers=dict(Accept="application/opds+json;api-version=2")
+        )
+
+        assert isinstance(
+            get_serializer(request.accept_mimetypes), OPDS2Version2Serializer
+        )
 
         # No valid accept mimetype should default to OPDS1.x
         request = Request.from_values(headers=dict(Accept="text/html"))
-        assert isinstance(get_serializer(request.accept_mimetypes), OPDS1Serializer)
+        assert isinstance(
+            get_serializer(request.accept_mimetypes), OPDS1Version1Serializer
+        )

--- a/tests/manager/feed/test_opds_serializer.py
+++ b/tests/manager/feed/test_opds_serializer.py
@@ -3,7 +3,7 @@ import datetime
 import pytz
 from lxml import etree
 
-from palace.manager.feed.serializer.opds import OPDS1Serializer, is_sort_link
+from palace.manager.feed.serializer.opds import OPDS1Version1Serializer, is_sort_link
 from palace.manager.feed.serializer.opds2 import PALACE_REL_SORT
 from palace.manager.feed.types import (
     Acquisition,
@@ -22,7 +22,7 @@ class TestOPDSSerializer:
         child = FeedEntryType.create(text="child", attr="chattr", grandchild=grandchild)
         parent = FeedEntryType.create(text="parent", attr="pattr", child=child)
 
-        serialized = OPDS1Serializer()._serialize_feed_entry("parent", parent)
+        serialized = OPDS1Version1Serializer()._serialize_feed_entry("parent", parent)
 
         assert serialized.tag == "parent"
         assert serialized.text == "parent"
@@ -50,7 +50,7 @@ class TestOPDSSerializer:
             lc="lc",
         )
 
-        element = OPDS1Serializer()._serialize_author_tag("author", author)
+        element = OPDS1Version1Serializer()._serialize_author_tag("author", author)
 
         assert element.tag == "author"
         assert element.get(f"{{{OPDSFeed.OPF_NS}}}role") == author.role
@@ -102,7 +102,7 @@ class TestOPDSSerializer:
                 vendor="vendor", clientToken=FeedEntryType(text="token")
             ),
         )
-        element = OPDS1Serializer()._serialize_acquistion_link(link)
+        element = OPDS1Version1Serializer()._serialize_acquistion_link(link)
         assert element.tag == "link"
         assert dict(element.attrib) == dict(href=link.href)
 
@@ -159,7 +159,7 @@ class TestOPDSSerializer:
             duration=10,
         )
 
-        element = OPDS1Serializer().serialize_work_entry(data)
+        element = OPDS1Version1Serializer().serialize_work_entry(data)
 
         assert (
             element.get(f"{{{OPDSFeed.SCHEMA_NS}}}additionalType")
@@ -246,21 +246,21 @@ class TestOPDSSerializer:
 
     def test_serialize_work_entry_empty(self):
         # A no-data work entry
-        element = OPDS1Serializer().serialize_work_entry(WorkEntryData())
+        element = OPDS1Version1Serializer().serialize_work_entry(WorkEntryData())
         # This will create an empty <entry> tag
         assert element.tag == "entry"
         assert list(element) == []
 
     def test_serialize_opds_message(self):
         message = OPDSMessage("URN", 200, "Description")
-        serializer = OPDS1Serializer()
+        serializer = OPDS1Version1Serializer()
         result = serializer.serialize_opds_message(message)
         assert serializer.to_string(result) == serializer.to_string(message.tag)
 
     def test_serialize_sort_link(self):
         link = Link(href="test", rel="test_rel", title="text1")
         link.add_attributes(dict(facetGroup="Sort by", activeFacet="true"))
-        serializer = OPDS1Serializer()
+        serializer = OPDS1Version1Serializer()
         assert is_sort_link(link)
         sort_link = serializer._serialize_sort_link(link)
         assert sort_link.attrib["title"] == "text1"

--- a/tests/manager/feed/test_opds_serializer.py
+++ b/tests/manager/feed/test_opds_serializer.py
@@ -268,7 +268,9 @@ class TestOPDSSerializer:
         )
         serializer = OPDS1Version2Serializer()
         assert is_sort_link(link)
-        sort_link = serializer._serialize_sort_link(link)
+        sort_links = serializer._serialize_sort_links(list([link]))
+        assert len(sort_links) == 1
+        sort_link = sort_links[0]
         assert sort_link.attrib["title"] == "text1"
         assert sort_link.attrib["href"] == "test"
         assert sort_link.attrib["rel"] == PALACE_REL_SORT
@@ -278,5 +280,27 @@ class TestOPDSSerializer:
         )
         assert (
             sort_link.attrib["{http://palaceproject.io/terms/properties/}default"]
+            == "true"
+        )
+
+    def test_serialize_non_sort_facetgroup_link(self):
+        link = Link(href="test", rel="test_rel", title="text1")
+        link.add_attributes(
+            dict(facetGroup="non_sort_group", activeFacet="true", defaultFacet="true")
+        )
+        assert not is_sort_link(link)
+        serializer = OPDS1Version2Serializer()
+        facet_links = serializer._serialize_facet_links(list([link]))
+        assert len(facet_links) == 1
+        facet_link = facet_links[0]
+        assert facet_link.attrib["title"] == "text1"
+        assert facet_link.attrib["href"] == "test"
+        assert facet_link.attrib["rel"] == "test_rel"
+        assert (
+            facet_link.attrib["{http://opds-spec.org/2010/catalog}activeFacet"]
+            == "true"
+        )
+        assert (
+            facet_link.attrib["{http://palaceproject.io/terms/properties/}default"]
             == "true"
         )

--- a/tests/manager/feed/test_opds_serializer.py
+++ b/tests/manager/feed/test_opds_serializer.py
@@ -3,7 +3,11 @@ import datetime
 import pytz
 from lxml import etree
 
-from palace.manager.feed.serializer.opds import OPDS1Version1Serializer, is_sort_link
+from palace.manager.feed.serializer.opds import (
+    OPDS1Version1Serializer,
+    OPDS1Version2Serializer,
+    is_sort_link,
+)
 from palace.manager.feed.serializer.opds2 import PALACE_REL_SORT
 from palace.manager.feed.types import (
     Acquisition,
@@ -260,7 +264,7 @@ class TestOPDSSerializer:
     def test_serialize_sort_link(self):
         link = Link(href="test", rel="test_rel", title="text1")
         link.add_attributes(dict(facetGroup="Sort by", activeFacet="true"))
-        serializer = OPDS1Version1Serializer()
+        serializer = OPDS1Version2Serializer()
         assert is_sort_link(link)
         sort_link = serializer._serialize_sort_link(link)
         assert sort_link.attrib["title"] == "text1"

--- a/tests/manager/feed/test_opds_serializer.py
+++ b/tests/manager/feed/test_opds_serializer.py
@@ -263,7 +263,9 @@ class TestOPDSSerializer:
 
     def test_serialize_sort_link(self):
         link = Link(href="test", rel="test_rel", title="text1")
-        link.add_attributes(dict(facetGroup="Sort by", activeFacet="true"))
+        link.add_attributes(
+            dict(facetGroup="Sort by", activeFacet="true", defaultFacet="true")
+        )
         serializer = OPDS1Version2Serializer()
         assert is_sort_link(link)
         sort_link = serializer._serialize_sort_link(link)
@@ -272,5 +274,9 @@ class TestOPDSSerializer:
         assert sort_link.attrib["rel"] == PALACE_REL_SORT
         assert (
             sort_link.attrib["{http://palaceproject.io/terms/properties/}active-sort"]
+            == "true"
+        )
+        assert (
+            sort_link.attrib["{http://palaceproject.io/terms/properties/}default"]
             == "true"
         )

--- a/tests/manager/feed/test_opds_serializer.py
+++ b/tests/manager/feed/test_opds_serializer.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import patch
 
 import pytz
 from lxml import etree
@@ -291,6 +292,11 @@ class TestOPDSSerializer:
             sort_link.attrib["{http://palaceproject.io/terms/properties/}default"]
             == "true"
         )
+
+        with patch.object(serializer, "_serialize_sort_links") as serialize_sort_links:
+
+            serializer.serialize_feed(feed)
+            assert serialize_sort_links.call_count == 1
 
     def test_serialize_non_sort_facetgroup_link_v2(self):
         facet_link = Link(href="test", rel="test_rel", title="text1")

--- a/tests/manager/sqlalchemy/model/test_lane.py
+++ b/tests/manager/sqlalchemy/model/test_lane.py
@@ -323,7 +323,7 @@ class TestFacets:
 
         # available=all, collection=full, and order=title are the selected
         # facets.
-        selected = sorted(x[:2] for x in all_groups if x[-1] == True)
+        selected = sorted(x[:2] for x in all_groups if x[-2] == True)
         assert [
             ("available", "all"),
             ("collection", "full"),
@@ -363,7 +363,7 @@ class TestFacets:
             ["order", "title", True],
             ["order", "work_id", False],
         ]
-        assert expect == sorted(list(x[:2]) + [x[-1]] for x in all_groups)
+        assert expect == sorted(list(x[:2]) + [x[-2]] for x in all_groups)
 
     def test_default(self, db: DatabaseTransactionFixture):
         # Calling Facets.default() is like calling the constructor with
@@ -494,7 +494,7 @@ class TestFacets:
         )
         all_groups = list(facets.facet_groups)
         expect = [["order", "author", False], ["order", "title", True]]
-        assert expect == sorted(list(x[:2]) + [x[-1]] for x in all_groups)
+        assert expect == sorted(list(x[:2]) + [x[-2]] for x in all_groups)
 
     def test_facets_dont_need_a_library(self):
         enabled_facets = {
@@ -517,7 +517,7 @@ class TestFacets:
         )
         all_groups = list(facets.facet_groups)
         expect = [["order", "author", False], ["order", "title", True]]
-        assert expect == sorted(list(x[:2]) + [x[-1]] for x in all_groups)
+        assert expect == sorted(list(x[:2]) + [x[-2]] for x in all_groups)
 
     def test_items(self, db: DatabaseTransactionFixture):
         """Verify that Facets.items() returns all information necessary


### PR DESCRIPTION
## Description

With this update,  the "default" facet or sort link will have a http://palaceproject.io/terms/properties/default property to indicate that it is a default property.  This default property will be present in both OPDS1 and OPDS2 feeds. However in order to see them, clients must specify an api-version of 2  in the mimetype.  

For OPDS 1: 
application/atom+xml;api-version=2
For OPDS 2:
application/opds+json;api-version=2

Otherwise version 1 of both formats will be delivered.  Version 1 is what is currently deployed in production.

Here is an [update to the documentation](https://www.notion.so/lyrasis/OPDS-Clients-3942ac215afb4b3aa4229df74aed938f?pvs=4#12e24d4ececa80728143cadd7ccf974e) that covers these updates.

<!--- Describe your changes -->

I do have an open question about whether or not a default facet that happens to be active should have an "activeFacet" or "active-sort" set to true.

## Motivation and Context

https://ebce-lyrasis.atlassian.net/browse/PP-1506

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
