### PR TITLE
[PP-2109] Remove loan expiration events.

### DIFF
--- a/src/palace/manager/sqlalchemy/model/circulationevent.py
+++ b/src/palace/manager/sqlalchemy/model/circulationevent.py
@@ -101,7 +101,6 @@ class CirculationEvent(Base):
     CM_HOLD_RELEASE = "circulation_manager_hold_release"
     CM_HOLD_EXPIRED = "circulation_manager_hold_expired"
     CM_HOLD_READY_FOR_CHECKOUT = "circulation_manager_hold_ready"
-    CM_LOAN_EXPIRED = "circulation_manager_loan_expired"
     CM_HOLD_CONVERTED_TO_LOAN = "circulation_manager_hold_converted_to_loan"
     CM_LOAN_CONVERTED_TO_HOLD = "circulation_manager_loan_converted_to_hold"
     CM_FULFILL = "circulation_manager_fulfill"

--- a/tests/manager/api/test_monitor.py
+++ b/tests/manager/api/test_monitor.py
@@ -189,7 +189,7 @@ class TestLoanlikeReaperMonitor:
         assert [sot_hold] == inactive_patron.holds
         assert 2 == len(current_patron.holds)
 
-        # verify expected circ event count and order for two monitor operations.
+        # verify expected circ event count for hold reaper run
         call_args_list = (
             services_fixture.analytics_fixture.analytics_mock.collect_event.call_args_list
         )

--- a/tests/manager/api/test_monitor.py
+++ b/tests/manager/api/test_monitor.py
@@ -193,11 +193,9 @@ class TestLoanlikeReaperMonitor:
         call_args_list = (
             services_fixture.analytics_fixture.analytics_mock.collect_event.call_args_list
         )
-        assert len(call_args_list) == 4
+        assert len(call_args_list) == 2
         event_types = [call_args.kwargs["event_type"] for call_args in call_args_list]
         assert event_types == [
-            CirculationEvent.CM_LOAN_EXPIRED,
-            CirculationEvent.CM_LOAN_EXPIRED,
             CirculationEvent.CM_HOLD_EXPIRED,
             CirculationEvent.CM_HOLD_EXPIRED,
         ]


### PR DESCRIPTION
## Description

This PR removes the loan expiration event, fixes the test, and does a minor refactor to move the event collection logic to the HoldReaper from the LoanLikeReapMonitor.
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2109
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests updated.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
