### PR TITLE
Remove unused `Collection.parents` attribute.

### DIFF
--- a/src/palace/manager/sqlalchemy/model/collection.py
+++ b/src/palace/manager/sqlalchemy/model/collection.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Generator
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from dependency_injector.wiring import Provide, inject
@@ -450,19 +449,6 @@ class Collection(Base, HasSessionCache, RedisKeyMixin):
             self._set_settings(
                 **{Collection.DATA_SOURCE_NAME_SETTING: new_datasource_name}
             )
-
-    @property
-    def parents(self) -> Generator[Collection]:
-        if not self.parent_id:
-            return None
-
-        _db = Session.object_session(self)
-        parent = Collection.by_id(_db, self.parent_id)
-        if parent is None:
-            return None
-
-        yield parent
-        yield from parent.parents
 
     @property
     def pools_with_no_delivery_mechanisms(self) -> Query[LicensePool]:

--- a/tests/manager/sqlalchemy/model/test_collection.py
+++ b/tests/manager/sqlalchemy/model/test_collection.py
@@ -118,21 +118,6 @@ class TestCollection:
         c1.marked_for_deletion = True
         assert [test_collection] == Collection.by_protocol(db.session, overdrive).all()
 
-    def test_parents(self, example_collection_fixture: ExampleCollectionFixture):
-        db = example_collection_fixture.database_fixture
-
-        # Collections can return all their parents recursively.
-        c1 = db.collection()
-        assert [] == list(c1.parents)
-
-        c2 = db.collection()
-        c2.parent_id = c1.id
-        assert [c1] == list(c2.parents)
-
-        c3 = db.collection()
-        c3.parent_id = c2.id
-        assert [c2, c1] == list(c3.parents)
-
     def test_get_protocol(self, db: DatabaseTransactionFixture):
         test_collection = db.collection()
         integration = test_collection.integration_configuration


### PR DESCRIPTION
## Description

Remove unused `Collection.parents` attribute.

## Motivation and Context

Noticed that, after #2191, this attribute is no longer used.

## How Has This Been Tested?

- Tests pass locally.
- [CI tests for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/12033541621) pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
