### PR TITLE
Move ISBN lookup to identifier module. (PP-1948)

### DIFF
--- a/alembic/versions/20240318_3e43ed59f256_playtime_tables_have_no_dependencies.py
+++ b/alembic/versions/20240318_3e43ed59f256_playtime_tables_have_no_dependencies.py
@@ -13,11 +13,8 @@ from alembic import op
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm.session import Session
 
-from palace.manager.sqlalchemy.model.identifier import Identifier
-from palace.manager.sqlalchemy.model.time_tracking import (
-    _isbn_for_identifier,
-    _title_for_identifier,
-)
+from palace.manager.sqlalchemy.model.identifier import Identifier, isbn_for_identifier
+from palace.manager.sqlalchemy.model.time_tracking import _title_for_identifier
 from palace.manager.sqlalchemy.util import get_one
 
 # revision identifiers, used by Alembic.
@@ -231,7 +228,7 @@ def update_summary_isbn_and_title(session: Session) -> None:
 @cache
 def cached_isbn_lookup(identifier: Identifier) -> str | None:
     """Given an identifier, return its ISBN."""
-    return _isbn_for_identifier(identifier)
+    return isbn_for_identifier(identifier)
 
 
 @cache

--- a/tests/manager/sqlalchemy/model/test_time_tracking.py
+++ b/tests/manager/sqlalchemy/model/test_time_tracking.py
@@ -3,14 +3,9 @@ import datetime
 import pytest
 from sqlalchemy.exc import IntegrityError
 
-from palace.manager.core.equivalents_coverage import (
-    EquivalentIdentifiersCoverageProvider,
-)
-from palace.manager.sqlalchemy.model.identifier import Equivalency, Identifier
 from palace.manager.sqlalchemy.model.time_tracking import (
     PlaytimeEntry,
     PlaytimeSummary,
-    _isbn_for_identifier,
     _title_for_identifier,
 )
 from palace.manager.sqlalchemy.util import create
@@ -239,77 +234,6 @@ class TestPlaytimeSummaries:
 
 
 class TestHelpers:
-    @pytest.mark.parametrize(
-        "id_key, equivalents, expected_isbn",
-        [
-            # If the identifier is an ISBN, we will not use an equivalency.
-            [
-                "i1",
-                (("g1", "g2", 1), ("g2", "i1", 1), ("g1", "i2", 0.5)),
-                "080442957X",
-            ],
-            [
-                "i2",
-                (("g1", "g2", 1), ("g2", "i1", 0.5), ("g1", "i2", 1)),
-                "9788175257665",
-            ],
-            ["i1", (("i1", "i2", 200),), "080442957X"],
-            ["i2", (("i2", "i1", 200),), "9788175257665"],
-            # If identifier is not an ISBN, but has an equivalency that is, use the strongest match.
-            [
-                "g2",
-                (("g1", "g2", 1), ("g2", "i1", 1), ("g1", "i2", 0.5)),
-                "080442957X",
-            ],
-            [
-                "g2",
-                (("g1", "g2", 1), ("g2", "i1", 0.5), ("g1", "i2", 1)),
-                "9788175257665",
-            ],
-            # If we don't find an equivalent ISBN identifier, then we should get None.
-            ["g2", (), None],
-            ["g1", (("g1", "g2", 1),), None],
-            # If identifier is None, expect default value.
-            [None, (), None],
-        ],
-    )
-    def test__isbn_for_identifier(
-        self,
-        db: DatabaseTransactionFixture,
-        id_key: str | None,
-        equivalents: tuple[tuple[str, str, int | float]],
-        expected_isbn: str,
-    ):
-        ids: dict[str, Identifier] = {
-            "i1": db.identifier(
-                identifier_type=Identifier.ISBN, foreign_id="080442957X"
-            ),
-            "i2": db.identifier(
-                identifier_type=Identifier.ISBN, foreign_id="9788175257665"
-            ),
-            "g1": db.identifier(identifier_type=Identifier.GUTENBERG_ID),
-            "g2": db.identifier(identifier_type=Identifier.GUTENBERG_ID),
-        }
-        equivalencies = [
-            Equivalency(
-                input_id=ids[equivalent[0]].id,
-                output_id=ids[equivalent[1]].id,
-                strength=equivalent[2],
-            )
-            for equivalent in equivalents
-        ]
-        test_identifier: Identifier | None = ids[id_key] if id_key is not None else None
-        if test_identifier is not None:
-            test_identifier.equivalencies = equivalencies
-
-        # We're using the RecursiveEquivalencyCache, so must refresh it.
-        EquivalentIdentifiersCoverageProvider(db.session).run()
-
-        # Act
-        result = _isbn_for_identifier(test_identifier)
-        # Assert
-        assert result == expected_isbn
-
     def test__title_for_identifier_multiple_editions(
         self,
         db: DatabaseTransactionFixture,


### PR DESCRIPTION
## Description

Moves identifier ISBN lookup to the `identifier` module.

## Motivation and Context

[Jira [PP-1948](https://ebce-lyrasis.atlassian.net/browse/PP-1948)]

## How Has This Been Tested?

- Tests pass locally.
- CI tests for associated branch pass.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-1948]: https://ebce-lyrasis.atlassian.net/browse/PP-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ