### PR TITLE
Add configuration settings for collections subscriptions. (PP-1850)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,9 +20,6 @@ repos:
     rev: v3.17.0
     hooks:
       - id: pyupgrade
-        # TODO: Remove when Pydantic supports `datetime.date | None` type annotation.
-        #  Otherwise, `pyupgrade` will rewrite from `Optional[datetime.date]`.
-        exclude: ^src/palace/manager/api/circulation.py
         args:
           - --py310-plus
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,9 @@ repos:
     rev: v3.17.0
     hooks:
       - id: pyupgrade
+        # TODO: Remove when Pydantic supports `datetime.date | None` type annotation.
+        #  Otherwise, `pyupgrade` will rewrite from `Optional[datetime.date]`.
+        exclude: ^src/palace/manager/api/circulation.py
         args:
           - --py310-plus
 

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -564,6 +564,33 @@ class BaseCirculationApiSettings(BaseSettings):
         )
     }
 
+    subscription_activation_date: str | None = FormField(
+        default=None,
+        form=ConfigurationFormItem(
+            label=_("Collection Subscription Activation Date"),
+            type=ConfigurationFormItemType.DATE,
+            description=(
+                "A date before which this collection is considered inactive. Associated libraries"
+                " will not be considered to be subscribed until this date). If not specified,"
+                " it will not restrict any associated library's subscription status."
+            ),
+            required=False,
+        ),
+    )
+    subscription_expiration_date: str | None = FormField(
+        default=None,
+        form=ConfigurationFormItem(
+            label=_("Collection Subscription Expiration Date"),
+            type=ConfigurationFormItemType.DATE,
+            description=(
+                "A date after which this collection is considered inactive. Associated libraries"
+                " will not be considered to be subscribed beyond this date). If not specified,"
+                " it will not restrict any associated library's subscription status."
+            ),
+            required=False,
+        ),
+    )
+
 
 SettingsType = TypeVar("SettingsType", bound=BaseCirculationApiSettings, covariant=True)
 LibrarySettingsType = TypeVar("LibrarySettingsType", bound=BaseSettings, covariant=True)

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -5,7 +5,7 @@ import datetime
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
-from typing import Literal, TypeVar
+from typing import Literal, Optional, TypeVar
 
 import flask
 import requests
@@ -564,7 +564,9 @@ class BaseCirculationApiSettings(BaseSettings):
         )
     }
 
-    subscription_activation_date: str | None = FormField(
+    # TODO: Using `Optional[datetime.date]` here because Pydantic does not
+    #  currently handle the annotation of `datetime.date | None` properly.
+    subscription_activation_date: Optional[datetime.date] = FormField(
         default=None,
         form=ConfigurationFormItem(
             label=_("Collection Subscription Activation Date"),
@@ -577,7 +579,7 @@ class BaseCirculationApiSettings(BaseSettings):
             required=False,
         ),
     )
-    subscription_expiration_date: str | None = FormField(
+    subscription_expiration_date: Optional[datetime.date] = FormField(
         default=None,
         form=ConfigurationFormItem(
             label=_("Collection Subscription Expiration Date"),

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -5,7 +5,7 @@ import datetime
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
-from typing import Literal, Optional, TypeVar
+from typing import Literal, TypeVar
 
 import flask
 import requests
@@ -564,9 +564,7 @@ class BaseCirculationApiSettings(BaseSettings):
         )
     }
 
-    # TODO: Using `Optional[datetime.date]` here because Pydantic does not
-    #  currently handle the annotation of `datetime.date | None` properly.
-    subscription_activation_date: Optional[datetime.date] = FormField(
+    subscription_activation_date: datetime.date | None = FormField(
         default=None,
         form=ConfigurationFormItem(
             label=_("Collection Subscription Activation Date"),
@@ -579,7 +577,7 @@ class BaseCirculationApiSettings(BaseSettings):
             required=False,
         ),
     )
-    subscription_expiration_date: Optional[datetime.date] = FormField(
+    subscription_expiration_date: datetime.date | None = FormField(
         default=None,
         form=ConfigurationFormItem(
             label=_("Collection Subscription Expiration Date"),

--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -178,6 +178,7 @@ class ConfigurationFormItemType(Enum):
     """Enumeration of configuration setting types"""
 
     TEXT = None
+    DATE = "date-picker"
     TEXTAREA = "textarea"
     SELECT = "select"
     LIST = "list"

--- a/tests/manager/api/admin/test_form_data.py
+++ b/tests/manager/api/admin/test_form_data.py
@@ -32,23 +32,7 @@ class MockSettings(BaseSettings):
             label="Field 3",
         ),
     )
-    field4: str | None = FormField(
-        None,
-        form=ConfigurationFormItem(
-            label="Date field",
-            type=ConfigurationFormItemType.DATE,
-            description="A date.",
-        ),
-    )
-    field5: str | None = FormField(
-        None,
-        form=ConfigurationFormItem(
-            label="Another date field",
-            type=ConfigurationFormItemType.DATE,
-            description="Another date.",
-        ),
-    )
-    field6: datetime.date | None = FormField(
+    field4: datetime.date | None = FormField(
         None,
         form=ConfigurationFormItem(
             label="Another date field with a date type",
@@ -56,7 +40,7 @@ class MockSettings(BaseSettings):
             description="A python date.",
         ),
     )
-    field7: datetime.date | None = FormField(
+    field5: datetime.date | None = FormField(
         None,
         form=ConfigurationFormItem(
             label="Another date field with a date type",
@@ -77,15 +61,11 @@ def test_get_settings():
             ("field3", "value5"),
             ("field4", "2024-10-23"),
             ("field5", ""),
-            ("field6", "2024-10-23"),
-            ("field7", ""),
         ]
     )
     settings = ProcessFormData.get_settings(MockSettings, data)
     assert settings.field1 == ["value1", "value2"]
     assert settings.field2 == ["value3", "value4"]
     assert settings.field3 == "value5"
-    assert settings.field4 == "2024-10-23"
+    assert settings.field4 == datetime.date(2024, 10, 23)
     assert settings.field5 is None
-    assert settings.field6 == datetime.date(2024, 10, 23)
-    assert settings.field7 is None

--- a/tests/manager/api/admin/test_form_data.py
+++ b/tests/manager/api/admin/test_form_data.py
@@ -1,3 +1,5 @@
+import datetime
+
 from werkzeug.datastructures import ImmutableMultiDict
 
 from palace.manager.api.admin.form_data import ProcessFormData
@@ -46,6 +48,22 @@ class MockSettings(BaseSettings):
             description="Another date.",
         ),
     )
+    field6: datetime.date | None = FormField(
+        None,
+        form=ConfigurationFormItem(
+            label="Another date field with a date type",
+            type=ConfigurationFormItemType.DATE,
+            description="A python date.",
+        ),
+    )
+    field7: datetime.date | None = FormField(
+        None,
+        form=ConfigurationFormItem(
+            label="Another date field with a date type",
+            type=ConfigurationFormItemType.DATE,
+            description="A python date.",
+        ),
+    )
 
 
 def test_get_settings():
@@ -59,6 +77,8 @@ def test_get_settings():
             ("field3", "value5"),
             ("field4", "2024-10-23"),
             ("field5", ""),
+            ("field6", "2024-10-23"),
+            ("field7", ""),
         ]
     )
     settings = ProcessFormData.get_settings(MockSettings, data)
@@ -67,3 +87,5 @@ def test_get_settings():
     assert settings.field3 == "value5"
     assert settings.field4 == "2024-10-23"
     assert settings.field5 is None
+    assert settings.field6 == datetime.date(2024, 10, 23)
+    assert settings.field7 is None

--- a/tests/manager/api/admin/test_form_data.py
+++ b/tests/manager/api/admin/test_form_data.py
@@ -30,6 +30,22 @@ class MockSettings(BaseSettings):
             label="Field 3",
         ),
     )
+    field4: str | None = FormField(
+        None,
+        form=ConfigurationFormItem(
+            label="Date field",
+            type=ConfigurationFormItemType.DATE,
+            description="A date.",
+        ),
+    )
+    field5: str | None = FormField(
+        None,
+        form=ConfigurationFormItem(
+            label="Another date field",
+            type=ConfigurationFormItemType.DATE,
+            description="Another date.",
+        ),
+    )
 
 
 def test_get_settings():
@@ -41,9 +57,13 @@ def test_get_settings():
             ("field2_value3", "blah blah"),
             ("field2_value4", "blah blah blah"),
             ("field3", "value5"),
+            ("field4", "2024-10-23"),
+            ("field5", ""),
         ]
     )
     settings = ProcessFormData.get_settings(MockSettings, data)
     assert settings.field1 == ["value1", "value2"]
     assert settings.field2 == ["value3", "value4"]
     assert settings.field3 == "value5"
+    assert settings.field4 == "2024-10-23"
+    assert settings.field5 is None


### PR DESCRIPTION
## Description

Adds start and end date configuration settings for collection subscriptions.

NB: Submitting this PR as draft, since additional work is needed fully implement the subscription functionality.
- CM Admin UI: support date picker field in configuration forms.
- CM backend: New functionality to use the configuration settings to block libraries from using the collection.

## Motivation and Context

Support automatic activation/deactivation of library associations with a collection.

[Jira [PP-1850](https://ebce-lyrasis.atlassian.net/browse/PP-1850)]

## How Has This Been Tested?

- Tests pass locally.
- [CI tests for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/11665946920) pass.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1850]: https://ebce-lyrasis.atlassian.net/browse/PP-1850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ