### PR TITLE
Filter on library when checking lane name unique (PP-1967)

### DIFF
--- a/src/palace/manager/api/admin/problem_details.py
+++ b/src/palace/manager/api/admin/problem_details.py
@@ -462,9 +462,9 @@ NO_CUSTOM_LISTS_FOR_LANE = pd(
 LANE_WITH_PARENT_AND_DISPLAY_NAME_ALREADY_EXISTS = pd(
     "http://librarysimplified.org/terms/problem/lane-with-parent-and-display-name-already-exists",
     status_code=400,
-    title=_("Lane with parent and display name already exists"),
+    title=_("Lane with parent and display name already exists for this library"),
     detail=_(
-        "You cannot create a lane with the same parent and display name as an existing lane."
+        "You cannot create a lane with the same parent and display name as an existing lane within the same library."
     ),
 )
 


### PR DESCRIPTION
## Description

This PR does a small bit of refactoring to DRY the check we use for lane name uniqueness and fixes a bug where the check for lane name uniqueness 

Previously one of the checks was missing a filter on the lanes library. Making it so that you couldn't create a lane with the same name as any other lane in the CM, rather then any other lane with the same library. 

## Motivation and Context

Debugging this unhandled traceback:
```
Traceback (most recent call last):
  File "/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/var/www/circulation/src/palace/manager/api/routes.py", line 120, in decorated
    return f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/api/admin/routes.py", line 84, in decorated
    v = f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/api/admin/routes.py", line 57, in decorated
    return f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/api/admin/routes.py", line 75, in decorated
    return f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/api/admin/routes.py", line 617, in lanes
    return app.manager.admin_lanes_controller.lanes()
  File "/var/www/circulation/src/palace/manager/api/admin/controller/lanes.py", line 94, in lanes
    old_lane = get_one(
  File "/var/www/circulation/src/palace/manager/sqlalchemy/util.py", line 99, in get_one
    return q.one()  # type: ignore[no-any-return]
  File "/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/query.py", line 2870, in one
    return self._iter().one()
  File "/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/engine/result.py", line 1522, in one
    return self._only_one_row(
  File "/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/engine/result.py", line 614, in _only_one_row
    raise exc.MultipleResultsFound(
sqlalchemy.exc.MultipleResultsFound: Multiple rows were found when exactly one was required
```

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
