### PR TITLE
Refactor our analytics providers

### DIFF
--- a/src/palace/manager/celery/tasks/opds_odl.py
+++ b/src/palace/manager/celery/tasks/opds_odl.py
@@ -1,5 +1,4 @@
 import datetime
-from dataclasses import dataclass
 
 from celery import shared_task
 from sqlalchemy import delete, select
@@ -9,29 +8,21 @@ from sqlalchemy.orm import Session
 from palace.manager.api.odl.api import OPDS2WithODLApi
 from palace.manager.celery.task import Task
 from palace.manager.service.analytics.analytics import Analytics
+from palace.manager.service.analytics.eventdata import AnalyticsEventData
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.redis.models.lock import RedisLock
 from palace.manager.service.redis.redis import Redis
 from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
 from palace.manager.sqlalchemy.model.collection import Collection
-from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.model.licensing import License, LicensePool
-from palace.manager.sqlalchemy.model.patron import Hold, Patron
+from palace.manager.sqlalchemy.model.patron import Hold
 from palace.manager.util.datetime_helpers import utc_now
 
 
-@dataclass
-class CirculationEventData:
-    library: Library
-    license_pool: LicensePool
-    event_type: str
-    patron: Patron
-
-
-def remove_expired_holds_for_collection(
+def _remove_expired_holds_for_collection(
     db: Session,
     collection_id: int,
-) -> list[CirculationEventData]:
+) -> list[AnalyticsEventData]:
     """
     Remove expired holds from the database for this collection.
     """
@@ -44,10 +35,10 @@ def remove_expired_holds_for_collection(
     )
 
     expired_holds = db.scalars(select_query).all()
-    expired_hold_events: list[CirculationEventData] = []
+    expired_hold_events = []
     for hold in expired_holds:
         expired_hold_events.append(
-            CirculationEventData(
+            AnalyticsEventData.create(
                 library=hold.library,
                 license_pool=hold.license_pool,
                 event_type=CirculationEvent.CM_HOLD_EXPIRED,
@@ -67,7 +58,7 @@ def remove_expired_holds_for_collection(
     return expired_hold_events
 
 
-def licensepool_ids_with_holds(
+def _licensepool_ids_with_holds(
     db: Session, collection_id: int, batch_size: int, after_id: int | None
 ) -> list[int]:
     query = (
@@ -85,7 +76,7 @@ def licensepool_ids_with_holds(
     return db.scalars(query).all()
 
 
-def lock_licenses(license_pool: LicensePool) -> None:
+def _lock_licenses(license_pool: LicensePool) -> None:
     """
     Acquire a row level lock on all the licenses for a license pool.
 
@@ -100,14 +91,14 @@ def lock_licenses(license_pool: LicensePool) -> None:
     ).all()
 
 
-def recalculate_holds_for_licensepool(
+def _recalculate_holds_for_licensepool(
     license_pool: LicensePool,
     reservation_period: datetime.timedelta,
-) -> tuple[int, list[CirculationEventData]]:
+) -> tuple[int, list[AnalyticsEventData]]:
     # We take out row level locks on all the licenses and holds for this license pool, so that
     # everything is in a consistent state while we update the hold queue. This means we should be
     # quickly committing the transaction, to avoid contention or deadlocks.
-    lock_licenses(license_pool)
+    _lock_licenses(license_pool)
     holds = license_pool.get_active_holds(for_update=True)
 
     license_pool.update_availability_from_licenses()
@@ -117,7 +108,7 @@ def recalculate_holds_for_licensepool(
     waiting = holds[reserved:]
     updated = 0
 
-    events: list[CirculationEventData] = []
+    events = []
 
     # These holds have a copy reserved for them.
     for hold in ready:
@@ -128,7 +119,7 @@ def recalculate_holds_for_licensepool(
             hold.end = utc_now() + reservation_period
             updated += 1
             events.append(
-                CirculationEventData(
+                AnalyticsEventData.create(
                     library=hold.library,
                     license_pool=hold.license_pool,
                     event_type=CirculationEvent.CM_HOLD_READY_FOR_CHECKOUT,
@@ -156,7 +147,7 @@ def remove_expired_holds_for_collection_task(task: Task, collection_id: int) -> 
 
     with task.transaction() as session:
         collection = Collection.by_id(session, collection_id)
-        events = remove_expired_holds_for_collection(
+        events = _remove_expired_holds_for_collection(
             session,
             collection_id,
         )
@@ -166,7 +157,8 @@ def remove_expired_holds_for_collection_task(task: Task, collection_id: int) -> 
             f"Removed {len(events)} expired holds for collection {collection_name} ({collection_id})."
         )
 
-    collect_events(task, events, analytics)
+    with task.transaction() as session:
+        _collect_events(session, events, analytics)
 
 
 @shared_task(queue=QueueNames.default, bind=True)
@@ -208,27 +200,16 @@ def _redis_lock_recalculate_holds(client: Redis, collection_id: int) -> RedisLoc
     )
 
 
-def collect_events(
-    task: Task, events: list[CirculationEventData], analytics: Analytics
+def _collect_events(
+    session: Session, events: list[AnalyticsEventData], analytics: Analytics
 ) -> None:
     """
     Collect events after successful database is commit and any row locks are removed.
     We perform this operation outside after completed the transaction to ensure that any row locks
     are held for the shortest possible duration in case writing to the s3 analytics provider is slow.
     """
-
-    for e in events:
-        with task.transaction() as session:
-            # one transaction per event to minimize possible database lock durations
-            library = session.merge(e.library)
-            license_pool = session.merge(e.license_pool)
-            patron = session.merge(e.patron)
-            analytics.collect_event(
-                event_type=e.event_type,
-                library=library,
-                license_pool=license_pool,
-                patron=patron,
-            )
+    for event in events:
+        analytics.collect(event, session)
 
 
 @shared_task(queue=QueueNames.default, bind=True)
@@ -257,7 +238,7 @@ def recalculate_hold_queue_collection(
                 f"Recalculating hold queue for collection {collection_name} ({collection_id})."
             )
 
-            license_pool_ids = licensepool_ids_with_holds(
+            license_pool_ids = _licensepool_ids_with_holds(
                 session, collection_id, batch_size, after_id
             )
 
@@ -277,7 +258,7 @@ def recalculate_hold_queue_collection(
                     )
                     continue
 
-                updated, events = recalculate_holds_for_licensepool(
+                updated, events = _recalculate_holds_for_licensepool(
                     license_pool,
                     reservation_period,
                 )
@@ -289,7 +270,8 @@ def recalculate_hold_queue_collection(
                     f"{updated} holds out of date."
                 )
 
-            collect_events(task, events, analytics)
+            with task.transaction() as session:
+                _collect_events(session, events, analytics)
 
     if len(license_pool_ids) == batch_size:
         # We are done this batch, but there is probably more work to do, we queue up the next batch.

--- a/src/palace/manager/service/analytics/analytics.py
+++ b/src/palace/manager/service/analytics/analytics.py
@@ -3,21 +3,22 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-import flask
+from sqlalchemy.orm import Session
 
+from palace.manager.service.analytics.eventdata import AnalyticsEventData
 from palace.manager.service.analytics.local import LocalAnalyticsProvider
+from palace.manager.service.analytics.provider import AnalyticsProvider
 from palace.manager.service.analytics.s3 import S3AnalyticsProvider
 from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.model.licensing import LicensePool
 from palace.manager.sqlalchemy.model.patron import Patron
-from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.log import LoggerMixin
 
 if TYPE_CHECKING:
     from palace.manager.service.storage.s3 import S3Service
 
 
-class Analytics(LoggerMixin):
+class Analytics(LoggerMixin, AnalyticsProvider):
     """Dispatches methods for analytics providers."""
 
     def __init__(
@@ -25,7 +26,7 @@ class Analytics(LoggerMixin):
         s3_analytics_enabled: bool = False,
         s3_service: S3Service | None = None,
     ) -> None:
-        self.providers = [LocalAnalyticsProvider()]
+        self.providers: list[AnalyticsProvider] = [LocalAnalyticsProvider()]
 
         if s3_analytics_enabled:
             if s3_service is not None:
@@ -34,6 +35,14 @@ class Analytics(LoggerMixin):
                 self.log.info(
                     "S3 analytics is not configured: No analytics bucket was specified."
                 )
+
+    def collect(
+        self,
+        event: AnalyticsEventData,
+        session: Session | None = None,
+    ) -> None:
+        for provider in self.providers:
+            provider.collect(event, session)
 
     def collect_event(
         self,
@@ -46,29 +55,18 @@ class Analytics(LoggerMixin):
         patron: Patron | None = None,
         neighborhood: str | None = None,
     ) -> None:
-        if not time:
-            time = utc_now()
-
-        user_agent: str | None = None
-        try:
-            user_agent = flask.request.user_agent.string
-            if user_agent == "":
-                user_agent = None
-        except Exception as e:
-            self.log.warning(f"Unable to resolve the user_agent: {repr(e)}")
-
-        for provider in self.providers:
-            provider.collect_event(
-                library,
-                license_pool,
-                event_type,
-                time,
-                old_value=old_value,
-                new_value=new_value,
-                user_agent=user_agent,
-                patron=patron,
-                neighborhood=neighborhood,
-            )
+        session = Session.object_session(library)
+        event = AnalyticsEventData.create(
+            library,
+            license_pool,
+            event_type,
+            time,
+            old_value,
+            new_value,
+            patron,
+            neighborhood,
+        )
+        self.collect(event, session=session)
 
     def is_configured(self) -> bool:
         return len(self.providers) > 0

--- a/src/palace/manager/service/analytics/eventdata.py
+++ b/src/palace/manager/service/analytics/eventdata.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from datetime import datetime
+from functools import cached_property
+from uuid import UUID
+
+import flask
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    computed_field,
+    field_serializer,
+)
+from pydantic_core.core_schema import FieldSerializationInfo
+from typing_extensions import Self
+
+from palace.manager.sqlalchemy.model.library import Library
+from palace.manager.sqlalchemy.model.licensing import LicensePool
+from palace.manager.sqlalchemy.model.patron import Patron
+from palace.manager.util.datetime_helpers import utc_now
+from palace.manager.util.log import LoggerMixin
+
+
+class AnalyticsEventData(BaseModel, LoggerMixin):
+    """
+    This class represents the data that is sent to the analytics provider.
+
+    It is a Pydantic model that is used to validate the data before it is sent. It stores
+    all the data without references to any database objects, so it can be serialized, stored
+    and sent outside a database transaction.
+    """
+
+    type: str
+    start: AwareDatetime
+
+    # TODO: We include the 'end' field as a copy of 'start' because that is
+    #   what the pre-pydantic implementation did. Since this is just duplicated
+    #   we should remove it in a future release.
+    @computed_field  # type: ignore[prop-decorator]
+    @cached_property
+    def end(self) -> AwareDatetime:
+        return self.start
+
+    library_id: int
+    library_name: str
+    library_short_name: str
+    old_value: int | None
+    new_value: int | None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @cached_property
+    def delta(self) -> int | None:
+        if self.new_value is None or self.old_value is None:
+            return None
+        return self.new_value - self.old_value
+
+    location: str | None
+    license_pool_id: int | None
+    publisher: str | None
+    imprint: str | None
+    issued: datetime | None
+    published: datetime | None
+    medium: str | None
+    collection: str | None
+    collection_id: int | None
+    identifier_type: str | None
+    identifier: str | None
+    data_source: str | None
+    distributor: str | None
+    audience: str | None
+    fiction: bool | None
+    summary_text: str | None
+    quality: float | None
+    rating: int | None
+    popularity: int | None
+    genre: str | None
+    availability_time: AwareDatetime | None
+    licenses_owned: int | None
+    licenses_available: int | None
+    licenses_reserved: int | None
+    patrons_in_hold_queue: int | None
+
+    # TODO: We no longer support self-hosted books, so this should always be False.
+    #  this value is still included in the response for backwards compatibility,
+    #  but should be removed in a future release.
+    self_hosted: bool = False
+    title: str | None
+    author: str | None
+    series: str | None
+    series_position: int | None
+    language: str | None
+    open_access: bool | None
+    user_agent: str | None
+    patron_uuid: UUID | None
+
+    model_config = ConfigDict(
+        frozen=True,
+    )
+
+    # We serialize the datetime fields as strings in the JSON output, to match what
+    # the output looked like before we switched to Pydantic.
+    # TODO: It would be nice to be able to drop this and just use the default
+    #   which is to serialize datetimes as ISO8601 strings. Need to see if the
+    #   analytics consumers can handle that.
+    @field_serializer("start", "end", "availability_time", when_used="json")
+    def serialize_dt(self, value: datetime, _info: FieldSerializationInfo) -> str:
+        return str(value)
+
+    @classmethod
+    def create(
+        cls,
+        library: Library,
+        license_pool: LicensePool | None,
+        event_type: str,
+        time: datetime | None = None,
+        old_value: int | None = None,
+        new_value: int | None = None,
+        patron: Patron | None = None,
+        neighborhood: str | None = None,
+        user_agent: str | None = None,
+    ) -> Self:
+        if user_agent is None:
+            try:
+                user_agent = flask.request.user_agent.string
+                if user_agent == "":
+                    user_agent = None
+            except Exception as e:
+                cls.logger().warning(f"Unable to resolve the user_agent: {repr(e)}")
+
+        if not time:
+            time = utc_now()
+
+        data_source = license_pool.data_source if license_pool else None
+        identifier = license_pool.identifier if license_pool else None
+        collection = license_pool.collection if license_pool else None
+        work = license_pool.work if license_pool else None
+        edition = work.presentation_edition if work else None
+        if not edition and license_pool:
+            edition = license_pool.presentation_edition
+
+        return cls(
+            type=event_type,
+            start=time,
+            library_id=library.id,
+            library_name=library.name,
+            library_short_name=library.short_name,
+            old_value=old_value,
+            new_value=new_value,
+            location=neighborhood,
+            license_pool_id=license_pool.id if license_pool else None,
+            publisher=edition.publisher if edition else None,
+            imprint=edition.imprint if edition else None,
+            issued=edition.issued if edition else None,
+            published=(
+                datetime.combine(edition.published, datetime.min.time())
+                if edition and edition.published
+                else None
+            ),
+            medium=edition.medium if edition else None,
+            collection=collection.name if collection else None,
+            collection_id=collection.id if collection else None,
+            identifier_type=identifier.type if identifier else None,
+            identifier=identifier.identifier if identifier else None,
+            data_source=data_source.name if data_source else None,
+            distributor=data_source.name if data_source else None,
+            audience=work.audience if work else None,
+            fiction=work.fiction if work else None,
+            summary_text=work.summary_text if work else None,
+            quality=work.quality if work else None,
+            rating=work.rating if work else None,
+            popularity=work.popularity if work else None,
+            genre=(
+                ", ".join(map(lambda genre: genre.name, work.genres)) if work else None
+            ),
+            availability_time=(
+                license_pool.availability_time if license_pool else None
+            ),
+            licenses_owned=license_pool.licenses_owned if license_pool else None,
+            licenses_available=(
+                license_pool.licenses_available if license_pool else None
+            ),
+            licenses_reserved=(
+                license_pool.licenses_reserved if license_pool else None
+            ),
+            patrons_in_hold_queue=(
+                license_pool.patrons_in_hold_queue if license_pool else None
+            ),
+            title=work.title if work else None,
+            author=work.author if work else None,
+            series=work.series if work else None,
+            series_position=work.series_position if work else None,
+            language=work.language if work else None,
+            open_access=license_pool.open_access if license_pool else None,
+            user_agent=user_agent,
+            patron_uuid=patron.uuid if patron else None,
+        )

--- a/src/palace/manager/service/analytics/eventdata.py
+++ b/src/palace/manager/service/analytics/eventdata.py
@@ -5,14 +5,7 @@ from functools import cached_property
 from uuid import UUID
 
 import flask
-from pydantic import (
-    AwareDatetime,
-    BaseModel,
-    ConfigDict,
-    computed_field,
-    field_serializer,
-)
-from pydantic_core.core_schema import FieldSerializationInfo
+from pydantic import AwareDatetime, BaseModel, ConfigDict, computed_field
 from typing_extensions import Self
 
 from palace.manager.sqlalchemy.model.library import Library
@@ -97,15 +90,6 @@ class AnalyticsEventData(BaseModel, LoggerMixin):
     model_config = ConfigDict(
         frozen=True,
     )
-
-    # We serialize the datetime fields as strings in the JSON output, to match what
-    # the output looked like before we switched to Pydantic.
-    # TODO: It would be nice to be able to drop this and just use the default
-    #   which is to serialize datetimes as ISO8601 strings. Need to see if the
-    #   analytics consumers can handle that.
-    @field_serializer("start", "end", "availability_time", when_used="json")
-    def serialize_dt(self, value: datetime, _info: FieldSerializationInfo) -> str:
-        return str(value)
 
     @classmethod
     def create(

--- a/src/palace/manager/service/analytics/local.py
+++ b/src/palace/manager/service/analytics/local.py
@@ -36,6 +36,4 @@ class LocalAnalyticsProvider(AnalyticsProvider, LoggerMixin):
             ),
         )
         if was_new:
-            self.log.info(
-                "EVENT %s %s=>%s", event.type, event.old_value, event.new_value
-            )
+            self.log.info(f"EVENT {event.type} {event.old_value}=>{event.new_value}")

--- a/src/palace/manager/service/analytics/provider.py
+++ b/src/palace/manager/service/analytics/provider.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+
+from sqlalchemy.orm import Session
+
+from palace.manager.service.analytics.eventdata import AnalyticsEventData
+
+
+class AnalyticsProvider(ABC):
+    @abstractmethod
+    def collect(
+        self,
+        event: AnalyticsEventData,
+        session: Session | None = None,
+    ) -> None:
+        """
+        Write the event to the appropriate data store.
+        """
+        ...

--- a/src/palace/manager/service/analytics/s3.py
+++ b/src/palace/manager/service/analytics/s3.py
@@ -26,10 +26,7 @@ class S3AnalyticsProvider(AnalyticsProvider):
         event: AnalyticsEventData,
         session: Session | None = None,
     ) -> None:
-        # We exclude the collection_id from the json because it wasn't included
-        # in our pre-pydantic implementation, it was only used in the file key.
-        # TODO: See if adding collection_id will cause any issue with the ingest process.
-        content = event.model_dump_json(exclude={"collection_id"})
+        content = event.model_dump_json()
 
         storage = self._get_storage()
         analytics_file_key = self._get_file_key(event)

--- a/src/palace/manager/service/analytics/s3.py
+++ b/src/palace/manager/service/analytics/s3.py
@@ -1,202 +1,38 @@
 from __future__ import annotations
 
-import datetime
-import json
 import random
 import string
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm import Session
 
 from palace.manager.core.config import CannotLoadConfiguration
-from palace.manager.service.analytics.local import LocalAnalyticsProvider
+from palace.manager.service.analytics.eventdata import AnalyticsEventData
+from palace.manager.service.analytics.provider import AnalyticsProvider
 from palace.manager.sqlalchemy.constants import MediaTypes
-from palace.manager.sqlalchemy.model.library import Library
-from palace.manager.sqlalchemy.model.licensing import LicensePool
-from palace.manager.sqlalchemy.model.patron import Patron
 
 if TYPE_CHECKING:
     from palace.manager.service.storage.s3 import S3Service
 
 
-class S3AnalyticsProvider(LocalAnalyticsProvider):
+class S3AnalyticsProvider(AnalyticsProvider):
     """Analytics provider storing data in a S3 bucket."""
 
     def __init__(self, s3_service: S3Service | None):
         self.s3_service = s3_service
 
-    @staticmethod
-    def _create_event_object(
-        library: Library,
-        license_pool: LicensePool | None,
-        event_type: str,
-        time: datetime.datetime,
-        old_value: int | None = None,
-        new_value: int | None = None,
-        neighborhood: str | None = None,
-        user_agent: str | None = None,
-        patron: Patron | None = None,
-    ) -> dict[str, Any]:
-        """Create a Python dict containing required information about the event.
-
-        :param library: Library associated with the event
-
-        :param license_pool: License pool associated with the event
-
-        :param event_type: Type of the event
-
-        :param time: Event's timestamp
-
-        :param old_value: Old value of the metric changed by the event
-
-        :param new_value: New value of the metric changed by the event
-
-        :param neighborhood: Geographic location of the event
-
-        :param user_agent: the user agent string of the caller
-
-        :return: Python dict containing required information about the event
-        """
-        start = time
-        if not start:
-            start = datetime.datetime.utcnow()
-        end = start
-
-        if new_value is None or old_value is None:
-            delta = None
-        else:
-            delta = new_value - old_value
-
-        data_source = license_pool.data_source if license_pool else None
-        identifier = license_pool.identifier if license_pool else None
-        collection = license_pool.collection if license_pool else None
-        work = license_pool.work if license_pool else None
-        edition = work.presentation_edition if work else None
-        if not edition and license_pool:
-            edition = license_pool.presentation_edition
-
-        event = {
-            "type": event_type,
-            "start": start,
-            "end": end,
-            "library_id": library.id,
-            "library_name": library.name,
-            "library_short_name": library.short_name,
-            "old_value": old_value,
-            "new_value": new_value,
-            "delta": delta,
-            "location": neighborhood,
-            "license_pool_id": license_pool.id if license_pool else None,
-            "publisher": edition.publisher if edition else None,
-            "imprint": edition.imprint if edition else None,
-            "issued": edition.issued if edition else None,
-            "published": (
-                datetime.datetime.combine(
-                    edition.published, datetime.datetime.min.time()
-                )
-                if edition and edition.published
-                else None
-            ),
-            "medium": edition.medium if edition else None,
-            "collection": collection.name if collection else None,
-            "identifier_type": identifier.type if identifier else None,
-            "identifier": identifier.identifier if identifier else None,
-            "data_source": data_source.name if data_source else None,
-            "distributor": data_source.name if data_source else None,
-            "audience": work.audience if work else None,
-            "fiction": work.fiction if work else None,
-            "summary_text": work.summary_text if work else None,
-            "quality": work.quality if work else None,
-            "rating": work.rating if work else None,
-            "popularity": work.popularity if work else None,
-            "genre": (
-                ", ".join(map(lambda genre: genre.name, work.genres)) if work else None
-            ),
-            "availability_time": (
-                license_pool.availability_time if license_pool else None
-            ),
-            "licenses_owned": license_pool.licenses_owned if license_pool else None,
-            "licenses_available": (
-                license_pool.licenses_available if license_pool else None
-            ),
-            "licenses_reserved": (
-                license_pool.licenses_reserved if license_pool else None
-            ),
-            "patrons_in_hold_queue": (
-                license_pool.patrons_in_hold_queue if license_pool else None
-            ),
-            # TODO: We no longer support self-hosted books, so this should always be False.
-            #  this value is still included in the response for backwards compatibility,
-            #  but should be removed in a future release.
-            "self_hosted": False,
-            "title": work.title if work else None,
-            "author": work.author if work else None,
-            "series": work.series if work else None,
-            "series_position": work.series_position if work else None,
-            "language": work.language if work else None,
-            "open_access": license_pool.open_access if license_pool else None,
-            "user_agent": user_agent,
-            "patron_uuid": str(patron.uuid) if patron else None,
-        }
-
-        return event
-
-    def collect_event(
+    def collect(
         self,
-        library: Library,
-        license_pool: LicensePool | None,
-        event_type: str,
-        time: datetime.datetime,
-        old_value: int | None = None,
-        new_value: int | None = None,
-        user_agent: str | None = None,
-        patron: Patron | None = None,
-        neighborhood: str | None = None,
+        event: AnalyticsEventData,
+        session: Session | None = None,
     ) -> None:
-        """Log the event using the appropriate for the specific provider's mechanism.
-
-        :param library: Library associated with the event
-        :type library: core.model.library.Library
-
-        :param license_pool: License pool associated with the event
-        :type license_pool: core.model.licensing.LicensePool
-
-        :param event_type: Type of the event
-        :type event_type: str
-
-        :param time: Event's timestamp
-        :type time: datetime.datetime
-
-        :param old_value: Old value of the metric changed by the event
-        :type old_value: Any
-
-        :param new_value: New value of the metric changed by the event
-        :type new_value: Any
-
-        :param user_agent: The user_agent of the caller.
-        :type user_agent:  str
-
-        :param patron: The patron associated with the event, where applicable
-        :type patron: Patron
-        """
-
-        event = self._create_event_object(
-            library,
-            license_pool,
-            event_type,
-            time,
-            old_value,
-            new_value,
-            user_agent=user_agent,
-            patron=patron,
-            neighborhood=neighborhood,
-        )
-        content = json.dumps(
-            event,
-            default=str,
-            ensure_ascii=True,
-        )
+        # We exclude the collection_id from the json because it wasn't included
+        # in our pre-pydantic implementation, it was only used in the file key.
+        # TODO: See if adding collection_id will cause any issue with the ingest process.
+        content = event.model_dump_json(exclude={"collection_id"})
 
         storage = self._get_storage()
-        analytics_file_key = self._get_file_key(library, license_pool, event_type, time)
+        analytics_file_key = self._get_file_key(event)
 
         storage.store(
             analytics_file_key,
@@ -206,31 +42,24 @@ class S3AnalyticsProvider(LocalAnalyticsProvider):
 
     def _get_file_key(
         self,
-        library: Library,
-        license_pool: LicensePool | None,
-        event_type: str,
-        end_time: datetime.datetime,
-        start_time: datetime.datetime | None = None,
+        event: AnalyticsEventData,
     ) -> str:
-        """The path to the analytics data file for the given library, license
-        pool and date range."""
-        root = library.short_name
-        if start_time:
-            time_part = str(start_time) + "-" + str(end_time)
-        else:
-            time_part = str(end_time)
+        """The path to the analytics data file."""
+        root = event.library_short_name
+        time_part = str(event.start)
 
         # ensure the uniqueness of file name (in case of overlapping events)
-        collection = license_pool.collection_id if license_pool else "NONE"
+        collection = event.collection_id if event.collection_id else "NONE"
         random_string = "".join(random.choices(string.ascii_lowercase, k=10))
-        file_name = "-".join([time_part, event_type, str(collection), random_string])
+        file_name = "-".join([time_part, event.type, str(collection), random_string])
+
         # nest file in directories that allow for easy purging by year, month or day
         return "/".join(
             [
                 str(root),
-                str(end_time.year),
-                str(end_time.month),
-                str(end_time.day),
+                str(event.start.year),
+                str(event.start.month),
+                str(event.start.day),
                 file_name + ".json",
             ]
         )

--- a/tests/manager/service/analytics/test_analytics.py
+++ b/tests/manager/service/analytics/test_analytics.py
@@ -1,29 +1,12 @@
-import datetime
-from collections.abc import Generator
 from unittest.mock import MagicMock
-
-import pytest
 
 from palace.manager.service.analytics.analytics import Analytics
 from palace.manager.service.analytics.local import LocalAnalyticsProvider
 from palace.manager.service.analytics.s3 import S3AnalyticsProvider
-from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
-from tests.fixtures.api_controller import ControllerFixture
-from tests.fixtures.database import DatabaseTransactionFixture
-from tests.fixtures.services import ServicesFixture
-
-
-@pytest.fixture(scope="function")
-def analytics_fixture(
-    db: DatabaseTransactionFixture, services_fixture: ServicesFixture
-) -> Generator[ControllerFixture, None, None]:
-    fixture = ControllerFixture(db, services_fixture)
-    with fixture.wired_container():
-        yield fixture
 
 
 class TestAnalytics:
-    def test_is_configured(self):
+    def test_is_configured(self) -> None:
         analytics = Analytics()
         assert analytics.is_configured() == True
 
@@ -34,7 +17,7 @@ class TestAnalytics:
         analytics.providers = []
         assert analytics.is_configured() == False
 
-    def test_init_analytics(self):
+    def test_init_analytics(self) -> None:
         analytics = Analytics()
 
         assert len(analytics.providers) == 1
@@ -48,53 +31,3 @@ class TestAnalytics:
         assert len(analytics.providers) == 2
         assert type(analytics.providers[0]) == LocalAnalyticsProvider
         assert type(analytics.providers[1]) == S3AnalyticsProvider
-
-    def test_user_agent_capture(
-        self,
-        analytics_fixture: ControllerFixture,
-    ):
-        db = analytics_fixture.db
-        edition = db.edition()
-        pool = db.licensepool(edition=edition)
-        library = db.default_library()
-
-        # user agent present
-        user_agent = "test_user_agent"
-        headers = {"User-Agent": user_agent}
-        analytics, provider = self.setup_analytics_mocks()
-        with analytics_fixture.request_context_with_library("/", headers=headers):
-            analytics.collect_event(library, pool, CirculationEvent.CM_CHECKOUT)
-            kwargs = provider.collect_event.call_args.kwargs
-            assert kwargs["user_agent"] == user_agent
-            args = provider.collect_event.call_args[0]
-            assert args[0] == library
-            assert args[1] == pool
-            assert args[2] == CirculationEvent.CM_CHECKOUT
-            assert isinstance(args[3], datetime.datetime)
-
-        # user agent empty
-        user_agent = ""
-        headers = {"User-Agent": user_agent}
-        analytics, provider = self.setup_analytics_mocks()
-        with analytics_fixture.request_context_with_library("/", headers=headers):
-            analytics.collect_event(library, pool, CirculationEvent.CM_CHECKOUT)
-            kwargs = provider.collect_event.call_args.kwargs
-            assert kwargs["user_agent"] is None
-
-        # no user agent header.
-        headers = {}
-        analytics, provider = self.setup_analytics_mocks()
-        with analytics_fixture.request_context_with_library("/", headers=headers):
-            analytics.collect_event(library, pool, CirculationEvent.CM_CHECKOUT)
-            assert provider.collect_event.call_args.kwargs["user_agent"] is None
-
-        # call outside of request context
-        analytics, provider = self.setup_analytics_mocks()
-        analytics.collect_event(library, pool, CirculationEvent.CM_CHECKOUT)
-        assert provider.collect_event.call_args.kwargs["user_agent"] is None
-
-    def setup_analytics_mocks(self):
-        provider = MagicMock()
-        analytics = Analytics()
-        analytics.providers.append(provider)
-        return analytics, provider

--- a/tests/manager/service/analytics/test_eventdata.py
+++ b/tests/manager/service/analytics/test_eventdata.py
@@ -1,0 +1,44 @@
+from palace.manager.service.analytics.eventdata import AnalyticsEventData
+from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.flask import FlaskAppFixture
+
+
+class TestAnalyticsEventData:
+    def test_user_agent(
+        self,
+        db: DatabaseTransactionFixture,
+        flask_app_fixture: FlaskAppFixture,
+    ) -> None:
+        edition = db.edition()
+        pool = db.licensepool(edition=edition)
+        library = db.default_library()
+
+        # user agent present
+        user_agent = "test_user_agent"
+        headers = {"User-Agent": user_agent}
+        with flask_app_fixture.test_request_context("/", headers=headers):
+            event = AnalyticsEventData.create(
+                library, pool, CirculationEvent.CM_CHECKOUT
+            )
+        assert event.user_agent == user_agent
+
+        # user agent empty
+        headers = {"User-Agent": ""}
+        with flask_app_fixture.test_request_context("/", headers=headers):
+            event = AnalyticsEventData.create(
+                library, pool, CirculationEvent.CM_CHECKOUT
+            )
+        assert event.user_agent is None
+
+        # no user agent header.
+        headers = {}
+        with flask_app_fixture.test_request_context("/", headers=headers):
+            event = AnalyticsEventData.create(
+                library, pool, CirculationEvent.CM_CHECKOUT
+            )
+        assert event.user_agent is None
+
+        # call outside of request context
+        event = AnalyticsEventData.create(library, pool, CirculationEvent.CM_CHECKOUT)
+        assert event.user_agent is None

--- a/tests/manager/service/analytics/test_local.py
+++ b/tests/manager/service/analytics/test_local.py
@@ -3,25 +3,24 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from freezegun import freeze_time
 
+from palace.manager.service.analytics.eventdata import AnalyticsEventData
 from palace.manager.service.analytics.local import LocalAnalyticsProvider
 from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
-from palace.manager.util.datetime_helpers import utc_now
+from palace.manager.util.datetime_helpers import datetime_utc, utc_now
 
 if TYPE_CHECKING:
     from tests.fixtures.database import DatabaseTransactionFixture
 
 
 class LocalAnalyticsProviderFixture:
-    transaction: DatabaseTransactionFixture
-    la: LocalAnalyticsProvider
-
     def __init__(
         self,
         transaction: DatabaseTransactionFixture,
     ):
-        self.transaction = transaction
-        self.la = LocalAnalyticsProvider()
+        self.db = transaction
+        self.provider = LocalAnalyticsProvider()
 
 
 @pytest.fixture()
@@ -32,15 +31,12 @@ def local_analytics_provider_fixture(
 
 
 class TestLocalAnalyticsProvider:
-    def test_collect_event(
-        self, local_analytics_provider_fixture: LocalAnalyticsProviderFixture
-    ):
-        data = local_analytics_provider_fixture
-        database = local_analytics_provider_fixture.transaction
-        session = database.session
-
-        library2 = database.library()
-        work = database.work(
+    def test_collect(
+        self,
+        db: DatabaseTransactionFixture,
+        local_analytics_provider_fixture: LocalAnalyticsProviderFixture,
+    ) -> None:
+        work = db.work(
             title="title",
             authors="author",
             fiction=True,
@@ -50,22 +46,109 @@ class TestLocalAnalyticsProvider:
         )
         [lp] = work.license_pools
         now = utc_now()
-        data.la.collect_event(
-            database.default_library(),
+        event_data = AnalyticsEventData.create(
+            db.default_library(),
             lp,
             CirculationEvent.DISTRIBUTOR_CHECKIN,
             now,
-            old_value=None,
-            new_value=None,
+        )
+        local_analytics_provider_fixture.provider.collect(
+            event_data,
+            db.session,
         )
 
-        qu = session.query(CirculationEvent).filter(
+        qu = db.session.query(CirculationEvent).filter(
             CirculationEvent.type == CirculationEvent.DISTRIBUTOR_CHECKIN
         )
         assert 1 == qu.count()
         [event] = qu.all()
 
         assert lp == event.license_pool
-        assert database.default_library() == event.library
+        assert db.default_library() == event.library
         assert CirculationEvent.DISTRIBUTOR_CHECKIN == event.type
         assert now == event.start
+
+    def test_collect_end_to_end(
+        self,
+        db: DatabaseTransactionFixture,
+        local_analytics_provider_fixture: LocalAnalyticsProviderFixture,
+    ) -> None:
+        pool = db.licensepool(edition=None)
+        library = db.default_library()
+        event_name = CirculationEvent.DISTRIBUTOR_CHECKOUT
+        old_value = 10
+        new_value = 8
+        start = datetime_utc(2019, 1, 1)
+        location = "Westgate Branch"
+
+        session = db.session
+        event_data = AnalyticsEventData.create(
+            library=library,
+            license_pool=pool,
+            event_type=event_name,
+            old_value=old_value,
+            new_value=new_value,
+            time=start,
+            neighborhood=location,
+        )
+        local_analytics_provider_fixture.provider.collect(
+            event_data,
+            db.session,
+        )
+        [event] = db.session.query(CirculationEvent).all()
+        assert pool == event.license_pool
+        assert library == event.library
+        assert -2 == event.delta  # calculated from old_value and new_value
+        assert start == event.start
+        assert start == event.end
+        assert location == event.location
+
+        # If collect finds another event with the same license pool,
+        # library, event name, and time, the new event is not recorded
+        # and the previous event is unchanged.
+        event_data = AnalyticsEventData.create(
+            library=library,
+            license_pool=pool,
+            event_type=event_name,
+            time=start,
+            # These values will be ignored.
+            old_value=500,
+            new_value=200,
+            neighborhood="another location",
+        )
+        local_analytics_provider_fixture.provider.collect(
+            event_data,
+            db.session,
+        )
+        [event] = db.session.query(CirculationEvent).all()
+        assert pool == event.license_pool
+        assert library == event.library
+        assert -2 == event.delta
+        assert start == event.start
+        assert location == event.location
+
+        # If no timestamp is provided, the current time is used. This
+        # is the most common case, so basically a new event will be
+        # created each time you call collect.
+        with freeze_time():
+            event_data = AnalyticsEventData.create(
+                library=library,
+                license_pool=pool,
+                event_type=event_name,
+                old_value=old_value,
+                new_value=new_value,
+                neighborhood=location,
+            )
+            local_analytics_provider_fixture.provider.collect(
+                event_data,
+                db.session,
+            )
+
+            [_, event] = (
+                db.session.query(CirculationEvent).order_by(CirculationEvent.id).all()
+            )
+            assert event.start == utc_now()
+            assert pool == event.license_pool
+            assert library == event.library
+            assert -2 == event.delta
+            assert location == event.location

--- a/tests/manager/service/analytics/test_s3.py
+++ b/tests/manager/service/analytics/test_s3.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
+from pydantic import TypeAdapter
 
 from palace.manager.core.classifier import Classifier
 from palace.manager.core.config import CannotLoadConfiguration
@@ -30,8 +31,9 @@ class S3AnalyticsFixture:
             self.analytics_storage,
         )
 
-    @staticmethod
-    def timestamp_to_string(timestamp: datetime.datetime) -> str:
+        self.timestamp_adapter = TypeAdapter(datetime.datetime)
+
+    def timestamp_to_string(self, timestamp: datetime.datetime) -> str:
         """Return a string representation of a datetime object.
 
         :param timestamp: datetime object storing a timestamp
@@ -40,7 +42,8 @@ class S3AnalyticsFixture:
         :return: String representation of the timestamp
         :rtype: str
         """
-        return str(timestamp)
+
+        return self.timestamp_adapter.dump_python(timestamp, mode="json")
 
 
 @pytest.fixture(scope="function")
@@ -162,7 +165,7 @@ class TestS3AnalyticsProvider:
         assert event["published"] == edition.published
         assert event["medium"] == edition.medium
         assert event["collection"] == collection.name
-        assert event.get("collection_id") is None
+        assert event["collection_id"] == collection.id
         assert event["identifier_type"] == identifier.type
         assert event["identifier"] == identifier.identifier
         assert event["data_source"] == data_source.name

--- a/tests/manager/sqlalchemy/model/test_collection.py
+++ b/tests/manager/sqlalchemy/model/test_collection.py
@@ -20,6 +20,7 @@ from palace.manager.sqlalchemy.model.integration import IntegrationLibraryConfig
 from palace.manager.sqlalchemy.model.licensing import Hold, License, LicensePool, Loan
 from palace.manager.sqlalchemy.model.work import Work
 from palace.manager.sqlalchemy.util import get_one_or_create
+from palace.manager.util.datetime_helpers import utc_now
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.services import ServicesFixture
 
@@ -577,8 +578,13 @@ class TestCollection:
         hold, is_new = pool.on_hold_to(patron2)
 
         # And a CirculationEvent.
-        CirculationEvent.log(
-            db.session, pool, CirculationEvent.DISTRIBUTOR_TITLE_ADD, 0, 1
+        get_one_or_create(
+            db.session,
+            CirculationEvent,
+            license_pool=pool,
+            type=CirculationEvent.DISTRIBUTOR_TITLE_ADD,
+            start=utc_now(),
+            end=utc_now(),
         )
 
         # There's a second Work which has _two_ LicensePools from two


### PR DESCRIPTION
## Description

This PR refactors our analytics providers to:
- Create a common abstract base class `AnalyticsProvider`
- Create a pydantic model for the json data that we output to s3 `AnalyticsEventData`
  - This model contains all the information needed to publish an analytics event, disconnected from the DB session, so we are able to save it across transaction boundaries without worrying about stale objects.
- Update our analytics providers to consume `AnalyticsEventData`
  - The local analytics provider and the s3 analytics provider both did overlapping serialization of the analytics data, they both now rely on the data provided by `AnalyticsEventData`
- Update opds_odl celery tasks to use the new `AnalyticsEventData` structure, instead of reattaching DB objects across the session.

## Motivation and Context

Did this refactoring as part of the work I was doing in PP-1470, as some of the reapers need to be able to persist event data across sessions similar to the opds_odl celery tasks

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
