### PR TITLE
Fix 'NoneType' object has no attribute 'computed' error (PP-1961)

### DIFF
--- a/src/palace/manager/api/controller/circulation_manager.py
+++ b/src/palace/manager/api/controller/circulation_manager.py
@@ -155,6 +155,12 @@ class CirculationManagerController(BaseCirculationManagerController):
         if work is None:
             # We have no work for this license pool. Return a ProblemDetail
             # that will give a 404 status code.
+            self.log.warning(
+                "No work found for license pool %r %s/%s",
+                pools[0],
+                identifier_type,
+                identifier,
+            )
             return NOT_FOUND_ON_REMOTE
 
         if work and not work.age_appropriate_for_patron(self.request_patron):

--- a/src/palace/manager/api/controller/circulation_manager.py
+++ b/src/palace/manager/api/controller/circulation_manager.py
@@ -14,6 +14,7 @@ from palace.manager.api.problem_details import (
     NO_LICENSES,
     NO_SUCH_LANE,
     NOT_AGE_APPROPRIATE,
+    NOT_FOUND_ON_REMOTE,
     REMOTE_INTEGRATION_FAILED,
 )
 from palace.manager.api.util.flask import get_request_library
@@ -35,6 +36,7 @@ from palace.manager.sqlalchemy.model.licensing import (
 from palace.manager.sqlalchemy.model.patron import Hold, Loan, Patron
 from palace.manager.sqlalchemy.model.work import Work
 from palace.manager.sqlalchemy.util import get_one
+from palace.manager.util import first_or_default
 from palace.manager.util.problem_detail import ProblemDetail
 
 T = TypeVar("T", Loan, Hold)
@@ -147,9 +149,13 @@ class CirculationManagerController(BaseCirculationManagerController):
         if isinstance(pools, ProblemDetail):
             return pools
 
-        # We know there is at least one LicensePool, and all LicensePools
-        # for an Identifier have the same Work.
-        work: Work = pools[0].work
+        # We know there is at least one LicensePool. Find the first one with
+        # a work set on it.
+        work: Work | None = first_or_default([lp.work for lp in pools if lp.work])
+        if work is None:
+            # We have no work for this license pool. Return a ProblemDetail
+            # that will give a 404 status code.
+            return NOT_FOUND_ON_REMOTE
 
         if work and not work.age_appropriate_for_patron(self.request_patron):
             # This work is not age-appropriate for the authenticated

--- a/src/palace/manager/api/controller/loan.py
+++ b/src/palace/manager/api/controller/loan.py
@@ -25,7 +25,6 @@ from palace.manager.api.problem_details import (
 )
 from palace.manager.api.util.flask import get_request_library, get_request_patron
 from palace.manager.celery.tasks.patron_activity import sync_patron_activity
-from palace.manager.core.exceptions import PalaceValueError
 from palace.manager.feed.acquisition import OPDSAcquisitionFeed
 from palace.manager.service.redis.models.patron_activity import PatronActivity
 from palace.manager.sqlalchemy.model.library import Library
@@ -370,19 +369,9 @@ class LoanController(CirculationManagerController):
         ):
             # If this is a streaming delivery mechanism, create an OPDS entry
             # with a fulfillment link to the streaming reader url.
-            feed = OPDSAcquisitionFeed.single_entry_loans_feed(
+            return OPDSAcquisitionFeed.single_entry_loans_feed(
                 self.circulation, loan, fulfillment=fulfillment
             )
-            if isinstance(feed, ProblemDetail):
-                # This should typically never happen, since we've gone through the entire fulfill workflow
-                # But for the sake of return-type completeness we are adding this here
-                return feed
-            if isinstance(feed, Response):
-                return feed
-            else:
-                raise PalaceValueError(
-                    "Unexpected return type from OPDSAcquisitionFeed.single_entry_loans_feed"
-                )
 
         try:
             return fulfillment.response()

--- a/src/palace/manager/api/controller/work.py
+++ b/src/palace/manager/api/controller/work.py
@@ -21,7 +21,6 @@ from palace.manager.api.util.flask import get_request_library, get_request_patro
 from palace.manager.core.app_server import load_pagination_from_request
 from palace.manager.core.config import CannotLoadConfiguration
 from palace.manager.core.metadata_layer import ContributorData
-from palace.manager.core.problem_details import INTERNAL_SERVER_ERROR
 from palace.manager.feed.acquisition import OPDSAcquisitionFeed
 from palace.manager.search.external_search import SortKeyPagination
 from palace.manager.sqlalchemy.model.lane import FeaturedFacets, Pagination
@@ -131,23 +130,13 @@ class WorkController(CirculationManagerController):
             item = loan or hold
             pool = pool or pools[0]
 
-            loans_feed = OPDSAcquisitionFeed.single_entry_loans_feed(
+            return OPDSAcquisitionFeed.single_entry_loans_feed(
                 self.circulation, item or pool
             )
-            if loans_feed is None:
-                self.log.error(
-                    "Could not generate loans feed for %r and %r", item, pool
-                )
-                return INTERNAL_SERVER_ERROR
-            return loans_feed
         else:
             annotator = self.manager.annotator(lane=None)
-            single_entry = OPDSAcquisitionFeed.single_entry(work, annotator)
-            if single_entry is None:
-                # There was some problem generating the entry.
-                return NOT_FOUND_ON_REMOTE
             return OPDSAcquisitionFeed.entry_as_response(
-                single_entry,
+                OPDSAcquisitionFeed.single_entry(work, annotator),
                 max_age=OPDSFeed.DEFAULT_MAX_AGE,
             )
 

--- a/src/palace/manager/api/controller/work.py
+++ b/src/palace/manager/api/controller/work.py
@@ -135,6 +135,7 @@ class WorkController(CirculationManagerController):
             )
         else:
             annotator = self.manager.annotator(lane=None)
+
             return OPDSAcquisitionFeed.entry_as_response(
                 OPDSAcquisitionFeed.single_entry(work, annotator),
                 max_age=OPDSFeed.DEFAULT_MAX_AGE,

--- a/src/palace/manager/feed/acquisition.py
+++ b/src/palace/manager/feed/acquisition.py
@@ -600,14 +600,10 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
 
         entry = cls.single_entry(work, annotator, even_if_no_license_pool=True)
 
-        if isinstance(entry, WorkEntry) and entry.computed:
-            return cls.entry_as_response(entry, **response_kwargs)
-        elif isinstance(entry, OPDSMessage):
-            return cls.entry_as_response(entry, max_age=0)
-        else:
-            raise PalaceValueError(
-                "Entry is not an instance of WorkEntry or OPDSMessage"
-            )
+        if isinstance(entry, OPDSMessage):
+            response_kwargs["max_age"] = 0
+
+        return cls.entry_as_response(entry, **response_kwargs)
 
     @classmethod
     def single_entry(

--- a/src/palace/manager/feed/opds.py
+++ b/src/palace/manager/feed/opds.py
@@ -16,6 +16,7 @@ from palace.manager.feed.serializer.opds2 import OPDS2Serializer
 from palace.manager.feed.types import FeedData, WorkEntry
 from palace.manager.sqlalchemy.model.lane import FeaturedFacets
 from palace.manager.util.flask_util import OPDSEntryResponse, OPDSFeedResponse
+from palace.manager.util.log import LoggerMixin
 from palace.manager.util.opds_writer import OPDSMessage
 
 
@@ -37,7 +38,7 @@ def get_serializer(
     return OPDS1Version1Serializer()
 
 
-class BaseOPDSFeed(FeedInterface):
+class BaseOPDSFeed(FeedInterface, LoggerMixin):
     def __init__(
         self,
         title: str,
@@ -48,7 +49,6 @@ class BaseOPDSFeed(FeedInterface):
         self.title = title
         self._precomposed_entries = precomposed_entries or []
         self._feed = FeedData()
-        self.log = logging.getLogger(self.__class__.__name__)
 
     def add_link(self, href: str, rel: str | None = None, **kwargs: Any) -> None:
         self._feed.add_link(href, rel=rel, **kwargs)

--- a/tests/manager/api/admin/controller/test_custom_lists.py
+++ b/tests/manager/api/admin/controller/test_custom_lists.py
@@ -31,6 +31,7 @@ from palace.manager.sqlalchemy.util import create, get_one
 from palace.manager.util.problem_detail import ProblemDetail
 from tests.fixtures.api_admin import AdminLibrarianFixture
 from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.services import ServicesFixture
 from tests.mocks.flask import add_request_context
 from tests.mocks.search import ExternalSearchIndexFake, SearchServiceFake
 
@@ -476,7 +477,9 @@ class TestCustomListsController:
             assert work2.presentation_edition.author == entry2.get("author")
 
     def test_custom_list_get_with_pagination(
-        self, admin_librarian_fixture: AdminLibrarianFixture
+        self,
+        admin_librarian_fixture: AdminLibrarianFixture,
+        services_fixture: ServicesFixture,
     ):
         data_source = DataSource.lookup(
             admin_librarian_fixture.ctrl.db.session, DataSource.LIBRARY_STAFF
@@ -495,7 +498,10 @@ class TestCustomListsController:
             work = admin_librarian_fixture.ctrl.db.work(with_license_pool=True)
             list.add_entry(work)
 
-        with admin_librarian_fixture.request_context_with_library_and_admin("/"):
+        with (
+            admin_librarian_fixture.request_context_with_library_and_admin("/"),
+            services_fixture.wired(),
+        ):
             assert isinstance(list.id, int)
             response = admin_librarian_fixture.manager.admin_custom_lists_controller.custom_list(
                 list.id

--- a/tests/manager/api/controller/test_work.py
+++ b/tests/manager/api/controller/test_work.py
@@ -286,6 +286,8 @@ class TestWorkController:
 
     def test_permalink(self, work_fixture: WorkFixture):
         with work_fixture.request_context_with_library("/"):
+            assert work_fixture.identifier.type is not None
+            assert work_fixture.identifier.identifier is not None
             response = work_fixture.manager.work_controller.permalink(
                 work_fixture.identifier.type, work_fixture.identifier.identifier
             )

--- a/tests/manager/feed/test_opds_acquisition_feed.py
+++ b/tests/manager/feed/test_opds_acquisition_feed.py
@@ -948,25 +948,6 @@ class TestOPDSAcquisitionFeed:
         assert isinstance(response, OPDSEntryResponse)
         assert response.status_code == 403
 
-    def test_single_entry_loans_feed_default_annotator(
-        self, db: DatabaseTransactionFixture
-    ):
-        patron = db.patron()
-        work = db.work(with_license_pool=True)
-        pool = work.active_license_pool()
-        assert pool is not None
-        loan, _ = pool.loan_to(patron)
-
-        with (
-            patch.object(OPDSAcquisitionFeed, "single_entry") as mock,
-            pytest.raises(
-                PalaceValueError,
-                match="Entry is not an instance of WorkEntry or OPDSMessage",
-            ),
-        ):
-            mock.return_value = None
-            OPDSAcquisitionFeed.single_entry_loans_feed(None, loan)
-
     def test_single_entry_with_edition(self, db: DatabaseTransactionFixture):
         work = db.work(with_license_pool=True)
         annotator = object()


### PR DESCRIPTION
## Description

There are two parts to this fix:
1. Trying a bit harder to get a work for the licensepools we are working with.
2. Tightening up some of our type hints and `None` handling, so that we log appropriate errors if we do get a `None` coming back.
  - I tried to make sure to add log statements for all of these so that we can figure out whats happening from the logs, if we see these happening in production. 

## Motivation and Context

This fixes an error we were seeing in production , where we couldn't generate a single item feed for a work. I was actually able to find an item this was happening to and reproduce it, which let me get a fix in place. 

Stack trace from production:
```
Traceback (most recent call last):
  File "/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/var/www/circulation/src/palace/manager/api/routes.py", line 120, in decorated
    return f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/api/routes.py", line 70, in decorated
    return f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/api/routes.py", line 93, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File "/var/www/circulation/src/palace/manager/core/app_server.py", line 87, in decorated
    v = f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/core/app_server.py", line 163, in compressor
    return f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/api/routes.py", line 510, in permalink
    return app.manager.work_controller.permalink(identifier_type, identifier)
  File "/var/www/circulation/src/palace/manager/api/controller/work.py", line 135, in permalink
    return OPDSAcquisitionFeed.entry_as_response(
  File "/var/www/circulation/src/palace/manager/feed/opds.py", line 88, in entry_as_response
    if not entry.computed:
AttributeError: 'NoneType' object has no attribute 'computed'
```

JIRA: 
- Parent: PP-1860 
- PP-1961

## How Has This Been Tested?

- Tested with item that was causing issue locally
- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
