### PR TITLE
Fix OPDS2 empty publication list validation (PP-2230)

### DIFF
--- a/src/palace/manager/opds/opds2.py
+++ b/src/palace/manager/opds/opds2.py
@@ -379,7 +379,7 @@ class BasePublicationFeed(BaseOpdsModel, Generic[T]):
 
     metadata: FeedMetadata
     links: CompactCollection[StrictLink]
-    publications: Annotated[list[T], Field(min_length=1)]
+    publications: list[T]
 
     _validate_links = field_validator("links")(validate_self_link)
 


### PR DESCRIPTION
## Description

On the last page of a feed sometimes we receive a feed that has no publications in it. This is causing a validation failure currently.

## Motivation and Context

In some cases we get an empty list for publications on the last page of the feed. We are failing validation in this case, but an empty list is allowed by the spec. I don't remember why I added this validation, perhaps I was just being overzealous in my validation. 

## How Has This Been Tested?

- Added test case
- Ran tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
