### PR TITLE
Add IP address to flask request logs

### DIFF
--- a/src/palace/manager/service/logging/log.py
+++ b/src/palace/manager/service/logging/log.py
@@ -99,10 +99,15 @@ class JSONFormatter(logging.Formatter):
                 data["request"]["query"] = flask_request.query_string.decode()
             if user_agent := flask_request.headers.get("User-Agent"):
                 data["request"]["user_agent"] = user_agent
+
+            forwarded_for_list = []
             if forwarded_for := flask_request.headers.get("X-Forwarded-For"):
-                forwarded_for_list = [ip.strip() for ip in forwarded_for.split(",")]
-                if final_address := flask_request.remote_addr:
-                    forwarded_for_list.append(final_address)
+                forwarded_for_list.extend(
+                    [ip.strip() for ip in forwarded_for.split(",")]
+                )
+            if remote_addr := flask_request.remote_addr:
+                forwarded_for_list.append(remote_addr)
+            if forwarded_for_list:
                 data["request"]["forwarded_for"] = forwarded_for_list
 
         # If we are running in uwsgi context, we include the worker id in the log

--- a/src/palace/manager/service/logging/log.py
+++ b/src/palace/manager/service/logging/log.py
@@ -99,6 +99,11 @@ class JSONFormatter(logging.Formatter):
                 data["request"]["query"] = flask_request.query_string.decode()
             if user_agent := flask_request.headers.get("User-Agent"):
                 data["request"]["user_agent"] = user_agent
+            if forwarded_for := flask_request.headers.get("X-Forwarded-For"):
+                forwarded_for_list = [ip.strip() for ip in forwarded_for.split(",")]
+                if final_address := flask_request.remote_addr:
+                    forwarded_for_list.append(final_address)
+                data["request"]["forwarded_for"] = forwarded_for_list
 
         # If we are running in uwsgi context, we include the worker id in the log
         if uwsgi:


### PR DESCRIPTION
## Description

If we are in a flask request context, include `X-Forwarded-For` header and `request.remote_addr` in the log message, so we are able to query on them.

## Motivation and Context

When tracing issues via our logs, its helpful to be able to see the requests IP address. I was wishing we had this while troubleshooting the issues in PP-1860.

## How Has This Been Tested?

- Tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
