### PR TITLE
Helper function to get flask.request.library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ module = [
     "palace.manager.api.metadata.*",
     "palace.manager.api.odl.*",
     "palace.manager.api.opds_for_distributors",
+    "palace.manager.api.util.flask",
     "palace.manager.core.opds2_import",
     "palace.manager.core.opds_import",
     "palace.manager.core.selftest",

--- a/src/palace/manager/api/admin/controller/admin_search.py
+++ b/src/palace/manager/api/admin/controller/admin_search.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import flask
 from sqlalchemy import func, or_
 
 from palace.manager.api.admin.controller.base import AdminController
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.sqlalchemy.model.classification import (
     Classification,
     Genre,
@@ -30,7 +30,7 @@ class AdminSearchController(AdminController):
         - Publisher
         - Subject
         """
-        library: Library = flask.request.library  # type: ignore
+        library = get_request_library()
         collection_ids = [coll.id for coll in library.collections if coll.id]
         return self._search_field_values_cached(collection_ids)
 

--- a/src/palace/manager/api/admin/controller/custom_lists.py
+++ b/src/palace/manager/api/admin/controller/custom_lists.py
@@ -23,6 +23,7 @@ from palace.manager.api.controller.circulation_manager import (
     CirculationManagerController,
 )
 from palace.manager.api.problem_details import CANNOT_DELETE_SHARED_LIST
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.core.app_server import load_pagination_from_request
 from palace.manager.core.problem_details import INVALID_INPUT, METHOD_NOT_ALLOWED
 from palace.manager.core.query.customlist import CustomListQueries
@@ -83,7 +84,7 @@ class CustomListsController(
         )
 
     def custom_lists(self) -> dict | ProblemDetail | Response | None:
-        library: Library = flask.request.library  # type: ignore  # "Request" has no attribute "library"
+        library = get_request_library()
         self.require_librarian(library)
 
         if flask.request.method == "GET":
@@ -322,7 +323,7 @@ class CustomListsController(
         return url_fn
 
     def custom_list(self, list_id: int) -> Response | dict | ProblemDetail | None:
-        library: Library = flask.request.library  # type: ignore
+        library = get_request_library()
         self.require_librarian(library)
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)
 
@@ -375,7 +376,7 @@ class CustomListsController(
 
         elif flask.request.method == "DELETE":
             # Deleting requires a library manager.
-            self.require_library_manager(flask.request.library)  # type: ignore
+            self.require_library_manager(get_request_library())
 
             if len(list.shared_locally_with_libraries) > 0:
                 return CANNOT_DELETE_SHARED_LIST
@@ -413,7 +414,7 @@ class CustomListsController(
         customlist = get_one(self._db, CustomList, id=customlist_id)
         if not customlist:
             return MISSING_CUSTOM_LIST
-        if customlist.library != flask.request.library:  # type: ignore
+        if customlist.library != get_request_library():
             return ADMIN_NOT_AUTHORIZED.detailed(
                 _("This library does not have permissions on this customlist.")
             )

--- a/src/palace/manager/api/admin/controller/dashboard.py
+++ b/src/palace/manager/api/admin/controller/dashboard.py
@@ -12,6 +12,7 @@ from palace.manager.api.controller.circulation_manager import (
     CirculationManagerController,
 )
 from palace.manager.api.local_analytics_exporter import LocalAnalyticsExporter
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.feed.annotator.admin import AdminAnnotator
 from palace.manager.sqlalchemy.model.admin import Admin
 from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
@@ -29,7 +30,7 @@ class DashboardController(CirculationManagerController):
         return stats_function(admin, self._db)
 
     def circulation_events(self):
-        annotator = AdminAnnotator(self.circulation, flask.request.library)
+        annotator = AdminAnnotator(self.circulation, get_request_library())
         num = min(int(flask.request.args.get("num", "100")), 500)
 
         results = (
@@ -92,7 +93,7 @@ class DashboardController(CirculationManagerController):
         date_end_label = get_date("dateEnd")
         date_end = date_end_label + timedelta(days=1)
         locations = flask.request.args.get("locations", None)
-        library = getattr(flask.request, "library", None)
+        library = get_request_library(default=None)
         library_short_name = library.short_name if library else None
 
         analytics_exporter = analytics_exporter or LocalAnalyticsExporter()

--- a/src/palace/manager/api/admin/controller/lanes.py
+++ b/src/palace/manager/api/admin/controller/lanes.py
@@ -215,9 +215,10 @@ class LanesController(CirculationManagerController, AdminPermissionsControllerMi
         return Response(str(_("Success")), 200)
 
     def reset(self):
-        self.require_library_manager(get_request_library())
+        library = get_request_library()
+        self.require_library_manager(library)
 
-        create_default_lanes(self._db, get_request_library())
+        create_default_lanes(self._db, library)
         return Response(str(_("Success")), 200)
 
     def change_order(self):

--- a/src/palace/manager/api/admin/controller/lanes.py
+++ b/src/palace/manager/api/admin/controller/lanes.py
@@ -20,6 +20,7 @@ from palace.manager.api.controller.circulation_manager import (
     CirculationManagerController,
 )
 from palace.manager.api.lanes import create_default_lanes
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.sqlalchemy.model.customlist import CustomList
 from palace.manager.sqlalchemy.model.lane import Lane
 from palace.manager.sqlalchemy.model.library import Library
@@ -28,7 +29,7 @@ from palace.manager.sqlalchemy.util import create, get_one
 
 class LanesController(CirculationManagerController, AdminPermissionsControllerMixin):
     def lanes(self):
-        library = flask.request.library
+        library = get_request_library()
         self.require_librarian(library)
 
         if flask.request.method == "GET":
@@ -56,7 +57,7 @@ class LanesController(CirculationManagerController, AdminPermissionsControllerMi
             return dict(lanes=lanes_for_parent(None))
 
         if flask.request.method == "POST":
-            self.require_library_manager(flask.request.library)
+            self.require_library_manager(get_request_library())
 
             id = flask.request.form.get("id")
             parent_id = flask.request.form.get("parent_id")
@@ -173,7 +174,7 @@ class LanesController(CirculationManagerController, AdminPermissionsControllerMi
 
     def lane(self, lane_identifier):
         if flask.request.method == "DELETE":
-            library = flask.request.library
+            library = get_request_library()
             self.require_library_manager(library)
 
             lane = get_one(self._db, Lane, id=lane_identifier, library=library)
@@ -192,7 +193,7 @@ class LanesController(CirculationManagerController, AdminPermissionsControllerMi
             return Response(str(_("Deleted")), 200)
 
     def show_lane(self, lane_identifier):
-        library = flask.request.library
+        library = get_request_library()
         self.require_library_manager(library)
 
         lane = get_one(self._db, Lane, id=lane_identifier, library=library)
@@ -204,7 +205,7 @@ class LanesController(CirculationManagerController, AdminPermissionsControllerMi
         return Response(str(_("Success")), 200)
 
     def hide_lane(self, lane_identifier):
-        library = flask.request.library
+        library = get_request_library()
         self.require_library_manager(library)
 
         lane = get_one(self._db, Lane, id=lane_identifier, library=library)
@@ -214,13 +215,13 @@ class LanesController(CirculationManagerController, AdminPermissionsControllerMi
         return Response(str(_("Success")), 200)
 
     def reset(self):
-        self.require_library_manager(flask.request.library)
+        self.require_library_manager(get_request_library())
 
-        create_default_lanes(self._db, flask.request.library)
+        create_default_lanes(self._db, get_request_library())
         return Response(str(_("Success")), 200)
 
     def change_order(self):
-        self.require_library_manager(flask.request.library)
+        self.require_library_manager(get_request_library())
 
         submitted_lanes = json.loads(flask.request.data)
 

--- a/src/palace/manager/api/admin/controller/work_editor.py
+++ b/src/palace/manager/api/admin/controller/work_editor.py
@@ -63,13 +63,14 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
         :return: An OPDSEntryResponse
         """
-        self.require_librarian(get_request_library())
+        library = get_request_library()
+        self.require_librarian(library)
 
-        work = self.load_work(get_request_library(), identifier_type, identifier)
+        work = self.load_work(library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
-        annotator = AdminAnnotator(self.circulation, get_request_library())
+        annotator = AdminAnnotator(self.circulation, library)
 
         # single_entry returns an OPDSEntryResponse that will not be
         # cached, which is perfect. We want the admin interface
@@ -137,7 +138,8 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
     def edit(self, identifier_type, identifier):
         """Edit a work's metadata."""
-        self.require_librarian(get_request_library())
+        library = get_request_library()
+        self.require_librarian(library)
 
         # TODO: It would be nice to use the metadata layer for this, but
         # this code handles empty values differently than other metadata
@@ -146,7 +148,7 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
         # db so that it can overrule other data sources that set a value,
         # unlike other sources which set empty fields to None.
 
-        work = self.load_work(get_request_library(), identifier_type, identifier)
+        work = self.load_work(library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -434,9 +436,10 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
     def refresh_metadata(self, identifier_type, identifier, provider=None):
         """Refresh the metadata for a book from the content server"""
-        self.require_librarian(get_request_library())
+        library = get_request_library()
+        self.require_librarian(library)
 
-        work = self.load_work(get_request_library(), identifier_type, identifier)
+        work = self.load_work(library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -465,9 +468,10 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
     def classifications(self, identifier_type, identifier):
         """Return list of this work's classifications."""
-        self.require_librarian(get_request_library())
+        library = get_request_library()
+        self.require_librarian(library)
 
-        work = self.load_work(get_request_library(), identifier_type, identifier)
+        work = self.load_work(library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -503,9 +507,10 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
     def edit_classifications(self, identifier_type, identifier):
         """Edit a work's audience, target age, fiction status, and genres."""
-        self.require_librarian(get_request_library())
+        library = get_request_library()
+        self.require_librarian(library)
 
-        work = self.load_work(get_request_library(), identifier_type, identifier)
+        work = self.load_work(library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -671,9 +676,8 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
         return Response("", 200)
 
     def custom_lists(self, identifier_type, identifier):
-        self.require_librarian(get_request_library())
-
         library = get_request_library()
+        self.require_librarian(library)
         work = self.load_work(library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work

--- a/src/palace/manager/api/admin/controller/work_editor.py
+++ b/src/palace/manager/api/admin/controller/work_editor.py
@@ -27,6 +27,7 @@ from palace.manager.api.problem_details import (
     LIBRARY_NOT_FOUND,
     REMOTE_INTEGRATION_FAILED,
 )
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.core.classifier import NO_NUMBER, NO_VALUE, genres
 from palace.manager.core.classifier.simplified import SimplifiedGenreClassifier
 from palace.manager.feed.acquisition import OPDSAcquisitionFeed
@@ -62,13 +63,13 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
         :return: An OPDSEntryResponse
         """
-        self.require_librarian(flask.request.library)
+        self.require_librarian(get_request_library())
 
-        work = self.load_work(flask.request.library, identifier_type, identifier)
+        work = self.load_work(get_request_library(), identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
-        annotator = AdminAnnotator(self.circulation, flask.request.library)
+        annotator = AdminAnnotator(self.circulation, get_request_library())
 
         # single_entry returns an OPDSEntryResponse that will not be
         # cached, which is perfect. We want the admin interface
@@ -136,7 +137,7 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
     def edit(self, identifier_type, identifier):
         """Edit a work's metadata."""
-        self.require_librarian(flask.request.library)
+        self.require_librarian(get_request_library())
 
         # TODO: It would be nice to use the metadata layer for this, but
         # this code handles empty values differently than other metadata
@@ -145,7 +146,7 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
         # db so that it can overrule other data sources that set a value,
         # unlike other sources which set empty fields to None.
 
-        work = self.load_work(flask.request.library, identifier_type, identifier)
+        work = self.load_work(get_request_library(), identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -372,7 +373,7 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
     ) -> Response | ProblemDetail:
         """Suppress a book at the level of a library."""
 
-        library: Library | None = getattr(flask.request, "library")
+        library: Library | None = get_request_library(default=None)
         if library is None:
             raise ProblemDetailException(LIBRARY_NOT_FOUND)
 
@@ -404,7 +405,7 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
     ) -> Response | ProblemDetail:
         """Remove a book suppression from a book at the level of a library"""
 
-        library: Library | None = getattr(flask.request, "library")
+        library: Library | None = get_request_library(default=None)
         if library is None:
             raise ProblemDetailException(LIBRARY_NOT_FOUND)
 
@@ -433,9 +434,9 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
     def refresh_metadata(self, identifier_type, identifier, provider=None):
         """Refresh the metadata for a book from the content server"""
-        self.require_librarian(flask.request.library)
+        self.require_librarian(get_request_library())
 
-        work = self.load_work(flask.request.library, identifier_type, identifier)
+        work = self.load_work(get_request_library(), identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -464,9 +465,9 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
     def classifications(self, identifier_type, identifier):
         """Return list of this work's classifications."""
-        self.require_librarian(flask.request.library)
+        self.require_librarian(get_request_library())
 
-        work = self.load_work(flask.request.library, identifier_type, identifier)
+        work = self.load_work(get_request_library(), identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -502,9 +503,9 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
 
     def edit_classifications(self, identifier_type, identifier):
         """Edit a work's audience, target age, fiction status, and genres."""
-        self.require_librarian(flask.request.library)
+        self.require_librarian(get_request_library())
 
-        work = self.load_work(flask.request.library, identifier_type, identifier)
+        work = self.load_work(get_request_library(), identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
 
@@ -670,9 +671,9 @@ class WorkController(CirculationManagerController, AdminPermissionsControllerMix
         return Response("", 200)
 
     def custom_lists(self, identifier_type, identifier):
-        self.require_librarian(flask.request.library)
+        self.require_librarian(get_request_library())
 
-        library = flask.request.library
+        library = get_request_library()
         work = self.load_work(library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work

--- a/src/palace/manager/api/authenticator.py
+++ b/src/palace/manager/api/authenticator.py
@@ -33,6 +33,7 @@ from palace.manager.api.problem_details import (
     UNKNOWN_SAML_PROVIDER,
     UNSUPPORTED_AUTHENTICATION_MECHANISM,
 )
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.core.user_profile import ProfileController
 from palace.manager.integration.goals import Goals
 from palace.manager.service.analytics.analytics import Analytics
@@ -129,7 +130,7 @@ class Authenticator(LoggerMixin):
 
     @property
     def current_library_short_name(self):
-        return flask.request.library.short_name
+        return get_request_library().short_name
 
     def populate_authenticators(
         self, _db, libraries: Iterable[Library], analytics: Analytics | None

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -35,6 +35,7 @@ from palace.manager.api.circulation_exceptions import (
     PatronHoldLimitReached,
     PatronLoanLimitReached,
 )
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.api.util.patron import PatronUtility
 from palace.manager.core.exceptions import PalaceValueError
 from palace.manager.integration.base import HasLibraryIntegrationConfiguration
@@ -948,12 +949,12 @@ class CirculationAPI(LoggerMixin):
         if patron:
             # The library of the patron who caused the event.
             library = patron.library
-        elif flask.request and getattr(flask.request, "library", None):
-            # The library associated with the current request.
-            library = getattr(flask.request, "library")
         else:
-            # The library associated with the CirculationAPI itself.
-            library = self.library
+            # The library associated with the current request, defaulting to
+            # the library associated with the CirculationAPI itself if we are
+            # outside a request context, or if the request context does not
+            # have a library associated with it.
+            library = get_request_library(default=self.library)
 
         neighborhood = None
         if (

--- a/src/palace/manager/api/circulation_manager.py
+++ b/src/palace/manager/api/circulation_manager.py
@@ -32,6 +32,7 @@ from palace.manager.api.controller.work import WorkController
 from palace.manager.api.lanes import load_lanes
 from palace.manager.api.problem_details import NO_SUCH_LANE
 from palace.manager.api.saml.controller import SAMLController
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.core.app_server import (
     ApplicationVersionController,
     load_facets_from_request,
@@ -392,7 +393,7 @@ class CirculationManager(LoggerMixin):
         elif lane and isinstance(lane, WorkList):
             library = lane.get_library(self._db)
         if not library and hasattr(flask.request, "library"):
-            library = flask.request.library
+            library = get_request_library()
 
         # If no library is provided, the best we can do is a generic
         # annotator for this application.
@@ -434,7 +435,7 @@ class CirculationManager(LoggerMixin):
         internal details of deployment, it should only be enabled when
         diagnosing deployment problems.
         """
-        name = flask.request.library.short_name
+        name = get_request_library().short_name
         value = self.authentication_for_opds_documents.get(name, None)
         if value is None:
             # The document was not in the cache, either because it's

--- a/src/palace/manager/api/controller/analytics.py
+++ b/src/palace/manager/api/controller/analytics.py
@@ -7,6 +7,7 @@ from palace.manager.api.controller.circulation_manager import (
     CirculationManagerController,
 )
 from palace.manager.api.problem_details import INVALID_ANALYTICS_EVENT_TYPE
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
 from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.problem_detail import ProblemDetail
@@ -18,7 +19,7 @@ class AnalyticsController(CirculationManagerController):
         # a way to distinguish between different LicensePools for the
         # same book.
         if event_type in CirculationEvent.CLIENT_EVENTS:
-            library = flask.request.library
+            library = get_request_library()
             # Authentication on the AnalyticsController is optional,
             # so flask.request.patron may or may not be set.
             patron = getattr(flask.request, "patron", None)

--- a/src/palace/manager/api/controller/base.py
+++ b/src/palace/manager/api/controller/base.py
@@ -123,5 +123,5 @@ class BaseCirculationManagerController(LoggerMixin):
 
         if not library:
             return LIBRARY_NOT_FOUND
-        flask.request.library = library  # type: ignore[attr-defined]
+        setattr(flask.request, "library", library)
         return library

--- a/src/palace/manager/api/controller/circulation_manager.py
+++ b/src/palace/manager/api/controller/circulation_manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TypeVar
 
-import flask
 from flask_babel import lazy_gettext as _
 from sqlalchemy import select
 from sqlalchemy.orm import Session, eagerload
@@ -17,6 +16,7 @@ from palace.manager.api.problem_details import (
     NOT_AGE_APPROPRIATE,
     REMOTE_INTEGRATION_FAILED,
 )
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.core.problem_details import INVALID_INPUT
 from palace.manager.search.external_search import ExternalSearchIndex
 from palace.manager.service.redis.redis import Redis
@@ -82,7 +82,7 @@ class CirculationManagerController(BaseCirculationManagerController):
     @property
     def circulation(self) -> CirculationAPI:
         """Return the appropriate CirculationAPI for the request Library."""
-        library_id = flask.request.library.id  # type: ignore[attr-defined]
+        library_id = get_request_library().id
         return self.manager.circulation_apis[library_id]  # type: ignore[no-any-return]
 
     @property
@@ -103,7 +103,7 @@ class CirculationManagerController(BaseCirculationManagerController):
 
     def load_lane(self, lane_identifier: int | None) -> Lane | WorkList | ProblemDetail:
         """Turn user input into a Lane object."""
-        library_id = flask.request.library.id  # type: ignore[attr-defined]
+        library_id = get_request_library().id
 
         lane = None
         if lane_identifier is None:

--- a/src/palace/manager/api/controller/index.py
+++ b/src/palace/manager/api/controller/index.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import flask
 from flask import Response, redirect, url_for
 
 from palace.manager.api.controller.circulation_manager import (
     CirculationManagerController,
 )
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.util.authentication_for_opds import AuthenticationForOPDSDocument
 from palace.manager.util.problem_detail import ProblemDetail
 
@@ -15,7 +15,7 @@ class IndexController(CirculationManagerController):
 
     def __call__(self):
         # The simple case: the app is equally open to all clients.
-        library_short_name = flask.request.library.short_name
+        library_short_name = get_request_library().short_name
         if not self.has_root_lanes():
             return redirect(
                 url_for(
@@ -43,7 +43,7 @@ class IndexController(CirculationManagerController):
 
         :return: A boolean
         """
-        return flask.request.library.has_root_lanes
+        return get_request_library().has_root_lanes
 
     def authenticated_patron_root_lane(self):
         patron = self.authenticated_patron_from_request()
@@ -54,7 +54,7 @@ class IndexController(CirculationManagerController):
         return patron.root_lane
 
     def appropriate_index_for_patron_type(self):
-        library_short_name = flask.request.library.short_name
+        library_short_name = get_request_library().short_name
         root_lane = self.authenticated_patron_root_lane()
         if isinstance(root_lane, ProblemDetail):
             return root_lane

--- a/src/palace/manager/api/controller/loan.py
+++ b/src/palace/manager/api/controller/loan.py
@@ -23,6 +23,7 @@ from palace.manager.api.problem_details import (
     NO_ACTIVE_LOAN_OR_HOLD,
     NO_LICENSES,
 )
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.celery.tasks.patron_activity import sync_patron_activity
 from palace.manager.core.problem_details import INTERNAL_SERVER_ERROR
 from palace.manager.feed.acquisition import OPDSAcquisitionFeed
@@ -89,7 +90,7 @@ class LoanController(CirculationManagerController):
            book or the license file.
         """
         patron = flask.request.patron  # type: ignore[attr-defined]
-        library = flask.request.library  # type: ignore[attr-defined]
+        library = get_request_library()
 
         header = self.authorization_header()
         credential = self.manager.auth.get_credential_from_header(header)
@@ -300,7 +301,7 @@ class LoanController(CirculationManagerController):
             # There's still a chance this request can succeed, but if not,
             # we'll be sending out authentication_response.
             patron = None
-        library = flask.request.library  # type: ignore
+        library = get_request_library()
         header = self.authorization_header()
         credential = self.manager.auth.get_credential_from_header(header)
 
@@ -492,7 +493,7 @@ class LoanController(CirculationManagerController):
         self, identifier_type: str, identifier: str
     ) -> OPDSEntryResponse | ProblemDetail | None:
         patron = flask.request.patron  # type: ignore[attr-defined]
-        library = flask.request.library  # type: ignore[attr-defined]
+        library = get_request_library()
         pools = self.load_licensepools(library, identifier_type, identifier)
         if isinstance(pools, ProblemDetail):
             return pools

--- a/src/palace/manager/api/controller/marc.py
+++ b/src/palace/manager/api/controller/marc.py
@@ -4,11 +4,11 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 
-import flask
 from flask import Response
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.integration.goals import Goals
 from palace.manager.marc.exporter import MarcExporter
 from palace.manager.service.integration_registry.catalog_services import (
@@ -60,7 +60,7 @@ class MARCRecordController:
 
     @staticmethod
     def library() -> Library:
-        return flask.request.library  # type: ignore[no-any-return,attr-defined]
+        return get_request_library()
 
     def has_integration(self, session: Session, library: Library) -> bool:
         protocols = self.registry.get_protocols(MarcExporter)

--- a/src/palace/manager/api/controller/opds_feed.py
+++ b/src/palace/manager/api/controller/opds_feed.py
@@ -15,6 +15,7 @@ from palace.manager.api.lanes import (
     JackpotWorkList,
 )
 from palace.manager.api.problem_details import NO_SUCH_COLLECTION, NO_SUCH_LIST
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.core.app_server import (
     load_facets_from_request,
     load_pagination_from_request,
@@ -45,7 +46,7 @@ class OPDSFeedController(CirculationManagerController):
         :param feed_class: A replacement for AcquisitionFeed, for use in
             tests.
         """
-        library = flask.request.library
+        library = get_request_library()
 
         # Special case: a patron with a root lane who attempts to access
         # the library's top-level WorkList is redirected to their root
@@ -128,7 +129,7 @@ class OPDSFeedController(CirculationManagerController):
         if isinstance(search_engine, ProblemDetail):
             return search_engine
 
-        library_short_name = flask.request.library.short_name
+        library_short_name = get_request_library().short_name
         url = url_for(
             "feed",
             lane_identifier=lane_identifier,
@@ -159,7 +160,7 @@ class OPDSFeedController(CirculationManagerController):
         lane = self.load_lane(lane_identifier)
         if isinstance(lane, ProblemDetail):
             return lane
-        library = flask.request.library
+        library = get_request_library()
         library_short_name = library.short_name
         url = url_for(
             "navigation_feed",
@@ -191,7 +192,7 @@ class OPDSFeedController(CirculationManagerController):
         """Build or retrieve a crawlable acquisition feed for the
         request library.
         """
-        library = flask.request.library
+        library = get_request_library()
         url = url_for(
             "crawlable_library_feed",
             library_short_name=library.short_name,
@@ -224,7 +225,7 @@ class OPDSFeedController(CirculationManagerController):
         # TODO: A library is not strictly required here, since some
         # CustomLists aren't associated with a library, but this isn't
         # a use case we need to support now.
-        library = flask.request.library
+        library = get_request_library()
         list = CustomList.find(self._db, list_name, library=library)
         if not list:
             return NO_SUCH_LIST
@@ -285,7 +286,7 @@ class OPDSFeedController(CirculationManagerController):
         )
 
     def _load_search_facets(self, lane):
-        entrypoints = list(flask.request.library.entrypoints)
+        entrypoints = list(get_request_library().entrypoints)
         if len(entrypoints) > 1:
             # There is more than one enabled EntryPoint.
             # By default, search them all.
@@ -326,7 +327,7 @@ class OPDSFeedController(CirculationManagerController):
         # Check whether there is a query string -- if not, we want to
         # send an OpenSearch document explaining how to search.
         query = flask.request.args.get("q")
-        library_short_name = flask.request.library.short_name
+        library_short_name = get_request_library().short_name
 
         # Create a function that, when called, generates a URL to the
         # search controller.
@@ -391,7 +392,7 @@ class OPDSFeedController(CirculationManagerController):
         :return: A ProblemDetail if there's a problem loading the faceting
             object; otherwise the return value of `feed_factory`.
         """
-        library = flask.request.library
+        library = get_request_library()
         search_engine = self.search_engine
         if isinstance(search_engine, ProblemDetail):
             return search_engine

--- a/src/palace/manager/api/controller/playtime_entries.py
+++ b/src/palace/manager/api/controller/playtime_entries.py
@@ -14,11 +14,11 @@ from palace.manager.api.model.time_tracking import (
     PlaytimeEntriesPostResponse,
 )
 from palace.manager.api.problem_details import NOT_FOUND_ON_REMOTE
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.core.problem_details import INVALID_INPUT
 from palace.manager.core.query.playtime_entries import PlaytimeEntries
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.identifier import Identifier
-from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.model.licensing import LicensePool
 from palace.manager.sqlalchemy.model.patron import Loan
 from palace.manager.sqlalchemy.util import get_one
@@ -39,7 +39,7 @@ def resolve_loan_identifier(loan: Loan | None) -> str:
 
 class PlaytimeEntriesController(CirculationManagerController):
     def track_playtimes(self, collection_id, identifier_type, identifier_idn):
-        library: Library = flask.request.library
+        library = get_request_library()
         identifier = get_one(
             self._db, Identifier, type=identifier_type, identifier=identifier_idn
         )

--- a/src/palace/manager/api/controller/urn_lookup.py
+++ b/src/palace/manager/api/controller/urn_lookup.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import flask
-
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.core.app_server import (
     URNLookupController as CoreURNLookupController,
 )
@@ -18,7 +17,7 @@ class URNLookupController(CoreURNLookupController):
         top-level WorkList, and use it to generate an OPDS lookup
         feed.
         """
-        library = flask.request.library
+        library = get_request_library()
         top_level_worklist = self.manager.top_level_lanes[library.id]
         annotator = CirculationManagerAnnotator(top_level_worklist)
         return super().work_lookup(annotator, route_name)

--- a/src/palace/manager/api/controller/work.py
+++ b/src/palace/manager/api/controller/work.py
@@ -17,6 +17,7 @@ from palace.manager.api.lanes import (
     SeriesLane,
 )
 from palace.manager.api.problem_details import NO_SUCH_LANE, NOT_FOUND_ON_REMOTE
+from palace.manager.api.util.flask import get_request_library
 from palace.manager.core.app_server import load_pagination_from_request
 from palace.manager.core.config import CannotLoadConfiguration
 from palace.manager.core.metadata_layer import ContributorData
@@ -40,7 +41,7 @@ class WorkController(CirculationManagerController):
         self, contributor_name, languages, audiences, feed_class=OPDSAcquisitionFeed
     ):
         """Serve a feed of books written by a particular author"""
-        library = flask.request.library
+        library = get_request_library()
         if not contributor_name:
             return NO_SUCH_LANE.detailed(_("No contributor provided"))
 
@@ -105,7 +106,7 @@ class WorkController(CirculationManagerController):
         returns a single entry while the /works lookup protocol returns a
         feed containing any number of entries.
         """
-        library = flask.request.library
+        library = get_request_library()
         work = self.load_work(library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
@@ -146,7 +147,7 @@ class WorkController(CirculationManagerController):
     ):
         """Serve a groups feed of books related to a given book."""
 
-        library = flask.request.library
+        library = get_request_library()
         work = self.load_work(library, identifier_type, identifier)
         if work is None:
             return NOT_FOUND_ON_REMOTE
@@ -203,7 +204,7 @@ class WorkController(CirculationManagerController):
     ):
         """Serve a feed of recommendations related to a given book."""
 
-        library = flask.request.library
+        library = get_request_library()
         work = self.load_work(library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
@@ -255,7 +256,7 @@ class WorkController(CirculationManagerController):
 
     def series(self, series_name, languages, audiences, feed_class=OPDSAcquisitionFeed):
         """Serve a feed of books in a given series."""
-        library = flask.request.library
+        library = get_request_library()
         if not series_name:
             return NO_SUCH_LANE.detailed(_("No series provided"))
 

--- a/src/palace/manager/api/util/flask.py
+++ b/src/palace/manager/api/util/flask.py
@@ -35,6 +35,23 @@ def get_request_var(
     *,
     default: TDefault | Literal[SentinelType.NotGiven] = SentinelType.NotGiven,
 ) -> TVar | TDefault:
+    """
+    Retrieve an attribute from the current Flask request object.
+
+    This helper function handles edge cases such as missing request context or unset attributes.
+    It ensures type checking and provides type hints for the expected attribute type.
+
+    :param name: The name of the attribute to retrieve.
+    :param var_cls: The expected type of the attribute.
+    :param default: The default value to return if the attribute is not set or if there is no request context.
+
+    :return: The attribute from the request object, or the default value if provided.
+
+    :raises PalaceValueError: If the attribute is not set or if the attribute type is incorrect,
+        and no default is provided.
+    :raises RuntimeError: If there is no request context and no default is provided.
+    """
+
     if default is not SentinelType.NotGiven and not flask.request:
         # We are not in a request context, so we can't get the variable
         # if we access it, it will raise an error, so we return the default
@@ -68,6 +85,22 @@ def get_request_library(*, default: TDefault) -> Library | TDefault: ...
 def get_request_library(
     *, default: TDefault | Literal[SentinelType.NotGiven] = SentinelType.NotGiven
 ) -> Library | TDefault:
+    """
+    Retrieve the 'library' attribute from the current Flask request object.
+
+    This attribute should be set by using the @has_library or @allows_library decorator
+    on the route or by calling the BaseCirculationManagerController.library_for_request
+    method.
+
+    Note: You need to specify a default of None if you want to allow the library to be
+      None (for example if you are using the @allows_library decorator).
+
+    :param default: The default value to return if the 'library' attribute is not set.
+        If not provided, a `PalaceValueError` will be raised if the attribute is missing
+        or has an incorrect type.
+
+    :return: The `Library` object from the request, or the default value if provided.
+    """
     return get_request_var("library", Library, default=default)
 
 

--- a/src/palace/manager/api/util/flask.py
+++ b/src/palace/manager/api/util/flask.py
@@ -1,10 +1,77 @@
-from flask import Flask
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
+
+import flask
 from sqlalchemy.orm import Session
 
-from palace.manager.api.circulation_manager import CirculationManager
+from palace.manager.core.exceptions import PalaceValueError
+from palace.manager.sqlalchemy.model.library import Library
+from palace.manager.util.sentinel import SentinelType
+
+if TYPE_CHECKING:
+    from palace.manager.api.circulation_manager import CirculationManager
 
 
-class PalaceFlask(Flask):
+TVar = TypeVar("TVar")
+TDefault = TypeVar("TDefault")
+
+
+@overload
+def get_request_var(
+    name: str, var_cls: type[TVar], *, default: Literal[SentinelType.NotGiven] = ...
+) -> TVar: ...
+
+
+@overload
+def get_request_var(
+    name: str, var_cls: type[TVar], *, default: TDefault
+) -> TVar | TDefault: ...
+
+
+def get_request_var(
+    name: str,
+    var_cls: type[TVar],
+    *,
+    default: TDefault | Literal[SentinelType.NotGiven] = SentinelType.NotGiven,
+) -> TVar | TDefault:
+    if default is not SentinelType.NotGiven and not flask.request:
+        # We are not in a request context, so we can't get the variable
+        # if we access it, it will raise an error, so we return the default
+        return default
+
+    try:
+        var = getattr(flask.request, name)
+    except AttributeError:
+        if default is SentinelType.NotGiven:
+            raise PalaceValueError(f"No '{name}' set on 'flask.request'")
+        return default
+
+    if not isinstance(var, var_cls):
+        if default is SentinelType.NotGiven:
+            raise PalaceValueError(
+                f"'{name}' on 'flask.request' has incorrect type "
+                f"'{var.__class__.__name__}' expected '{var_cls.__name__}'",
+            )
+        return default
+    return var
+
+
+@overload
+def get_request_library() -> Library: ...
+
+
+@overload
+def get_request_library(*, default: TDefault) -> Library | TDefault: ...
+
+
+def get_request_library(
+    *, default: TDefault | Literal[SentinelType.NotGiven] = SentinelType.NotGiven
+) -> Library | TDefault:
+    return get_request_var("library", Library, default=default)
+
+
+class PalaceFlask(flask.Flask):
     """
     A subclass of Flask sets properties used by Palace.
 
@@ -40,7 +107,7 @@ class PalaceFlask(Flask):
     Palace: You're going to need a stiff drink after this.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._db: Session
         self.manager: CirculationManager

--- a/src/palace/manager/core/app_server.py
+++ b/src/palace/manager/core/app_server.py
@@ -6,7 +6,7 @@ import gzip
 from collections.abc import Callable
 from functools import wraps
 from io import BytesIO
-from typing import TYPE_CHECKING, ParamSpec, TypeVar
+from typing import ParamSpec, TypeVar
 
 import flask
 from flask import Response, make_response, url_for
@@ -15,6 +15,7 @@ from werkzeug.exceptions import HTTPException
 
 from palace import manager
 from palace.manager.api.admin.config import Configuration as AdminUiConfig
+from palace.manager.api.util.flask import PalaceFlask, get_request_library
 from palace.manager.core.problem_details import INVALID_URN
 from palace.manager.feed.acquisition import LookupAcquisitionFeed, OPDSAcquisitionFeed
 from palace.manager.sqlalchemy.model.identifier import Identifier
@@ -22,9 +23,6 @@ from palace.manager.sqlalchemy.model.lane import Facets, Pagination
 from palace.manager.util.log import LoggerMixin
 from palace.manager.util.opds_writer import OPDSMessage
 from palace.manager.util.problem_detail import BaseProblemDetailException, ProblemDetail
-
-if TYPE_CHECKING:
-    from palace.manager.api.util.flask import PalaceFlask
 
 
 def load_facets_from_request(
@@ -51,7 +49,7 @@ def load_facets_from_request(
     kwargs = base_class_constructor_kwargs or dict()
     get_arg = flask.request.args.get
     get_header = flask.request.headers.get
-    library = flask.request.library
+    library = get_request_library()
     facet_config = facet_config or library
     return base_class.from_request(
         library,

--- a/src/palace/manager/util/sentinel.py
+++ b/src/palace/manager/util/sentinel.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class SentinelType(Enum):
+    """
+    Sentinel value for when a variable is not given.
+
+    We use this so we can differentiate between a variable that is not given
+    and a variable that is given as None. If https://peps.python.org/pep-0661/
+    is accepted, we should update this is use a proper sentinel value. For now,
+    we use this enum, since we can type check it.
+
+    This solution is based on discussion here:
+    https://github.com/python/typing/issues/236#issuecomment-227180301
+
+    It can be type hinted as: Literal[SentinelType.NotGiven]
+    """
+
+    NotGiven = "NotGiven"

--- a/tests/fixtures/api_controller.py
+++ b/tests/fixtures/api_controller.py
@@ -6,7 +6,6 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from typing import Any
 
-import flask
 import pytest
 from sqlalchemy.orm import Session
 from werkzeug.datastructures import Authorization
@@ -250,7 +249,7 @@ class ControllerFixture:
         else:
             library = self.db.default_library()
         with self.app.test_request_context(route, *args, **kwargs) as c:
-            flask.request.library = library
+            setattr(c.request, "library", library)
             yield c
 
 

--- a/tests/fixtures/flask.py
+++ b/tests/fixtures/flask.py
@@ -4,7 +4,6 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
 
-import flask
 import pytest
 from flask.ctx import RequestContext
 from flask_babel import Babel
@@ -43,10 +42,10 @@ class FlaskAppFixture:
     ) -> Generator[RequestContext]:
         with self.app.test_request_context(*args, **kwargs) as c:
             self.db.session.begin_nested()
-            flask.request.library = library  # type: ignore[attr-defined]
-            flask.request.admin = admin  # type: ignore[attr-defined]
-            flask.request.form = ImmutableMultiDict()
-            flask.request.files = ImmutableMultiDict()
+            setattr(c.request, "library", library)
+            setattr(c.request, "admin", admin)
+            setattr(c.request, "form", ImmutableMultiDict())
+            setattr(c.request, "files", ImmutableMultiDict())
             try:
                 yield c
             finally:

--- a/tests/manager/api/admin/controller/test_custom_lists.py
+++ b/tests/manager/api/admin/controller/test_custom_lists.py
@@ -249,8 +249,8 @@ class TestCustomListsController:
         library = admin_librarian_fixture.ctrl.db.library()
         with admin_librarian_fixture.request_context_with_admin(
             "/", method="POST", admin=admin
-        ):
-            flask.request.library = library  # type: ignore[attr-defined]
+        ) as ctx:
+            setattr(ctx.request, "library", library)
             form = ImmutableMultiDict(
                 [
                     ("name", "name"),

--- a/tests/manager/api/admin/controller/test_lanes.py
+++ b/tests/manager/api/admin/controller/test_lanes.py
@@ -1,6 +1,5 @@
 import json
 
-import flask
 import pytest
 from werkzeug.datastructures import ImmutableMultiDict
 
@@ -84,8 +83,7 @@ class TestLanesController:
         lane_for_list.priority = 2
         lane_for_list.size = 1
 
-        with alm_fixture.request_context_with_library_and_admin("/"):
-            flask.request.library = library  # type: ignore[attr-defined]
+        with alm_fixture.request_context_with_library_and_admin("/", library=library):
             # The admin is not a librarian for this library.
             pytest.raises(
                 AdminNotAuthorized,
@@ -135,13 +133,17 @@ class TestLanesController:
             assert True == list_info.get("inherit_parent_restrictions")
 
     def test_lanes_post_errors(self, alm_fixture: AdminLibraryManagerFixture):
-        with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.form = ImmutableMultiDict([])
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="POST"
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict([])
             response = alm_fixture.manager.admin_lanes_controller.lanes()
             assert NO_DISPLAY_NAME_FOR_LANE == response
 
-        with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.form = ImmutableMultiDict(
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="POST"
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("display_name", "lane"),
                 ]
@@ -154,8 +156,10 @@ class TestLanesController:
         )
         list.library = alm_fixture.ctrl.db.default_library()
 
-        with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.form = ImmutableMultiDict(
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="POST"
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("id", "12345"),
                     ("display_name", "lane"),
@@ -166,9 +170,10 @@ class TestLanesController:
             assert MISSING_LANE == response
 
         library = alm_fixture.ctrl.db.library()
-        with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.library = library  # type: ignore[attr-defined]
-            flask.request.form = ImmutableMultiDict(
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="POST", library=library
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("display_name", "lane"),
                     ("custom_list_ids", json.dumps([list.id])),
@@ -183,8 +188,10 @@ class TestLanesController:
         lane2 = alm_fixture.ctrl.db.lane("lane2")
         lane1.customlists += [list]
 
-        with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.form = ImmutableMultiDict(
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="POST"
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("id", lane1.id),
                     ("display_name", "lane2"),
@@ -194,8 +201,10 @@ class TestLanesController:
             response = alm_fixture.manager.admin_lanes_controller.lanes()
             assert LANE_WITH_PARENT_AND_DISPLAY_NAME_ALREADY_EXISTS == response
 
-        with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.form = ImmutableMultiDict(
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="POST"
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("display_name", "lane2"),
                     ("custom_list_ids", json.dumps([list.id])),
@@ -204,8 +213,10 @@ class TestLanesController:
             response = alm_fixture.manager.admin_lanes_controller.lanes()
             assert LANE_WITH_PARENT_AND_DISPLAY_NAME_ALREADY_EXISTS == response
 
-        with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.form = ImmutableMultiDict(
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="POST"
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("parent_id", "12345"),
                     ("display_name", "lane"),
@@ -215,8 +226,10 @@ class TestLanesController:
             response = alm_fixture.manager.admin_lanes_controller.lanes()
             assert MISSING_LANE.uri == response.uri
 
-        with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.form = ImmutableMultiDict(
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="POST"
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("parent_id", lane1.id),
                     ("display_name", "lane"),
@@ -236,8 +249,10 @@ class TestLanesController:
         parent = alm_fixture.ctrl.db.lane("parent")
         sibling = alm_fixture.ctrl.db.lane("sibling", parent=parent)
 
-        with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.form = ImmutableMultiDict(
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="POST"
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("parent_id", parent.id),
                     ("display_name", "lane"),
@@ -274,8 +289,8 @@ class TestLanesController:
 
         with alm_fixture.request_context_with_library_and_admin(
             "/", method="POST", library=library
-        ):
-            flask.request.form = ImmutableMultiDict(
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("display_name", "lane"),
                     ("custom_list_ids", json.dumps([list.id])),
@@ -292,8 +307,8 @@ class TestLanesController:
 
         with alm_fixture.request_context_with_library_and_admin(
             "/", method="POST", library=library
-        ):
-            flask.request.form = ImmutableMultiDict(
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("display_name", "lane"),
                     ("custom_list_ids", json.dumps([list.id])),
@@ -330,8 +345,10 @@ class TestLanesController:
         # are two works in the lane.
         assert 0 == lane.size
 
-        with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.form = ImmutableMultiDict(
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="POST"
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("id", str(lane.id)),
                     ("display_name", "new name"),
@@ -353,8 +370,10 @@ class TestLanesController:
         """Default lanes only allow the display_name to be edited"""
         lane: Lane = alm_fixture.ctrl.db.lane("default")
         customlist, _ = alm_fixture.ctrl.db.customlist()
-        with alm_fixture.request_context_with_library_and_admin("/", method="POST"):
-            flask.request.form = ImmutableMultiDict(
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="POST"
+        ) as ctx:
+            ctx.request.form = ImmutableMultiDict(
                 [
                     ("id", str(lane.id)),
                     ("parent_id", "12345"),
@@ -390,8 +409,9 @@ class TestLanesController:
             .count()
         )
 
-        with alm_fixture.request_context_with_library_and_admin("/", method="DELETE"):
-            flask.request.library = library  # type: ignore[attr-defined]
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="DELETE", library=library
+        ):
             response = alm_fixture.manager.admin_lanes_controller.lane(lane.id)
             assert 200 == response.status_code
 
@@ -426,8 +446,9 @@ class TestLanesController:
             .count()
         )
 
-        with alm_fixture.request_context_with_library_and_admin("/", method="DELETE"):
-            flask.request.library = library  # type: ignore[attr-defined]
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="DELETE", library=library
+        ):
             response = alm_fixture.manager.admin_lanes_controller.lane(lane.id)
             assert 200 == response.status_code
 
@@ -454,8 +475,9 @@ class TestLanesController:
 
         lane = alm_fixture.ctrl.db.lane("lane")
         library = alm_fixture.ctrl.db.library()
-        with alm_fixture.request_context_with_library_and_admin("/", method="DELETE"):
-            flask.request.library = library  # type: ignore[attr-defined]
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", method="DELETE", library=library
+        ):
             pytest.raises(
                 AdminNotAuthorized,
                 alm_fixture.manager.admin_lanes_controller.lane,
@@ -526,8 +548,7 @@ class TestLanesController:
         library = alm_fixture.ctrl.db.library()
         old_lane = alm_fixture.ctrl.db.lane("old lane", library=library)
 
-        with alm_fixture.request_context_with_library_and_admin("/"):
-            flask.request.library = library  # type: ignore[attr-defined]
+        with alm_fixture.request_context_with_library_and_admin("/", library=library):
             pytest.raises(
                 AdminNotAuthorized,
                 alm_fixture.manager.admin_lanes_controller.reset,
@@ -570,9 +591,10 @@ class TestLanesController:
             {"id": parent1.id},
         ]
 
-        with alm_fixture.request_context_with_library_and_admin("/"):
-            flask.request.library = library  # type: ignore[attr-defined]
-            flask.request.data = json.dumps(new_order).encode()
+        with alm_fixture.request_context_with_library_and_admin(
+            "/", library=library
+        ) as ctx:
+            ctx.request.data = json.dumps(new_order).encode()
 
             pytest.raises(
                 AdminNotAuthorized,

--- a/tests/manager/api/admin/controller/test_work_editor.py
+++ b/tests/manager/api/admin/controller/test_work_editor.py
@@ -767,8 +767,7 @@ class TestWorkController:
             )
 
         # test no library
-        with work_fixture.request_context_with_library_and_admin("/"):
-            flask.request.library = None  # type: ignore[attr-defined]
+        with work_fixture.request_context_with_library_and_admin("/", library=None):
             with pytest.raises(ProblemDetailException) as exc:
                 work_fixture.manager.admin_work_controller.suppress(
                     lp.identifier.type, lp.identifier.identifier
@@ -817,8 +816,7 @@ class TestWorkController:
             )
 
         # test no library
-        with work_fixture.request_context_with_library_and_admin("/"):
-            flask.request.library = None  # type: ignore[attr-defined]
+        with work_fixture.request_context_with_library_and_admin("/", library=None):
             with pytest.raises(ProblemDetailException) as exc:
                 work_fixture.manager.admin_work_controller.unsuppress(
                     lp.identifier.type, lp.identifier.identifier

--- a/tests/manager/api/controller/test_base.py
+++ b/tests/manager/api/controller/test_base.py
@@ -497,19 +497,21 @@ class TestBaseController:
             value = circulation_fixture.controller.library_for_request("not-a-library")
             assert LIBRARY_NOT_FOUND == value
 
-        with circulation_fixture.app.test_request_context("/"):
+        with circulation_fixture.app.test_request_context("/") as ctx:
             value = circulation_fixture.controller.library_for_request(
                 circulation_fixture.db.default_library().short_name
             )
             assert circulation_fixture.db.default_library() == value
-            assert circulation_fixture.db.default_library() == flask.request.library  # type: ignore
+            assert circulation_fixture.db.default_library() == getattr(
+                ctx.request, "library"
+            )
 
         # If you don't specify a library, the default library is used.
         with circulation_fixture.app.test_request_context("/"):
             value = circulation_fixture.controller.library_for_request(None)
             expect_default = Library.default(circulation_fixture.db.session)
             assert expect_default == value
-            assert expect_default == flask.request.library  # type: ignore
+            assert expect_default == getattr(ctx.request, "library")
 
     def test_load_lane(self, circulation_fixture: CirculationControllerFixture):
         # Verify that requests for specific lanes are mapped to

--- a/tests/manager/api/controller/test_base.py
+++ b/tests/manager/api/controller/test_base.py
@@ -507,7 +507,7 @@ class TestBaseController:
             )
 
         # If you don't specify a library, the default library is used.
-        with circulation_fixture.app.test_request_context("/"):
+        with circulation_fixture.app.test_request_context("/") as ctx:
             value = circulation_fixture.controller.library_for_request(None)
             expect_default = Library.default(circulation_fixture.db.session)
             assert expect_default == value

--- a/tests/manager/api/controller/test_index.py
+++ b/tests/manager/api/controller/test_index.py
@@ -1,7 +1,5 @@
 import json
 
-import flask
-
 from palace.manager.sqlalchemy.model.lane import Lane
 from palace.manager.util.authentication_for_opds import AuthenticationForOPDSDocument
 from tests.fixtures.api_controller import CirculationControllerFixture
@@ -9,8 +7,8 @@ from tests.fixtures.api_controller import CirculationControllerFixture
 
 class TestIndexController:
     def test_simple_redirect(self, circulation_fixture: CirculationControllerFixture):
-        with circulation_fixture.app.test_request_context("/"):
-            flask.request.library = circulation_fixture.library  # type: ignore
+        with circulation_fixture.app.test_request_context("/") as ctx:
+            setattr(ctx.request, "library", circulation_fixture.library)
             response = circulation_fixture.manager.index_controller()
             assert 302 == response.status_code
             assert "http://localhost/default/groups/" == response.headers["location"]

--- a/tests/manager/api/test_authenticator.py
+++ b/tests/manager/api/test_authenticator.py
@@ -14,7 +14,6 @@ from functools import partial
 from typing import TYPE_CHECKING, Literal, cast
 from unittest.mock import MagicMock, PropertyMock, patch
 
-import flask
 import pytest
 from _pytest._code import ExceptionInfo
 from flask import url_for
@@ -588,8 +587,8 @@ class TestAuthenticator:
         # This new library isn't in the authenticator.
         l3 = db.library(short_name="l3")
 
-        with app.test_request_context("/"):
-            flask.request.library = l3  # type:ignore
+        with app.test_request_context("/") as ctx:
+            setattr(ctx.request, "library", l3)
             assert LIBRARY_NOT_FOUND == auth.authenticated_patron(db.session, {})
             assert LIBRARY_NOT_FOUND == auth.create_authentication_document()
             assert LIBRARY_NOT_FOUND == auth.create_authentication_headers()
@@ -597,8 +596,8 @@ class TestAuthenticator:
             assert LIBRARY_NOT_FOUND == auth.create_bearer_token()
 
         # The other libraries are in the authenticator.
-        with app.test_request_context("/"):
-            flask.request.library = l1  # type:ignore
+        with app.test_request_context("/") as ctx:
+            setattr(ctx.request, "library", l1)
             assert "authenticated patron for l1" == auth.authenticated_patron(
                 db.session, {}
             )
@@ -613,8 +612,8 @@ class TestAuthenticator:
             assert "bearer token for l1" == auth.create_bearer_token()
             assert "decoded bearer token for l1" == auth.decode_bearer_token()
 
-        with app.test_request_context("/"):
-            flask.request.library = l2  # type:ignore
+        with app.test_request_context("/") as ctx:
+            setattr(ctx.request, "library", l2)
             assert "authenticated patron for l2" == auth.authenticated_patron(
                 db.session, {}
             )

--- a/tests/manager/api/test_circulationapi.py
+++ b/tests/manager/api/test_circulationapi.py
@@ -960,11 +960,11 @@ class TestCirculationAPI:
         # We must run the rest of the tests in a simulated Flask request
         # context.
         app = Flask(__name__)
-        with app.test_request_context():
+        with app.test_request_context() as ctx:
             # The request library takes precedence over the Library
             # associated with the CirculationAPI (though this
             # shouldn't happen).
-            flask.request.library = l2  # type: ignore
+            setattr(ctx.request, "library", l2)
             assert_event(
                 (None, None, "event"),
                 (
@@ -976,11 +976,11 @@ class TestCirculationAPI:
                 ),
             )
 
-        with app.test_request_context():
+        with app.test_request_context() as ctx:
             # The library of the request patron also takes precedence
             # over both (though again, this shouldn't happen).
-            flask.request.library = l1  # type: ignore
-            flask.request.patron = p2  # type: ignore
+            setattr(ctx.request, "library", l1)
+            setattr(ctx.request, "patron", p2)
             assert_event(
                 (None, None, "event"),
                 (

--- a/tests/manager/api/util/test_flask.py
+++ b/tests/manager/api/util/test_flask.py
@@ -1,0 +1,35 @@
+import pytest
+
+from palace.manager.api.util.flask import get_request_var
+from palace.manager.core.exceptions import PalaceValueError
+from tests.fixtures.flask import FlaskAppFixture
+
+
+class TestGetRequestVar:
+    def test_no_request_context(self) -> None:
+        # If we supply a default, we get the default if there is no request context.
+        assert get_request_var("foo", str, default="bar") == "bar"
+
+        # If we don't supply a default, we get the normal RuntimeError.
+        with pytest.raises(RuntimeError, match="Working outside of request context"):
+            get_request_var("foo", str)
+
+    def test_no_var_set(self, flask_app_fixture: FlaskAppFixture) -> None:
+        with flask_app_fixture.test_request_context():
+            assert get_request_var("foo", str, default=None) is None
+
+            with pytest.raises(
+                PalaceValueError, match="No 'foo' set on 'flask.request'"
+            ):
+                get_request_var("foo", str)
+
+    def test_var_set_to_wrong_type(self, flask_app_fixture: FlaskAppFixture) -> None:
+        with flask_app_fixture.test_request_context() as ctx:
+            setattr(ctx.request, "foo", 123)
+
+            assert get_request_var("foo", str, default=None) is None
+
+            with pytest.raises(
+                PalaceValueError, match="incorrect type 'int' expected 'str'"
+            ):
+                get_request_var("foo", str)


### PR DESCRIPTION
## Description

Add a helper function `get_request_library()` to get `flask.request.library` in a type safe way. Update the existing code to use the new helper.

The bulk of the changes in this PR are updates to use the new function.

## Motivation and Context

While working on PP-1860, I'm handling some type errors, and I was trying to add type hints to make it clear if these errors happen again, but I keep getting type errors from `flask.request.library` attribute not existing. 

I don't love how we set and use `flask.request.library` all over the place, but its fairly embedded in the code at this point. Instead of constantly fighting with type errors from it, I thought it makes sense to isolate the untyped parts of it to this one function and make sure the edge cases of the function are well tested.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
