### PR TITLE
Allow empty string for username and password in ODL settings.

### DIFF
--- a/src/palace/manager/api/odl/settings.py
+++ b/src/palace/manager/api/odl/settings.py
@@ -78,14 +78,14 @@ class OPDS2WithODLSettings(OPDS2ImporterSettings):
         ),
     )
     password: str = FormField(
-        default=None,
+        default="",
         form=ConfigurationFormItem(
             label=_("Library's API password"),
             required=False,
         ),
     )
     username: str = FormField(
-        default=None,
+        default="",
         form=ConfigurationFormItem(
             label=_("Library's API username"),
             required=False,


### PR DESCRIPTION
## Description
A follow-on PR for https://ebce-lyrasis.atlassian.net/browse/PP-1834 to address validation error in ODL 2.0 collection config when no specifying username and password.  Validation requires a string albeit empty for a string type control.  Changing the return type had undesirable ripple effects.   This changes the default value from None to an empty string which seemed to me the more straightforward solution.
<!--- Describe your changes -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tested it manually on my local instance.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
