### PR TITLE
Retry celery patron sync on StaleDataError (PP-2005)

### DIFF
--- a/src/palace/manager/celery/tasks/patron_activity.py
+++ b/src/palace/manager/celery/tasks/patron_activity.py
@@ -83,7 +83,7 @@ def sync_patron_activity(
                 return
             except (RemoteIntegrationException, StaleDataError) as e:
                 # This may have been a transient network error with the remote integration or some data
-                # changed while we were processing the sync. Retry the task.
+                # changed while we were processing the sync. Attempt to retry.
                 retries = task.request.retries
                 if retries < task.max_retries:
                     wait_time = exponential_backoff(retries)


### PR DESCRIPTION
## Description

Retry when we get a `StaleDataError` while running a patron sync.

## Motivation and Context

Looking at the cloudwatch alarms we are getting for failed Celery tasks, it looks like almost all of them are:

```
sqlalchemy.orm.exc.StaleDataError: UPDATE statement on table 'loans' expected to update 1 row(s); 0 were matched.
```

These are probably mostly unavoidable, due to something happening (like a checkout or checkin) while the sync task is running. Just retrying should solve the issue.

## How Has This Been Tested?

- Added unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
