### PR TITLE
Fix uwsgi log file permissions (PP-2067)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,12 +73,7 @@ COPY docker/services/nginx /etc/nginx/
 
 # Setup uwsgi
 COPY docker/services/uwsgi /etc/
-RUN mkdir -p /var/log/uwsgi && \
-    chown root:adm /var/log/uwsgi && \
-    touch /var/log/uwsgi/uwsgi.log && \
-    chown simplified:adm /var/log/uwsgi/uwsgi.log && \
-    chmod 644 /var/log/uwsgi/uwsgi.log && \
-    mkdir /var/run/uwsgi && \
+RUN mkdir /var/run/uwsgi && \
     chown simplified:simplified /var/run/uwsgi
 
 # Setup runit

--- a/docker/runit-web/nginx/run
+++ b/docker/runit-web/nginx/run
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -e
 
+mkdir -p /var/log/nginx
+chown root:adm /var/log/nginx
 exec /usr/sbin/nginx

--- a/docker/runit-web/uwsgi/run
+++ b/docker/runit-web/uwsgi/run
@@ -1,4 +1,9 @@
 #!/bin/bash
 set -e
 
+mkdir -p /var/log/uwsgi
+chown root:adm /var/log/uwsgi
+touch /var/log/uwsgi/uwsgi.log
+chown simplified:adm /var/log/uwsgi/uwsgi.log
+chmod 644 /var/log/uwsgi/uwsgi.log
 exec /var/www/circulation/env/bin/uwsgi --ini /etc/uwsgi.ini


### PR DESCRIPTION
## Description

This builds on the changes from https://github.com/ThePalaceProject/circulation/pull/2077. It moves setting permissions on the log files from container build time to run time for both uwsgi and nginx logs. That way if the logs volume is mounted in a host system, we still get the correct log permissions at run time.

## Motivation and Context

JIRA: PP-2067

After the recent docker host system ubuntu upgrade, our logs are not being created with the correct permissions.

## How Has This Been Tested?

- Tested locally with docker

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
