### PR TITLE
[PP-2055] Use Ensure that local analytics events are committed to the…

### DIFF
--- a/src/palace/manager/celery/tasks/opds_odl.py
+++ b/src/palace/manager/celery/tasks/opds_odl.py
@@ -216,8 +216,10 @@ def collect_events(
     We perform this operation outside after completed the transaction to ensure that any row locks
     are held for the shortest possible duration in case writing to the s3 analytics provider is slow.
     """
-    with task.session() as session:
-        for e in events:
+
+    for e in events:
+        with task.transaction() as session:
+            # one transaction per event to minimize possible database lock durations
             library = session.merge(e.library)
             license_pool = session.merge(e.license_pool)
             patron = session.merge(e.patron)


### PR DESCRIPTION
… database by running the event collection within a transaction.

Also use one transaction per event collected to minimize database lock durations.

Before this update, we were using task.session() which does not automatically commit when used in a `with` block.  While the S3 analytics provider doesn't make any database updates,  the Local Analytics Provider does.  As a result, the updates to the local analytics provider which is backed by the database were not being committed.
<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2055
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
