### PR TITLE
Set default to None for odl username and password form elements.

### DIFF
--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -130,11 +130,11 @@ class OPDS2WithODLApi(
 
     @cached_property
     def _username(self) -> str:
-        return self.settings.username
+        return self.settings.username if self.settings.username else ""
 
     @cached_property
     def _password(self) -> str:
-        return self.settings.password
+        return self.settings.password if self.settings.password else ""
 
     @cached_property
     def _auth_type(self) -> OPDS2AuthType:

--- a/src/palace/manager/api/odl/importer.py
+++ b/src/palace/manager/api/odl/importer.py
@@ -385,11 +385,11 @@ class OPDS2WithODLImportMonitor(OdlAuthenticatedRequest, OPDS2ImportMonitor):
 
     @property
     def _username(self) -> str:
-        return self.settings.username
+        return self.settings.username if self.settings.username else ""
 
     @property
     def _password(self) -> str:
-        return self.settings.password
+        return self.settings.password if self.settings.password else ""
 
     @property
     def _auth_type(self) -> OPDS2AuthType:

--- a/src/palace/manager/api/odl/settings.py
+++ b/src/palace/manager/api/odl/settings.py
@@ -77,15 +77,15 @@ class OPDS2WithODLSettings(OPDS2ImporterSettings):
             options={auth: auth.value for auth in OPDS2AuthType},
         ),
     )
-    password: str = FormField(
-        default="",
+    password: str | None = FormField(
+        default=None,
         form=ConfigurationFormItem(
             label=_("Library's API password"),
             required=False,
         ),
     )
-    username: str = FormField(
-        default="",
+    username: str | None = FormField(
+        default=None,
         form=ConfigurationFormItem(
             label=_("Library's API username"),
             required=False,


### PR DESCRIPTION
## Description
@jonathangreen :  you were right.  `str | None` is the way to go.  I must have not tested my changes manually when I set the default value of the username and password to `""` because when I did a sanity check on minotaur it didn't work.

So I must have had it set to `str | None`, then I tested locally, then ran into mypy issues and changed it to "" but then did not retest locally.

This is one has definitely been tested locally now and it works.

Sorry for the rigamarole.

<!--- Describe your changes -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I  tried creating and saving a new ODL 2.0 collection and was able to save successfully.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
