### PR TITLE
Ignore axis now fulfillment (PP-1929)

### DIFF
--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -1585,8 +1585,8 @@ class AvailabilityResponseParser(XMLResponseParser[Union[AxisLoanInfo, HoldInfo]
                 checkout_format == self.api.AXISNOW or checkout_format == "Blio"
             ):
                 # If we didn't explicitly ask for a format, ignore any AxisNow or Blio formats, since
-                # we can't fulfill them. If we add AxisNow and Blio support in the future, we will need
-                # to drop this line.
+                # we can't fulfill them. If we add AxisNow and Blio support in the future, we can remove
+                # this check.
                 return None
 
             fulfillment: Fulfillment | None

--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -1568,6 +1568,9 @@ class AvailabilityResponseParser(XMLResponseParser[Union[AxisLoanInfo, HoldInfo]
 
         info: AxisLoanInfo | HoldInfo | None = None
         if checked_out:
+            checkout_format = self.text_of_optional_subtag(
+                availability, "axis:checkoutFormat", ns
+            )
             start_date = self._xpath1_date(availability, "axis:checkoutStartDate", ns)
             end_date = self._xpath1_date(availability, "axis:checkoutEndDate", ns)
             download_url = self.text_of_optional_subtag(
@@ -1577,6 +1580,14 @@ class AvailabilityResponseParser(XMLResponseParser[Union[AxisLoanInfo, HoldInfo]
                 self.text_of_optional_subtag(availability, "axis:transactionID", ns)
                 or ""
             )
+
+            if not self.internal_format and (
+                checkout_format == self.api.AXISNOW or checkout_format == "Blio"
+            ):
+                # If we didn't explicitly ask for a format, ignore any AxisNow or Blio formats, since
+                # we can't fulfill them. If we add AxisNow and Blio support in the future, we will need
+                # to drop this line.
+                return None
 
             fulfillment: Fulfillment | None
             if download_url and self.internal_format != self.api.AXISNOW:

--- a/tests/manager/api/test_axis.py
+++ b/tests/manager/api/test_axis.py
@@ -485,7 +485,7 @@ class TestAxis360API:
         pytest.raises(NoActiveLoan, fulfill)
 
         # If an ebook is checked out and we're not asking for it to be
-        # fulfilled through AxisNow, we get a Axis360AcsFulfillment
+        # fulfilled through Adobe DRM, we get a Axis360AcsFulfillment
         # object with a content link.
         data = axis360.sample_data("availability_with_loan_and_hold.xml")
         axis360.api.queue_response(200, content=data)
@@ -550,6 +550,12 @@ class TestAxis360API:
         assert isinstance(hold1, HoldInfo)
         assert isinstance(hold2, HoldInfo)
         assert isinstance(loan, LoanInfo)
+
+        # If the activity includes something with a Blio format, it is not included in the results.
+        data = axis360.sample_data("availability_with_axisnow_fulfillment.xml")
+        axis360.api.queue_response(200, content=data)
+        results = axis360.api.patron_activity(patron, "pin")
+        assert len(results) == 0
 
     def test_update_licensepools_for_identifiers(self, axis360: Axis360Fixture):
         class Mock(MockAxis360API):


### PR DESCRIPTION
## Description

Ignore any AxisNow/Blio fulfillment information we get back from B&T. 

## Motivation and Context

Right now, we are adding these items to a users bookshelf, but failing when they try to fulfill the item. It is preferable to not display it for now. See jira: PP-1929

## How Has This Been Tested?

Tested locally.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
