### PR TITLE
Axis 360 loan exception 

### DIFF
--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -348,7 +348,6 @@ class LoanInfo(LoanAndHoldInfoMixin):
     identifier: str
     start_date: datetime.datetime | None = None
     end_date: datetime.datetime | None
-    fulfillment: Fulfillment | None = None
     external_identifier: str | None = None
     locked_to: DeliveryMechanismInfo | None = None
     license_identifier: str | None = None
@@ -360,7 +359,6 @@ class LoanInfo(LoanAndHoldInfoMixin):
         *,
         start_date: datetime.datetime | None = None,
         end_date: datetime.datetime | None,
-        fulfillment: Fulfillment | None = None,
         external_identifier: str | None = None,
         locked_to: DeliveryMechanismInfo | None = None,
         license_identifier: str | None = None,
@@ -377,23 +375,17 @@ class LoanInfo(LoanAndHoldInfoMixin):
             identifier=identifier,
             start_date=start_date,
             end_date=end_date,
-            fulfillment=fulfillment,
             external_identifier=external_identifier,
             locked_to=locked_to,
             license_identifier=license_identifier,
         )
 
     def __repr__(self) -> str:
-        if self.fulfillment:
-            fulfillment = " Fulfilled by: " + repr(self.fulfillment)
-        else:
-            fulfillment = ""
-        return "<LoanInfo for {}/{}, start={} end={}>{}".format(
+        return "<LoanInfo for {}/{}, start={} end={}>".format(
             self.identifier_type,
             self.identifier,
             self.start_date.isoformat() if self.start_date else self.start_date,
             self.end_date.isoformat() if self.end_date else self.end_date,
-            fulfillment,
         )
 
     def create_or_update(

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -402,6 +402,7 @@ class LoanInfo(LoanAndHoldInfoMixin):
         session = Session.object_session(patron)
         license_pool = license_pool or self.license_pool(session)
 
+        loanable: LicensePool | License
         if self.license_identifier is not None:
             loanable = session.execute(
                 select(License).where(
@@ -416,7 +417,6 @@ class LoanInfo(LoanAndHoldInfoMixin):
             patron,
             start=self.start_date,
             end=self.end_date,
-            fulfillment=self.fulfillment,
             external_identifier=self.external_identifier,
         )
 

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -169,8 +169,17 @@ class License(Base, LicenseFunctions):
             and self.checkouts_available > 0
         )
 
-    def loan_to(self, patron: Patron, **kwargs) -> tuple[Loan, bool]:
-        loan, is_new = self.license_pool.loan_to(patron, **kwargs)
+    def loan_to(
+        self,
+        patron: Patron,
+        start: datetime.datetime | None = None,
+        end: datetime.datetime | None = None,
+        fulfillment: LicensePoolDeliveryMechanism | None = None,
+        external_identifier: str | None = None,
+    ) -> tuple[Loan, bool]:
+        loan, is_new = self.license_pool.loan_to(
+            patron, start, end, fulfillment, external_identifier
+        )
         loan.license = self
         return loan, is_new
 
@@ -1050,10 +1059,10 @@ class LicensePool(Base):
     def loan_to(
         self,
         patron: Patron,
-        start=None,
-        end=None,
-        fulfillment=None,
-        external_identifier=None,
+        start: datetime.datetime | None = None,
+        end: datetime.datetime | None = None,
+        fulfillment: LicensePoolDeliveryMechanism | None = None,
+        external_identifier: str | None = None,
     ) -> tuple[Loan, bool]:
         _db = Session.object_session(patron)
         kwargs = dict(start=start or utc_now(), end=end)


### PR DESCRIPTION
## Description

- Update `LoanInfo` to remove the `fulfillment` attribute since it is confusing, and only used in the Axis360 API code.
- Add `AxisLoanInfo` which extends `LoanInfo` with the extra `fulfillment` attribute, and update the Axis360 API code to use this new class.
- Add some type hints to `licensing.py` that would have caught this issue if they had existed before.

## Motivation and Context

In https://github.com/ThePalaceProject/circulation/pull/2113 it looks like I confused the `LoanInfo.fulfillment` parameter with `Loan.fulfillment`. These are actually different types and represent different things.

This was resulting in the following traces in our logs:
```
Traceback (most recent call last):
  File "/var/www/circulation/src/palace/manager/celery/tasks/patron_activity.py", line 75, in sync_patron_activity
    api.sync_patron_activity(patron, pin)
  File "/var/www/circulation/src/palace/manager/api/circulation.py", line 852, in sync_patron_activity
    self.sync_loans(patron, remote_loans, local_loans)
  File "/var/www/circulation/src/palace/manager/api/circulation.py", line 826, in sync_loans
    loan.create_or_update(patron)
  File "/var/www/circulation/src/palace/manager/api/circulation.py", line 415, in create_or_update
    loan, is_new = loanable.loan_to(
  File "/var/www/circulation/src/palace/manager/sqlalchemy/model/licensing.py", line 1069, in loan_to
    loan.fulfillment = fulfillment
  File "/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/attributes.py", line 465, in __set__
    self.impl.set(
  File "/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/attributes.py", line 1286, in set
    value = self.fire_replace_event(state, dict_, value, old, initiator)
  File "/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/attributes.py", line 1312, in fire_replace_event
    value = fn(
  File "/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/unitofwork.py", line 119, in set_
    newvalue_state = attributes.instance_state(newvalue)
AttributeError: 'Axis360AcsFulfillment' object has no attribute '_sa_instance_state'
```

I believe this is occurring both during loan, and during the sync process.

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
