### PR TITLE
[PP-1956] Ensure the context transaction manager is being used for cr…

### DIFF
--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -629,7 +629,7 @@ class Axis360API(
         # NOTE: availability is bibliographic.circulation, so it's a
         # little redundant to call availability.apply() -- it's taken
         # care of inside bibliographic.apply().
-        bibliographic.apply(edition, self.collection, replace=policy)
+        bibliographic.apply(edition, self.collection, replace=policy, db=self._db)
         availability.apply(self._db, self.collection, replace=policy)
         return edition, new_edition, license_pool, new_license_pool
 

--- a/src/palace/manager/api/bibliotheca.py
+++ b/src/palace/manager/api/bibliotheca.py
@@ -1278,7 +1278,10 @@ class BibliothecaCirculationSweep(IdentifierSweepMonitor):
         edition, _ = metadata.edition(self._db)
 
         metadata.apply(
-            edition, collection=self.collection, replace=self.replacement_policy
+            edition,
+            collection=self.collection,
+            replace=self.replacement_policy,
+            db=self._db,
         )
 
 

--- a/src/palace/manager/api/overdrive.py
+++ b/src/palace/manager/api/overdrive.py
@@ -1725,7 +1725,7 @@ class OverdriveAPI(
         edition, ignore = self._edition(licensepool)
 
         replace = ReplacementPolicy.from_license_source(self._db)
-        metadata.apply(edition, self.collection, replace=replace)
+        metadata.apply(edition, self.collection, replace=replace, db=self._db)
 
     def update_licensepool(self, book_id):
         """Update availability information for a single book.

--- a/src/palace/manager/core/metadata_layer.py
+++ b/src/palace/manager/core/metadata_layer.py
@@ -962,6 +962,7 @@ class CirculationData:
                     data_source=data_source,
                     media_type=link.media_type,
                     content=link.content,
+                    db=_db,
                 )
                 link_objects[link] = link_obj
 
@@ -1436,6 +1437,7 @@ class Metadata:
         replace_formats=False,
         replace_rights=False,
         force=False,
+        db=None,
     ):
         """Apply this metadata to the given edition.
 
@@ -1445,8 +1447,10 @@ class Metadata:
             New: If contributors changed, this is now considered a core change,
             so work.simple_opds_feed refresh can be triggered.
         """
-        _db = Session.object_session(edition)
-
+        if not db:
+            _db = Session.object_session(edition)
+        else:
+            _db = db
         # If summary, subjects, or measurements change, then any Work
         # associated with this edition will need a full presentation
         # recalculation.
@@ -1637,6 +1641,7 @@ class Metadata:
                     rights_explanation=link.rights_explanation,
                     original_resource=original_resource,
                     transformation_settings=link.transformation_settings,
+                    db=_db,
                 )
                 if link.rel in self.REL_REQUIRES_NEW_PRESENTATION_EDITION:
                     work_requires_new_presentation_edition = True
@@ -1717,7 +1722,7 @@ class Metadata:
             elif link.thumbnail:
                 # We need to make sure that its thumbnail exists locally and
                 # is associated with the original image.
-                self.make_thumbnail(data_source, link, link_obj)
+                self.make_thumbnail(_db, data_source, link, link_obj)
 
         # Make sure the work we just did shows up.
         made_changes = edition.calculate_presentation(
@@ -1757,7 +1762,7 @@ class Metadata:
 
         return edition, work_requires_new_presentation_edition
 
-    def make_thumbnail(self, data_source, link, link_obj):
+    def make_thumbnail(self, _db, data_source, link, link_obj):
         """Make sure a Hyperlink representing an image is connected
         to its thumbnail.
         """
@@ -1782,6 +1787,7 @@ class Metadata:
             data_source=data_source,
             media_type=thumbnail.media_type,
             content=thumbnail.content,
+            db=_db,
         )
         # And make sure the thumbnail knows it's a thumbnail of the main
         # image.

--- a/src/palace/manager/sqlalchemy/model/identifier.py
+++ b/src/palace/manager/sqlalchemy/model/identifier.py
@@ -756,6 +756,7 @@ class Identifier(Base, IdentifierConstants):
         rights_explanation=None,
         original_resource=None,
         transformation_settings=None,
+        db=None,
     ):
         """Create a link between this Identifier and a (potentially new)
         Resource.
@@ -769,7 +770,10 @@ class Identifier(Base, IdentifierConstants):
             Resource,
         )
 
-        _db = Session.object_session(self)
+        if not db:
+            _db = Session.object_session(self)
+        else:
+            _db = db
         # Find or create the Resource.
         if not href:
             href = Hyperlink.generic_uri(data_source, self, rel, content)

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -659,6 +659,7 @@ class LicensePool(Base):
         rights_explanation=None,
         original_resource=None,
         transformation_settings=None,
+        db=None,
     ):
         """Add a link between this LicensePool and a Resource.
 
@@ -689,6 +690,7 @@ class LicensePool(Base):
             rights_explanation,
             original_resource,
             transformation_settings,
+            db,
         )
 
     def needs_update(self):


### PR DESCRIPTION
…eating identifiers in SweepMonitor runs.

## Description
This PR attempts to fix a problem we are seeing in production where the database session associated with the identifier object (obtained via the Session.object_session() method )  is sometimes not the same as the one associated with the context manager when the sweep monitor is running.   I'm not sure that this will fix it, but hopefully is will get us closer to a fix for the sweep monitors.
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1956

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests still pass.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
