### PR TITLE
Ensure that empty subtitles - ie those with a value of None - are set…

### DIFF
--- a/alembic/versions/20250114_c800cc42184a_set_none_subtitles_to_null.py
+++ b/alembic/versions/20250114_c800cc42184a_set_none_subtitles_to_null.py
@@ -1,0 +1,23 @@
+"""Set none subtitles to null
+
+Revision ID: c800cc42184a
+Revises: 579786fecbf4
+Create Date: 2025-01-14 18:36:21.116427+00:00
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c800cc42184a"
+down_revision = "579786fecbf4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("update editions set subtitle = null where subtitle = 'None'")
+
+
+def downgrade() -> None:
+    pass

--- a/src/palace/manager/core/opds2_import.py
+++ b/src/palace/manager/core/opds2_import.py
@@ -630,7 +630,11 @@ class OPDS2Importer(BaseOPDSImporter[OPDS2ImporterSettings]):
         self.log.debug(f"Started extracting metadata from publication {publication}")
 
         title = str(publication.metadata.title)
-        subtitle = str(publication.metadata.subtitle)
+        subtitle = (
+            str(publication.metadata.subtitle)
+            if publication.metadata.subtitle
+            else None
+        )
 
         languages = first_or_default(publication.metadata.languages)
         derived_medium = self._extract_medium_from_links(publication.links)


### PR DESCRIPTION
… to null in the database rather than the string "None"

## Description
This is a follow on PR:  Included is a database migration to sweep out the "None"s without requiring a complete reimport.  Though we'll still to wait for the search refresh.
<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2043
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
