### PR TITLE
Simplify getting logger for function outside of a class

### DIFF
--- a/src/palace/manager/api/lanes.py
+++ b/src/palace/manager/api/lanes.py
@@ -1,3 +1,5 @@
+import logging
+
 from sqlalchemy.orm import Session
 
 import palace.manager.core.classifier as genres
@@ -24,7 +26,8 @@ from palace.manager.sqlalchemy.model.lane import (
 from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.util import create
 from palace.manager.util.languages import LanguageCodes
-from palace.manager.util.log import logger_for_function
+
+log = logging.getLogger(__name__)
 
 
 def load_lanes(_db, library, collection_ids):
@@ -850,7 +853,7 @@ def create_lane_for_small_collection(_db, library, parent, languages, priority=0
     try:
         language_identifier = LanguageCodes.name_for_languageset(languages)
     except ValueError as e:
-        logger_for_function().warning(
+        log.warning(
             "Could not create a lane for small collection with languages %s", languages
         )
         return 0
@@ -922,7 +925,7 @@ def create_lane_for_tiny_collection(_db, library, parent, languages, priority=0)
     try:
         name = LanguageCodes.name_for_languageset(languages)
     except ValueError as e:
-        logger_for_function().warning(
+        log.warning(
             "Could not create a lane for tiny collection with languages %s", languages
         )
         return 0

--- a/src/palace/manager/sqlalchemy/util.py
+++ b/src/palace/manager/sqlalchemy/util.py
@@ -11,8 +11,6 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError, MultipleResultsFound, NoResultFound
 from sqlalchemy.orm import Session
 
-from palace.manager.util.log import logger_for_function
-
 # This is the lock ID used to ensure that only one circulation manager
 # initializes or migrates the database at a time.
 LOCK_ID_DB_INIT = 1000000001
@@ -112,6 +110,9 @@ def get_one(
         return None
 
 
+log = logging.getLogger(__name__)
+
+
 def get_one_or_create(
     db: Session,
     model: type[T],
@@ -133,7 +134,7 @@ def get_one_or_create(
                 obj = create(db, model, create_method, create_method_kwargs, **kwargs)
                 return obj
         except IntegrityError as e:
-            logger_for_function().debug(
+            log.debug(
                 "INTEGRITY ERROR on %r %r, %r: %r",
                 model,
                 create_method_kwargs,

--- a/src/palace/manager/util/log.py
+++ b/src/palace/manager/util/log.py
@@ -1,5 +1,4 @@
 import functools
-import inspect
 import logging
 import time
 from collections.abc import Callable, Generator
@@ -87,20 +86,6 @@ def elapsed_time_logging(
         toc = time.perf_counter()
         elapsed_time = toc - tic
         log_method(f"{prefix}Completed. (elapsed time: {elapsed_time:0.4f} seconds)")
-
-
-def logger_for_function() -> logging.Logger:
-    try:
-        stack = inspect.stack()
-        previous_frame = stack[1]
-        fn_name = previous_frame.function
-        module = inspect.getmodule(previous_frame.frame)
-        module_name = module.__name__  # type: ignore[union-attr]
-    except:
-        fn_name = "<unknown>"
-        module_name = "palace.manager"
-
-    return logging.getLogger(f"{module_name}.{fn_name}")
 
 
 def logger_for_cls(cls: type[object]) -> logging.Logger:

--- a/tests/manager/util/test_log.py
+++ b/tests/manager/util/test_log.py
@@ -1,10 +1,8 @@
-from unittest.mock import patch
-
 import pytest
 from pytest import LogCaptureFixture
 
 from palace.manager.service.logging.configuration import LogLevel
-from palace.manager.util.log import LoggerMixin, log_elapsed_time, logger_for_function
+from palace.manager.util.log import LoggerMixin, log_elapsed_time
 
 
 class MockClass(LoggerMixin):
@@ -53,12 +51,3 @@ def test_log_elapsed_time_invalid(caplog: LogCaptureFixture):
     with pytest.raises(RuntimeError):
         log_elapsed_time(log_level=LogLevel.info, message_prefix="Test")(lambda: None)()
     assert len(caplog.records) == 0
-
-
-def test_logger_for_function():
-    logger = logger_for_function()
-    assert logger.name == "tests.manager.util.test_log.test_logger_for_function"
-
-    with patch("palace.manager.util.log.inspect", side_effect=Exception("Boom")):
-        logger = logger_for_function()
-    assert logger.name == "palace.manager.<unknown>"


### PR DESCRIPTION
## Description

Just use the module name for a logger used by a function that doesn't live in a class. 

## Motivation and Context

In https://github.com/ThePalaceProject/circulation/pull/2288 I was looking at how we get a logger for a python function that lives outside of a class, because this is a somewhat common case in our celery tasks. 

I over-thought this by 100x when I initially wrote this function. We don't need the function name in the logger. It would be nice to have if it were easy to do, but the overhead of having to inspect the stack to get a logger this way doesn't seem worth it.

The `logger_for_function` function was only called in a couple places, and I replaced it with `log = logging.getLogger(__name__)` in those places, so the function will just use a logger with its module name.

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
