### PR TITLE
[PP-1818] implement month active user data

### DIFF
--- a/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
+++ b/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
@@ -22,7 +22,29 @@ depends_on = None
 def upgrade() -> None:
     op.add_column(
         "patrons",
-        sa.Column("uuid", UUID(as_uuid=True), nullable=False, default=uuid.uuid4),
+        sa.Column("uuid", UUID(as_uuid=True), nullable=True, default=uuid.uuid4),
+    )
+
+    conn = op.get_bind()
+    rows = conn.execute("SELECT id from patrons").all()
+
+    for row in rows:
+        conn.execute(
+            """
+            UPDATE patrons
+            SET uuid = %(uuid)s
+            WHERE id = %(id)s
+            """,
+            {
+                "id": row.id,
+                "uuid": uuid.uuid4(),
+            },
+        )
+
+    op.alter_column(
+        table_name="patrons",
+        column_name="uuid",
+        nullable=True,
     )
 
 

--- a/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
+++ b/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
@@ -1,0 +1,30 @@
+"""Add UUID to patron table
+
+Revision ID: 272da5f400de
+Revises: 1938277e993f
+Create Date: 2024-10-30 17:41:28.151677+00:00
+
+"""
+
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "272da5f400de"
+down_revision = "1938277e993f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "patrons",
+        sa.Column("uuid", UUID(as_uuid=True), nullable=False, default=uuid.uuid4),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("patrons", "uuid")

--- a/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
+++ b/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
@@ -44,7 +44,7 @@ def upgrade() -> None:
     op.alter_column(
         table_name="patrons",
         column_name="uuid",
-        nullable=True,
+        nullable=False,
     )
 
 

--- a/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
+++ b/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
@@ -29,16 +29,13 @@ def upgrade() -> None:
     rows = conn.execute("SELECT id from patrons").all()
 
     for row in rows:
+        uid = str(uuid.uuid4())
         conn.execute(
-            """
-            UPDATE patrons
-            SET uuid = %(uuid)s
-            WHERE id = %(id)s
-            """,
-            {
-                "id": row.id,
-                "uuid": uuid.uuid4(),
-            },
+            "UPDATE patrons SET uuid = ? WHERE id = ?",
+            (
+                uid,
+                row.id,
+            ),
         )
 
     op.alter_column(

--- a/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
+++ b/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
@@ -1,7 +1,7 @@
 """Add UUID to patron table
 
 Revision ID: 272da5f400de
-Revises: 1938277e993f
+Revises: 3faa5bba3ddf
 Create Date: 2024-10-30 17:41:28.151677+00:00
 
 """
@@ -14,7 +14,7 @@ from sqlalchemy.dialects.postgresql import UUID
 
 # revision identifiers, used by Alembic.
 revision = "272da5f400de"
-down_revision = "1938277e993f"
+down_revision = "3faa5bba3ddf"
 branch_labels = None
 depends_on = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ module = [
     "palace.manager.api.controller.loan",
     "palace.manager.api.controller.marc",
     "palace.manager.api.controller.odl_notification",
+    "palace.manager.api.controller.patron_activity_history",
     "palace.manager.api.discovery.*",
     "palace.manager.api.enki",
     "palace.manager.api.lcp.hash",

--- a/src/palace/manager/api/authentication/base.py
+++ b/src/palace/manager/api/authentication/base.py
@@ -449,7 +449,9 @@ class PatronData:
         if is_new and analytics:
             # Send out an analytics event to record the fact
             # that a new patron was created.
-            analytics.collect_event(patron.library, None, CirculationEvent.NEW_PATRON)
+            analytics.collect_event(
+                patron.library, None, CirculationEvent.NEW_PATRON, patron=patron
+            )
 
         # This makes sure the Patron is brought into sync with the
         # other fields of this PatronData object, regardless of

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -973,7 +973,11 @@ class CirculationAPI(LoggerMixin):
             neighborhood = getattr(request_patron, "neighborhood", None)
 
         self.analytics.collect_event(
-            library, licensepool, name, neighborhood=neighborhood
+            library,
+            licensepool,
+            name,
+            neighborhood=neighborhood,
+            patron=patron,
         )
 
     def _collect_checkout_event(self, patron: Patron, licensepool: LicensePool) -> None:

--- a/src/palace/manager/api/circulation_manager.py
+++ b/src/palace/manager/api/circulation_manager.py
@@ -21,6 +21,9 @@ from palace.manager.api.controller.loan import LoanController
 from palace.manager.api.controller.marc import MARCRecordController
 from palace.manager.api.controller.odl_notification import ODLNotificationController
 from palace.manager.api.controller.opds_feed import OPDSFeedController
+from palace.manager.api.controller.patron_activity_history import (
+    PatronActivityHistoryController,
+)
 from palace.manager.api.controller.patron_auth_token import PatronAuthTokenController
 from palace.manager.api.controller.playtime_entries import PlaytimeEntriesController
 from palace.manager.api.controller.profile import ProfileController
@@ -110,6 +113,7 @@ class CirculationManager(LoggerMixin):
     work_controller: WorkController
     analytics_controller: AnalyticsController
     profiles: ProfileController
+    patron_activity_history: PatronActivityHistoryController
     patron_devices: DeviceTokensController
     version: ApplicationVersionController
     odl_notification_controller: ODLNotificationController
@@ -356,6 +360,7 @@ class CirculationManager(LoggerMixin):
         self.analytics_controller = AnalyticsController(self)
         self.profiles = ProfileController(self)
         self.patron_devices = DeviceTokensController(self)
+        self.patron_activity_history = PatronActivityHistoryController(self)
         self.version = ApplicationVersionController()
         self.odl_notification_controller = ODLNotificationController(
             self._db,

--- a/src/palace/manager/api/circulation_manager.py
+++ b/src/palace/manager/api/circulation_manager.py
@@ -360,7 +360,7 @@ class CirculationManager(LoggerMixin):
         self.analytics_controller = AnalyticsController(self)
         self.profiles = ProfileController(self)
         self.patron_devices = DeviceTokensController(self)
-        self.patron_activity_history = PatronActivityHistoryController(self)
+        self.patron_activity_history = PatronActivityHistoryController()
         self.version = ApplicationVersionController()
         self.odl_notification_controller = ODLNotificationController(
             self._db,

--- a/src/palace/manager/api/controller/analytics.py
+++ b/src/palace/manager/api/controller/analytics.py
@@ -29,7 +29,12 @@ class AnalyticsController(CirculationManagerController):
             if isinstance(pools, ProblemDetail):
                 return pools
             self.manager.analytics.collect_event(
-                library, pools[0], event_type, utc_now(), neighborhood=neighborhood
+                library,
+                pools[0],
+                event_type,
+                utc_now(),
+                neighborhood=neighborhood,
+                patron=patron,
             )
             return Response({}, 200)
         else:

--- a/src/palace/manager/api/controller/patron_activity_history.py
+++ b/src/palace/manager/api/controller/patron_activity_history.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import uuid
+
+import flask
+from flask import Response
+
+from palace.manager.api.controller.circulation_manager import (
+    CirculationManagerController,
+)
+
+
+class PatronActivityHistoryController(CirculationManagerController):
+
+    def erase(self):
+        """Erases the patron's activity by resetting the UUID that links the patron to past activity"""
+        patron = flask.request.patron
+        patron.uuid = uuid.uuid4()
+        return Response("Erased", 200)

--- a/src/palace/manager/api/controller/patron_activity_history.py
+++ b/src/palace/manager/api/controller/patron_activity_history.py
@@ -5,15 +5,14 @@ import uuid
 import flask
 from flask import Response
 
-from palace.manager.api.controller.circulation_manager import (
-    CirculationManagerController,
-)
+from palace.manager.sqlalchemy.model.patron import Patron
 
 
-class PatronActivityHistoryController(CirculationManagerController):
+class PatronActivityHistoryController:
 
-    def erase(self):
-        """Erases the patron's activity by resetting the UUID that links the patron to past activity"""
-        patron = flask.request.patron
+    def reset_statistics_uuid(self) -> Response:
+        """Resets the patron's the statistics UUID that links the patron to past activity thus effectively erasing the
+        link between activity history and patron."""
+        patron: Patron = flask.request.patron  # type: ignore [attr-defined]
         patron.uuid = uuid.uuid4()
-        return Response("Erased", 200)
+        return Response("UUID reset", 200)

--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -332,6 +332,15 @@ def patron_profile():
     return app.manager.profiles.protocol()
 
 
+@library_dir_route("/patrons/me/erase_activity_history", methods=["PUT"])
+@has_library
+@allows_patron_web
+@requires_auth
+@returns_problem_detail
+def erase_activity_history():
+    return app.manager.patron_activity_history.erase()
+
+
 @library_dir_route("/patrons/me/devices", methods=["GET"])
 @has_library
 @allows_patron_web

--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -332,13 +332,12 @@ def patron_profile():
     return app.manager.profiles.protocol()
 
 
-@library_dir_route("/patrons/me/erase_activity_history", methods=["PUT"])
+@library_dir_route("/patrons/me/reset_statistics_uuid", methods=["PUT"])
 @has_library
 @allows_patron_web
 @requires_auth
-@returns_problem_detail
-def erase_activity_history():
-    return app.manager.patron_activity_history.erase()
+def reset_statistics_uuid():
+    return app.manager.patron_activity_history.reset_statistics_uuid()
 
 
 @library_dir_route("/patrons/me/devices", methods=["GET"])

--- a/src/palace/manager/api/s3_analytics_provider.py
+++ b/src/palace/manager/api/s3_analytics_provider.py
@@ -26,11 +26,11 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
     @staticmethod
     def _create_event_object(
         library: Library,
-        license_pool: LicensePool,
+        license_pool: LicensePool | None,
         event_type: str,
         time: datetime.datetime,
-        old_value,
-        new_value,
+        old_value: Any = None,
+        new_value: Any = None,
         neighborhood: str | None = None,
         user_agent: str | None = None,
         patron: Patron | None = None,
@@ -142,9 +142,9 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
     def collect_event(
         self,
         library: Library,
-        license_pool: LicensePool,
+        license_pool: LicensePool | None,
         event_type: str,
-        time: datetime,
+        time: datetime.datetime,
         old_value: Any = None,
         new_value: Any = None,
         user_agent: str | None = None,
@@ -178,7 +178,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         :type patron: Patron
         """
 
-        if not library and not license_pool:
+        if not library:
             raise ValueError("Either library or license_pool must be provided.")
 
         event = self._create_event_object(

--- a/src/palace/manager/api/s3_analytics_provider.py
+++ b/src/palace/manager/api/s3_analytics_provider.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import random
 import string
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from palace.manager.core.config import CannotLoadConfiguration
 from palace.manager.core.local_analytics_provider import LocalAnalyticsProvider
@@ -29,8 +29,8 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         license_pool: LicensePool | None,
         event_type: str,
         time: datetime.datetime,
-        old_value: Any = None,
-        new_value: Any = None,
+        old_value: int | None = None,
+        new_value: int | None = None,
         neighborhood: str | None = None,
         user_agent: str | None = None,
         patron: Patron | None = None,
@@ -145,8 +145,8 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         license_pool: LicensePool | None,
         event_type: str,
         time: datetime.datetime,
-        old_value: Any = None,
-        new_value: Any = None,
+        old_value: int | None = None,
+        new_value: int | None = None,
         user_agent: str | None = None,
         patron: Patron | None = None,
         **kwargs,
@@ -177,9 +177,6 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         :param patron: The patron associated with the event, where applicable
         :type patron: Patron
         """
-
-        if not library:
-            raise ValueError("Either library or license_pool must be provided.")
 
         event = self._create_event_object(
             library,

--- a/src/palace/manager/api/s3_analytics_provider.py
+++ b/src/palace/manager/api/s3_analytics_provider.py
@@ -11,6 +11,7 @@ from palace.manager.core.local_analytics_provider import LocalAnalyticsProvider
 from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.model.licensing import LicensePool
+from palace.manager.sqlalchemy.model.patron import Patron
 
 if TYPE_CHECKING:
     from palace.manager.service.storage.s3 import S3Service
@@ -32,6 +33,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         new_value,
         neighborhood: str | None = None,
         user_agent: str | None = None,
+        patron: Patron | None = None,
     ) -> dict:
         """Create a Python dict containing required information about the event.
 
@@ -132,6 +134,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
             "language": work.language if work else None,
             "open_access": license_pool.open_access if license_pool else None,
             "user_agent": user_agent,
+            "patron_uuid": str(patron.uuid) if patron else None,
         }
 
         return event
@@ -145,6 +148,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         old_value=None,
         new_value=None,
         user_agent: str | None = None,
+        patron: Patron | None = None,
         **kwargs,
     ):
         """Log the event using the appropriate for the specific provider's mechanism.
@@ -188,6 +192,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
             old_value,
             new_value,
             user_agent=user_agent,
+            patron=patron,
         )
         content = json.dumps(
             event,

--- a/src/palace/manager/api/s3_analytics_provider.py
+++ b/src/palace/manager/api/s3_analytics_provider.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import random
 import string
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from palace.manager.core.config import CannotLoadConfiguration
 from palace.manager.core.local_analytics_provider import LocalAnalyticsProvider
@@ -141,20 +141,17 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
 
     def collect_event(
         self,
-        library,
-        license_pool,
-        event_type,
-        time,
-        old_value=None,
-        new_value=None,
+        library: Library,
+        license_pool: LicensePool,
+        event_type: str,
+        time: datetime,
+        old_value: Any = None,
+        new_value: Any = None,
         user_agent: str | None = None,
         patron: Patron | None = None,
         **kwargs,
     ):
         """Log the event using the appropriate for the specific provider's mechanism.
-
-        :param db: Database session
-        :type db: sqlalchemy.orm.session.Session
 
         :param library: Library associated with the event
         :type library: core.model.library.Library
@@ -168,9 +165,6 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
         :param time: Event's timestamp
         :type time: datetime.datetime
 
-        :param neighborhood: Geographic location of the event
-        :type neighborhood: str
-
         :param old_value: Old value of the metric changed by the event
         :type old_value: Any
 
@@ -179,6 +173,9 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
 
         :param user_agent: The user_agent of the caller.
         :type user_agent:  str
+
+        :param patron: The patron associated with the event, where applicable
+        :type patron: Patron
         """
 
         if not library and not license_pool:
@@ -193,6 +190,7 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
             new_value,
             user_agent=user_agent,
             patron=patron,
+            **kwargs,
         )
         content = json.dumps(
             event,

--- a/src/palace/manager/core/local_analytics_provider.py
+++ b/src/palace/manager/core/local_analytics_provider.py
@@ -1,27 +1,29 @@
+from datetime import datetime
+from typing import Any
+
 from sqlalchemy.orm.session import Session
 
 from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
+from palace.manager.sqlalchemy.model.library import Library
+from palace.manager.sqlalchemy.model.licensing import LicensePool
+from palace.manager.sqlalchemy.model.patron import Patron
 from palace.manager.util.log import LoggerMixin
 
 
 class LocalAnalyticsProvider(LoggerMixin):
     def collect_event(
         self,
-        library,
-        license_pool,
-        event_type,
-        time,
-        old_value=None,
-        new_value=None,
-        patron=None,
+        library: Library,
+        license_pool: LicensePool | None,
+        event_type: str,
+        time: datetime,
+        old_value: Any = None,
+        new_value: Any = None,
+        user_agent: str | None = None,
+        patron: Patron | None = None,
         **kwargs
     ):
-        if not library and not license_pool:
-            raise ValueError("Either library or license_pool must be provided.")
-        if library:
-            _db = Session.object_session(library)
-        else:
-            _db = Session.object_session(license_pool)
+        _db = Session.object_session(library)
 
         return CirculationEvent.log(
             _db,

--- a/src/palace/manager/core/local_analytics_provider.py
+++ b/src/palace/manager/core/local_analytics_provider.py
@@ -13,6 +13,7 @@ class LocalAnalyticsProvider(LoggerMixin):
         time,
         old_value=None,
         new_value=None,
+        patron=None,
         **kwargs
     ):
         if not library and not license_pool:

--- a/src/palace/manager/service/analytics/analytics.py
+++ b/src/palace/manager/service/analytics/analytics.py
@@ -31,7 +31,7 @@ class Analytics(LoggerMixin):
                     "S3 analytics is not configured: No analytics bucket was specified."
                 )
 
-    def collect_event(self, library, license_pool, event_type, time=None, patron: Patron | None = None, **kwargs):  # type: ignore[no-untyped-def]
+    def collect_event(self, library: Library, license_pool: LicensePool, event_type: str, time: datetime = None, patron: Patron | None = None, **kwargs):  # type: ignore[no-untyped-def]
         if not time:
             time = utc_now()
 

--- a/src/palace/manager/service/analytics/analytics.py
+++ b/src/palace/manager/service/analytics/analytics.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
 
 import flask
 
 from palace.manager.api.s3_analytics_provider import S3AnalyticsProvider
 from palace.manager.core.local_analytics_provider import LocalAnalyticsProvider
+from palace.manager.sqlalchemy.model.library import Library
+from palace.manager.sqlalchemy.model.licensing import LicensePool
+from palace.manager.sqlalchemy.model.patron import Patron
 from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.log import LoggerMixin
 
@@ -31,7 +35,15 @@ class Analytics(LoggerMixin):
                     "S3 analytics is not configured: No analytics bucket was specified."
                 )
 
-    def collect_event(self, library: Library, license_pool: LicensePool, event_type: str, time: datetime = None, patron: Patron | None = None, **kwargs):  # type: ignore[no-untyped-def]
+    def collect_event(
+        self,
+        library: Library,
+        license_pool: LicensePool | None,
+        event_type: str,
+        time: datetime | None = None,
+        patron: Patron | None = None,
+        **kwargs: Any,
+    ) -> None:
         if not time:
             time = utc_now()
 

--- a/src/palace/manager/service/analytics/analytics.py
+++ b/src/palace/manager/service/analytics/analytics.py
@@ -31,7 +31,7 @@ class Analytics(LoggerMixin):
                     "S3 analytics is not configured: No analytics bucket was specified."
                 )
 
-    def collect_event(self, library, license_pool, event_type, time=None, **kwargs):  # type: ignore[no-untyped-def]
+    def collect_event(self, library, license_pool, event_type, time=None, patron: Patron | None = None, **kwargs):  # type: ignore[no-untyped-def]
         if not time:
             time = utc_now()
 
@@ -45,7 +45,13 @@ class Analytics(LoggerMixin):
 
         for provider in self.providers:
             provider.collect_event(
-                library, license_pool, event_type, time, user_agent=user_agent, **kwargs
+                library,
+                license_pool,
+                event_type,
+                time,
+                user_agent=user_agent,
+                patron=patron,
+                **kwargs,
             )
 
     def is_configured(self) -> bool:

--- a/src/palace/manager/sqlalchemy/model/patron.py
+++ b/src/palace/manager/sqlalchemy/model/patron.py
@@ -112,7 +112,7 @@ class Patron(Base, RedisKeyMixin):
     # in a way that allows users to disassociate their patron info
     # with account activity at any time.  When this UUID is reset it effectively
     # dissociates any patron activity history with this patron.
-    uuid = Column(UUID(as_uuid=True), default=uuid.uuid4)
+    uuid = Column(UUID(as_uuid=True), nullable=False, default=uuid.uuid4)
 
     # The last time this record was synced up with an external library
     # system such as an ILS.

--- a/src/palace/manager/sqlalchemy/model/patron.py
+++ b/src/palace/manager/sqlalchemy/model/patron.py
@@ -20,6 +20,7 @@ from sqlalchemy import (
     Unicode,
     UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, relationship
 from sqlalchemy.orm.session import Session
 
@@ -106,6 +107,12 @@ class Patron(Base, RedisKeyMixin):
     # but does not give them the authority to borrow books. i.e. their
     # website username.
     username = Column(Unicode)
+
+    # A universally unique identifier across all CMs used to track patron activity
+    # in a way that allows users to disassociate their patron info
+    # with account activity at any time.  When this UUID is reset it effectively
+    # dissociates any patron activity history with this patron.
+    uuid = Column(UUID(as_uuid=True), default=uuid.uuid4)
 
     # The last time this record was synced up with an external library
     # system such as an ILS.

--- a/tests/manager/api/controller/test_patron_activity_history.py
+++ b/tests/manager/api/controller/test_patron_activity_history.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from palace.manager.sqlalchemy.model.patron import Patron
+from tests.fixtures.api_controller import ControllerFixture
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.services import ServicesFixture
+
+
+class PatronActivityHistoryFixture(ControllerFixture):
+    def __init__(
+        self, db: DatabaseTransactionFixture, services_fixture: ServicesFixture
+    ):
+        super().__init__(db, services_fixture)
+        self.default_patron = db.patron()
+        self.auth = dict(Authorization=self.valid_auth)
+
+
+@pytest.fixture(scope="function")
+def patron_activity_history_fixture(
+    db: DatabaseTransactionFixture, services_fixture: ServicesFixture
+):
+    return PatronActivityHistoryFixture(db, services_fixture)
+
+
+class TestPatronActivityHistoryController:
+    """Test that a client can interact with the Patron Activity History."""
+
+    def test_erase(self, patron_activity_history_fixture: PatronActivityHistoryFixture):
+        with patron_activity_history_fixture.request_context_with_library(
+            "/", method="PUT", headers=patron_activity_history_fixture.auth
+        ):
+            patron = (
+                patron_activity_history_fixture.controller.authenticated_patron_from_request()
+            )
+            assert isinstance(patron, Patron)
+            uuid1 = patron.uuid
+            assert uuid1
+            response = (
+                patron_activity_history_fixture.manager.patron_activity_history.erase()
+            )
+            uuid2 = patron.uuid
+            assert uuid1 != uuid2
+            assert 200 == response.status_code

--- a/tests/manager/api/controller/test_patron_activity_history.py
+++ b/tests/manager/api/controller/test_patron_activity_history.py
@@ -1,45 +1,48 @@
 from __future__ import annotations
 
+import flask
 import pytest
 
+from palace.manager.api.controller.patron_activity_history import (
+    PatronActivityHistoryController,
+)
 from palace.manager.sqlalchemy.model.patron import Patron
-from tests.fixtures.api_controller import ControllerFixture
 from tests.fixtures.database import DatabaseTransactionFixture
-from tests.fixtures.services import ServicesFixture
+from tests.fixtures.flask import FlaskAppFixture
 
 
-class PatronActivityHistoryFixture(ControllerFixture):
+class PatronActivityHistoryControllerFixture:
     def __init__(
-        self, db: DatabaseTransactionFixture, services_fixture: ServicesFixture
+        self,
+        db: DatabaseTransactionFixture,
     ):
-        super().__init__(db, services_fixture)
-        self.default_patron = db.patron()
-        self.auth = dict(Authorization=self.valid_auth)
+        self.controller = PatronActivityHistoryController()
+        self.db = db
 
 
-@pytest.fixture(scope="function")
-def patron_activity_history_fixture(
-    db: DatabaseTransactionFixture, services_fixture: ServicesFixture
-):
-    return PatronActivityHistoryFixture(db, services_fixture)
+@pytest.fixture
+def controller_fixture(
+    db: DatabaseTransactionFixture,
+) -> PatronActivityHistoryControllerFixture:
+    return PatronActivityHistoryControllerFixture(db)
 
 
 class TestPatronActivityHistoryController:
     """Test that a client can interact with the Patron Activity History."""
 
-    def test_erase(self, patron_activity_history_fixture: PatronActivityHistoryFixture):
-        with patron_activity_history_fixture.request_context_with_library(
-            "/", method="PUT", headers=patron_activity_history_fixture.auth
-        ):
-            patron = (
-                patron_activity_history_fixture.controller.authenticated_patron_from_request()
-            )
+    def test_reset_statistics_uuid(
+        self,
+        controller_fixture: PatronActivityHistoryControllerFixture,
+        flask_app_fixture: FlaskAppFixture,
+    ):
+
+        with flask_app_fixture.test_request_context("/", method="PUT"):
+            patron = controller_fixture.db.patron()
+            flask.request.patron = patron  # type: ignore[attr-defined]
             assert isinstance(patron, Patron)
             uuid1 = patron.uuid
             assert uuid1
-            response = (
-                patron_activity_history_fixture.manager.patron_activity_history.erase()
-            )
+            response = controller_fixture.controller.reset_statistics_uuid()
             uuid2 = patron.uuid
             assert uuid1 != uuid2
-            assert 200 == response.status_code
+            assert response.status_code == 200

--- a/tests/manager/core/test_local_analytics_provider.py
+++ b/tests/manager/core/test_local_analytics_provider.py
@@ -69,22 +69,3 @@ class TestLocalAnalyticsProvider:
         assert database.default_library() == event.library
         assert CirculationEvent.DISTRIBUTOR_CHECKIN == event.type
         assert now == event.start
-
-    def test_collect_with_missing_information(
-        self, local_analytics_provider_fixture: LocalAnalyticsProviderFixture
-    ):
-        """A circulation event may be collected with either the
-        library or the license pool missing, but not both.
-        """
-
-        data = local_analytics_provider_fixture
-        database = local_analytics_provider_fixture.transaction
-        now = utc_now()
-        data.la.collect_event(database.default_library(), None, "event", now)
-
-        pool = database.licensepool(None)
-        data.la.collect_event(None, pool, "event", now)
-
-        with pytest.raises(ValueError) as excinfo:
-            data.la.collect_event(None, None, "event", now)
-        assert "Either library or license_pool must be provided." in str(excinfo.value)

--- a/tests/manager/core/test_s3_analytics_provider.py
+++ b/tests/manager/core/test_s3_analytics_provider.py
@@ -112,6 +112,8 @@ class TestS3AnalyticsProvider:
             audience=Classifier.AUDIENCE_ADULT,
             with_license_pool=True,
         )
+
+        neighborhood = "test neighborhood"
         license_pool = work.license_pools[0]
         edition = work.presentation_edition
 
@@ -130,6 +132,7 @@ class TestS3AnalyticsProvider:
             event_time,
             user_agent=user_agent,
             patron=patron,
+            neighborhood=neighborhood,
         )
 
         # Assert
@@ -185,3 +188,4 @@ class TestS3AnalyticsProvider:
         assert event["language"] == work.language
         assert event["user_agent"] == user_agent
         assert event["patron_uuid"] == str(patron.uuid)
+        assert event["location"] == neighborhood

--- a/tests/manager/core/test_s3_analytics_provider.py
+++ b/tests/manager/core/test_s3_analytics_provider.py
@@ -100,6 +100,8 @@ class TestS3AnalyticsProvider:
     def test_analytics_data_with_associated_license_pool_is_correctly_stored_in_s3(
         self, s3_analytics_fixture: S3AnalyticsFixture
     ):
+        patron = s3_analytics_fixture.db.patron()
+
         # Create a test book
         work = s3_analytics_fixture.db.work(
             data_source_name=DataSource.GUTENBERG,
@@ -127,6 +129,7 @@ class TestS3AnalyticsProvider:
             event_type,
             event_time,
             user_agent=user_agent,
+            patron=patron,
         )
 
         # Assert
@@ -181,3 +184,4 @@ class TestS3AnalyticsProvider:
         assert event["series_position"] == work.series_position
         assert event["language"] == work.language
         assert event["user_agent"] == user_agent
+        assert event["patron_uuid"] == str(patron.uuid)


### PR DESCRIPTION
## Description
This update includes the following changes: 
1. The patron object now has a uuid field.
2. Patrons can erase their activity history with a PUT to  the `/patrons/me/erase_activity_history` endpoint.
3. The uuid is passed to the s3 analytics provider.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1818
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
