### PR TITLE
Ignore a couple more lines for codecov

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ requires = ["poetry-core>=1.0.0"]
 [tool.coverage.report]
 exclude_also = [
     "if TYPE_CHECKING:",
+    '@(abc\.)?abstractmethod$',
+    '@(typing\.)?overload$',
     '^\s*\.\.\.\s*$',
     '^\s*pass\s*$',
     '^\s*raise NotImplementedError\s*$',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires = ["poetry-core>=1.0.0"]
 [tool.coverage.report]
 exclude_also = [
     "if TYPE_CHECKING:",
-    '@(abc\.)?abstractmethod$',
     '@(typing\.)?overload$',
     '^\s*\.\.\.\s*$',
     '^\s*pass\s*$',


### PR DESCRIPTION
## Description

It doesn't matter a great deal, but adding a `@overload` decorator is counted as a partial by codecov, since it never get actually called. Since they can never be called, it seems better to just exclude them.

## Motivation and Context

I noticed in https://github.com/ThePalaceProject/circulation/pull/2168 when I added a couple `@overload` for a function, these were counted as *partials* by coverage. 

## How Has This Been Tested?

Letting codecov run in CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
