### PR TITLE
Add some better logging when we have issues parsing an identifier (PP-2157)

### DIFF
--- a/src/palace/manager/core/opds_import.py
+++ b/src/palace/manager/core/opds_import.py
@@ -427,7 +427,7 @@ class BaseOPDSImporter(
                 parsed_identifier, _ = result
         except Exception as e:
             self.log.exception(
-                f"An unexpected exception occurred during parsing identifier {identifier}: {e}"
+                f"An unexpected exception occurred during parsing identifier '{identifier}': {e}"
             )
 
         return parsed_identifier

--- a/src/palace/manager/core/opds_import.py
+++ b/src/palace/manager/core/opds_import.py
@@ -425,9 +425,9 @@ class BaseOPDSImporter(
             result = Identifier.parse_urn(self._db, identifier)
             if result is not None:
                 parsed_identifier, _ = result
-        except Exception:
-            self.log.error(
-                f"An unexpected exception occurred during parsing identifier {identifier}"
+        except Exception as e:
+            self.log.exception(
+                f"An unexpected exception occurred during parsing identifier {identifier}: {e}"
             )
 
         return parsed_identifier

--- a/tests/manager/core/test_opds_import.py
+++ b/tests/manager/core/test_opds_import.py
@@ -1498,7 +1498,7 @@ class TestOPDSImporter:
         mock_parse_urn.side_effect = ValueError("My god, it's full of stars")
         assert importer.parse_identifier(test_identifier) is None
         assert (
-            "An unexpected exception occurred during parsing identifier test: My god, it's full of stars"
+            "An unexpected exception occurred during parsing identifier 'test': My god, it's full of stars"
             in caplog.text
         )
         assert "Traceback" in caplog.text


### PR DESCRIPTION
## Description

Output the exception and a stack trace into our logs when an exception prevents us from parsing an identifier.

## Motivation and Context

Currently when an exception is triggered parsing an identifier, we don't include any details about the exception, or a stack trace we just output:
```
An unexpected exception occurred during parsing identifier
```

This makes it hard to know what caused the identifier to fail to parse. This gives us some additional logging info.

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
