### PR TITLE
Fix format sweep script by ensuring all operations within the context…

### DIFF
--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -184,6 +184,7 @@ class DeliveryMechanismInfo(CirculationInfo):
             self.drm_scheme,
             self.rights_uri,
             self.resource,
+            db=_db,
         )
         loan.fulfillment = lpdm
         return lpdm

--- a/src/palace/manager/core/metadata_layer.py
+++ b/src/palace/manager/core/metadata_layer.py
@@ -996,6 +996,7 @@ class CirculationData:
                 format.drm_scheme,
                 format.rights_uri or self.default_rights_uri,
                 resource,
+                db=_db,
             )
             new_lpdms.append(lpdm)
 

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -1557,6 +1557,7 @@ class LicensePoolDeliveryMechanism(Base):
         drm_scheme,
         rights_uri,
         resource=None,
+        db=None,
     ) -> LicensePoolDeliveryMechanism:
         """Register the fact that a distributor makes a title available in a
         certain format.
@@ -1571,7 +1572,12 @@ class LicensePoolDeliveryMechanism(Base):
         :param resource: A Resource representing the book itself in
             a freely redistributable form.
         """
-        _db = Session.object_session(data_source)
+
+        if db:
+            _db = db
+        else:
+            _db = Session.object_session(data_source)
+
         delivery_mechanism, ignore = DeliveryMechanism.lookup(
             _db, content_type, drm_scheme
         )


### PR DESCRIPTION
… manager are performed on the same session.

## Description
This is a follow-up PR to https://github.com/ThePalaceProject/circulation/pull/2181.   #2181 fixed the bug at a particular but it revealed another similar issue with the database session associated with the object being different from the session associated with the context manager further down the execution path.   I didn't see any other uses of Session.object_session() in this execution path so I thing this should fix this issue with the format sweep scripts.
<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1956
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
