### PR TITLE
Disable overdrive format sweep script until OD provides a path for eb…

### DIFF
--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -55,7 +55,10 @@ HOME=/var/www/circulation
 0 3 * * * root bin/run overdrive_new_titles >> /var/log/cron.log 2>&1
 */15 * * * * root bin/run overdrive_monitor_recent >> /var/log/cron.log 2>&1
 */15 * * * * root bin/run overdrive_reaper >> /var/log/cron.log 2>&1
-0 4 * * * root bin/run overdrive_format_sweep >> /var/log/cron.log 2>&1
+
+# TODO: reenable the overdrive_format_sweep script once overdrive provides a new delivery mechanism for ebooks
+# other than application/epub+zip
+# 0 4 * * * root bin/run overdrive_format_sweep >> /var/log/cron.log 2>&1
 
 # Enki
 #


### PR DESCRIPTION
…ook fulfillment.

## Description
Disables the overdrive_format_sweep script. 

[Here is a new ticket to enable it again once the overdrive fulfillment issue is addressed.
](https://ebce-lyrasis.atlassian.net/browse/PP-2046)
<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1956

Without this change, all production overdrive ebooks will no longer be available.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I manually confirmed that not disabling results in the removal of OD ebook availability on the mobile client side.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
