### PR TITLE
Playback time tracking failures return 207 multi-response, instead of 400/404. (PP-2129)

### DIFF
--- a/src/palace/manager/api/controller/playtime_entries.py
+++ b/src/palace/manager/api/controller/playtime_entries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+from typing import Any
 
 import flask
 from pydantic import ValidationError
@@ -12,8 +13,8 @@ from palace.manager.api.controller.circulation_manager import (
 from palace.manager.api.model.time_tracking import (
     PlaytimeEntriesPost,
     PlaytimeEntriesPostResponse,
+    PlaytimeEntriesPostSummary,
 )
-from palace.manager.api.problem_details import NOT_FOUND_ON_REMOTE
 from palace.manager.api.util.flask import get_request_library, get_request_patron
 from palace.manager.core.problem_details import INVALID_INPUT
 from palace.manager.core.query.playtime_entries import PlaytimeEntries
@@ -39,33 +40,42 @@ def resolve_loan_identifier(loan: Loan | None) -> str:
 
 class PlaytimeEntriesController(CirculationManagerController):
     def track_playtimes(self, collection_id, identifier_type, identifier_idn):
-        library = get_request_library()
+        library = get_request_library(default=None)
         identifier = get_one(
             self._db, Identifier, type=identifier_type, identifier=identifier_idn
         )
         collection = Collection.by_id(self._db, collection_id)
 
-        if not identifier:
-            return NOT_FOUND_ON_REMOTE.detailed(
-                f"The identifier {identifier_type}/{identifier_idn} was not found."
-            )
-        if not collection:
-            return NOT_FOUND_ON_REMOTE.detailed(
-                f"The collection {collection_id} was not found."
-            )
-
-        if collection not in library.associated_collections:
-            return INVALID_INPUT.detailed("Collection was not found in the Library.")
-
-        if not identifier.licensed_through_collection(collection):
-            return INVALID_INPUT.detailed(
-                "This Identifier was not found in the Collection."
-            )
-
         try:
             data = PlaytimeEntriesPost(**flask.request.json)
         except ValidationError as ex:
             return INVALID_INPUT.detailed(ex.json())
+
+        if not library:
+            return handle_unrecoverable_entries(
+                data,
+                "The library was not found.",
+            )
+
+        if not identifier:
+            return handle_unrecoverable_entries(
+                data,
+                f"The identifier {identifier_type}/{identifier_idn} was not found.",
+            )
+        if not collection:
+            return handle_unrecoverable_entries(
+                data, f"The collection {collection_id} was not found."
+            )
+
+        if collection not in library.associated_collections:
+            return handle_unrecoverable_entries(
+                data, "Collection was not found in the Library."
+            )
+
+        if not identifier.licensed_through_collection(collection):
+            return handle_unrecoverable_entries(
+                data, "This Identifier was not found in the Collection."
+            )
 
         # attempt to resolve a loan associated with the patron, identifier, in the time period
         entry_max_start_time = max([x.during_minute for x in data.time_entries])
@@ -95,9 +105,27 @@ class PlaytimeEntriesController(CirculationManagerController):
             loan_identifier,
         )
 
-        response_data = PlaytimeEntriesPostResponse(
-            summary=summary, responses=responses
-        )
-        response = flask.jsonify(response_data.model_dump())
-        response.status_code = 207
-        return response
+        return make_response(responses, summary)
+
+
+def handle_unrecoverable_entries(
+    data: PlaytimeEntriesPost, reason: str, status: int = 410
+):
+    entries = data.time_entries
+    count = len(entries)
+    summary = PlaytimeEntriesPostSummary(failures=count, total=count)
+    entry_responses = [
+        dict(id=entry.id, status=status, message=reason) for entry in entries
+    ]
+    return make_response(entry_responses, summary)
+
+
+def make_response(
+    response_entries: list[dict[str, Any]], summary: PlaytimeEntriesPostSummary
+):
+    response_data = PlaytimeEntriesPostResponse(
+        summary=summary, responses=response_entries
+    )
+    response = flask.jsonify(response_data.model_dump())
+    response.status_code = 207
+    return response

--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -543,11 +543,11 @@ def track_analytics_event(identifier_type, identifier, event_type):
     "/playtimes/<int:collection_id>/<identifier_type>/<path:identifier>",
     methods=["POST"],
 )
-@has_library
+@allows_library
 @requires_auth
 @returns_problem_detail
 def track_playtime_events(collection_id, identifier_type, identifier):
-    """The actual response type is 207, but due to a bug in flask-pydantic-spec we must document it as a 200"""
+    """The usual response status is 207."""
     return app.manager.playtime_entries.track_playtimes(
         collection_id, identifier_type, identifier
     )

--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -539,6 +539,11 @@ def track_analytics_event(identifier_type, identifier, event_type):
     )
 
 
+# TODO: For the time being, we need to use `@allows_library` instead of
+#  `@requires_library` here because the latter would immediately return a
+#  404 if the library was not found. This is a problem right now, since
+#  some still-supported versions of the client apps need this to be handled
+#  specially.
 @library_route(
     "/playtimes/<int:collection_id>/<identifier_type>/<path:identifier>",
     methods=["POST"],


### PR DESCRIPTION
## Description

For playback time tracking requests, return a 207 multi-status response instead of a 400 or 404 when a collection, library, or identifier is missing or not properly associated.

## Motivation and Context

When audiobook requests have unrecoverable errors, they should not be retried. However, existing versions of client apps do not handle the 400 and 404 responses; so, we send them the 207 multi-status response that they do understand to invalidate each entry individually.

[Jira [PP-2129](https://ebce-lyrasis.atlassian.net/browse/PP-2129)]

## How Has This Been Tested?

- Updated tests and added new ones.
- Tests pass locally.
- CI tests for local branch pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-2129]: https://ebce-lyrasis.atlassian.net/browse/PP-2129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ