### PR TITLE
Fixes Axis 360 response parser exception code mapping.

### DIFF
--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -1325,10 +1325,10 @@ class ResponseParser:
         2000: LibraryAuthorizationFailedException,
         2001: LibraryAuthorizationFailedException,
         2002: LibraryAuthorizationFailedException,
-        2003: LibraryAuthorizationFailedException,  # "Encoded input parameters exceed limit", whatever that meaus
-        2004: LibraryAuthorizationFailedException,
+        2003: LibraryAuthorizationFailedException,  # "Encoded input parameters exceed limit", whatever that means
+        2004: LibraryAuthorizationFailedException,  # Authorization string is not properly encoded
         2005: LibraryAuthorizationFailedException,  # Invalid credentials
-        2005: LibraryAuthorizationFailedException,  # Wrong library ID
+        2006: LibraryAuthorizationFailedException,  # Library ID not associated with given vendor
         2007: LibraryAuthorizationFailedException,  # Invalid library ID
         2008: LibraryAuthorizationFailedException,  # Invalid library ID
         3100: LibraryInvalidInputException,  # Missing title ID


### PR DESCRIPTION
## Description

Fixes a duplicate key in the Axis 360 `ResponseParser`'s ``code_to_exception` map.

## Motivation and Context

I noticed this while poking around for PP-818-related stuff.

## How Has This Been Tested?

- Tests passed locally.
- Running [CI tests for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/11635371423).

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
