### PR TITLE
Update runs-on to address segfault when building for arm64 (PP-2093)

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -14,7 +14,11 @@ concurrency:
 jobs:
   docker-build-baseimage:
     name: Build Base Image
-    runs-on: ubuntu-latest
+    # Some issue with the ubuntu-latest image is causing gcc to segfault with building
+    # an emulated arm64 target. Downgrading to 22.04 seems to fix this.
+    # See https://github.com/actions/runner-images/issues/11471
+    # runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,11 @@ concurrency:
 jobs:
   build:
     name: Docker build
-    runs-on: ubuntu-latest
+    # Some issue with the ubuntu-latest image is causing gcc to segfault with building
+    # an emulated arm64 target. Downgrading to 22.04 seems to fix this.
+    # See https://github.com/actions/runner-images/issues/11471
+    # runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Description

Our base image builds are failing with a segfault coming from GCC. 

I believe this is the same issue noted here: https://github.com/actions/runner-images/issues/11471

Attempt the mitigation that is mentioned in that thread.

## Motivation and Context

Unblocking our docker builds.

I tried updating the base image build in my fork of circulation, and this change allowed the base image build to pass: https://github.com/jonathangreen/circulation/actions/runs/13013623180

PP-2093

## How Has This Been Tested?

- Running actions in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
