### PR TITLE
Remove `Library.all_collections` property.

### DIFF
--- a/src/palace/manager/api/admin/controller/custom_lists.py
+++ b/src/palace/manager/api/admin/controller/custom_lists.py
@@ -114,7 +114,7 @@ class CustomListsController(
             .join(LicensePool, LicensePool.work_id == Work.id)
             .join(Collection, LicensePool.collection_id == Collection.id)
             .filter(LicensePool.identifier_id == identifier.id)
-            .filter(Collection.id.in_([c.id for c in library.all_collections]))
+            .filter(Collection.id.in_([c.id for c in library.collections]))
         )
         work = query.one()
         return work

--- a/src/palace/manager/api/admin/dashboard_stats.py
+++ b/src/palace/manager/api/admin/dashboard_stats.py
@@ -129,9 +129,7 @@ class Statistics:
         all_collections = self._all_collections()
 
         for library in authorized_libraries:
-            library_collections = {
-                all_collections[c.id] for c in library.all_collections
-            }
+            library_collections = {all_collections[c.id] for c in library.collections}
             authorized_collections_by_library[library.short_name] = sorted(
                 library_collections, key=lambda c: c.id
             )

--- a/src/palace/manager/sqlalchemy/model/library.py
+++ b/src/palace/manager/sqlalchemy/model/library.py
@@ -311,12 +311,6 @@ class Library(Base, HasSessionCache):
         integration_settings_update(LibrarySettings, self, new_settings, merge=True)
 
     @property
-    def all_collections(self) -> Generator[Collection]:
-        for collection in self.collections:
-            yield collection
-            yield from collection.parents
-
-    @property
     def entrypoints(self) -> Generator[type[EntryPoint] | None]:
         """The EntryPoints enabled for this library."""
         values = self.settings.enabled_entry_points
@@ -394,7 +388,7 @@ class Library(Base, HasSessionCache):
         from palace.manager.sqlalchemy.model.collection import Collection
 
         collection_ids = collection_ids or [
-            x.id for x in self.all_collections if x.id is not None
+            x.id for x in self.collections if x.id is not None
         ]
         return Collection.restrict_to_ready_deliverable_works(
             query,

--- a/tests/manager/sqlalchemy/model/test_library.py
+++ b/tests/manager/sqlalchemy/model/test_library.py
@@ -98,14 +98,13 @@ class TestLibrary:
         db.session.flush()
         assert False == library.has_root_lanes
 
-    def test_all_collections(self, db: DatabaseTransactionFixture):
+    def test_collections(self, db: DatabaseTransactionFixture):
         library = db.default_library()
 
         parent = db.collection()
         db.default_collection().parent_id = parent.id
 
         assert [db.default_collection()] == library.collections
-        assert {db.default_collection(), parent} == set(library.all_collections)
 
     def test_estimated_holdings_by_language(self, db: DatabaseTransactionFixture):
         library = db.default_library()


### PR DESCRIPTION
## Description

Removes `Library.all_collections` (and its functionality), replaces its usage with `Library.collections`, and removes a test assertion specific to this method.

## Motivation and Context

While working on PP-1875, I ran into this attribute, which provides a generator that yields both the collections associated with a library and the parents of those collections, where present. 

It came in on this [commit](https://github.com/NYPL-Simplified/circulation/commit/d58ee6b83af1f57ae32a2acf8f7a01344271ed05) on [this PR](https://github.com/NYPL-Simplified/server_core/pull/570/commits/d58ee6b83af1f57ae32a2acf8f7a01344271ed05).

Here's some context from the PR description:

> When I tried setting up an Overdrive Advantage collection, I expected that I would be able to add the Overdrive Advantage collection to a library and have that library’s feeds also contain the books from the parent consortium collection. Without this change, I’d have to separately add the consortium collection to the library.
>
> The downside is that now there’s no way to get a feed that has the Overdrive Advantage books without the consortium’s books.

So, based on how we currently configure our collections that have parents -- specifically, we configure the library association for both OD main accounts and Advantage accounts, as appropriate -- I don't think we need the functionality it provides.

## How Has This Been Tested?

- Tests pass locally.
- [CI tests for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/12019497840) pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
