### PR TITLE
Update simple auth to allow no password auth

### DIFF
--- a/src/palace/manager/api/simple_authentication.py
+++ b/src/palace/manager/api/simple_authentication.py
@@ -27,7 +27,9 @@ class SimpleAuthSettings(BasicAuthProviderSettings):
         form=ConfigurationFormItem(
             required=True,
             label="Test password",
-            description="A test password to use when testing the authentication provider.",
+            description="A test password to use when testing the authentication provider. If you do not want to "
+            "collect passwords, leave this field blank and set the 'Keyboard for password entry' option to "
+            "'patrons have no password'.",
         ),
     )
     additional_test_identifiers: list[str] | None = FormField(
@@ -99,11 +101,6 @@ class SimpleAuthenticationProvider(
                 self.test_identifiers += [identifier, identifier + "_username"]
 
         self.test_neighborhood = settings.neighborhood
-
-    @property
-    def collects_password(self) -> bool:
-        """Do we expect a username and a password, or just a username?"""
-        return super().collects_password and self.test_password is not None
 
     def remote_authenticate(
         self, username: str | None, password: str | None

--- a/tests/manager/api/test_simple_auth.py
+++ b/tests/manager/api/test_simple_auth.py
@@ -90,8 +90,22 @@ class TestSimpleAuth:
         assert "barcode" == user.authorization_identifier
         assert "neighborhood" == user.neighborhood
 
+    @pytest.mark.parametrize(
+        "provider_settings",
+        [
+            pytest.param(
+                {"password_keyboard": Keyboards.NULL},
+                id="null keyboard",
+            ),
+            pytest.param(
+                {"test_password": None},
+                id="no password",
+            ),
+        ],
+    )
     def test_no_password_authentication(
         self,
+        provider_settings: dict[str, str | None],
         create_settings: Callable[..., SimpleAuthSettings],
         create_provider: Callable[..., SimpleAuthenticationProvider],
     ):
@@ -99,7 +113,7 @@ class TestSimpleAuth:
         simpler by having it authenticate solely based on username.
         """
         settings = create_settings(
-            password_keyboard=Keyboards.NULL,
+            **provider_settings,
         )
         provider = create_provider(settings=settings)
 

--- a/tests/manager/api/test_simple_auth.py
+++ b/tests/manager/api/test_simple_auth.py
@@ -90,22 +90,8 @@ class TestSimpleAuth:
         assert "barcode" == user.authorization_identifier
         assert "neighborhood" == user.neighborhood
 
-    @pytest.mark.parametrize(
-        "provider_settings",
-        [
-            pytest.param(
-                {"password_keyboard": Keyboards.NULL},
-                id="null keyboard",
-            ),
-            pytest.param(
-                {"test_password": None},
-                id="no password",
-            ),
-        ],
-    )
     def test_no_password_authentication(
         self,
-        provider_settings: dict[str, str | None],
         create_settings: Callable[..., SimpleAuthSettings],
         create_provider: Callable[..., SimpleAuthenticationProvider],
     ):
@@ -113,7 +99,7 @@ class TestSimpleAuth:
         simpler by having it authenticate solely based on username.
         """
         settings = create_settings(
-            **provider_settings,
+            password_keyboard=Keyboards.NULL,
         )
         provider = create_provider(settings=settings)
 


### PR DESCRIPTION
## Description

Updates the configuration for the Simple Auth integration to allow auth with no password.

## Motivation and Context

I was using this integration to do some testing with a CT library that doesn't require passwords. Instead of setting up port forwarding or anything, i just setup simple auth as a fake ILS while I was testing.

I expected that I could just enter no password, and it would act as if the integration didn't need a password, but this wasn't the case. Since this integration is mostly just used in testing it seems reasonable to support this case.

## How Has This Been Tested?

- Tested locally
- Added test in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
