### PR TITLE
Log exceptions due to bad credentials in axis tasks (PP-2231)

### DIFF
--- a/src/palace/manager/celery/tasks/axis.py
+++ b/src/palace/manager/celery/tasks/axis.py
@@ -24,6 +24,7 @@ from palace.manager.sqlalchemy.model.licensing import LicensePool
 from palace.manager.sqlalchemy.util import get_one_or_create
 from palace.manager.util.backoff import exponential_backoff
 from palace.manager.util.datetime_helpers import datetime_utc, utc_now
+from palace.manager.util.http import BadResponseException
 
 DEFAULT_BATCH_SIZE: int = 25
 DEFAULT_START_TIME = datetime_utc(1970, 1, 1)
@@ -112,6 +113,9 @@ def list_identifiers_for_import(
             # loop through feed :  for every {batch_size} items, pack them in a list and pass along to sub task for
             # processing
             api = create_api(collection, session)
+            if not _check_api_credentials(task, collection, api):
+                return None
+
             task.log.info(
                 f"Starting process of queuing items in collection {collection_name} (id={collection_id} "
                 f"for import that have changed since {start_time_of_last_scan}. "
@@ -142,6 +146,21 @@ def list_identifiers_for_import(
 
 def create_api(collection: Collection, session: Session) -> Axis360API:
     return Axis360API(session, collection)
+
+
+def _check_api_credentials(task: Task, collection: Collection, api: Axis360API) -> bool:
+    # Try to get a bearer token, to make sure the collection is configured correctly.
+    try:
+        api.bearer_token()
+        return True
+    except BadResponseException as e:
+        if e.response.status_code == 401:
+            task.log.error(
+                f"Failed to authenticate with Axis 360 API for collection {collection.name} "
+                f"(id={collection.id}). Please check the collection configuration."
+            )
+            return False
+        raise
 
 
 def timestamp(
@@ -382,7 +401,13 @@ def reap_collection(
     for identifier in identifiers:
         with task.transaction() as session:
             collection = Collection.by_id(session, collection_id)
-            api = create_api(session=session, collection=collection)  # type: ignore[arg-type]
+            # We just checked that the collection exists, so it should still exist. Assert
+            # that is does for the sake of the type checker.
+            assert collection is not None
+            api = create_api(session=session, collection=collection)
+            if not _check_api_credentials(task, collection, api):
+                return
+
             api.update_licensepools_for_identifiers(identifiers=[identifier])
 
     task.log.info(

--- a/tests/manager/api/test_axis.py
+++ b/tests/manager/api/test_axis.py
@@ -161,7 +161,7 @@ class TestAxis360API:
             "Mock every method used by Axis360API._run_self_tests."
 
             # First we will refresh the bearer token.
-            def refresh_bearer_token(self):
+            def _refresh_bearer_token(self):
                 return "the new token"
 
             # Then we will count the number of events in the past
@@ -244,7 +244,7 @@ class TestAxis360API:
         # self-tests aren't even run.
 
         class Mock(MockAxis360API):
-            def refresh_bearer_token(self):
+            def _refresh_bearer_token(self):
                 raise Exception("no way")
 
         # Now that everything is set up, run the self-test. Only one
@@ -298,7 +298,7 @@ class TestAxis360API:
         api = MockAxis360API(axis360.db.session, axis360.collection, with_token=False)
         api.queue_response(412)
         with pytest.raises(RemoteIntegrationException) as excinfo:
-            api.refresh_bearer_token()
+            api._refresh_bearer_token()
         assert (
             "Bad response from http://axis.test/accesstoken: Got status code 412 from external server, but can only continue on: 200."
             in str(excinfo.value)

--- a/tests/manager/celery/tasks/test_axis.py
+++ b/tests/manager/celery/tasks/test_axis.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy.orm.exc import ObjectDeletedError
 
 from palace.manager.api.axis import Axis360API
+from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import axis
 from palace.manager.celery.tasks.axis import (
     DEFAULT_BATCH_SIZE,
@@ -19,6 +20,7 @@ from palace.manager.celery.tasks.axis import (
     timestamp,
 )
 from palace.manager.core.metadata_layer import CirculationData, IdentifierData, Metadata
+from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.http import BadResponseException
@@ -450,8 +452,8 @@ def test_transient_failure_if_requested_book_not_mentioned(
 
 
 def test__check_api_credentials():
-    mock_task = MagicMock()
-    mock_collection = MagicMock()
+    mock_task = create_autospec(Task)
+    mock_collection = create_autospec(Collection)
     mock_api = create_autospec(Axis360API)
 
     # If api.bearer_token() runs successfully, the function should return True

--- a/tests/mocks/axis.py
+++ b/tests/mocks/axis.py
@@ -36,7 +36,7 @@ class MockAxis360API(Axis360API):
         """
         super().__init__(_db, collection, **kwargs)
         if with_token:
-            self.token = "mock token"
+            self._cached_bearer_token = "mock token"
         self.responses = []
         self.requests = []
 


### PR DESCRIPTION
## Description

Log exceptions due to bad credential configuration in Axis tasks.

## Motivation and Context

Want to keep our Celery task unhandled exception alerts from going off due to Axis collections with misconfigured credentials.

## How Has This Been Tested?

- Unit tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
