### PR TITLE
Make sure we handle ProblemDetail response from _crawlable_feed (PP-1975)

### DIFF
--- a/src/palace/manager/api/controller/opds_feed.py
+++ b/src/palace/manager/api/controller/opds_feed.py
@@ -34,6 +34,7 @@ from palace.manager.sqlalchemy.model.lane import (
     SearchFacets,
     WorkList,
 )
+from palace.manager.util.flask_util import OPDSFeedResponse
 from palace.manager.util.problem_detail import ProblemDetail
 
 
@@ -243,7 +244,7 @@ class OPDSFeedController(CirculationManagerController):
 
     def _crawlable_feed(
         self, title, url, worklist, annotator=None, feed_class=OPDSAcquisitionFeed
-    ):
+    ) -> OPDSFeedResponse | ProblemDetail:
         """Helper method to create a crawlable feed.
 
         :param title: The title to use for the feed.
@@ -270,6 +271,8 @@ class OPDSFeedController(CirculationManagerController):
             worklist=worklist,
             base_class=CrawlableFacets,
         )
+        if isinstance(facets, ProblemDetail):
+            return facets
         annotator = annotator or self.manager.annotator(worklist, facets=facets)
 
         return feed_class.page(


### PR DESCRIPTION
## Description

Make sure we are checking for a `ProblemDetail` response from `_crawlable_feed`.

## Motivation and Context

We are seeing this exception happening in our logs:

```
Traceback (most recent call last):
  File "/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/var/www/circulation/src/palace/manager/api/routes.py", line 120, in decorated
    return f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/api/routes.py", line 93, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File "/var/www/circulation/src/palace/manager/core/app_server.py", line 87, in decorated
    v = f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/core/app_server.py", line 163, in compressor
    return f(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/api/routes.py", line 288, in crawlable_library_feed
    return app.manager.opds_feeds.crawlable_library_feed()
  File "/var/www/circulation/src/palace/manager/api/controller/opds_feed.py", line 203, in crawlable_library_feed
    return self._crawlable_feed(title=title, url=url, worklist=lane)
  File "/var/www/circulation/src/palace/manager/api/controller/opds_feed.py", line 274, in _crawlable_feed
    return feed_class.page(
  File "src/dependency_injector/_cwiring.pyx", line 28, in dependency_injector._cwiring._get_sync_patched._patched
  File "/var/www/circulation/src/palace/manager/feed/acquisition.py", line 461, in page
    works = worklist.works(
  File "src/dependency_injector/_cwiring.pyx", line 28, in dependency_injector._cwiring._get_sync_patched._patched
  File "/var/www/circulation/src/palace/manager/sqlalchemy/model/lane.py", line 1892, in works
    filter = self.filter(_db, facets)
  File "/var/www/circulation/src/palace/manager/sqlalchemy/model/lane.py", line 1906, in filter
    filter = Filter.from_worklist(_db, self, facets)
  File "/var/www/circulation/src/palace/manager/search/external_search.py", line 1477, in from_worklist
    return cls(
  File "/var/www/circulation/src/palace/manager/search/external_search.py", line 1660, in __init__
    facets.modify_search_filter(self)
AttributeError: 'ProblemDetail' object has no attribute 'modify_search_filter'
```

JIRA:
PP-1975
PP-1860

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
