### PR TITLE
Mitigate freezegun and pydantic issue in our fixtures (PP-2007)

### DIFF
--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -414,6 +414,14 @@ class DatabaseTransactionFixture:
         self._session = SessionManager.session_from_connection(database.connection)
         self._transaction = database.connection.begin_nested()
 
+        self._goal_registry_mapping: Mapping[Goals, IntegrationRegistry[Any]] = {
+            Goals.CATALOG_GOAL: self._services.services.integration_registry.catalog_services(),
+            Goals.DISCOVERY_GOAL: self._services.services.integration_registry.discovery(),
+            Goals.LICENSE_GOAL: self._services.services.integration_registry.license_providers(),
+            Goals.METADATA_GOAL: self._services.services.integration_registry.metadata(),
+            Goals.PATRON_AUTH_GOAL: self._services.services.integration_registry.patron_auth(),
+        }
+
     def _make_default_library(self) -> Library:
         """Ensure that the default library exists in the given database."""
         library = self.library("default", "default")
@@ -971,16 +979,6 @@ class DatabaseTransactionFixture:
 
     def isbn_take(self) -> str:
         return self._isbns.pop()
-
-    @cached_property
-    def _goal_registry_mapping(self) -> Mapping[Goals, IntegrationRegistry[Any]]:
-        return {
-            Goals.CATALOG_GOAL: self._services.services.integration_registry.catalog_services(),
-            Goals.DISCOVERY_GOAL: self._services.services.integration_registry.discovery(),
-            Goals.LICENSE_GOAL: self._services.services.integration_registry.license_providers(),
-            Goals.METADATA_GOAL: self._services.services.integration_registry.metadata(),
-            Goals.PATRON_AUTH_GOAL: self._services.services.integration_registry.patron_auth(),
-        }
 
     def protocol_string(
         self, goal: Goals, protocol: type[BaseCirculationAPI[Any, Any]]


### PR DESCRIPTION
## Description

Move some of our fixture initialization code from being lazy loaded when the property is accessed, to being initialized when the fixture is setup. 

This was moved around to work around an issue where the fixture was failing to initialize due to the `freeze_time` decorator. I believe this resolves the issue noted in [PP-2007](https://ebce-lyrasis.atlassian.net/browse/PP-2007). It doesn't resolve the incompatibility between `freeze_time` and `pydantic`, but it updates the initialization order so that pydantic initializes before the `freeze_time` decorator in the tests patches datetime.

## Motivation and Context

Ran into this issue in https://github.com/ThePalaceProject/circulation/pull/2288, and was able to work around it like this.

## How Has This Been Tested?

- Running unit tests
- The tests in https://github.com/ThePalaceProject/circulation/pull/2288 fail before this patch, but succeed after.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.


[PP-2007]: https://ebce-lyrasis.atlassian.net/browse/PP-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ