### PR TITLE
Add support for suppressing config settings in admin ui. (PP-2064)

### DIFF
--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -234,6 +234,9 @@ class ConfigurationFormItem(LoggerMixin):
     # weight will be displayed in the order they were added.
     weight: int = 0
 
+    # If set to True, the Admin UI will be directed to hide this field.
+    suppressed: bool = False
+
     @staticmethod
     def get_form_value(value: Any) -> Any:
         if value is None:
@@ -258,6 +261,7 @@ class ConfigurationFormItem(LoggerMixin):
             "label": self.label,
             "key": key,
             "required": required or self.required,
+            "suppressed": self.suppressed,
         }
 
         if required and not self.required:

--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -235,7 +235,7 @@ class ConfigurationFormItem(LoggerMixin):
     weight: int = 0
 
     # If set to True, the Admin UI will be directed to hide this field.
-    suppressed: bool = False
+    hidden: bool = False
 
     @staticmethod
     def get_form_value(value: Any) -> Any:
@@ -261,7 +261,7 @@ class ConfigurationFormItem(LoggerMixin):
             "label": self.label,
             "key": key,
             "required": required or self.required,
-            "suppressed": self.suppressed,
+            "hidden": self.hidden,
         }
 
         if required and not self.required:

--- a/tests/manager/integration/test_settings.py
+++ b/tests/manager/integration/test_settings.py
@@ -68,14 +68,14 @@ class BaseSettingsFixture:
             "key": "test",
             "label": "Test",
             "required": False,
-            "suppressed": False,
+            "hidden": False,
         }
         self.number_config_dict = {
             "description": "Number description",
             "key": "number",
             "label": "Number",
             "required": True,
-            "suppressed": False,
+            "hidden": False,
         }
         self.with_alias_config_dict = {
             "default": -1.1,
@@ -83,7 +83,7 @@ class BaseSettingsFixture:
             "key": "with_alias",
             "label": "With Alias",
             "required": False,
-            "suppressed": False,
+            "hidden": False,
         }
         self.mock_db = MagicMock(spec=Session)
         self.settings = partial(MockSettings, number=1)
@@ -258,30 +258,40 @@ class TestBaseSettings:
         base_settings_fixture: BaseSettingsFixture,
     ) -> None:
         class MockConfigSettings(BaseSettings):
-            unsuppressed_field: str = FormField(
+            explicitly_unhidden_field: str = FormField(
                 "default",
                 form=ConfigurationFormItem(
-                    label="Unsuppressed",
-                    description="An unsuppressed field",
+                    label="Explicitly Unhidden",
+                    description="An explicitly unhidden field",
+                    hidden=False,
                 ),
             )
-            suppressed_field: str = FormField(
+            implicitly_unhidden_field: str = FormField(
                 "default",
                 form=ConfigurationFormItem(
-                    label="Suppressed",
-                    description="Suppressed field with default value",
-                    suppressed=True,
+                    label="Implicitly Unhidden",
+                    description="An implicitly unhidden field",
+                ),
+            )
+            hidden_field: str = FormField(
+                "default",
+                form=ConfigurationFormItem(
+                    label="Hidden",
+                    description="An explicitly hidden field",
+                    hidden=True,
                 ),
             )
 
-        [item1, item2] = MockConfigSettings().configuration_form(
+        [item1, item2, item3] = MockConfigSettings().configuration_form(
             base_settings_fixture.mock_db
         )
 
-        assert item1["key"] == "unsuppressed_field"
-        assert item1["suppressed"] is False
-        assert item2["key"] == "suppressed_field"
-        assert item2["suppressed"] is True
+        assert item1["key"] == "explicitly_unhidden_field"
+        assert item1["hidden"] is False
+        assert item2["key"] == "implicitly_unhidden_field"
+        assert item2["hidden"] is False
+        assert item3["key"] == "hidden_field"
+        assert item3["hidden"] is True
 
     def test_configuration_form_options(
         self, base_settings_fixture: BaseSettingsFixture
@@ -353,6 +363,6 @@ class TestBaseSettings:
                 "key": "test",
                 "label": "Test",
                 "required": False,
-                "suppressed": False,
+                "hidden": False,
             }
         ]

--- a/tests/manager/integration/test_settings.py
+++ b/tests/manager/integration/test_settings.py
@@ -68,12 +68,14 @@ class BaseSettingsFixture:
             "key": "test",
             "label": "Test",
             "required": False,
+            "suppressed": False,
         }
         self.number_config_dict = {
             "description": "Number description",
             "key": "number",
             "label": "Number",
             "required": True,
+            "suppressed": False,
         }
         self.with_alias_config_dict = {
             "default": -1.1,
@@ -81,6 +83,7 @@ class BaseSettingsFixture:
             "key": "with_alias",
             "label": "With Alias",
             "required": False,
+            "suppressed": False,
         }
         self.mock_db = MagicMock(spec=Session)
         self.settings = partial(MockSettings, number=1)
@@ -250,6 +253,36 @@ class TestBaseSettings:
         assert item1["key"] == "number"
         assert item2["key"] == "string"
 
+    def test_configuration_form_suppressed(
+        self,
+        base_settings_fixture: BaseSettingsFixture,
+    ) -> None:
+        class MockConfigSettings(BaseSettings):
+            unsuppressed_field: str = FormField(
+                "default",
+                form=ConfigurationFormItem(
+                    label="Unsuppressed",
+                    description="An unsuppressed field",
+                ),
+            )
+            suppressed_field: str = FormField(
+                "default",
+                form=ConfigurationFormItem(
+                    label="Suppressed",
+                    description="Suppressed field with default value",
+                    suppressed=True,
+                ),
+            )
+
+        [item1, item2] = MockConfigSettings().configuration_form(
+            base_settings_fixture.mock_db
+        )
+
+        assert item1["key"] == "unsuppressed_field"
+        assert item1["suppressed"] is False
+        assert item2["key"] == "suppressed_field"
+        assert item2["suppressed"] is True
+
     def test_configuration_form_options(
         self, base_settings_fixture: BaseSettingsFixture
     ) -> None:
@@ -320,5 +353,6 @@ class TestBaseSettings:
                 "key": "test",
                 "label": "Test",
                 "required": False,
+                "suppressed": False,
             }
         ]


### PR DESCRIPTION
## Description

Adds the "hidden" property to configuration form items to indicate to the admin client that the form element for the setting should be hidden from view, but should be transmitted back when the settings are saved.

## Motivation and Context

It is sometimes necessary to hide a configuration setting.

[Jira [PP-2064](https://ebce-lyrasis.atlassian.net/browse/PP-2064)]

## How Has This Been Tested?

- Tested behavior in local dev environment.
- All tests pass locally.
- [CI tests for associated branch](https://github.com/ThePalaceProject/circulation/actions/runs/12931626136) pass.

## Checklist

- N/A I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-2064]: https://ebce-lyrasis.atlassian.net/browse/PP-2064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ