### PR TITLE
Allow `LazyString` types for `ConfigurationFormItem` arguments.

### DIFF
--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -143,8 +143,8 @@ class Axis360Settings(BaseCirculationApiSettings):
         form=ConfigurationFormItem(
             label=_("Verify SSL Certificate"),
             description=_(
-                "This should always be True in production, it may need to be set to False to use the"
-                "Axis 360 QA Environment."
+                "This should always be True in production; though, it may need "
+                "to be set to False to use the Axis 360 QA Environment."
             ),
             type=ConfigurationFormItemType.SELECT,
             options={

--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -4,10 +4,11 @@ import typing
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Union
+from typing import Any
 
 import annotated_types
 import typing_extensions
+from flask_babel import LazyString
 from pydantic import (
     AliasChoices,
     AliasPath,
@@ -187,7 +188,7 @@ class ConfigurationFormItemType(Enum):
     IMAGE = "image"
 
 
-ConfigurationFormOptionsType = Mapping[Union[Enum, str, None], str]
+ConfigurationFormOptionsType = Mapping[Enum | str | None, str | LazyString]
 
 
 @dataclass(frozen=True)
@@ -201,14 +202,14 @@ class ConfigurationFormItem:
     """
 
     # The label for the form item, used as the field label in the admin interface.
-    label: str
+    label: str | LazyString
 
     # The type of the form item, used to determine the type of the field displayed
     # in the admin interface.
     type: ConfigurationFormItemType = ConfigurationFormItemType.TEXT
 
     # The description of the form item, displayed below the field in the admin interface.
-    description: str | None = None
+    description: str | LazyString | None = None
 
     # The format of the form item, in some cases used to determine the format of the field
     # displayed in the admin interface.


### PR DESCRIPTION
## Description

- Allow `LazyString` types for label text in arguments for `ConfigurationFormItem`s.
- Fix a missing space in a configuration description.

## Motivation and Context

I noticed this while doing some investigation for [PP-818](https://ebce-lyrasis.atlassian.net/browse/PP-818)-related stuff.

## How Has This Been Tested?

- Tests passed locally.
- Running [CI tests for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/11635660042).

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-818]: https://ebce-lyrasis.atlassian.net/browse/PP-818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ