### PR TITLE
Rename collection library associations. (PP-1875)

### DIFF
--- a/src/palace/manager/api/admin/controller/admin_search.py
+++ b/src/palace/manager/api/admin/controller/admin_search.py
@@ -31,7 +31,7 @@ class AdminSearchController(AdminController):
         - Subject
         """
         library = get_request_library()
-        collection_ids = [coll.id for coll in library.collections if coll.id]
+        collection_ids = [coll.id for coll in library.associated_collections if coll.id]
         return self._search_field_values_cached(collection_ids)
 
     @classmethod

--- a/src/palace/manager/api/admin/controller/custom_lists.py
+++ b/src/palace/manager/api/admin/controller/custom_lists.py
@@ -114,7 +114,7 @@ class CustomListsController(
             .join(LicensePool, LicensePool.work_id == Work.id)
             .join(Collection, LicensePool.collection_id == Collection.id)
             .filter(LicensePool.identifier_id == identifier.id)
-            .filter(Collection.id.in_([c.id for c in library.collections]))
+            .filter(Collection.id.in_([c.id for c in library.associated_collections]))
         )
         work = query.one()
         return work

--- a/src/palace/manager/api/admin/controller/custom_lists.py
+++ b/src/palace/manager/api/admin/controller/custom_lists.py
@@ -286,7 +286,7 @@ class CustomListsController(
             if not collection:
                 self._db.rollback()
                 return MISSING_COLLECTION
-            if list.library not in collection.libraries:
+            if list.library not in collection.associated_libraries:
                 self._db.rollback()
                 return COLLECTION_NOT_ASSOCIATED_WITH_LIBRARY
             new_collections.append(collection)

--- a/src/palace/manager/api/admin/dashboard_stats.py
+++ b/src/palace/manager/api/admin/dashboard_stats.py
@@ -129,7 +129,9 @@ class Statistics:
         all_collections = self._all_collections()
 
         for library in authorized_libraries:
-            library_collections = {all_collections[c.id] for c in library.collections}
+            library_collections = {
+                all_collections[c.id] for c in library.associated_collections
+            }
             authorized_collections_by_library[library.short_name] = sorted(
                 library_collections, key=lambda c: c.id
             )

--- a/src/palace/manager/api/circulation_manager.py
+++ b/src/palace/manager/api/circulation_manager.py
@@ -259,7 +259,7 @@ class CirculationManager(LoggerMixin):
             collections: set[Collection] = set()
             libraries_collections: dict[int | None, list[Collection]] = {}
             for library in libraries:
-                library_collections = library.collections
+                library_collections = library.associated_collections
                 collections.update(library_collections)
                 libraries_collections[library.id] = library_collections
 

--- a/src/palace/manager/api/controller/marc.py
+++ b/src/palace/manager/api/controller/marc.py
@@ -146,7 +146,7 @@ class MARCRecordController:
 
         if len(marc_files) == 0:
             # Are there any collections configured to export MARC records?
-            if any(c.export_marc_records for c in library.collections):
+            if any(c.export_marc_records for c in library.associated_collections):
                 return "<p>" + "MARC files aren't ready to download yet." + "</p>"
             else:
                 return (

--- a/src/palace/manager/api/controller/playtime_entries.py
+++ b/src/palace/manager/api/controller/playtime_entries.py
@@ -54,7 +54,7 @@ class PlaytimeEntriesController(CirculationManagerController):
                 f"The collection {collection_id} was not found."
             )
 
-        if collection not in library.collections:
+        if collection not in library.associated_collections:
             return INVALID_INPUT.detailed("Collection was not found in the Library.")
 
         if not identifier.licensed_through_collection(collection):

--- a/src/palace/manager/api/lanes.py
+++ b/src/palace/manager/api/lanes.py
@@ -1396,7 +1396,7 @@ class CrawlableCollectionBasedLane(CrawlableLane):
         if isinstance(library_or_collections, Library):
             # We're looking at all the collections in a given library.
             library = library_or_collections
-            collections = library.collections
+            collections = library.associated_collections
             identifier = library.name
         else:
             # We're looking at collections directly, without respect
@@ -1532,7 +1532,7 @@ class JackpotWorkList(WorkList):
         # Add one or more WorkLists for every collection in the
         # system, so that a client can test borrowing a book from
         # every collection.
-        for collection in sorted(library.collections, key=lambda x: x.name):
+        for collection in sorted(library.associated_collections, key=lambda x: x.name):
             for medium in Edition.FULFILLABLE_MEDIA:
                 # Give each Worklist a name that is distinctive
                 # and easy for a client to parse.

--- a/src/palace/manager/api/metadata/novelist.py
+++ b/src/palace/manager/api/metadata/novelist.py
@@ -551,7 +551,7 @@ class NoveListAPI(
         :return: a list of Novelist objects to send
         """
         collectionList = []
-        for c in library.collections:
+        for c in library.associated_collections:
             collectionList.append(c.id)
 
         LEFT_OUTER_JOIN = True

--- a/src/palace/manager/api/selftest.py
+++ b/src/palace/manager/api/selftest.py
@@ -51,7 +51,7 @@ class HasPatronSelfTests(HasSelfTests, ABC):
                 - a failure SelfTestResult when it cannot.
         """
         _db = Session.object_session(collection)
-        if not collection.libraries:
+        if not collection.associated_libraries:
             yield cls.test_failure(
                 "Acquiring test patron credentials.",
                 "Collection is not associated with any libraries.",
@@ -60,7 +60,7 @@ class HasPatronSelfTests(HasSelfTests, ABC):
             # Not strictly necessary, but makes it obvious that we won't do anything else.
             return
 
-        for library in collection.libraries:
+        for library in collection.associated_libraries:
             task = "Acquiring test patron credentials for library %s" % library.name
             try:
                 patron, password = cls._determine_self_test_patron(library, _db=_db)

--- a/src/palace/manager/core/query/customlist.py
+++ b/src/palace/manager/core/query/customlist.py
@@ -31,14 +31,14 @@ class CustomListQueries(LoggerMixin):
             f"Attempting to share customlist '{customlist.name}' with library '{library.name}'."
         )
         for collection in customlist.collections:
-            if collection not in library.collections:
+            if collection not in library.associated_collections:
                 log.info(
                     f"Unable to share customlist: Collection '{collection.name}' is missing from the library."
                 )
                 return CUSTOMLIST_SOURCE_COLLECTION_MISSING
 
         # All entries must be valid for the library
-        library_collection_ids = [c.id for c in library.collections]
+        library_collection_ids = [c.id for c in library.associated_collections]
         entry: CustomListEntry
         missing_work_id_count = 0
         for entry in customlist.entries:

--- a/src/palace/manager/scripts/configuration.py
+++ b/src/palace/manager/scripts/configuration.py
@@ -216,7 +216,7 @@ class ConfigureCollectionScript(ConfigurationSettingScript):
                         message += " I only know about: %s" % library_names
                     raise ValueError(message)
                 if collection not in library.collections:
-                    collection.libraries.append(library)
+                    collection.associated_libraries.append(library)
         site_configuration_has_changed(_db)
         _db.commit()
         output.write("Configuration settings stored.\n")

--- a/src/palace/manager/scripts/configuration.py
+++ b/src/palace/manager/scripts/configuration.py
@@ -215,7 +215,7 @@ class ConfigureCollectionScript(ConfigurationSettingScript):
                     if library_names:
                         message += " I only know about: %s" % library_names
                     raise ValueError(message)
-                if collection not in library.collections:
+                if collection not in library.associated_collections:
                     collection.associated_libraries.append(library)
         site_configuration_has_changed(_db)
         _db.commit()

--- a/src/palace/manager/scripts/informational.py
+++ b/src/palace/manager/scripts/informational.py
@@ -474,10 +474,10 @@ class WhereAreMyBooksScript(CollectionInputScript):
         self.out("Checking library %s", library.name)
 
         # Make sure it has collections.
-        if not library.collections:
+        if not library.associated_collections:
             self.out(" This library has no collections -- that's a problem.")
         else:
-            for collection in library.collections:
+            for collection in library.associated_collections:
                 self.out(" Associated with collection %s.", collection.name)
 
         # Make sure it has lanes.

--- a/src/palace/manager/scripts/informational.py
+++ b/src/palace/manager/scripts/informational.py
@@ -338,7 +338,9 @@ class Explain(IdentifierInputScript):
         self.write("Licensepool info:")
         if pool.collection:
             self.write(" Collection: %r" % pool.collection)
-            libraries = [library.name for library in pool.collection.libraries]
+            libraries = [
+                library.name for library in pool.collection.associated_libraries
+            ]
             if libraries:
                 self.write(" Available to libraries: %s" % ", ".join(libraries))
             else:

--- a/src/palace/manager/scripts/self_test.py
+++ b/src/palace/manager/scripts/self_test.py
@@ -17,7 +17,7 @@ class RunSelfTestsScript(LibraryInputScript):
         for library in parsed.libraries:
             api_map = self.services.integration_registry.license_providers()
             self.out.write("Testing %s\n" % library.name)
-            for collection in library.collections:
+            for collection in library.associated_collections:
                 try:
                     self.test_collection(collection, api_map)
                 except Exception as e:

--- a/src/palace/manager/search/external_search.py
+++ b/src/palace/manager/search/external_search.py
@@ -1581,7 +1581,7 @@ class Filter(SearchBase):
 
         if isinstance(collections, Library):
             # Find all works in this Library's collections.
-            collections = collections.collections
+            collections = collections.associated_collections
         self.collection_ids = self._filter_ids(collections)
 
         self.media = media

--- a/src/palace/manager/service/redis/models/patron_activity.py
+++ b/src/palace/manager/service/redis/models/patron_activity.py
@@ -379,7 +379,7 @@ class PatronActivity(LoggerMixin):
         patron activity sync. This indicates that the collection is ready to be
         synced.
         """
-        collections = patron.library.collections
+        collections = patron.library.associated_collections
         keys = [
             cls._get_key(redis_client, patron.id, collection.id)
             for collection in collections

--- a/src/palace/manager/sqlalchemy/model/admin.py
+++ b/src/palace/manager/sqlalchemy/model/admin.py
@@ -208,7 +208,7 @@ class Admin(Base, HasSessionCache):
     def can_see_collection(self, collection):
         if self.is_system_admin():
             return True
-        for library in collection.libraries:
+        for library in collection.associated_libraries:
             if self.is_librarian(library):
                 return True
         return False

--- a/src/palace/manager/sqlalchemy/model/collection.py
+++ b/src/palace/manager/sqlalchemy/model/collection.py
@@ -105,7 +105,7 @@ class Collection(Base, HasSessionCache, RedisKeyMixin):
 
     # A Collection can provide books to many Libraries.
     # https://docs.sqlalchemy.org/en/14/orm/extensions/associationproxy.html#composite-association-proxies
-    libraries: Mapped[list[Library]] = association_proxy(
+    associated_libraries: Mapped[list[Library]] = association_proxy(
         "integration_configuration", "libraries"
     )
 
@@ -563,7 +563,7 @@ class Collection(Base, HasSessionCache, RedisKeyMixin):
         _db = Session.object_session(self)
 
         # Disassociate all libraries from this collection.
-        self.libraries.clear()
+        self.associated_libraries.clear()
 
         # Delete all the license pools. This should be the only part
         # of the application where LicensePools are permanently

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -2776,7 +2776,7 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
 
     @property
     def collection_ids(self):
-        return [x.id for x in self.library.collections]
+        return [x.id for x in self.library.associated_collections]
 
     @property
     def children(self):

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -1500,7 +1500,7 @@ class WorkList:
             self.library_id = library.id
             if self.collection_ids is None:
                 self.collection_ids = [
-                    collection.id for collection in library.collection_ids
+                    collection.id for collection in library.associated_collections_ids
                 ]
         self.display_name = display_name
         if genres:

--- a/src/palace/manager/sqlalchemy/model/library.py
+++ b/src/palace/manager/sqlalchemy/model/library.py
@@ -196,8 +196,8 @@ class Library(Base, HasSessionCache):
         return [CollectionInfoTuple(*row) for row in results]
 
     @property
-    def collections(self) -> Sequence[Collection]:
-        """Get the collections for this library"""
+    def associated_collections(self) -> Sequence[Collection]:
+        """Get all associated collections for this library."""
         _db = Session.object_session(self)
         return _db.scalars(self.collections_query()).all()
 
@@ -323,14 +323,14 @@ class Library(Base, HasSessionCache):
         """Look up the enabled facets for a given facet group."""
         if group_name == FacetConstants.DISTRIBUTOR_FACETS_GROUP_NAME:
             enabled = []
-            for collection in self.collections:
+            for collection in self.associated_collections:
                 if collection.data_source and collection.data_source.name:
                     enabled.append(collection.data_source.name)
             return list(set(enabled))
 
         if group_name == FacetConstants.COLLECTION_NAME_FACETS_GROUP_NAME:
             enabled = []
-            for collection in self.collections:
+            for collection in self.associated_collections:
                 if collection.name is not None:
                     enabled.append(collection.name)
             return enabled
@@ -388,7 +388,7 @@ class Library(Base, HasSessionCache):
         from palace.manager.sqlalchemy.model.collection import Collection
 
         collection_ids = collection_ids or [
-            x.id for x in self.collections if x.id is not None
+            x.id for x in self.associated_collections if x.id is not None
         ]
         return Collection.restrict_to_ready_deliverable_works(
             query,

--- a/src/palace/manager/sqlalchemy/model/library.py
+++ b/src/palace/manager/sqlalchemy/model/library.py
@@ -163,7 +163,7 @@ class Library(Base, HasSessionCache):
         uselist=False,
     )
 
-    def collections_query(self, base_query: Select | None = None) -> Select:
+    def _associated_collections_query(self, base_query: Select | None = None) -> Select:
         from palace.manager.sqlalchemy.model.collection import Collection
         from palace.manager.sqlalchemy.model.integration import (
             IntegrationConfiguration,
@@ -182,7 +182,7 @@ class Library(Base, HasSessionCache):
         )
 
     @property
-    def collection_ids(self) -> list[CollectionInfoTuple]:
+    def associated_collections_ids(self) -> list[CollectionInfoTuple]:
         """Get the collection ids for this library"""
         from palace.manager.sqlalchemy.model.collection import Collection
         from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
@@ -191,7 +191,7 @@ class Library(Base, HasSessionCache):
         query = select(Collection.id, IntegrationConfiguration.protocol).select_from(
             Collection
         )
-        query = self.collections_query(query)
+        query = self._associated_collections_query(query)
         results = _db.execute(query).all()
         return [CollectionInfoTuple(*row) for row in results]
 
@@ -199,7 +199,7 @@ class Library(Base, HasSessionCache):
     def associated_collections(self) -> Sequence[Collection]:
         """Get all associated collections for this library."""
         _db = Session.object_session(self)
-        return _db.scalars(self.collections_query()).all()
+        return _db.scalars(self._associated_collections_query()).all()
 
     # Cache of the libraries loaded settings object
     _settings: LibrarySettings | None

--- a/src/palace/manager/sqlalchemy/model/work.py
+++ b/src/palace/manager/sqlalchemy/model/work.py
@@ -1165,7 +1165,7 @@ class Work(Base, LoggerMixin):
         # associated with a loan, were a loan to be issued right
         # now.
         active_license_pool = None
-        collections = [] if not library else [c for c in library.collections]
+        collections = [] if not library else [c for c in library.associated_collections]
         for p in self.license_pools:
             if collections and p.collection not in collections:
                 continue

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -470,7 +470,7 @@ class DatabaseTransactionFixture:
         saves time.
         """
         if not self._default_collection:
-            self._default_collection = self.default_library().collections[0]
+            self._default_collection = self.default_library().associated_collections[0]
 
         return self._default_collection
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -422,7 +422,7 @@ class DatabaseTransactionFixture:
             protocol=OPDSAPI,
             settings=self.opds_settings(data_source="OPDS"),
         )
-        collection.libraries.append(library)
+        collection.associated_libraries.append(library)
         return library
 
     @classmethod
@@ -606,8 +606,8 @@ class DatabaseTransactionFixture:
             collection.integration_configuration.settings_dict = settings
             flag_modified(collection.integration_configuration, "settings_dict")
 
-        if library and library not in collection.libraries:
-            collection.libraries.append(library)
+        if library and library not in collection.associated_libraries:
+            collection.associated_libraries.append(library)
         return collection
 
     def work(

--- a/tests/fixtures/marc.py
+++ b/tests/fixtures/marc.py
@@ -38,9 +38,9 @@ class MarcExporterFixture:
         self.collection2 = db.collection()
         self.collection3 = db.collection()
 
-        self.collection1.libraries = [self.library1, self.library2]
-        self.collection2.libraries = [self.library1]
-        self.collection3.libraries = [self.library2]
+        self.collection1.associated_libraries = [self.library1, self.library2]
+        self.collection2.associated_libraries = [self.library1]
+        self.collection3.associated_libraries = [self.library2]
 
     def integration(self) -> IntegrationConfiguration:
         return self._db.integration_configuration(

--- a/tests/manager/api/admin/controller/test_collections.py
+++ b/tests/manager/api/admin/controller/test_collections.py
@@ -114,7 +114,7 @@ class TestCollectionSettings:
         flask_app_fixture: FlaskAppFixture,
         db: DatabaseTransactionFixture,
     ) -> None:
-        [c1] = db.default_library().collections
+        [c1] = db.default_library().associated_collections
 
         c2 = db.collection(
             name="Collection 2",
@@ -426,9 +426,9 @@ class TestCollectionSettings:
         )
 
         # Two libraries now have access to the collection.
-        assert [collection] == l1.collections
-        assert [collection] == l2.collections
-        assert [] == l3.collections
+        assert [collection] == l1.associated_collections
+        assert [collection] == l2.associated_collections
+        assert [] == l3.associated_collections
 
         # Additional settings were set on the collection.
         assert (
@@ -480,7 +480,7 @@ class TestCollectionSettings:
         assert "website_id" not in child.integration_configuration.settings_dict
 
         # One library has access to the collection.
-        assert [child] == l3.collections
+        assert [child] == l3.associated_collections
         assert isinstance(l3.id, int)
         l3_settings = child.integration_configuration.for_library(l3.id)
         assert l3_settings is not None

--- a/tests/manager/api/admin/controller/test_collections.py
+++ b/tests/manager/api/admin/controller/test_collections.py
@@ -137,7 +137,7 @@ class TestCollectionSettings:
         c3.parent = c2
 
         l1 = db.library(short_name="L1")
-        c3.libraries += [l1, db.default_library()]
+        c3.associated_libraries += [l1, db.default_library()]
         db.integration_library_configuration(
             c3.integration_configuration,
             l1,
@@ -534,7 +534,7 @@ class TestCollectionSettings:
         )
 
         # A library now has access to the collection.
-        assert collection.libraries == [l1]
+        assert collection.associated_libraries == [l1]
 
         # Additional settings were set on the collection.
         assert "1234" == collection.integration_configuration.settings_dict.get(
@@ -571,7 +571,7 @@ class TestCollectionSettings:
         assert OverdriveAPI.label() == collection.protocol
 
         # But the library has been removed.
-        assert collection.libraries == []
+        assert collection.associated_libraries == []
 
         # All settings for that library and collection have been deleted.
         assert collection.integration_configuration.library_configurations == []
@@ -704,7 +704,7 @@ class TestCollectionSettings:
         # when the connection between collection and library was deleted.
         assert isinstance(l1.id, int)
         assert collection.integration_configuration.for_library(l1.id) is None
-        assert [] == collection.libraries
+        assert [] == collection.associated_libraries
 
     def test_collection_delete(
         self,

--- a/tests/manager/api/admin/controller/test_custom_lists.py
+++ b/tests/manager/api/admin/controller/test_custom_lists.py
@@ -277,7 +277,9 @@ class TestCustomListsController:
     def test_custom_lists_create(self, admin_librarian_fixture: AdminLibrarianFixture):
         work = admin_librarian_fixture.ctrl.db.work(with_open_access_download=True)
         collection = admin_librarian_fixture.ctrl.db.collection()
-        collection.libraries = [admin_librarian_fixture.ctrl.db.default_library()]
+        collection.associated_libraries = [
+            admin_librarian_fixture.ctrl.db.default_library()
+        ]
 
         with admin_librarian_fixture.request_context_with_library_and_admin(
             "/", method="POST"
@@ -595,9 +597,9 @@ class TestCustomListsController:
         ]
 
         c1 = admin_librarian_fixture.ctrl.db.collection()
-        c1.libraries = [admin_librarian_fixture.ctrl.db.default_library()]
+        c1.associated_libraries = [admin_librarian_fixture.ctrl.db.default_library()]
         c2 = admin_librarian_fixture.ctrl.db.collection()
-        c2.libraries = [admin_librarian_fixture.ctrl.db.default_library()]
+        c2.associated_libraries = [admin_librarian_fixture.ctrl.db.default_library()]
         list.collections = [c1]
         new_collections = [c2]
 
@@ -875,7 +877,7 @@ class TestCustomListsController:
         shared_with = admin_librarian_fixture.ctrl.db.library("shared_with")
         primary_library = admin_librarian_fixture.ctrl.db.library("primary")
         collection1 = admin_librarian_fixture.ctrl.db.collection("c1")
-        collection1.libraries.append(primary_library)
+        collection1.associated_libraries.append(primary_library)
 
         data_source = DataSource.lookup(
             admin_librarian_fixture.ctrl.db.session, DataSource.LIBRARY_STAFF
@@ -921,7 +923,7 @@ class TestCustomListsController:
         self, admin_librarian_fixture: AdminLibrarianFixture
     ):
         s = self._setup_share_locally(admin_librarian_fixture)
-        s.collection1.libraries.append(s.shared_with)
+        s.collection1.associated_libraries.append(s.shared_with)
         response = self._share_locally(
             s.list, s.primary_library, admin_librarian_fixture
         )
@@ -945,11 +947,11 @@ class TestCustomListsController:
             logging.INFO, "palace.manager.core.query.customlist.CustomListQueries"
         )
         s = self._setup_share_locally(admin_librarian_fixture)
-        s.collection1.libraries.append(s.shared_with)
+        s.collection1.associated_libraries.append(s.shared_with)
 
         # Second collection with work in list
         collection2 = admin_librarian_fixture.ctrl.db.collection()
-        collection2.libraries.append(s.primary_library)
+        collection2.associated_libraries.append(s.primary_library)
         w = admin_librarian_fixture.ctrl.db.work(collection=collection2)
         s.list.add_entry(w)
 
@@ -973,7 +975,7 @@ class TestCustomListsController:
             logging.INFO, "palace.manager.core.query.customlist.CustomListQueries"
         )
         s = self._setup_share_locally(admin_librarian_fixture)
-        s.collection1.libraries.append(s.shared_with)
+        s.collection1.associated_libraries.append(s.shared_with)
 
         w = admin_librarian_fixture.ctrl.db.work(collection=s.collection1)
         entry, ignore = s.list.add_entry(w)
@@ -1010,7 +1012,7 @@ class TestCustomListsController:
     def test_share_locally_get(self, admin_librarian_fixture: AdminLibrarianFixture):
         """Does the GET method fetch shared lists"""
         s = self._setup_share_locally(admin_librarian_fixture)
-        s.collection1.libraries.append(s.shared_with)
+        s.collection1.associated_libraries.append(s.shared_with)
 
         resp = self._share_locally(s.list, s.primary_library, admin_librarian_fixture)
         assert resp["successes"] == 1
@@ -1045,7 +1047,7 @@ class TestCustomListsController:
     def test_share_locally_delete(self, admin_librarian_fixture: AdminLibrarianFixture):
         """Test the deleting of a lists shared status"""
         s = self._setup_share_locally(admin_librarian_fixture)
-        s.collection1.libraries.append(s.shared_with)
+        s.collection1.associated_libraries.append(s.shared_with)
 
         resp = self._share_locally(s.list, s.primary_library, admin_librarian_fixture)
         assert resp["successes"] == 1

--- a/tests/manager/api/admin/controller/test_lanes.py
+++ b/tests/manager/api/admin/controller/test_lanes.py
@@ -41,7 +41,7 @@ class TestLanesController:
     def test_lanes_get(self, alm_fixture: AdminLibraryManagerFixture):
         library = alm_fixture.ctrl.db.library()
         collection = alm_fixture.ctrl.db.collection()
-        collection.libraries.append(library)
+        collection.associated_libraries.append(library)
 
         english = alm_fixture.ctrl.db.lane(
             "English", library=library, languages=["eng"]

--- a/tests/manager/api/admin/controller/test_report.py
+++ b/tests/manager/api/admin/controller/test_report.py
@@ -114,7 +114,7 @@ class TestReportController:
         collection = db.collection(
             protocol=OPDSAPI,
         )
-        collection.libraries = [library1, library2]
+        collection.associated_libraries = [library1, library2]
 
         def assert_and_clear_caplog(
             response: Response | ProblemDetail, email: str
@@ -179,7 +179,7 @@ class TestReportController:
         collection = db.collection(
             protocol=OPDSAPI,
         )
-        collection.libraries = [library1, library2]
+        collection.associated_libraries = [library1, library2]
 
         success_payload_dict = InventoryReportInfo(
             collections=[
@@ -291,7 +291,7 @@ class TestReportController:
 
         library = db.library()
         collection = db.collection(protocol=protocol, settings=settings)
-        collection.libraries = [library]
+        collection.associated_libraries = [library]
 
         if parent_settings:
             parent = db.collection(

--- a/tests/manager/api/admin/test_dashboard_stats.py
+++ b/tests/manager/api/admin/test_dashboard_stats.py
@@ -323,7 +323,7 @@ def test_stats_collections(admin_statistics_session: AdminStatisticsSessionFixtu
 
     default_library = db.library("Default Library", "default")
     default_collection = db.collection(name="Default Collection")
-    default_collection.libraries += [default_library]
+    default_collection.associated_libraries += [default_library]
 
     # default collection adds an OA title.
     _, _ = db.edition(
@@ -360,7 +360,7 @@ def test_stats_collections(admin_statistics_session: AdminStatisticsSessionFixtu
 
     c2 = db.collection()
     c3 = db.collection()
-    c3.libraries += [default_library]
+    c3.associated_libraries += [default_library]
 
     # c2 adds a 5/10 metered license title.
     edition, pool = db.edition(
@@ -627,7 +627,7 @@ def test_stats_parent_collection_permissions(
     child: Collection = db.collection()
     child.parent = parent
     library = db.library()
-    child.libraries.append(library)
+    child.associated_libraries.append(library)
     admin.add_role(AdminRole.LIBRARIAN, library)
 
     response = session.get_statistics()

--- a/tests/manager/api/controller/test_base.py
+++ b/tests/manager/api/controller/test_base.py
@@ -198,7 +198,7 @@ class TestBaseController:
         library = circulation_fixture.library
         [c1] = library.collections
         c2 = circulation_fixture.db.collection()
-        c2.libraries.append(library)
+        c2.associated_libraries.append(library)
 
         # Here's a Collection not affiliated with any Library.
         c3 = circulation_fixture.db.collection()

--- a/tests/manager/api/controller/test_base.py
+++ b/tests/manager/api/controller/test_base.py
@@ -196,7 +196,7 @@ class TestBaseController:
     def test_load_licensepools(self, circulation_fixture: CirculationControllerFixture):
         # Here's a Library that has two Collections.
         library = circulation_fixture.library
-        [c1] = library.collections
+        [c1] = library.associated_collections
         c2 = circulation_fixture.db.collection()
         c2.associated_libraries.append(library)
 

--- a/tests/manager/api/controller/test_crawlfeed.py
+++ b/tests/manager/api/controller/test_crawlfeed.py
@@ -79,7 +79,7 @@ class TestCrawlableFeed:
         lane = kwargs.pop("worklist")
         assert isinstance(lane, CrawlableCollectionBasedLane)
         assert library.id == lane.library_id
-        assert [x.id for x in library.collections] == lane.collection_ids
+        assert [x.id for x in library.associated_collections] == lane.collection_ids
         assert {} == kwargs
 
     def test_crawlable_collection_feed(

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -1419,8 +1419,10 @@ class TestLoanController:
 
         # We queued up a sync_patron_activity task to go sync the patrons information
         assert isinstance(patron, Patron)
-        assert sync_task.apply_async.call_count == len(patron.library.collections)
-        for library in patron.library.collections:
+        assert sync_task.apply_async.call_count == len(
+            patron.library.associated_collections
+        )
+        for library in patron.library.associated_collections:
             sync_task.apply_async.assert_any_call(
                 (library.id, patron.id, loan_fixture.valid_credentials["password"]),
             )

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -1698,7 +1698,7 @@ class TestLoanController:
                 protocol=collection_protocol,
             )
 
-            collection.libraries.append(loan_fixture.db.default_library())
+            collection.associated_libraries.append(loan_fixture.db.default_library())
             if collection_default_loan_period:
                 loan_fixture.db.integration_library_configuration(
                     collection.integration_configuration,

--- a/tests/manager/api/controller/test_marc.py
+++ b/tests/manager/api/controller/test_marc.py
@@ -169,7 +169,7 @@ class TestMARCRecordController:
         assert len(files) == 1
 
         # The collection is removed from the library, so it's not returned.
-        marc_record_controller_fixture.collection.libraries = []
+        marc_record_controller_fixture.collection.associated_libraries = []
 
         files = marc_record_controller_fixture.controller.get_files(
             marc_record_controller_fixture.db.session,
@@ -191,7 +191,7 @@ class TestMARCRecordController:
         # Create a second collection, with a full file and a delta.
         collection_2 = db.collection(name="Second Collection")
         collection_2.export_marc_records = True
-        collection_2.libraries = [marc_record_controller_fixture.library]
+        collection_2.associated_libraries = [marc_record_controller_fixture.library]
         marc_record_controller_fixture.file(collection=collection_2, created=now)
         marc_record_controller_fixture.file(
             collection=collection_2, created=now, since=last_week
@@ -200,13 +200,13 @@ class TestMARCRecordController:
         # Create a third collection that doesn't export MARC records.
         collection_3 = db.collection()
         collection_3.export_marc_records = False
-        collection_3.libraries = [marc_record_controller_fixture.library]
+        collection_3.associated_libraries = [marc_record_controller_fixture.library]
         marc_record_controller_fixture.file(collection=collection_3, created=now)
 
         # Create a fourth collection that doesn't belong to the library.
         collection_4 = db.collection()
         collection_4.export_marc_records = True
-        collection_4.libraries = []
+        collection_4.associated_libraries = []
         marc_record_controller_fixture.file(collection=collection_4, created=now)
 
         files = marc_record_controller_fixture.controller.get_files(

--- a/tests/manager/api/controller/test_multilib.py
+++ b/tests/manager/api/controller/test_multilib.py
@@ -26,7 +26,7 @@ class TestMultipleLibraries:
                 external_account_id="http://url.com", data_source="OPDS"
             )
             OPDSAPI.settings_update(collection.integration_configuration, settings)
-            library.collections.append(collection)
+            library.associated_collections.append(collection)
             return collection
 
         controller_fixture.circulation_manager_setup(

--- a/tests/manager/api/controller/test_playtime_entries.py
+++ b/tests/manager/api/controller/test_playtime_entries.py
@@ -336,7 +336,7 @@ class TestPlaytimeEntriesController:
             assert response.detail == "Collection was not found in the Library."
 
             # Identifier not part of collection
-            collection.libraries.append(library)
+            collection.associated_libraries.append(library)
             response = playtime_entries_controller_fixture.controller.track_playtimes(
                 collection.id, identifier.type, identifier.identifier
             )

--- a/tests/manager/api/test_axis.py
+++ b/tests/manager/api/test_axis.py
@@ -185,7 +185,7 @@ class TestAxis360API:
         # Collection -- one library with a default patron and one
         # without.
         no_default_patron = axis360.db.library()
-        axis360.collection.libraries.append(no_default_patron)
+        axis360.collection.associated_libraries.append(no_default_patron)
 
         with_default_patron = axis360.db.default_library()
         axis360.db.simple_auth_integration(with_default_patron)

--- a/tests/manager/api/test_bibliotheca.py
+++ b/tests/manager/api/test_bibliotheca.py
@@ -122,7 +122,7 @@ class TestBibliothecaAPI:
         # Collection -- one library with a default patron and one
         # without.
         no_default_patron = db.library()
-        bibliotheca_fixture.collection.libraries.append(no_default_patron)
+        bibliotheca_fixture.collection.associated_libraries.append(no_default_patron)
 
         with_default_patron = db.default_library()
         db.simple_auth_integration(with_default_patron)

--- a/tests/manager/api/test_enki.py
+++ b/tests/manager/api/test_enki.py
@@ -183,7 +183,7 @@ class TestEnkiAPI:
         # patron and one without.
         no_default_patron = db.library()
         assert api.collection is not None
-        api.collection.libraries.append(no_default_patron)
+        api.collection.associated_libraries.append(no_default_patron)
 
         with_default_patron = db.default_library()
         db.simple_auth_integration(with_default_patron)

--- a/tests/manager/api/test_lanes.py
+++ b/tests/manager/api/test_lanes.py
@@ -933,7 +933,7 @@ class TestCrawlableFacets:
         # Except for distributor and collectionName, which have the default
         # and data for each collection in the library.
         for facet in [distributor, collectionName]:
-            assert len(facet) == 1 + len(db.default_library().collections)
+            assert len(facet) == 1 + len(db.default_library().associated_collections)
 
     @pytest.mark.parametrize(
         "group_name, expected",
@@ -994,7 +994,9 @@ class TestCrawlableCollectionBasedLane:
         lane = CrawlableCollectionBasedLane()
         lane.initialize(library)
         assert "Crawlable feed: %s" % library.name == lane.display_name
-        assert {x.id for x in library.collections} == set(lane.collection_ids)
+        assert {x.id for x in library.associated_collections} == set(
+            lane.collection_ids
+        )
 
         # A lane for specific collection, regardless of their library
         # affiliation.

--- a/tests/manager/api/test_lanes.py
+++ b/tests/manager/api/test_lanes.py
@@ -985,7 +985,7 @@ class TestCrawlableCollectionBasedLane:
         library = db.default_library()
         default_collection = db.default_collection()
         other_library_collection = db.collection()
-        other_library_collection.libraries.append(library)
+        other_library_collection.associated_libraries.append(library)
 
         # This collection is not associated with any library.
         unused_collection = db.collection()
@@ -1174,7 +1174,7 @@ class TestJackpotWorkList:
             "Test Overdrive Collection",
             protocol=OverdriveAPI,
         )
-        overdrive_collection.libraries.append(library)
+        overdrive_collection.associated_libraries.append(library)
 
         # Create another collection that is _not_ associated with this
         # library. It will not be used at all.

--- a/tests/manager/api/test_overdrive.py
+++ b/tests/manager/api/test_overdrive.py
@@ -658,7 +658,7 @@ class TestOverdriveAPI:
         # Collection -- one library with a default patron and one
         # without.
         no_default_patron = db.library()
-        overdrive_api_fixture.collection.libraries.append(no_default_patron)
+        overdrive_api_fixture.collection.associated_libraries.append(no_default_patron)
 
         with_default_patron = db.default_library()
         db.simple_auth_integration(with_default_patron)
@@ -2353,7 +2353,7 @@ class TestOverdriveAPICredentials:
 
         # clear out any collections added before we add ours
         for collection in library.collections:
-            collection.libraries = []
+            collection.associated_libraries = []
 
         # Distinct credentials for the two OverDrive collections in which our
         # library has membership.

--- a/tests/manager/api/test_overdrive.py
+++ b/tests/manager/api/test_overdrive.py
@@ -2352,7 +2352,7 @@ class TestOverdriveAPICredentials:
         pin = "patron_pin"
 
         # clear out any collections added before we add ours
-        for collection in library.collections:
+        for collection in library.associated_collections:
             collection.associated_libraries = []
 
         # Distinct credentials for the two OverDrive collections in which our

--- a/tests/manager/api/test_selftest.py
+++ b/tests/manager/api/test_selftest.py
@@ -122,7 +122,7 @@ class TestHasPatronSelfTests:
 
         # This library has no default patron set up.
         no_default_patron = db.library()
-        collection.libraries.append(no_default_patron)
+        collection.associated_libraries.append(no_default_patron)
 
         # This library has a default patron set up.
         db.simple_auth_integration(db.default_library())

--- a/tests/manager/celery/tasks/test_generate_inventory_and_hold_reports.py
+++ b/tests/manager/celery/tasks/test_generate_inventory_and_hold_reports.py
@@ -59,7 +59,7 @@ def test_job_run(
     collection = create_test_opds_collection(collection_name, data_source, db, library)
     library2 = db.library(short_name="test_library2")
     # add another library
-    collection.libraries.append(library2)
+    collection.associated_libraries.append(library2)
 
     # Configure test data we expect will not be picked up.
     create_test_opds_collection(
@@ -71,7 +71,7 @@ def test_job_run(
         name="Overdrive Test Collection",
     )
 
-    od_collection_not_to_include.libraries = [library]
+    od_collection_not_to_include.associated_libraries = [library]
 
     ds = collection.data_source
     assert ds
@@ -281,7 +281,7 @@ def create_test_opds_collection(
         data_source=data_source,
     )
     collection = db.collection(name=collection_name, settings=settings)
-    collection.libraries = [library]
+    collection.associated_libraries = [library]
     return collection
 
 

--- a/tests/manager/core/test_opds2_import.py
+++ b/tests/manager/core/test_opds2_import.py
@@ -99,7 +99,7 @@ class OPDS2ImporterFixture:
             ),
         )
         self.library = db.default_library()
-        self.collection.libraries.append(self.library)
+        self.collection.associated_libraries.append(self.library)
         self.data_source = DataSource.lookup(
             db.session, "OPDS 2.0 Data Source", autocreate=True
         )

--- a/tests/manager/core/test_opds_import.py
+++ b/tests/manager/core/test_opds_import.py
@@ -1428,7 +1428,7 @@ class TestOPDSImporter:
                     saml_wayfless_url_template="https://fsso.springer.com/saml/login?idp={idp}&targetUrl={targetUrl}",
                 ),
             )
-            collection.libraries.append(library)
+            collection.associated_libraries.append(library)
 
             imported_editions, pools, works, failures = OPDSImporter(
                 session, collection=collection

--- a/tests/manager/feed/test_loan_and_hold_annotator.py
+++ b/tests/manager/feed/test_loan_and_hold_annotator.py
@@ -209,7 +209,7 @@ class TestLibraryLoanAndHoldAnnotator:
 
         # Annotate time tracking
         opds_for_distributors = db.collection(protocol=OPDSForDistributorsAPI)
-        opds_for_distributors.libraries.append(library)
+        opds_for_distributors.associated_libraries.append(library)
         work = db.work(with_license_pool=True, collection=opds_for_distributors)
         work.active_license_pool().should_track_playtime = True
         edition = work.presentation_edition

--- a/tests/manager/scripts/test_configuration.py
+++ b/tests/manager/scripts/test_configuration.py
@@ -180,9 +180,9 @@ class TestConfigureCollectionScript:
         )
 
         # Two libraries now have access to the collection.
-        assert [collection] == l1.collections
-        assert [collection] == l2.collections
-        assert [] == l3.collections
+        assert [collection] == l1.associated_collections
+        assert [collection] == l2.associated_collections
+        assert [] == l3.associated_collections
 
         # One CollectionSetting was set on the collection, in addition
         # to url, username, and password.

--- a/tests/manager/scripts/test_self_test.py
+++ b/tests/manager/scripts/test_self_test.py
@@ -42,7 +42,7 @@ class TestRunSelfTestsScript:
         # The default library is the only one with a collection;
         # test_collection() was called on that collection.
         [(collection, api_map)] = script.tested
-        assert [collection] == library1.collections
+        assert [collection] == library1.associated_collections
 
         # The API lookup map passed into test_collection() is a LicenseProvidersRegistry.
         assert isinstance(api_map, LicenseProvidersRegistry)

--- a/tests/manager/search/test_external_search.py
+++ b/tests/manager/search/test_external_search.py
@@ -3414,7 +3414,7 @@ class TestFilter:
         # If the library has no collections, the collection filter
         # will filter everything out.
         transaction.default_collection().associated_libraries = []
-        assert transaction.default_library().collections == []
+        assert transaction.default_library().associated_collections == []
         library_filter = Filter(collections=transaction.default_library())
         assert [] == library_filter.collection_ids
 

--- a/tests/manager/search/test_external_search.py
+++ b/tests/manager/search/test_external_search.py
@@ -3413,7 +3413,7 @@ class TestFilter:
 
         # If the library has no collections, the collection filter
         # will filter everything out.
-        transaction.default_collection().libraries = []
+        transaction.default_collection().associated_libraries = []
         assert transaction.default_library().collections == []
         library_filter = Filter(collections=transaction.default_library())
         assert [] == library_filter.collection_ids
@@ -3651,7 +3651,7 @@ class TestFilter:
         # library.
         library2 = transaction.library()
         collection2 = transaction.collection()
-        collection2.libraries.append(library2)
+        collection2.associated_libraries.append(library2)
         for_other_library = WorkList()
         for_other_library.initialize(library2)
         for_default_library.append_child(for_other_library)

--- a/tests/manager/sqlalchemy/model/test_admin.py
+++ b/tests/manager/sqlalchemy/model/test_admin.py
@@ -160,7 +160,7 @@ class TestAdmin:
 
         # This collection is visible to libraries of its library.
         c2 = admin_fixture.db.collection()
-        c2.libraries += [admin_fixture.db.default_library()]
+        c2.associated_libraries += [admin_fixture.db.default_library()]
 
         # The admin has no roles yet.
         admin = admin_fixture.admin

--- a/tests/manager/sqlalchemy/model/test_collection.py
+++ b/tests/manager/sqlalchemy/model/test_collection.py
@@ -384,7 +384,7 @@ class TestCollection:
 
         # It's gone.
         assert db.default_library() not in collection.associated_libraries
-        assert collection not in db.default_library().collections
+        assert collection not in db.default_library().associated_collections
 
         # The library-specific settings for that library have been deleted.
         library_config_ids = [
@@ -528,7 +528,7 @@ class TestCollection:
         assert collection not in db.session.query(Collection).all()
 
         # The default library now has no collections.
-        assert [] == db.default_library().collections
+        assert [] == db.default_library().associated_collections
 
         # The collection based coverage record got deleted
         assert db.session.query(CoverageRecord).get(record.id) == None

--- a/tests/manager/sqlalchemy/model/test_collection.py
+++ b/tests/manager/sqlalchemy/model/test_collection.py
@@ -217,7 +217,7 @@ class TestCollection:
         db = example_collection_fixture.database_fixture
         test_collection = example_collection_fixture.collection
         library = db.default_library()
-        test_collection.libraries.append(library)
+        test_collection.associated_libraries.append(library)
 
         ebook = Edition.BOOK_MEDIUM
         audio = Edition.AUDIO_MEDIUM
@@ -307,7 +307,7 @@ class TestCollection:
         library.short_name = "only one"
 
         test_collection = example_collection_fixture.collection
-        test_collection.libraries.append(library)
+        test_collection.associated_libraries.append(library)
 
         data = test_collection.explain()
         assert [
@@ -363,9 +363,9 @@ class TestCollection:
         collection = db.default_collection()
 
         # It's associated with two different libraries.
-        assert db.default_library() in collection.libraries
+        assert db.default_library() in collection.associated_libraries
         other_library = db.library()
-        collection.libraries.append(other_library)
+        collection.associated_libraries.append(other_library)
 
         # It has an integration, which has some settings.
         integration = collection.integration_configuration
@@ -380,10 +380,10 @@ class TestCollection:
         other_library_settings.settings_dict = {"c": "d"}
 
         # Now, disassociate one of the libraries from the collection.
-        collection.libraries.remove(db.default_library())
+        collection.associated_libraries.remove(db.default_library())
 
         # It's gone.
-        assert db.default_library() not in collection.libraries
+        assert db.default_library() not in collection.associated_libraries
         assert collection not in db.default_library().collections
 
         # The library-specific settings for that library have been deleted.
@@ -396,19 +396,19 @@ class TestCollection:
         assert db.default_library().id not in library_config_ids
 
         # But the library-specific settings for the other library are still there.
-        assert other_library in collection.libraries
+        assert other_library in collection.associated_libraries
         assert other_library.id in library_config_ids
         assert collection.integration_configuration.library_configurations[
             0
         ].settings_dict == {"c": "d"}
 
         # We now disassociate all libraries from the collection.
-        collection.libraries.clear()
+        collection.associated_libraries.clear()
 
         # All the library-specific settings have been deleted.
         assert collection.integration_configuration.library_configurations == []
         assert collection.integration_configuration.libraries == []
-        assert collection.libraries == []
+        assert collection.associated_libraries == []
 
         # The integration settings are still there.
         assert collection.integration_configuration.settings_dict == {"key": "value"}
@@ -470,7 +470,7 @@ class TestCollection:
         collection = db.default_collection()
 
         # It's associated with a library.
-        assert db.default_library() in collection.libraries
+        assert db.default_library() in collection.associated_libraries
 
         # It's got a Work that has a LicensePool, which has a License,
         # which has a loan.

--- a/tests/manager/sqlalchemy/model/test_lane.py
+++ b/tests/manager/sqlalchemy/model/test_lane.py
@@ -2618,7 +2618,7 @@ class TestWorkList:
 
         # Work1 now has 2 licensepools, one of which has availability
         alternate_collection = db.collection()
-        alternate_collection.libraries.append(db.default_library())
+        alternate_collection.associated_libraries.append(db.default_library())
         alternate_w1_lp: LicensePool = db.licensepool(
             w1.presentation_edition, collection=alternate_collection
         )
@@ -2705,7 +2705,7 @@ class TestWorkList:
 
         # Work1 now has 2 license pools, one of which has availability
         alternate_collection = db.collection()
-        alternate_collection.libraries.append(db.default_library())
+        alternate_collection.associated_libraries.append(db.default_library())
         alternate_w1_lp: LicensePool = db.licensepool(
             w1.presentation_edition, collection=alternate_collection
         )
@@ -2952,16 +2952,16 @@ class TestDatabaseBackedWorkList:
 
         # A DatabaseBackedWorkList will only find books licensed
         # through one of its collections.
-        db.default_collection().libraries = []
+        db.default_collection().associated_libraries = []
         collection = db.collection()
-        collection.libraries.append(db.default_library())
+        collection.associated_libraries.append(db.default_library())
         assert db.default_library().collections == [collection]
         wl.initialize(db.default_library())
         assert 0 == wl.works_from_database(db.session).count()
 
         # If a DatabaseBackedWorkList has no collections, it has no
         # books.
-        collection.libraries = []
+        collection.associated_libraries = []
         assert db.default_library().collections == []
         wl.initialize(db.default_library())
         assert 0 == wl.works_from_database(db.session).count()
@@ -4721,7 +4721,7 @@ class TestWorkListGroupsEndToEnd:
         decoy_library = db.library()
         another_library = db.library()
 
-        db.default_collection().libraries += [decoy_library, another_library]
+        db.default_collection().associated_libraries += [decoy_library, another_library]
 
         # Add a couple suppressed works, to make sure they don't show up in the results.
         globally_suppressed_work = db.work(

--- a/tests/manager/sqlalchemy/model/test_lane.py
+++ b/tests/manager/sqlalchemy/model/test_lane.py
@@ -1831,7 +1831,7 @@ class TestWorkList:
         # The Collections associated with the WorkList are those associated
         # with the Library.
         assert set(wl.collection_ids) == {
-            x.id for x in db.default_library().collections
+            x.id for x in db.default_library().associated_collections
         }
 
         # The Genres associated with the WorkList are the ones passed
@@ -2955,14 +2955,14 @@ class TestDatabaseBackedWorkList:
         db.default_collection().associated_libraries = []
         collection = db.collection()
         collection.associated_libraries.append(db.default_library())
-        assert db.default_library().collections == [collection]
+        assert db.default_library().associated_collections == [collection]
         wl.initialize(db.default_library())
         assert 0 == wl.works_from_database(db.session).count()
 
         # If a DatabaseBackedWorkList has no collections, it has no
         # books.
         collection.associated_libraries = []
-        assert db.default_library().collections == []
+        assert db.default_library().associated_collections == []
         wl.initialize(db.default_library())
         assert 0 == wl.works_from_database(db.session).count()
 

--- a/tests/manager/sqlalchemy/model/test_library.py
+++ b/tests/manager/sqlalchemy/model/test_library.py
@@ -104,7 +104,7 @@ class TestLibrary:
         parent = db.collection()
         db.default_collection().parent_id = parent.id
 
-        assert [db.default_collection()] == library.collections
+        assert [db.default_collection()] == library.associated_collections
 
     def test_estimated_holdings_by_language(self, db: DatabaseTransactionFixture):
         library = db.default_library()

--- a/tests/manager/sqlalchemy/model/test_library.py
+++ b/tests/manager/sqlalchemy/model/test_library.py
@@ -132,7 +132,7 @@ class TestLibrary:
 
         # If we remove the default collection from the default library,
         # it loses all its works.
-        db.default_collection().libraries = []
+        db.default_collection().associated_libraries = []
         estimate = library.estimated_holdings_by_language(include_open_access=False)
         assert dict() == estimate
 

--- a/tests/manager/sqlalchemy/model/test_work.py
+++ b/tests/manager/sqlalchemy/model/test_work.py
@@ -1067,7 +1067,7 @@ class TestWork:
         # for the same Work.
         collection1 = db.default_collection()
         collection2 = db.collection()
-        collection2.libraries.append(db.default_library())
+        collection2.associated_libraries.append(db.default_library())
         pool2 = db.licensepool(edition=edition, collection=collection2)
         pool2.work_id = work.id
         pool2.licenses_available = 0
@@ -1905,8 +1905,8 @@ class TestWork:
         l2 = db.library()
         c1 = db.collection()
         c2 = db.collection()
-        c1.libraries = [l1]
-        c2.libraries = [l2]
+        c1.associated_libraries = [l1]
+        c2.associated_libraries = [l2]
         work: Work = db.work(presentation_edition=db.edition())
         lp1: LicensePool = db.licensepool(
             work.presentation_edition,

--- a/tests/mocks/axis.py
+++ b/tests/mocks/axis.py
@@ -20,8 +20,8 @@ class MockAxis360API(Axis360API):
             "url": "http://axis.test/",
             "external_account_id": "c",
         }
-        if library not in collection.libraries:
-            collection.libraries.append(library)
+        if library not in collection.associated_libraries:
+            collection.associated_libraries.append(library)
         return collection
 
     def __init__(self, _db, collection, with_token=True, **kwargs):

--- a/tests/mocks/bibliotheca.py
+++ b/tests/mocks/bibliotheca.py
@@ -23,8 +23,8 @@ class MockBibliothecaAPI(BibliothecaAPI):
             "password": "b",
             "external_account_id": "c",
         }
-        if library not in collection.libraries:
-            collection.libraries.append(library)
+        if library not in collection.associated_libraries:
+            collection.associated_libraries.append(library)
         return collection
 
     def __init__(self, _db, collection, *args, **kwargs):

--- a/tests/mocks/overdrive.py
+++ b/tests/mocks/overdrive.py
@@ -63,8 +63,8 @@ class MockOverdriveAPI(OverdriveAPI):
             overdrive_client_secret=client_secret,
         )
         OverdriveAPI.settings_update(collection.integration_configuration, settings)
-        if library not in collection.libraries:
-            collection.libraries.append(library)
+        if library not in collection.associated_libraries:
+            collection.associated_libraries.append(library)
         library_settings = OverdriveLibrarySettings(
             ils_name=ils_name,
         )


### PR DESCRIPTION
## Description

- Rename some collection/library association attributes.
- ~Still to do: Some renaming from the library side.~

## Motivation and Context

With the introduction of the subscription concept, it would be helpful to clearly make the distinction between (1) all configured associations between `Collection`s and `Library`s and (2) those that are currently in effect or active.

This PR separates out some of the renaming of the existing association attributes to both 
- simplify the review process, and
- reduce the time that a PR with such sweeping changes is in flight, hopefully reducing conflicts amongst PRs.

[Jira [PP-1875](https://ebce-lyrasis.atlassian.net/browse/PP-1875)]

## How Has This Been Tested?

- Tests pass locally.
- [CI tests for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/12037619395) pass.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1875]: https://ebce-lyrasis.atlassian.net/browse/PP-1875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ