### PR TITLE
[PP-1905] Ensure OPDS 1 Feed defaults to Version 1.

### DIFF
--- a/src/palace/manager/feed/opds.py
+++ b/src/palace/manager/feed/opds.py
@@ -24,8 +24,8 @@ def get_serializer(
 ) -> SerializerInterface[Any]:
     # Ordering matters for poor matches (eg. */*), so we will keep OPDS1 first
     serializers: dict[str, type[SerializerInterface[Any]]] = {
-        "application/atom+xml; api-version=2": OPDS1Version2Serializer,
         "application/atom+xml": OPDS1Version1Serializer,
+        "application/atom+xml; api-version=2": OPDS1Version2Serializer,
         "application/opds+json": OPDS2Serializer,
     }
     if mime_types:

--- a/tests/manager/feed/test_opds_base.py
+++ b/tests/manager/feed/test_opds_base.py
@@ -15,6 +15,7 @@ class TestBaseOPDSFeed:
         "accept_header, serializer",
         [
             # test api-version parameter when specified return the appropriate version
+            ["*/*", OPDS1Version1Serializer],
             ["application/atom+xml;", OPDS1Version1Serializer],
             ["application/atom+xml;api-version=1", OPDS1Version1Serializer],
             ["application/atom+xml;api-version=2", OPDS1Version2Serializer],


### PR DESCRIPTION
## Description

Adds a test for an ACCEPT header of  */* which is what the CM produces.
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1905
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test added after confirming that CM was passing an ACCEPT type of */*.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
