### PR TITLE
Loosen overly restrictive S3 type hint.

### DIFF
--- a/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
+++ b/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
@@ -156,7 +156,7 @@ class GenerateInventoryAndHoldsReportsJob(Job):
                     )
                     self.s3_service.store_stream(
                         key,
-                        report_zip,  # type: ignore[arg-type]
+                        report_zip,
                         content_type="application/zip",
                     )
 

--- a/src/palace/manager/service/storage/s3.py
+++ b/src/palace/manager/service/storage/s3.py
@@ -5,7 +5,7 @@ from functools import cached_property
 from io import BytesIO
 from string import Formatter
 from types import TracebackType
-from typing import IO, TYPE_CHECKING, BinaryIO
+from typing import IO, TYPE_CHECKING
 from urllib.parse import quote
 
 from botocore.exceptions import BotoCoreError, ClientError
@@ -21,6 +21,7 @@ else:
 
 if TYPE_CHECKING:
     from mypy_boto3_s3 import S3Client
+    from mypy_boto3_s3.type_defs import FileobjTypeDef
 
 
 class MultipartS3UploadPart(BaseModel):
@@ -170,7 +171,7 @@ class S3Service(LoggerMixin):
     def store_stream(
         self,
         key: str,
-        stream: BinaryIO,
+        stream: FileobjTypeDef,
         content_type: str | None = None,
     ) -> str | None:
         try:

--- a/tests/fixtures/s3.py
+++ b/tests/fixtures/s3.py
@@ -5,7 +5,7 @@ import sys
 import uuid
 from collections.abc import Generator
 from dataclasses import dataclass, field
-from typing import IO, TYPE_CHECKING, BinaryIO, NamedTuple, Protocol
+from typing import IO, TYPE_CHECKING, NamedTuple, Protocol
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -29,6 +29,7 @@ else:
 
 if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client
+    from mypy_boto3_s3.type_defs import FileobjTypeDef
 
 
 class MockS3ServiceUpload(NamedTuple):
@@ -114,7 +115,7 @@ class MockS3Service(S3Service):
     def store_stream(
         self,
         key: str,
-        stream: BinaryIO,
+        stream: FileobjTypeDef,
         content_type: str | None = None,
     ) -> str | None:
         self.uploads[key] = MockS3ServiceUpload(key, stream.read(), content_type)


### PR DESCRIPTION
## Description

- Changed the type hint for Palace Manager's `S3Service.store_stream`s `stream` parameter from `BinaryIO` to Boto S3's own `FileobjTypeDef`.
- Dropped a no-longer-needed type ignore.

## Motivation and Context

While trying to track down a typing issue on PP-1888, I noticed that our type hint was more restrictive than necessary.

## How Has This Been Tested?

- Mypy is happy.
- Manually tested with celery in local dev environment.
- All tests pass locally.
- CI tests.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- N/A I have updated the documentation accordingly.
- [x] All new and existing tests passed.
