### PR TITLE
Build arm containers with new github actions arm runner (PP-2139)

### DIFF
--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -51,7 +51,7 @@ runs:
       id: cache
       with:
         path: ${{ steps.poetry-dir.outputs.home }}
-        key: ${{ runner.os }}-poetry${{ inputs.version }}-install-py${{ steps.python-version.outputs.version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-poetry${{ inputs.version }}-install-py${{ steps.python-version.outputs.version }}
 
     - run: curl -sSL https://install.python-poetry.org | python - --yes --version ${{ inputs.version }}
       env:
@@ -72,18 +72,18 @@ runs:
       with:
         path: ${{ steps.poetry-info.outputs.cache-dir }}
         key: |
-          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-${{ hashFiles('**/poetry.lock') }}
+          ${{ runner.os }}-${{ runner.arch }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-${{ hashFiles('**/poetry.lock') }}
         restore-keys: |
-          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-
-          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-
+          ${{ runner.os }}-${{ runner.arch }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-
+          ${{ runner.os }}-${{ runner.arch }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-
       if: inputs.cache != 'false' && inputs.cache-restore-only == 'false'
 
     - uses: actions/cache/restore@v4
       with:
         path: ${{ steps.poetry-info.outputs.cache-dir }}
         key: |
-          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-${{ hashFiles('**/poetry.lock') }}
+          ${{ runner.os }}-${{ runner.arch }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-${{ hashFiles('**/poetry.lock') }}
         restore-keys: |
-          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-
-          ${{ runner.os }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-
+          ${{ runner.os }}-${{ runner.arch }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-${{ inputs.cache-name }}-
+          ${{ runner.os }}-${{ runner.arch }}-poetry${{ inputs.version }}-cache-py${{ steps.python-version.outputs.version }}-
       if: inputs.cache != 'false' && inputs.cache-restore-only != 'false'

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -3,6 +3,13 @@ on:
   schedule:
     # Every Monday at 6:22am Eastern Time
     - cron: '22 10 * * 1'
+  push:
+    # Build base image when the Dockerfile or the workflow file changes
+    branches:
+      - main
+    paths:
+      - .github/workflows/build-base-image.yml
+      - docker/Dockerfile.baseimage
   workflow_dispatch:
     # Allow us to manually trigger build
 
@@ -12,17 +19,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  docker-build-baseimage:
-    name: Build Base Image
-    # Some issue with the ubuntu-latest image is causing gcc to segfault with building
-    # an emulated arm64 target. Downgrading to 22.04 seems to fix this.
-    # See https://github.com/actions/runner-images/issues/11471
-    # runs-on: ubuntu-latest
-    runs-on: ubuntu-22.04
+  build:
+    name: Build Base Image (${{ matrix.arch.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - name: "amd64"
+            runner: "ubuntu-22.04"
+          - name: "arm64"
+            runner: "ubuntu-22.04-arm"
+
+    runs-on: ${{ matrix.arch.runner }}
+
     timeout-minutes: 120
     permissions:
       contents: read
       packages: write
+
+    outputs:
+      repo: ${{ steps.ghcr-repo.outputs.baseimage }}
+      meta: ${{ steps.meta.outputs.json }}
 
     steps:
       - uses: actions/checkout@v4
@@ -32,9 +49,6 @@ jobs:
       # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
       - name: Disable network offload
         run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -46,11 +60,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set GHCR repos
+        # Docker doesn't support uppercase letters in repo names, so we need to lowercase the owner
+        id: ghcr-repo
+        run: |
+          baseimage="ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/circ-baseimage"
+          echo "$baseimage"
+          echo "baseimage=$baseimage" >> "$GITHUB_OUTPUT"
+
       - name: Generate tags for image
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/circ-baseimage
+          images: ${{ steps.ghcr-repo.outputs.baseimage }}
           # Generate tags for the image
           # We use the following tags:
             # - The date in YYYYww format, which is the year and week number. 202052 is the last week of 2020.
@@ -60,13 +82,59 @@ jobs:
             type=raw,value=latest
 
       - name: Build base image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile.baseimage
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: true
           target: baseimage
           cache-to: type=inline
-          platforms: linux/amd64, linux/arm64
+          outputs: type=image,"name=${{ steps.ghcr-repo.outputs.baseimage }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digests
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch.name }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push:
+    name: Tag & Push Images
+    runs-on: ubuntu-22.04
+    needs: [build]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest & push images
+        working-directory: ${{ runner.temp }}/digests
+        run: >
+          docker buildx imagetools create
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ needs.build.outputs.meta }}')
+          $(printf '${{ needs.build.outputs.repo }}@sha256:%s ' *)

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -26,9 +26,9 @@ jobs:
       matrix:
         arch:
           - name: "amd64"
-            runner: "ubuntu-22.04"
+            runner: "ubuntu-24.04"
           - name: "arm64"
-            runner: "ubuntu-22.04-arm"
+            runner: "ubuntu-24.04-arm"
 
     runs-on: ${{ matrix.arch.runner }}
 
@@ -108,7 +108,7 @@ jobs:
 
   push:
     name: Tag & Push Images
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [build]
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,214 +7,32 @@ concurrency:
 
 jobs:
   build:
-    name: Docker build
-    # Some issue with the ubuntu-latest image is causing gcc to segfault with building
-    # an emulated arm64 target. Downgrading to 22.04 seems to fix this.
-    # See https://github.com/actions/runner-images/issues/11471
-    # runs-on: ubuntu-latest
-    runs-on: ubuntu-22.04
+    name: Docker build (${{ matrix.arch.name }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - name: "amd64"
+            runner: "ubuntu-22.04"
+          - name: "arm64"
+            runner: "ubuntu-22.04-arm"
+
+    runs-on: ${{ matrix.arch.runner }}
     permissions:
       contents: read
       packages: write
 
     outputs:
-      baseimage-changed: ${{ steps.changes.outputs.baseimage }}
-      baseimage: ${{ steps.baseimage.outputs.tag }}
+      webapp-repo: ${{ steps.ghcr-repo.outputs.webapp }}
+      webapp-meta: ${{ steps.meta-webapp.outputs.json }}
+      scripts-repo: ${{ steps.ghcr-repo.outputs.scripts }}
+      scripts-meta: ${{ steps.meta-scripts.outputs.json }}
+      exec-repo: ${{ steps.ghcr-repo.outputs.exec }}
+      exec-meta: ${{ steps.meta-exec.outputs.json }}
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
-      - name: Disable network offload
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      # If the base image build was changed, we build it first, so we can test
-      # using these changes throughout the rest of the build. If the base image
-      # build wasn't changed, we don't use it and just rely on scheduled build.
-      - name: Check if base image was changed by this branch
-        uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            baseimage:
-              - 'docker/Dockerfile.baseimage'
-
-      # We use docker/metadata-action to generate tags, instead of using string
-      # interpolation, because it properly handles making sure special
-      # characters are escaped, and the repo owner string is lowercase.
-      - name: Generate tags for base image
-        id: baseimage-meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/circ-baseimage
-          tags: |
-            type=ref,event=branch
-            type=sha
-            type=raw,value=latest,enable=${{ github.ref_name == 'main' }}
-
-      # We are using docker/metadata-action here for the same reason as above.
-      - name: Generate tag for latest
-        id: baseimage-latest
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/circ-baseimage
-          tags: |
-            type=raw,value=latest
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        if: steps.changes.outputs.baseimage == 'true'
-
-      # Build the base image, only if needed.
-      - name: Build base image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./docker/Dockerfile.baseimage
-          target: baseimage
-          cache-from: |
-            type=registry,ref=${{ fromJSON(steps.baseimage-latest.outputs.json).tags[0] }}
-            type=registry,ref=${{ fromJSON(steps.baseimage-meta.outputs.json).tags[0] }}
-          cache-to: |
-             type=inline
-          platforms: linux/amd64, linux/arm64
-          tags: ${{ steps.baseimage-meta.outputs.tags }}
-          labels: ${{ steps.baseimage-meta.outputs.labels }}
-          push: true
-        if: steps.changes.outputs.baseimage == 'true'
-
-      # If the base image was changed, we need to use the tag we just pushed
-      # to build the common image. Otherwise, if the base image wasn't changed,
-      # we use the latest tag. If the local repo has a built base image, we use
-      # that, otherwise we just fall back to the main projects tag.
-      - name: Set correct base-image for common image build
-        id: baseimage
-        run: |
-          docker buildx imagetools inspect ${{ fromJSON(steps.baseimage-latest.outputs.json).tags[0] }} > /dev/null
-          tag_exists=$?
-          if [[ "${{ steps.changes.outputs.baseimage }}" == "true" ]]; then
-            tag="${{ fromJSON(steps.baseimage-meta.outputs.json).tags[0] }}"
-          elif [[ $tag_exists -eq 0 ]]; then
-            tag="${{ fromJSON(steps.baseimage-latest.outputs.json).tags[0] }}"
-          else
-            tag="ghcr.io/thepalaceproject/circ-baseimage:latest"
-          fi
-          echo "Base image tag: $tag"
-          echo tag="$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Build common image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          target: common
-          cache-to: |
-            type=gha,scope=buildkit-${{ github.run_id }},mode=min
-          platforms: linux/amd64, linux/arm64
-          build-args: |
-            BASE_IMAGE=${{ steps.baseimage.outputs.tag }}
-
-  integration-test:
-    name: Test circ-${{ matrix.image }} (${{ matrix.platform }})
-    runs-on: ubuntu-latest
-    needs: [build]
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ["linux/amd64", "linux/arm64"]
-        image: ["scripts", "webapp"]
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
-      - name: Disable network offload
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build & Start container
-        run: docker compose up -d --build ${{ matrix.image }}
-        env:
-          BUILD_PLATFORM: ${{ matrix.platform }}
-          BUILD_CACHE_FROM: type=gha,scope=buildkit-${{ github.run_id }}
-          BUILD_BASE_IMAGE: ${{ needs.build.outputs.baseimage }}
-
-      - name: Run tests
-        run: ./docker/ci/test_${{ matrix.image }}.sh ${{ matrix.image }}
-
-      - name: Output logs
-        if: failure()
-        run: docker logs circulation-${{ matrix.image }}-1
-
-      - name: Stop container
-        if: always()
-        run: docker compose down
-
-  unit-test:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    needs: [build]
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
-      - name: Disable network offload
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Run unit tests
-        run: >
-          docker compose run --build webapp
-          bash -c "
-            source env/bin/activate &&
-            poetry install --without ci --no-root --sync &&
-            pytest --no-cov tests
-          "
-        env:
-          BUILD_CACHE_FROM: type=gha,scope=buildkit-${{ github.run_id }}
-          BUILD_BASE_IMAGE: ${{ needs.build.outputs.baseimage }}
-
-      - name: Stop container
-        if: always()
-        run: docker compose down
-
-  migration-test:
-    name: Migration test
-    runs-on: ubuntu-latest
-    needs: [build]
-    permissions:
-      contents: read
+# This build is heavily based on this example from the docker buildx documentation:
+# https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
 
     steps:
       - uses: actions/checkout@v4
@@ -222,47 +40,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
-      - name: Disable network offload
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Test migrations
-        run: ./docker/ci/test_migrations.sh
-        env:
-          BUILD_CACHE_FROM: type=gha,scope=buildkit-${{ github.run_id }}
-          BUILD_BASE_IMAGE: ${{ needs.build.outputs.baseimage }}
-
-  push:
-    name: Push circ-${{ matrix.image }}
-    runs-on: ubuntu-latest
-    needs: [build, integration-test, unit-test, migration-test]
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        image: ["scripts", "webapp", "exec"]
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
-      - name: Disable network offload
-        run: sudo ethtool -K eth0 tx off rx off
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
+      # Creates version files we use to track the version of code in the container
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -281,6 +59,58 @@ jobs:
           echo "__version__ = '$(dunamai from git --style semver)'" >> src/palace/manager/_version.py
           echo "__commit__ = '$(dunamai from git --format {commit} --full-commit)'" >> src/palace/manager/_version.py
           echo "__branch__ = '$(dunamai from git --format {branch})'" >> src/palace/manager/_version.py
+          cat src/palace/manager/_version.py
+
+      # Docker doesn't support uppercase letters in repo names, so we need to lowercase the owner
+      - name: Set output repos
+        id: ghcr-repo
+        run: |
+          repo=${GITHUB_REPOSITORY_OWNER,,}
+          webapp="ghcr.io/$repo/circ-webapp"
+          scripts="ghcr.io/$repo/circ-scripts"
+          exec="ghcr.io/$repo/circ-exec"
+          baseimage="ghcr.io/$repo/circ-baseimage"
+          echo "webapp=$webapp"
+          echo "webapp=$webapp" >> "$GITHUB_OUTPUT"
+          echo "scripts=$scripts"
+          echo "scripts=$scripts" >> "$GITHUB_OUTPUT"
+          echo "exec=$exec"
+          echo "exec=$exec" >> "$GITHUB_OUTPUT"
+          echo "baseimage=$baseimage"
+          echo "baseimage=$baseimage" >> "$GITHUB_OUTPUT"
+
+      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable network offload
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # If the base image build was changed, we build it first, so we can test
+      # using these changes throughout the rest of the build. If the base image
+      # build wasn't changed, we don't use it and just rely on scheduled build.
+      - name: Check if base image was changed by this branch
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            baseimage:
+              - 'docker/Dockerfile.baseimage'
+
+      # Build the base image, only if needed.
+      - name: Build base image
+        id: build-baseimage
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile.baseimage
+          target: baseimage
+          cache-from: |
+            type=registry,ref=${{ steps.ghcr-repo.outputs.baseimage }}:latest
+            type=registry,ref=ghcr.io/thepalaceproject/circ-baseimage:latest
+          load: true
+          tags: circ-baseimage:local-build
+        if: steps.changes.outputs.baseimage == 'true'
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -289,27 +119,330 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate tags for image
-        id: meta
+      # If the base image was changed, we need to use the tag we just pushed
+      # to build the common image. Otherwise, if the base image wasn't changed,
+      # we use the latest tag. If the local repo has a built base image, we use
+      # that, otherwise we just fall back to the main projects tag.
+      - name: Set correct base-image for common image build
+        id: baseimage
+        run: |
+          docker buildx imagetools inspect ${{ steps.ghcr-repo.outputs.baseimage }}:latest > /dev/null
+          tag_exists=$?
+          if [[ "${{ steps.changes.outputs.baseimage }}" == "true" ]]; then
+            tag="circ-baseimage:local-build"
+          elif [[ $tag_exists -eq 0 ]]; then
+            tag="${{ steps.ghcr-repo.outputs.baseimage }}:latest"
+          else
+            tag="ghcr.io/thepalaceproject/circ-baseimage:latest"
+          fi
+          echo "Base image tag: $tag"
+          echo tag="$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Build common image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          target: common
+          build-args: |
+            BASE_IMAGE=${{ steps.baseimage.outputs.tag }}
+
+      - name: Generate tags for circ-webapp
+        id: meta-webapp
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/circ-${{ matrix.image }}
+          images: ${{ steps.ghcr-repo.outputs.webapp }}
           tags: |
             type=semver,pattern={{major}}.{{minor}},priority=10
             type=semver,pattern={{version}},priority=20
             type=ref,event=branch,priority=30
             type=sha,priority=40
 
-      - name: Push image
+      - name: Build circ-webapp image
+        id: build-webapp
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          target: ${{ matrix.image }}
-          cache-from: type=gha,scope=buildkit-${{ github.run_id }}
-          platforms: linux/amd64, linux/arm64
+          target: webapp
           build-args: |
-            BASE_IMAGE=${{ needs.build.outputs.baseimage }}
+            BASE_IMAGE=${{ steps.baseimage.outputs.tag }}
+          labels: ${{ steps.meta-webapp.outputs.labels }}
+          outputs: type=image,"name=${{ steps.ghcr-repo.outputs.webapp }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Generate tags for circ-scripts
+        id: meta-scripts
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.ghcr-repo.outputs.scripts }}
+          tags: |
+            type=semver,pattern={{major}}.{{minor}},priority=10
+            type=semver,pattern={{version}},priority=20
+            type=ref,event=branch,priority=30
+            type=sha,priority=40
+
+      - name: Build circ-scripts image
+        id: build-scripts
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          target: scripts
+          build-args: |
+            BASE_IMAGE=${{ steps.baseimage.outputs.tag }}
+          labels: ${{ steps.meta-scripts.outputs.labels }}
+          outputs: type=image,"name=${{ steps.ghcr-repo.outputs.scripts }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Generate tags for circ-exec
+        id: meta-exec
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.ghcr-repo.outputs.exec }}
+          tags: |
+            type=semver,pattern={{major}}.{{minor}},priority=10
+            type=semver,pattern={{version}},priority=20
+            type=ref,event=branch,priority=30
+            type=sha,priority=40
+
+      - name: Build circ-exec image
+        id: build-exec
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          target: exec
+          build-args: |
+            BASE_IMAGE=${{ steps.baseimage.outputs.tag }}
+          labels: ${{ steps.meta-exec.outputs.labels }}
+          outputs: type=image,"name=${{ steps.ghcr-repo.outputs.exec }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digests
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/webapp
+          webapp_digest="${{ steps.build-webapp.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/webapp/${webapp_digest#sha256:}"
+          echo "WEBAPP_DIGEST=$webapp_digest"
+          mkdir -p ${{ runner.temp }}/digests/scripts
+          scripts_digest="${{ steps.build-scripts.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/scripts/${scripts_digest#sha256:}"
+          echo "SCRIPTS_DIGEST=$scripts_digest"
+          mkdir -p ${{ runner.temp }}/digests/exec
+          exec_digest="${{ steps.build-exec.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/exec/${exec_digest#sha256:}"
+          echo "EXEC_DIGEST=$exec_digest"
+
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch.name }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  integration-test:
+    name: Integration test (${{ matrix.arch.name }})
+    runs-on: ${{ matrix.arch.runner }}
+    needs: [build]
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - name: "amd64"
+            runner: "ubuntu-22.04"
+          - name: "arm64"
+            runner: "ubuntu-22.04-arm"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}
+          pattern: digests-${{ matrix.arch.name }}
+
+      - name: Set scripts image
+        working-directory: ${{ runner.temp }}/digests-${{ matrix.arch.name }}/scripts
+        run: |
+          IMAGE="${{needs.build.outputs.scripts-repo}}$(printf '@sha256:%s' *)"
+          echo "$IMAGE"
+          echo "SCRIPTS_IMAGE=$IMAGE" >> $GITHUB_ENV
+
+      - name: Set webapp image
+        working-directory: ${{ runner.temp }}/digests-${{ matrix.arch.name }}/webapp
+        run: |
+          IMAGE="${{needs.build.outputs.webapp-repo}}$(printf '@sha256:%s' *)"
+          echo "$IMAGE"
+          echo "WEBAPP_IMAGE=$IMAGE" >> $GITHUB_ENV
+
+      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable network offload
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Pull & Start containers
+        run: docker compose up -d
+
+      - name: Run webapp image tests
+        run: ./docker/ci/test_webapp.sh webapp
+
+      - name: Run scripts image tests
+        run: ./docker/ci/test_scripts.sh scripts
+
+      - name: Output logs
+        if: failure()
+        run: docker compose logs
+
+      - name: Stop container
+        if: always()
+        run: docker compose down
+
+  unit-test:
+    name: Unit tests (${{ matrix.arch.name }})
+    runs-on: ${{ matrix.arch.runner }}
+    needs: [build]
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - name: "amd64"
+            runner: "ubuntu-22.04"
+          - name: "arm64"
+            runner: "ubuntu-22.04-arm"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}
+          pattern: digests-${{ matrix.arch.name }}
+
+      - name: Set webapp image
+        working-directory: ${{ runner.temp }}/digests-${{ matrix.arch.name }}/webapp
+        run: |
+          IMAGE="${{needs.build.outputs.webapp-repo}}$(printf '@sha256:%s' *)"
+          echo "$IMAGE"
+          echo "WEBAPP_IMAGE=$IMAGE" >> $GITHUB_ENV
+
+      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable network offload
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run unit tests
+        run: >
+          docker compose run webapp
+          bash -c "
+            cat src/palace/manager/_version.py &&
+            source env/bin/activate &&
+            poetry install --without ci --no-root --sync &&
+            pytest --no-cov tests
+          "
+
+      - name: Stop container
+        if: always()
+        run: docker compose down
+
+  migration-test:
+    name: Migration test
+    runs-on: ubuntu-22.04
+    needs: [build]
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}
+          pattern: digests-amd64
+
+      - name: Set scripts image
+        working-directory: ${{ runner.temp }}/digests-amd64/scripts
+        run: |
+          IMAGE="${{needs.build.outputs.scripts-repo}}$(printf '@sha256:%s' *)"
+          echo "$IMAGE"
+          echo "SCRIPTS_IMAGE=$IMAGE" >> $GITHUB_ENV
+
+      - name: Set webapp image
+        working-directory: ${{ runner.temp }}/digests-amd64/webapp
+        run: |
+          IMAGE="${{needs.build.outputs.webapp-repo}}$(printf '@sha256:%s' *)"
+          echo "$IMAGE"
+          echo "WEBAPP_IMAGE=$IMAGE" >> $GITHUB_ENV
+
+      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable network offload
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Test migrations
+        run: ./docker/ci/test_migrations.sh
+
+  push:
+    name: Tag & Push Images
+    runs-on: ubuntu-22.04
+    needs: [build, integration-test, unit-test, migration-test]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest & push circ-webapp
+        working-directory: ${{ runner.temp }}/digests/webapp
+        run: >
+          docker buildx imagetools create
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ needs.build.outputs.webapp-meta }}')
+          $(printf '${{ needs.build.outputs.webapp-repo }}@sha256:%s ' *)
+
+      - name: Create manifest & push circ-scripts
+        working-directory: ${{ runner.temp }}/digests/scripts
+        run: >
+          docker buildx imagetools create
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ needs.build.outputs.scripts-meta }}')
+          $(printf '${{ needs.build.outputs.scripts-repo }}@sha256:%s ' *)
+
+      - name: Create manifest & push circ-exec
+        working-directory: ${{ runner.temp }}/digests/exec
+        run: >
+          docker buildx imagetools create
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ needs.build.outputs.exec-meta }}')
+          $(printf '${{ needs.build.outputs.exec-repo }}@sha256:%s ' *)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,6 +264,9 @@ jobs:
           path: ${{ runner.temp }}
           pattern: digests-${{ matrix.arch.name }}
 
+      # This sets the environment variable referenced in the docker-compose file
+      # for the image to use for the scripts container to the digest of the image
+      # that was built in the build job.
       - name: Set scripts image
         working-directory: ${{ runner.temp }}/digests-${{ matrix.arch.name }}/scripts
         run: |
@@ -271,6 +274,9 @@ jobs:
           echo "$IMAGE"
           echo "SCRIPTS_IMAGE=$IMAGE" >> $GITHUB_ENV
 
+      # This sets the environment variable referenced in the docker-compose file
+      # for the image to use for the webapp container to the digest of the image
+      # that was built in the build job.
       - name: Set webapp image
         working-directory: ${{ runner.temp }}/digests-${{ matrix.arch.name }}/webapp
         run: |
@@ -328,6 +334,9 @@ jobs:
           path: ${{ runner.temp }}
           pattern: digests-${{ matrix.arch.name }}
 
+      # This sets the environment variable referenced in the docker-compose file
+      # for the image to use for the webapp container to the digest of the image
+      # that was built in the build job.
       - name: Set webapp image
         working-directory: ${{ runner.temp }}/digests-${{ matrix.arch.name }}/webapp
         run: |
@@ -375,6 +384,9 @@ jobs:
           path: ${{ runner.temp }}
           pattern: digests-amd64
 
+      # This sets the environment variable referenced in the docker-compose file
+      # for the image to use for the scripts container to the digest of the image
+      # that was built in the build job.
       - name: Set scripts image
         working-directory: ${{ runner.temp }}/digests-amd64/scripts
         run: |
@@ -382,6 +394,9 @@ jobs:
           echo "$IMAGE"
           echo "SCRIPTS_IMAGE=$IMAGE" >> $GITHUB_ENV
 
+      # This sets the environment variable referenced in the docker-compose file
+      # for the image to use for the webapp container to the digest of the image
+      # that was built in the build job.
       - name: Set webapp image
         working-directory: ${{ runner.temp }}/digests-amd64/webapp
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         arch:
           - name: "amd64"
-            runner: "ubuntu-22.04"
+            runner: "ubuntu-24.04"
           - name: "arm64"
-            runner: "ubuntu-22.04-arm"
+            runner: "ubuntu-24.04-arm"
 
     runs-on: ${{ matrix.arch.runner }}
     permissions:
@@ -249,9 +249,9 @@ jobs:
       matrix:
         arch:
           - name: "amd64"
-            runner: "ubuntu-22.04"
+            runner: "ubuntu-24.04"
           - name: "arm64"
-            runner: "ubuntu-22.04-arm"
+            runner: "ubuntu-24.04-arm"
 
     steps:
       - uses: actions/checkout@v4
@@ -319,9 +319,9 @@ jobs:
       matrix:
         arch:
           - name: "amd64"
-            runner: "ubuntu-22.04"
+            runner: "ubuntu-24.04"
           - name: "arm64"
-            runner: "ubuntu-22.04-arm"
+            runner: "ubuntu-24.04-arm"
 
     steps:
       - uses: actions/checkout@v4
@@ -367,7 +367,7 @@ jobs:
 
   migration-test:
     name: Migration test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [build]
     permissions:
       contents: read
@@ -416,7 +416,7 @@ jobs:
 
   push:
     name: Tag & Push Images
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [build, integration-test, unit-test, migration-test]
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
 
       # If the base image build was changed, we build it first, so we can test
       # using these changes throughout the rest of the build. If the base image
-      # build wasn't changed, we don't use it and just rely on scheduled build.
+      # build wasn't changed, we just rely on scheduled build.
       - name: Check if base image was changed by this branch
         uses: dorny/paths-filter@v3
         id: changes
@@ -97,7 +97,7 @@ jobs:
             baseimage:
               - 'docker/Dockerfile.baseimage'
 
-      # Build the base image, only if needed.
+      # Build the base image, only if needed, and load it into the local docker daemon.
       - name: Build base image
         id: build-baseimage
         uses: docker/build-push-action@v6
@@ -119,10 +119,9 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # If the base image was changed, we need to use the tag we just pushed
-      # to build the common image. Otherwise, if the base image wasn't changed,
-      # we use the latest tag. If the local repo has a built base image, we use
-      # that, otherwise we just fall back to the main projects tag.
+      # If the base image was changed, we need to use the image we just build and tagged locally.
+      # Otherwise, if the base image wasn't changed, we use the latest tag. If the local repo has
+      # a built base image, we use that, otherwise we just fall back to the main projects tag.
       - name: Set correct base-image for common image build
         id: baseimage
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,6 @@
-version: "3.9"
-
 # Common CM setup
 # see: https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension
 x-cm-variables: &cm
-  platform: "${BUILD_PLATFORM-}"
   environment:
     SIMPLIFIED_PRODUCTION_DATABASE: "postgresql://palace:test@pg:5432/circ"
     PALACE_SEARCH_URL: "http://os:9200"
@@ -44,8 +41,6 @@ x-cm-build: &cm-build
   dockerfile: docker/Dockerfile
   args:
     - BASE_IMAGE=${BUILD_BASE_IMAGE-ghcr.io/thepalaceproject/circ-baseimage:latest}
-  cache_from:
-    - ${BUILD_CACHE_FROM-ghcr.io/thepalaceproject/circ-webapp:main}
 
 services:
   # example docker compose configuration for testing and development
@@ -55,6 +50,7 @@ services:
     build:
       <<: *cm-build
       target: webapp
+    image: "${WEBAPP_IMAGE-}"
     ports:
       - "6500:80"
 
@@ -63,6 +59,7 @@ services:
     build:
       <<: *cm-build
       target: scripts
+    image: "${SCRIPTS_IMAGE-}"
 
   pg:
     image: "postgres:16"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 # Common CM setup
 # see: https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension
 x-cm-variables: &cm
+  platform: "${BUILD_PLATFORM-}"
   environment:
     SIMPLIFIED_PRODUCTION_DATABASE: "postgresql://palace:test@pg:5432/circ"
     PALACE_SEARCH_URL: "http://os:9200"
@@ -41,6 +42,8 @@ x-cm-build: &cm-build
   dockerfile: docker/Dockerfile
   args:
     - BASE_IMAGE=${BUILD_BASE_IMAGE-ghcr.io/thepalaceproject/circ-baseimage:latest}
+  cache_from:
+    - ${BUILD_CACHE_FROM-ghcr.io/thepalaceproject/circ-webapp:main}
 
 services:
   # example docker compose configuration for testing and development

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:1 as opensearch
+FROM opensearchproject/opensearch:1 AS opensearch
 
 # Install ICU Analysis Plugin
 RUN /usr/share/opensearch/bin/opensearch-plugin install --batch analysis-icu

--- a/docker/ci/test_migrations.sh
+++ b/docker/ci/test_migrations.sh
@@ -100,7 +100,7 @@ run_in_container()
   local CONTAINER_NAME=$1
   shift 1
   debug_echo "+" "$@"
-  compose_cmd run --build --rm --no-deps "${CONTAINER_NAME}" /bin/bash -c "source env/bin/activate && $*"
+  compose_cmd run --rm --no-deps "${CONTAINER_NAME}" /bin/bash -c "source env/bin/activate && $*"
 }
 
 # Cleanup any running containers
@@ -139,6 +139,11 @@ check_db() {
   fi
   success "Database is in sync."
 }
+
+# Output the version file for debugging
+gh_group "Version file"
+run_in_container "webapp" cat /var/www/circulation/src/palace/manager/_version.py
+gh_endgroup
 
 # Find all the info we need about the first migration in the git history.
 gh_group "Finding first migration"

--- a/docker/ci/test_migrations.yml
+++ b/docker/ci/test_migrations.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 # This docker-compose file is used to run the old webapp for testing purposes
 # see test_migrations.sh for more information.
 

--- a/docker/ci/test_scripts.sh
+++ b/docker/ci/test_scripts.sh
@@ -15,7 +15,10 @@ docker compose exec "$container" cat /var/www/circulation/src/palace/manager/_ve
 # Wait for container to start
 wait_for_runit "$container"
 
-# Make sure database initialization completed successfully
+# Make sure database initialization or migration script completed successfully. If
+# the scripts container starts first it will initialize the database, but if the
+# database is already initialized, it will run migrations instead. For our purposes
+# this doesn't matter, we just want to know that the database is ready.
 timeout 240s grep -q -e 'Initialization complete' -e "Migrations complete" <(docker compose logs "$container" -f 2>&1)
 
 # Make sure that cron is running in the scripts container

--- a/docker/ci/test_scripts.sh
+++ b/docker/ci/test_scripts.sh
@@ -9,11 +9,14 @@ container="$1"
 dir=$(dirname "${BASH_SOURCE[0]}")
 source "${dir}/check_service_status.sh"
 
+# Output the version file for debugging
+docker compose exec "$container" cat /var/www/circulation/src/palace/manager/_version.py
+
 # Wait for container to start
 wait_for_runit "$container"
 
 # Make sure database initialization completed successfully
-timeout 240s grep -q 'Initialization complete' <(docker compose logs "$container" -f 2>&1)
+timeout 240s grep -q -e 'Initialization complete' -e "Migrations complete" <(docker compose logs "$container" -f 2>&1)
 
 # Make sure that cron is running in the scripts container
 check_service_status "$container" /etc/service/cron

--- a/docker/ci/test_webapp.sh
+++ b/docker/ci/test_webapp.sh
@@ -9,6 +9,9 @@ container="$1"
 dir=$(dirname "${BASH_SOURCE[0]}")
 source "${dir}/check_service_status.sh"
 
+# Output the version file for debugging
+docker compose exec "$container" cat /var/www/circulation/src/palace/manager/_version.py
+
 # Wait for container to start
 wait_for_runit "$container"
 

--- a/tests/manager/api/util/test_xray.py
+++ b/tests/manager/api/util/test_xray.py
@@ -1,17 +1,21 @@
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
+
+import pytest
 
 from palace import manager
 from palace.manager.api.util.xray import PalaceXrayMiddleware
 
 
 class TestPalaceXrayMiddleware:
-    def test_put_annotations(self):
+    @patch.object(manager, "__version__", None)
+    def test_put_annotations(self) -> None:
         # Type annotation set based on seg_type passed into put_annotation
         segment = MagicMock()
         PalaceXrayMiddleware.put_annotations(segment, "test")
         segment.put_annotation.assert_called_once_with("type", "test")
 
-    def test_put_annotations_env(self, monkeypatch):
+    @patch.object(manager, "__version__", None)
+    def test_put_annotations_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Annotations are made based on environment variables
         segment = MagicMock()
         monkeypatch.setenv(f"{PalaceXrayMiddleware.XRAY_ENV_ANNOTATE}TEST", "test")
@@ -26,9 +30,9 @@ class TestPalaceXrayMiddleware:
             call("another_test", "test123"),
         ]
 
-    def test_put_annotations_version(self, monkeypatch):
+    @patch.object(manager, "__version__", "foo")
+    def test_put_annotations_version(self) -> None:
         # The version number is added as an annotation
         segment = MagicMock()
-        monkeypatch.setattr(manager, "__version__", "foo")
         PalaceXrayMiddleware.put_annotations(segment)
         segment.put_annotation.assert_called_once_with("version", "foo")


### PR DESCRIPTION
## Description

Build our images using the github ARM runners.

This makes several changes:
- Actually run out unit tests on the ARM image (I think this is a bit win, it was too slow with emulation, but since native libraries can cause issues, its nice to verify that our tests actually run in the built arm image).
- Technically our images get pushed every commit now, but they are not tagged until the tests pass. 
  - This lets us use the images in other workflow jobs easily, while making it unlikely anyone will come across a broken image.
  - It has the advantage that if desired, you could pull the image via its hash for debugging. 
- The build takes place in a (pretty ugly IMO) two step process, where native images are built for each platform, then they are combined together into a manifest and tagged. 
  - This is the process that that docker documentation recommends for a multipart build like this, so despite being kind of ugly, it is the officially blessed way to do things. 

## Motivation and Context

Github now has native arm runners: 
https://github.com/community/community/discussions/148648

This allows us to build our ARM images faster, and without relying on emulation which was causing issues (see: https://github.com/actions/runner-images/issues/11471). 

This work is mainly based on this documentation from docker: 
https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners

But adapted to our environment / workflow.

## How Has This Been Tested?

- I did some testing of these workflows on my fork 
- Workflows running in CI on this PR

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
