### PR TITLE
[PP-2018] Replace email attachments with links to S3 on time tracking…

### DIFF
--- a/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
+++ b/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
@@ -150,7 +150,7 @@ class GenerateInventoryAndHoldsReportsJob(Job):
 
                     uid = uuid.uuid4()
                     key = (
-                        f"inventory_and_holds/{library.short_name}/"
+                        f"{S3Service.CM_REPORT_PREFIX}/inventory_and_holds/{library.short_name}/"
                         f"inventory-and-holds-for-library-{file_name_modifier}-{uid}.zip"
                     )
                     self.s3_service.store_stream(

--- a/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
+++ b/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
@@ -150,7 +150,7 @@ class GenerateInventoryAndHoldsReportsJob(Job):
 
                     uid = uuid.uuid4()
                     key = (
-                        f"{S3Service.CM_REPORT_PREFIX}/inventory_and_holds/{library.short_name}/"
+                        f"{S3Service.DOWNLOADS_PREFIX}/inventory_and_holds/{library.short_name}/"
                         f"inventory-and-holds-for-library-{file_name_modifier}-{uid}.zip"
                     )
                     self.s3_service.store_stream(

--- a/src/palace/manager/scripts/playtime_entries.py
+++ b/src/palace/manager/scripts/playtime_entries.py
@@ -213,7 +213,7 @@ class PlaytimeEntriesEmailReportsScript(Script):
             if recipient:
                 uid = uuid.uuid4()
                 key = (
-                    f"{S3Service.CM_REPORT_PREFIX}/{reporting_name}/"
+                    f"{S3Service.DOWNLOADS_PREFIX}/{reporting_name}/"
                     f"{linked_file_name}"
                 )
 

--- a/src/palace/manager/service/storage/s3.py
+++ b/src/palace/manager/service/storage/s3.py
@@ -108,6 +108,7 @@ class MultipartS3ContextManager(LoggerMixin):
 
 class S3Service(LoggerMixin):
     MINIMUM_MULTIPART_UPLOAD_SIZE = 5 * 1024 * 1024  # 5MB
+    CM_REPORT_PREFIX = "cm_report"
 
     def __init__(
         self,

--- a/src/palace/manager/service/storage/s3.py
+++ b/src/palace/manager/service/storage/s3.py
@@ -108,7 +108,7 @@ class MultipartS3ContextManager(LoggerMixin):
 
 class S3Service(LoggerMixin):
     MINIMUM_MULTIPART_UPLOAD_SIZE = 5 * 1024 * 1024  # 5MB
-    CM_REPORT_PREFIX = "cm_report"
+    DOWNLOADS_PREFIX = "downloads"
 
     def __init__(
         self,


### PR DESCRIPTION
… reports.

## Description
As the title says, we are using S3 to store the reports and sending the user a link that will perish in 30 days.  There is a [PR in hosting-playbook](https://github.com/ThePalaceProject/hosting-playbook/pull/728) to ensure that all keys in public buckets with a cm_reports/  prefix expire in 30 days.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2018
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Covered by unit tests.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
