### PR TITLE
[PP-2043] Prevent None from displaying when there are no subtitles.

### DIFF
--- a/src/palace/manager/feed/serializer/opds.py
+++ b/src/palace/manager/feed/serializer/opds.py
@@ -163,7 +163,8 @@ class BaseOPDS1Serializer(SerializerInterface[etree._Element], OPDSFeed, abc.ABC
 
         if feed_entry.title:
             entry.append(OPDSFeed.E("title", feed_entry.title.text))
-        if feed_entry.subtitle:
+
+        if feed_entry.subtitle and feed_entry.subtitle.text:
             entry.append(
                 OPDSFeed.E(
                     f"{{{OPDSFeed.SCHEMA_NS}}}alternativeHeadline",

--- a/tests/manager/feed/test_opds_serializer.py
+++ b/tests/manager/feed/test_opds_serializer.py
@@ -389,3 +389,21 @@ class TestOPDSSerializer:
             "{http://palaceproject.io/terms/properties/}default"
             not in facet_link.attrib
         )
+
+    def test_serialize_work_entry_with_subtitle_equals_none(self):
+        data = WorkEntryData(
+            subtitle=FeedEntryType(text=None),
+        )
+
+        element = OPDS1Version1Serializer().serialize_work_entry(data)
+        child = element.findall(f"{{{OPDSFeed.SCHEMA_NS}}}alternativeHeadline")
+        assert len(child) == 0
+
+        data = WorkEntryData(
+            subtitle=FeedEntryType(text="test"),
+        )
+
+        element = OPDS1Version1Serializer().serialize_work_entry(data)
+        child = element.findall(f"{{{OPDSFeed.SCHEMA_NS}}}alternativeHeadline")
+        assert len(child) == 1
+        assert child[0].text == "test"


### PR DESCRIPTION
## Description

Ensures that no subtitle element is returned in the OPDS 2 feed when the subtitle value is None thus preventing the rendering of "None" for the subtitle  in the user interface.
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2043
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit test added to verify the fix works.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
