### PR TITLE
Increase circulationevents.type field length to 50 (from 32) to aacco…

### DIFF
--- a/alembic/versions/20241220_579786fecbf4_increase_circulation_event_type_field_.py
+++ b/alembic/versions/20241220_579786fecbf4_increase_circulation_event_type_field_.py
@@ -1,0 +1,28 @@
+"""Increase circulation event type field length
+
+Revision ID: 579786fecbf4
+Revises: 603b8ebd6daf
+Create Date: 2024-12-20 06:30:30.148748+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "579786fecbf4"
+down_revision = "603b8ebd6daf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "circulationevents", "type", existing_type=sa.VARCHAR(32), type_=sa.VARCHAR(50)
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "circulationevents", "type", existing_type=sa.VARCHAR(50), type_=sa.VARCHAR(32)
+    )

--- a/src/palace/manager/sqlalchemy/model/circulationevent.py
+++ b/src/palace/manager/sqlalchemy/model/circulationevent.py
@@ -35,7 +35,7 @@ class CirculationEvent(Base):
         "LicensePool", back_populates="circulation_events"
     )
 
-    type = Column(String(32), index=True)
+    type = Column(String(50), index=True)
     start = Column(DateTime(timezone=True), index=True)
     end = Column(DateTime(timezone=True))
     old_value = Column(Integer)


### PR DESCRIPTION
…modate new event types.

## Description
Self explanatory.  Redshift is okay:  field length is 255.
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2026

Addresses the issue discovered in testing: 
```
{"host": "ip-10-8-6-239.us-west-2.compute.internal", "name": "palace.manager.core.app_server.ErrorHandler", "level": "ERROR", "filename": "app_server.py", "message": "Exception in web app: (psycopg2.errors.StringDataRightTruncation) value too long for type character varying(32)\n\n[SQL: INSERT INTO circulationevents (license_pool_id, type, start, \"end\", old_value, delta, new_value, library_id, location) VALUES (%(license_pool_id)s, %(type)s, %(start)s, %(end)s, %(old_value)s, %(delta)s, %(new_value)s, %(library_id)s, %(location)s) RETURNING circulationevents.id]\n[parameters: {'license_pool_id': 196513, 'type': 'circulation_manager_hold_converted_to_loan', 'start': datetime.datetime(2024, 12, 18, 19, 58, 23, 885375, tzinfo=<UTC>), 'end': datetime.datetime(2024, 12, 18, 19, 58, 23, 885375, tzinfo=<UTC>), 'old_value': None, 'delta': None, 'new_value': None, 'library_id': 1, 'location': None}]\n(Background on this error at: https://sqlalche.me/e/14/9h9h)", "timestamp": "2024-12-18T19:58:23.899820+00:00", "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/engine/base.py\", line 1910, in _execute_context\n    self.dialect.do_execute(\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 736, in do_execute\n    cursor.execute(statement, parameters)\npsycopg2.errors.StringDataRightTruncation: value too long for type character varying(32)\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py\", line 917, in full_dispatch_request\n    rv = self.dispatch_request()\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/flask/app.py\", line 902, in dispatch_request\n    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]\n  File \"/var/www/circulation/src/palace/manager/api/routes.py\", line 120, in decorated\n    return f(*args, **kwargs)\n  File \"/var/www/circulation/src/palace/manager/api/routes.py\", line 93, in wrapped_function\n    resp = make_response(f(*args, **kwargs))\n  File \"/var/www/circulation/src/palace/manager/api/routes.py\", line 49, in decorated\n    return f(*args, **kwargs)\n  File \"/var/www/circulation/src/palace/manager/core/app_server.py\", line 85, in decorated\n    v = f(*args, **kwargs)\n  File \"/var/www/circulation/src/palace/manager/api/routes.py\", line 430, in borrow\n    return app.manager.loans.borrow(identifier_type, identifier, mechanism_id)\n  File \"/var/www/circulation/src/palace/manager/api/controller/loan.py\", line 117, in borrow\n    loan_or_hold_or_pd, is_new = self._borrow(\n  File \"/var/www/circulation/src/palace/manager/api/controller/loan.py\", line 170, in _borrow\n    loan, hold, is_new = self.circulation.borrow(\n  File \"/var/www/circulation/src/palace/manager/api/circulation.py\", line 1147, in borrow\n    self._collect_event(\n  File \"/var/www/circulation/src/palace/manager/api/circulation.py\", line 964, in _collect_event\n    self.analytics.collect_event(\n  File \"/var/www/circulation/src/palace/manager/service/analytics/analytics.py\", line 59, in collect_event\n    provider.collect_event(\n  File \"/var/www/circulation/src/palace/manager/core/local_analytics_provider.py\", line 28, in collect_event\n    return CirculationEvent.log(\n  File \"/var/www/circulation/src/palace/manager/sqlalchemy/model/circulationevent.py\", line 154, in log\n    event, was_new = get_one_or_create(\n  File \"/var/www/circulation/src/palace/manager/sqlalchemy/util.py\", line 133, in get_one_or_create\n    obj = create(db, model, create_method, create_method_kwargs, **kwargs)\n  File \"/var/www/circulation/src/palace/manager/sqlalchemy/util.py\", line 77, in create\n    flush(db)\n  File \"/var/www/circulation/src/palace/manager/sqlalchemy/util.py\", line 61, in flush\n    db.flush()\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/session.py\", line 3449, in flush\n    self._flush(objects)\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/session.py\", line 3588, in _flush\n    with util.safe_reraise():\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py\", line 70, in __exit__\n    compat.raise_(\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/util/compat.py\", line 211, in raise_\n    raise exception\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/session.py\", line 3549, in _flush\n    flush_context.execute()\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/unitofwork.py\", line 456, in execute\n    rec.execute(self)\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/unitofwork.py\", line 630, in execute\n    util.preloaded.orm_persistence.save_obj(\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/persistence.py\", line 245, in save_obj\n    _emit_insert_statements(\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/orm/persistence.py\", line 1238, in _emit_insert_statements\n    result = connection._execute_20(\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/engine/base.py\", line 1710, in _execute_20\n    return meth(self, args_10style, kwargs_10style, execution_options)\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/sql/elements.py\", line 334, in _execute_on_connection\n    return connection._execute_clauseelement(\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/engine/base.py\", line 1577, in _execute_clauseelement\n    ret = self._execute_context(\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/engine/base.py\", line 1953, in _execute_context\n    self._handle_dbapi_exception(\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/engine/base.py\", line 2134, in _handle_dbapi_exception\n    util.raise_(\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/util/compat.py\", line 211, in raise_\n    raise exception\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/engine/base.py\", line 1910, in _execute_context\n    self.dialect.do_execute(\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/sqlalchemy/engine/default.py\", line 736, in do_execute\n    cursor.execute(statement, parameters)\nsqlalchemy.exc.DataError: (psycopg2.errors.StringDataRightTruncation) value too long for type character varying(32)\n\n[SQL: INSERT INTO circulationevents (license_pool_id, type, start, \"end\", old_value, delta, new_value, library_id, location) VALUES (%(license_pool_id)s, %(type)s, %(start)s, %(end)s, %(old_value)s, %(delta)s, %(new_value)s, %(library_id)s, %(location)s) RETURNING circulationevents.id]\n[parameters: {'license_pool_id': 196513, 'type': 'circulation_manager_hold_converted_to_loan', 'start': datetime.datetime(2024, 12, 18, 19, 58, 23, 885375, tzinfo=<UTC>), 'end': datetime.datetime(2024, 12, 18, 19, 58, 23, 885375, tzinfo=<UTC>), 'old_value': None, 'delta': None, 'new_value': None, 'library_id': 1, 'location': None}]\n(Background on this error at: https://sqlalche.me/e/14/9h9h)", "process": 79, "request": {"path": "/minotaur-test-library/works/ISBN/9780593402238/borrow", "method": "GET", "host": "https://minotaur.dev.palaceproject.io/", "user_agent": "Palace/1.1.4 (iOS; 18.1.1)", "forwarded_for": ["71.182.195.58", "130.176.134.68", "10.8.1.202"], "library": {"uuid": "f85d6ad1-1c50-4ab8-8dc4-800170afd53c", "name": "Minotaur Test Library", "short_name": "minotaur-test-library"}, "patron": {"authorization_identifier": "MINO1NA3Z47YL1"}}, "uwsgi": {"worker": 1}}
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
