### PR TITLE
Log additional Palace request data

### DIFF
--- a/src/palace/manager/service/logging/log.py
+++ b/src/palace/manager/service/logging/log.py
@@ -124,16 +124,13 @@ class JSONFormatter(logging.Formatter):
 
                 if patron := get_request_patron(default=None):
                     patron_information = {}
-                    if patron.authorization_identifier:
-                        patron_information["authorization_identifier"] = (
-                            patron.authorization_identifier
-                        )
-                    if patron.username:
-                        patron_information["username"] = patron.username
-                    if patron.external_identifier:
-                        patron_information["external_identifier"] = (
-                            patron.external_identifier
-                        )
+                    for key in (
+                        "authorization_identifier",
+                        "username",
+                        "external_identifier",
+                    ):
+                        if value := getattr(patron, key, None):
+                            patron_information[key] = value
                     if patron_information:
                         data["request"]["patron"] = patron_information
 

--- a/src/palace/manager/service/logging/log.py
+++ b/src/palace/manager/service/logging/log.py
@@ -8,8 +8,11 @@ from collections.abc import Callable, Mapping, Sequence
 from logging import Handler
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy.exc import SQLAlchemyError
 from watchtower import CloudWatchLogHandler
 
+from palace.manager.api.admin.util.flask import get_request_admin
+from palace.manager.api.util.flask import get_request_library, get_request_patron
 from palace.manager.service.logging.configuration import LogLevel
 from palace.manager.util.datetime_helpers import from_timestamp
 
@@ -109,6 +112,37 @@ class JSONFormatter(logging.Formatter):
                 forwarded_for_list.append(remote_addr)
             if forwarded_for_list:
                 data["request"]["forwarded_for"] = forwarded_for_list
+
+            # If we have Palace specific request data, we also want to include that in the log
+            try:
+                if library := get_request_library(default=None):
+                    data["request"]["library"] = {
+                        "uuid": library.uuid,
+                        "name": library.name,
+                        "short_name": library.short_name,
+                    }
+
+                if patron := get_request_patron(default=None):
+                    patron_information = {}
+                    if patron.authorization_identifier:
+                        patron_information["authorization_identifier"] = (
+                            patron.authorization_identifier
+                        )
+                    if patron.username:
+                        patron_information["username"] = patron.username
+                    if patron.external_identifier:
+                        patron_information["external_identifier"] = (
+                            patron.external_identifier
+                        )
+                    if patron_information:
+                        data["request"]["patron"] = patron_information
+
+                if admin := get_request_admin(default=None):
+                    data["request"]["admin"] = admin.email
+            except SQLAlchemyError:
+                # All the Palace specific data are SQLAlchemy objects, so if we are logging errors
+                # when the database is in a bad state, we may not be able to access these objects.
+                pass
 
         # If we are running in uwsgi context, we include the worker id in the log
         if uwsgi:

--- a/tests/manager/service/logging/test_log.py
+++ b/tests/manager/service/logging/test_log.py
@@ -274,15 +274,13 @@ class TestJSONFormatter:
         assert "external_identifier" not in request["patron"]
         assert "username" not in request["patron"]
 
-        # Patron data - missing authorization_identifier
-        patron = db.patron(external_identifier="123")
+        # Patron data - No information to include
+        patron.authorization_identifier = None
         with flask_app_fixture.test_request_context(patron=patron):
             data = json.loads(formatter.format(record))
         assert "request" in data
         request = data["request"]
-        assert "patron" in request
-        assert "authorization_identifier" not in request["patron"]
-        assert request["patron"]["external_identifier"] == "123"
+        assert "patron" not in request
 
         # Admin data
         admin, _ = get_one_or_create(db.session, Admin, email="test@email.com")


### PR DESCRIPTION
## Description

If we are in a request context when we log a message, we include information from `request.admin`, `request.library` and `request.patron` if any of them are set.

## Motivation and Context

While troubleshooting the issues in PP-1860, it would have been very helpful to have this additional information included with log messages.

## How Has This Been Tested?

- Tested locally
- New unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
