### PR TITLE
Fix detached object error in axis reaper task.

### DIFF
--- a/src/palace/manager/celery/tasks/axis.py
+++ b/src/palace/manager/celery/tasks/axis.py
@@ -401,6 +401,7 @@ def reap_collection(
 
     for identifier in identifiers:
         with task.transaction() as session:
+            identifier = session.merge(identifier)
             collection = Collection.by_id(session, collection_id)
             # We just checked that the collection exists, so it should still exist. Assert
             # that is does for the sake of the type checker.


### PR DESCRIPTION
## Description
A follow on fix for PP-2233.  The identifier list, having been retrieved in one session, needed to be reattached (via the sqlalchemy session.merge method) in downstream session where the update operations occur.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2233
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
