### PR TITLE
Refactor RedisLock (PP-1481)

### DIFF
--- a/src/palace/manager/celery/tasks/marc.py
+++ b/src/palace/manager/celery/tasks/marc.py
@@ -130,17 +130,9 @@ def marc_export_collection(
         context or {}
     )
 
-    lock = marc_export_collection_lock(
+    with marc_export_collection_lock(
         task.services.redis.client(), collection_id, delta
-    )
-
-    with lock.lock() as locked:
-        if not locked:
-            task.log.info(
-                f"Skipping collection {collection_id} because another task is already processing it."
-            )
-            return
-
+    ).lock():
         with ExitStack() as stack, task.transaction() as session:
             files = {
                 library: stack.enter_context(TemporaryFile())

--- a/src/palace/manager/celery/tasks/opds_odl.py
+++ b/src/palace/manager/celery/tasks/opds_odl.py
@@ -238,14 +238,9 @@ def recalculate_hold_queue_collection(
     """
     Recalculate the hold queue for a collection.
     """
-    lock = _redis_lock_recalculate_holds(task.services.redis.client(), collection_id)
     analytics = task.services.analytics.analytics()
-    with lock.lock() as locked:
-        if not locked:
-            task.log.info(
-                f"Skipping collection {collection_id} because another task holds its lock."
-            )
-            return
+    redis_client = task.services.redis.client()
+    with _redis_lock_recalculate_holds(redis_client, collection_id).lock():
         with task.transaction() as session:
             collection = Collection.by_id(session, collection_id)
             if collection is None:

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -72,12 +72,7 @@ def search_reindex(task: Task, offset: int = 0, batch_size: int = 500) -> None:
     redis_client = task.services.redis.client()
     task_lock = TaskLock(redis_client, task, lock_name="search_reindex")
 
-    with task_lock.lock(
-        release_on_exit=False, ignored_exceptions=(Retry, Ignore)
-    ) as acquired:
-        if not acquired:
-            raise BasePalaceException("Another re-index task is already running.")
-
+    with task_lock.lock(release_on_exit=False, ignored_exceptions=(Retry, Ignore)):
         task.log.info(
             f"Running search reindex at offset {offset} with batch size {batch_size}."
         )
@@ -134,11 +129,7 @@ def update_read_pointer(task: Task) -> None:
 @shared_task(queue=QueueNames.default, bind=True)
 def search_indexing(task: Task, batch_size: int = 500) -> None:
     redis_client = task.services.redis.client()
-    task_lock = TaskLock(redis_client, task)
-    with task_lock.lock() as acquired:
-        if not acquired:
-            raise BasePalaceException(f"{task.name} is already running.")
-
+    with TaskLock(redis_client, task).lock():
         waiting = WaitingForIndexing(redis_client)
         works = waiting.pop(batch_size)
 

--- a/src/palace/manager/service/redis/models/lock.py
+++ b/src/palace/manager/service/redis/models/lock.py
@@ -80,7 +80,7 @@ class BaseRedisLock(ABC):
     @contextmanager
     def lock(
         self,
-        raise_when_not_acquired: bool = False,
+        raise_when_not_acquired: bool = True,
         release_on_error: bool = True,
         release_on_exit: bool = True,
         ignored_exceptions: tuple[type[BaseException], ...] = (),

--- a/src/palace/manager/service/redis/models/lock.py
+++ b/src/palace/manager/service/redis/models/lock.py
@@ -17,6 +17,14 @@ class LockError(BasePalaceException):
     pass
 
 
+class LockValueError(LockError, ValueError):
+    pass
+
+
+class LockNotAcquired(LockError):
+    pass
+
+
 class BaseRedisLock(ABC):
     def __init__(
         self,
@@ -72,6 +80,7 @@ class BaseRedisLock(ABC):
     @contextmanager
     def lock(
         self,
+        raise_when_not_acquired: bool = False,
         release_on_error: bool = True,
         release_on_exit: bool = True,
         ignored_exceptions: tuple[type[BaseException], ...] = (),
@@ -79,6 +88,7 @@ class BaseRedisLock(ABC):
         """
         Context manager for acquiring and releasing the lock.
 
+        :param raise_when_not_acquired: If True, raise an exception if the lock is not acquired.
         :param release_on_error: If True, release the lock if an exception occurs.
         :param release_on_exit: If True, release the lock when the context manager exits.
         :param ignored_exceptions: Exceptions that should not cause the lock to be released.
@@ -86,6 +96,9 @@ class BaseRedisLock(ABC):
         :return: The result of the lock acquisition. You must check the return value to see if the lock was acquired.
         """
         locked = self.acquire()
+        if raise_when_not_acquired and not locked:
+            raise LockNotAcquired(f"Lock {self.key} could not be acquired")
+
         exception_occurred = False
         try:
             yield locked
@@ -180,7 +193,7 @@ class RedisLock(BaseRedisLock):
         :return: The result of the lock acquisition. You must check the return value to see if the lock was acquired.
         """
         if timeout < 0:
-            raise LockError("Cannot specify a negative timeout")
+            raise LockValueError("Cannot specify a negative timeout")
 
         start_time = time.time()
         while timeout == 0 or (time.time() - start_time) < timeout:
@@ -225,7 +238,7 @@ class TaskLock(RedisLock):
         random_value = task.request.root_id or task.request.id
         if lock_name is None:
             if task.name is None:
-                raise LockError(
+                raise LockValueError(
                     "Task.name must not be None if lock_name is not provided."
                 )
             name = ["Task", task.name]

--- a/src/palace/manager/service/redis/models/lock.py
+++ b/src/palace/manager/service/redis/models/lock.py
@@ -229,8 +229,8 @@ class RedisLock(BaseRedisLock):
 class TaskLock(RedisLock):
     def __init__(
         self,
-        redis_client: Redis,
         task: Task,
+        redis_client: Redis | None = None,
         lock_name: str | None = None,
         lock_timeout: timedelta | None = timedelta(minutes=5),
         retry_delay: float = 0.2,
@@ -244,4 +244,6 @@ class TaskLock(RedisLock):
             name = ["Task", task.name]
         else:
             name = [lock_name]
+        if redis_client is None:
+            redis_client = task.services.redis.client()
         super().__init__(redis_client, name, random_value, lock_timeout, retry_delay)

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -36,7 +36,7 @@ class SearchReindexTaskLockFixture:
         self.task = MagicMock()
         self.task.request.root_id = "fake"
         self.task_lock = TaskLock(
-            self.redis_client, self.task, lock_name="search_reindex"
+            self.task, lock_name="search_reindex", redis_client=self.redis_client
         )
 
 
@@ -351,7 +351,7 @@ class SearchIndexingFixture:
         task = MagicMock()
         task.request.root_id = "fake"
         task.name = "palace.manager.celery.tasks.search.search_indexing"
-        self.lock = TaskLock(self.redis_client, task)
+        self.lock = TaskLock(task, redis_client=self.redis_client)
 
         self.waiting = WaitingForIndexing(self.redis_client)
         self.mock_works = {w_id for w_id in range(10)}

--- a/tests/manager/service/redis/models/test_lock.py
+++ b/tests/manager/service/redis/models/test_lock.py
@@ -127,8 +127,8 @@ class TestRedisLock:
             ) as acquired:
                 assert not acquired
 
-        # If the raise_when_not_acquired parameter is set, the context manager raises
-        # an exception is the lock is not acquired.
+        # If the raise_when_not_acquired parameter is set (the default), the context manager raises
+        # an exception if the lock is not acquired.
         with redis_lock_fixture.no_timeout_lock.lock() as acquired:
             assert acquired
             with pytest.raises(LockNotAcquired):

--- a/tests/manager/service/redis/models/test_lock.py
+++ b/tests/manager/service/redis/models/test_lock.py
@@ -119,9 +119,12 @@ class TestRedisLock:
             assert redis_lock_fixture.lock.locked() is True
         assert redis_lock_fixture.lock.locked() is False
 
-        # The context manager returns false if the lock is not acquired
+        # The context manager returns false if the lock is not acquired and the
+        # raise_when_not_acquired parameter is set to False
         with redis_lock_fixture.no_timeout_lock.lock():
-            with redis_lock_fixture.lock.lock() as acquired:
+            with redis_lock_fixture.lock.lock(
+                raise_when_not_acquired=False
+            ) as acquired:
                 assert not acquired
 
         # If the raise_when_not_acquired parameter is set, the context manager raises
@@ -129,7 +132,7 @@ class TestRedisLock:
         with redis_lock_fixture.no_timeout_lock.lock() as acquired:
             assert acquired
             with pytest.raises(LockNotAcquired):
-                with redis_lock_fixture.lock.lock(raise_when_not_acquired=True):
+                with redis_lock_fixture.lock.lock():
                     ...
 
         # If the lock is extended, the context manager returns True

--- a/tests/manager/service/redis/models/test_lock.py
+++ b/tests/manager/service/redis/models/test_lock.py
@@ -188,13 +188,15 @@ class TestTaskLock:
 
         # If we don't provide a lock_name, and the task name is None, we should get an error
         with pytest.raises(LockValueError):
-            TaskLock(redis_fixture.client, mock_task)
+            TaskLock(mock_task, redis_client=redis_fixture.client)
 
         # If we don't provide a lock_name, we should use the task name
         mock_task.name = "test_task"
-        task_lock = TaskLock(redis_fixture.client, mock_task)
+        task_lock = TaskLock(mock_task, redis_client=redis_fixture.client)
         assert task_lock.key.endswith("::TaskLock::Task::test_task")
 
         # If we provide a lock_name, we should use that instead
-        task_lock = TaskLock(redis_fixture.client, mock_task, lock_name="test_lock")
+        task_lock = TaskLock(
+            mock_task, lock_name="test_lock", redis_client=redis_fixture.client
+        )
         assert task_lock.key.endswith("::TaskLock::test_lock")


### PR DESCRIPTION
## Description

Small refactor to the `RedisLock` class.

- Add a new parameter to the `lock()` function called `raise_when_not_acquired` that raises an exception if the lock isn't acquired.
- Make the `TaskLock` class only optionally take a `redis_client` parameter.

## Motivation and Context

This is a small refactor to attempt to DRY some uses of the `RedisLock` classes.

Almost all the uses of `RedisLock` have the same pattern where they try to acquire the lock, then they raise (or exit) if the lock wasn't acquired. Since we are doing this everywhere anyway, this should be the default behavior. I added `raise_when_not_acquired` to do this, and refactored existing code to use it.

Note: This changes the behavior of some tasks slightly. They used to silently exit if they couldn't acquire a lock, now they will exit with an error. Since we don't expect tasks to fail to get the lock, I think this is the correct thing to do, but it is a slight change.

The `TaskLock` class used to take a required `redis_client` parameter. Since it also takes a `Task` parameter, which has access to the redis client, we make it optional, and fall back to the redis client on the task.

## How Has This Been Tested?

- Unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
