### PR TITLE
Use SQL formatting that aligns with other alembic scripts.

### DIFF
--- a/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
+++ b/alembic/versions/20241030_272da5f400de_add_uuid_to_patron_table.py
@@ -29,9 +29,12 @@ def upgrade() -> None:
     rows = conn.execute("SELECT id from patrons").all()
 
     for row in rows:
-        uid = str(uuid.uuid4())
+        uid = uuid.uuid4()
         conn.execute(
-            "UPDATE patrons SET uuid = ? WHERE id = ?",
+            """
+            UPDATE patrons SET uuid = %s
+            WHERE id = %s
+            """,
             (
                 uid,
                 row.id,


### PR DESCRIPTION
## Description
Brings the sql parameter substitution style in line with other alembic scripts. 
<!--- Describe your changes -->

## Motivation and Context
After trying to update the containers on minotaur, the most recent alembic script was failing, but only on minotaur.  The exception was complaining about the SQL statement.

I ensured that this update both passes the test_migrations.sh as well as ensured that when we upgrade the database to the current version locally when initializing with an existing database with at least one patron that this alembic script works as expected.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
