### PR TITLE
[PP-2065] Address library not persistent within session errors by ens…

### DIFF
--- a/src/palace/manager/celery/tasks/opds_odl.py
+++ b/src/palace/manager/celery/tasks/opds_odl.py
@@ -218,14 +218,14 @@ def collect_events(
     """
     with task.session() as session:
         for e in events:
-            session.refresh(e.library)
-            session.refresh(e.license_pool)
-            session.refresh(e.patron)
+            library = session.merge(e.library)
+            license_pool = session.merge(e.license_pool)
+            patron = session.merge(e.patron)
             analytics.collect_event(
                 event_type=e.event_type,
-                library=e.library,
-                license_pool=e.license_pool,
-                patron=e.patron,
+                library=library,
+                license_pool=license_pool,
+                patron=patron,
             )
 
 


### PR DESCRIPTION
…uring the

library and other objects accessed within the new transaction are attached to the session.

## Description
I was using session.refresh(obj) instead of session.merge(obj).  `merge` reattaches a detached object to the session where `refresh` refreshes an object that is already associated with the session. 
<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2065
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
