### PR TITLE
Use admin UI v1.28.1. (PP-2187)

### DIFF
--- a/src/palace/manager/api/admin/config.py
+++ b/src/palace/manager/api/admin/config.py
@@ -60,7 +60,7 @@ class OperationalMode(str, Enum):
 class Configuration(LoggerMixin):
     APP_NAME = "Palace Collection Manager"
     PACKAGE_NAME = "@thepalaceproject/circulation-admin"
-    PACKAGE_VERSION = "1.28.0"
+    PACKAGE_VERSION = "1.28.1"
 
     STATIC_ASSETS = {
         "admin_js": "circulation-admin.js",


### PR DESCRIPTION
## Description

Configure Palace Manager to default to [Admin UI v1.28.1](https://github.com/ThePalaceProject/circulation-admin/releases/tag/v1.28.1).

## Motivation and Context

[Jira PP-2187]

## How Has This Been Tested?

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.