### PR TITLE
Filter work summary to remove non-xml safe characters (PP-1969)

### DIFF
--- a/alembic/versions/20241127_c3458e1ef9aa_remove_unsafe_characters_summary.py
+++ b/alembic/versions/20241127_c3458e1ef9aa_remove_unsafe_characters_summary.py
@@ -1,0 +1,32 @@
+"""Remove unsafe characters summary
+
+Revision ID: c3458e1ef9aa
+Revises: 272da5f400de
+Create Date: 2024-11-27 20:32:41.431147+00:00
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3458e1ef9aa"
+down_revision = "272da5f400de"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Remove any characters that are not XML safe from the summary_text field. The code has been
+    # updated to filter out these characters, but this cleans up any existing data.
+    # https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP
+    op.execute(
+        "UPDATE works SET summary_text = regexp_replace("
+        "  summary_text, '[^\u0020-\uD7FF\u0009\u000A\u000D\uE000-\uFFFD\U00010000-\U0010FFFF]+', '', 'g'"
+        ") WHERE "
+        "summary_text ~ '[^\u0020-\uD7FF\u0009\u000A\u000D\uE000-\uFFFD\U00010000-\U0010FFFF]'"
+    )
+
+
+def downgrade() -> None:
+    # No need to do anything on downgrade.
+    pass

--- a/tests/manager/sqlalchemy/model/test_edition.py
+++ b/tests/manager/sqlalchemy/model/test_edition.py
@@ -403,20 +403,32 @@ class TestEdition:
         work = db.work(presentation_edition=e)
         overdrive = DataSource.lookup(db.session, DataSource.OVERDRIVE)
 
-        # Set the work's summmary.
+        # Set the work's summary.
         l1, new = pool.add_link(
             Hyperlink.DESCRIPTION, None, overdrive, "text/plain", "F"
         )
         work.set_summary(l1.resource)
 
-        assert l1.resource == work.summary
-        assert "F" == work.summary_text
+        assert work.summary == l1.resource
+        assert work.summary_text == "F"
+
+        # Set the work's summary to a string that contains characters that cannot be
+        # represented in XML.
+        l2, new = pool.add_link(
+            Hyperlink.DESCRIPTION,
+            None,
+            overdrive,
+            "text/plain",
+            "\u0000💣ü🔥\u0001\u000C",
+        )
+        work.set_summary(l2.resource)
+        assert work.summary_text == "💣ü🔥"
 
         # Remove the summary.
         work.set_summary(None)
 
-        assert None == work.summary
-        assert "" == work.summary_text
+        assert work.summary is None
+        assert work.summary_text == ""
 
     def test_calculate_evaluate_summary_quality_with_privileged_data_sources(
         self, db: DatabaseTransactionFixture


### PR DESCRIPTION
## Description

Add some filtering to our `set_summary` function to filter out xml unsafe characters and add a DB migration to remove these characters from our existing database.

## Motivation and Context

Seeing `Exception in web app: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters` in our logs.

```
Traceback (most recent call last):
  File "src/lxml/builder.py", line 161, in lxml.builder.ElementMaker.__init__.add_text
  File "src/lxml/etree.pyx", line 1202, in lxml.etree._Element.__getitem__
IndexError: list index out of range
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/var/www/circulation/src/palace/manager/api/routes.py", line 120, in decorated
    return f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/api/routes.py", line 93, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File "/var/www/circulation/src/palace/manager/core/app_server.py", line 87, in decorated
    v = f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/core/app_server.py", line 163, in compressor
    return f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/api/routes.py", line 239, in acquisition_groups
    return app.manager.opds_feeds.groups(lane_identifier)
  File "/var/www/circulation/src/palace/manager/api/controller/opds_feed.py", line 100, in groups
    return feed_class.groups(
  File "/var/www/circulation/src/palace/manager/feed/opds.py", line 64, in as_response
    serializer.serialize_feed(
  File "/var/www/circulation/src/palace/manager/feed/serializer/opds.py", line 102, in serialize_feed
    element = self.serialize_work_entry(entry.computed)
  File "/var/www/circulation/src/palace/manager/feed/serializer/opds.py", line 180, in serialize_work_entry
    entry.append(OPDSFeed.E("summary", feed_entry.summary.text))
  File "src/lxml/builder.py", line 221, in lxml.builder.ElementMaker.__call__
  File "src/lxml/builder.py", line 163, in lxml.builder.ElementMaker.__init__.add_text
  File "src/lxml/etree.pyx", line 1065, in lxml.etree._Element.text.__set__
  File "src/lxml/apihelpers.pxi", line 749, in lxml.etree._setNodeText
  File "src/lxml/apihelpers.pxi", line 737, in lxml.etree._createTextNode
  File "src/lxml/apihelpers.pxi", line 1530, in lxml.etree._utf8
ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters
```

Looking at the data in our database, these are only coming in via the Enki integration, but it seemed like a good idea to make sure they can't make it in though any integration.

## How Has This Been Tested?

- Tested locally
- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
