### PR TITLE
Create ability to make delivery mechanisms unavailable

### DIFF
--- a/alembic/versions/20250314_df27b4867e56_add_licensepooldeliverymechanism_.py
+++ b/alembic/versions/20250314_df27b4867e56_add_licensepooldeliverymechanism_.py
@@ -1,0 +1,29 @@
+"""Add LicensePoolDeliveryMechanism.available
+
+Revision ID: df27b4867e56
+Revises: 61df6012a5e6
+Create Date: 2025-03-14 18:22:01.825315+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "df27b4867e56"
+down_revision = "61df6012a5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "licensepooldeliveries",
+        sa.Column(
+            "available", sa.Boolean(), server_default=sa.text("true"), nullable=False
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("licensepooldeliveries", "available")

--- a/src/palace/manager/api/enki.py
+++ b/src/palace/manager/api/enki.py
@@ -496,7 +496,7 @@ class EnkiAPI(
         # ACSM file) but since Enki titles only have a single delivery
         # mechanism, it's easy to make a guess.
         drm_type = DeliveryMechanism.NO_DRM
-        for lpdm in licensepool.delivery_mechanisms:
+        for lpdm in licensepool.available_delivery_mechanisms:
             mechanism = lpdm.delivery_mechanism
             if mechanism:
                 drm_type = mechanism.drm_scheme

--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -508,7 +508,7 @@ class OPDS2WithODLApi(
         resource = next(
             (
                 lpdm.resource
-                for lpdm in licensepool.delivery_mechanisms
+                for lpdm in licensepool.available_delivery_mechanisms
                 if lpdm.delivery_mechanism == requested_delivery_mechanism
                 and lpdm.resource is not None
             ),

--- a/src/palace/manager/core/metadata_layer.py
+++ b/src/palace/manager/core/metadata_layer.py
@@ -551,6 +551,7 @@ class FormatData:
         drm_scheme: str | None,
         link: LinkData | None = None,
         rights_uri: str | None = None,
+        available: bool = True,
     ):
         self.content_type = content_type
         self.drm_scheme = drm_scheme
@@ -560,6 +561,7 @@ class FormatData:
         self.rights_uri = rights_uri
         if (not self.rights_uri) and self.link and self.link.rights_uri:
             self.rights_uri = self.link.rights_uri
+        self.available = available
 
 
 class LicenseData(LicenseFunctions):
@@ -1047,6 +1049,7 @@ class CirculationData(LoggerMixin):
                 format.drm_scheme,
                 format.rights_uri or self.default_rights_uri,
                 resource,
+                available=format.available,
                 db=_db,
             )
             new_lpdms.append(lpdm)

--- a/src/palace/manager/core/opds_import.py
+++ b/src/palace/manager/core/opds_import.py
@@ -301,7 +301,7 @@ class BaseOPDSAPI(
     ) -> RedirectFulfillment:
         requested_mechanism = delivery_mechanism.delivery_mechanism
         rep = None
-        for lpdm in licensepool.delivery_mechanisms:
+        for lpdm in licensepool.available_delivery_mechanisms:
             if (
                 lpdm.resource is None
                 or lpdm.resource.representation is None

--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -523,7 +523,7 @@ class CirculationManagerAnnotator(Annotator):
                 # Since the delivery mechanism has already been locked in,
                 # we choose not to use visible_delivery_mechanisms --
                 # they already chose it and they're stuck with it.
-                for lpdm in active_license_pool.delivery_mechanisms:
+                for lpdm in active_license_pool.available_delivery_mechanisms:
                     if (
                         lpdm is active_loan.fulfillment
                         or lpdm.delivery_mechanism.is_streaming
@@ -579,7 +579,7 @@ class CirculationManagerAnnotator(Annotator):
             and active_license_pool
             and active_license_pool.open_access
         ):
-            for lpdm in active_license_pool.delivery_mechanisms:
+            for lpdm in active_license_pool.available_delivery_mechanisms:
                 if lpdm.resource:
                     open_access_links.append(
                         self.open_access_link(active_license_pool, lpdm)
@@ -1292,7 +1292,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
                 api.SET_DELIVERY_MECHANISM_AT == BaseCirculationAPI.BORROW_STEP
             )
             if active_license_pool and not self.identifies_patrons and not active_loan:
-                for lpdm in active_license_pool.delivery_mechanisms:
+                for lpdm in active_license_pool.available_delivery_mechanisms:
                     if api.can_fulfill_without_loan(None, active_license_pool, lpdm):
                         # This title can be fulfilled without an
                         # active loan, so we're going to add an acquisition

--- a/src/palace/manager/integration/configuration/formats.py
+++ b/src/palace/manager/integration/configuration/formats.py
@@ -64,7 +64,7 @@ class FormatPriorities:
         :param pool: The license pool
         :return: A list of suitable delivery mechanisms in priority order, highest priority first
         """
-        return self.prioritize_mechanisms(pool.delivery_mechanisms)
+        return self.prioritize_mechanisms(pool.available_delivery_mechanisms)
 
     def prioritize_mechanisms(
         self, mechanisms: list[LicensePoolDeliveryMechanism]

--- a/src/palace/manager/marc/annotator.py
+++ b/src/palace/manager/marc/annotator.py
@@ -175,7 +175,7 @@ class Annotator(LoggerMixin):
         # Since this depends on the pool, it might be better not to cache it.
         # But it's probably not a huge problem if it's outdated.
         # File formats: a=one format, m=multiple formats, u=unknown
-        if len(pool.delivery_mechanisms) == 1:
+        if len(pool.available_delivery_mechanisms) == 1:
             file_formats_code = "a"
         else:
             file_formats_code = "m"
@@ -479,7 +479,7 @@ class Annotator(LoggerMixin):
 
     @classmethod
     def add_formats(cls, record: Record, pool: LicensePool) -> None:
-        for lpdm in pool.delivery_mechanisms:
+        for lpdm in pool.available_delivery_mechanisms:
             dm = lpdm.delivery_mechanism
             format = cls.FORMAT_TERMS.get((dm.content_type, dm.drm_scheme))
             if format:

--- a/src/palace/manager/marc/exporter.py
+++ b/src/palace/manager/marc/exporter.py
@@ -242,7 +242,7 @@ class MarcExporter(
                             selectinload(Contribution.contributor)
                         )
                     ),
-                    selectinload(LicensePool.delivery_mechanisms).options(
+                    selectinload(LicensePool.available_delivery_mechanisms).options(
                         selectinload(LicensePoolDeliveryMechanism.delivery_mechanism)
                     ),
                     selectinload(LicensePool.data_source),

--- a/src/palace/manager/scripts/informational.py
+++ b/src/palace/manager/scripts/informational.py
@@ -355,7 +355,10 @@ class Explain(IdentifierInputScript):
                     fulfillable = "Fulfillable"
                 else:
                     fulfillable = "Unfulfillable"
-                self.write(f"  {fulfillable} {dm.content_type}/{dm.drm_scheme}")
+                available = "Available" if lpdm.available else "Unavailable"
+                self.write(
+                    f"  {available} {fulfillable} {dm.content_type}/{dm.drm_scheme}"
+                )
         else:
             self.write(" No delivery mechanisms.")
         self.write(

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -2343,14 +2343,19 @@ class DatabaseBackedWorkList(WorkList):
         # else who uses this.)
         qu = qu.options(
             # These speed up the process of generating acquisition links.
-            joinedload(license_pool_name, "delivery_mechanisms"),
-            joinedload(license_pool_name, "delivery_mechanisms", "delivery_mechanism"),
+            joinedload(license_pool_name, "available_delivery_mechanisms"),
+            joinedload(
+                license_pool_name, "available_delivery_mechanisms", "delivery_mechanism"
+            ),
             joinedload(license_pool_name, "identifier"),
             # These speed up the process of generating the open-access link
             # for open-access works.
-            joinedload(license_pool_name, "delivery_mechanisms", "resource"),
+            joinedload(license_pool_name, "available_delivery_mechanisms", "resource"),
             joinedload(
-                license_pool_name, "delivery_mechanisms", "resource", "representation"
+                license_pool_name,
+                "available_delivery_mechanisms",
+                "resource",
+                "representation",
             ),
         )
         return qu

--- a/src/palace/manager/sqlalchemy/model/work.py
+++ b/src/palace/manager/sqlalchemy/model/work.py
@@ -1160,7 +1160,7 @@ class Work(Base, LoggerMixin):
                 continue
             if pool.open_access:
                 expect_downloads = True
-            for lpdm in pool.delivery_mechanisms:
+            for lpdm in pool.available_delivery_mechanisms:
                 if lpdm.resource and lpdm.resource.final_url:
                     downloads.append(lpdm.resource)
 

--- a/tests/manager/core/test_opds2_import.py
+++ b/tests/manager/core/test_opds2_import.py
@@ -754,7 +754,7 @@ class Opds2ApiFixture:
 
         self.pool = MagicMock(spec=LicensePool)
         self.mechanism = MagicMock(spec=LicensePoolDeliveryMechanism)
-        self.pool.delivery_mechanisms = [self.mechanism]
+        self.pool.available_delivery_mechanisms = [self.mechanism]
         self.pool.data_source = self.data_source
         self.mechanism.resource.representation.public_url = (
             "http://example.org/11234/fulfill?authToken={authentication_token}"

--- a/tests/manager/core/test_opds_import.py
+++ b/tests/manager/core/test_opds_import.py
@@ -2194,7 +2194,7 @@ class TestOPDSAPI:
         mock_lpdm.delivery_mechanism = mock_mechanism
 
         # This license pool has no available formats.
-        opds_api_fixture.mock_licensepool.delivery_mechanisms = []
+        opds_api_fixture.mock_licensepool.available_delivery_mechanisms = []
         with pytest.raises(FormatNotAvailable):
             opds_api_fixture.api.fulfill(
                 opds_api_fixture.mock_patron,
@@ -2205,7 +2205,7 @@ class TestOPDSAPI:
 
         # This license pool has a delivery mechanism, but it's not the one
         # we're looking for.
-        opds_api_fixture.mock_licensepool.delivery_mechanisms = [
+        opds_api_fixture.mock_licensepool.available_delivery_mechanisms = [
             MagicMock(),
             MagicMock(),
         ]
@@ -2220,7 +2220,7 @@ class TestOPDSAPI:
         # This license pool has the delivery mechanism we're looking for, but
         # it does not have a resource.
         mock_lpdm.resource = None
-        opds_api_fixture.mock_licensepool.delivery_mechanisms = [mock_lpdm]
+        opds_api_fixture.mock_licensepool.available_delivery_mechanisms = [mock_lpdm]
         with pytest.raises(FormatNotAvailable):
             opds_api_fixture.api.fulfill(
                 opds_api_fixture.mock_patron,
@@ -2233,7 +2233,7 @@ class TestOPDSAPI:
         # it has a resource, but the resource doesn't have a representation.
         mock_lpdm.resource = MagicMock(spec=Resource)
         mock_lpdm.resource.representation = None
-        opds_api_fixture.mock_licensepool.delivery_mechanisms = [mock_lpdm]
+        opds_api_fixture.mock_licensepool.available_delivery_mechanisms = [mock_lpdm]
         with pytest.raises(FormatNotAvailable):
             opds_api_fixture.api.fulfill(
                 opds_api_fixture.mock_patron,
@@ -2247,7 +2247,7 @@ class TestOPDSAPI:
         # representation doesn't have a URL.
         mock_lpdm.resource.representation = MagicMock(spec=Representation)
         mock_lpdm.resource.representation.public_url = None
-        opds_api_fixture.mock_licensepool.delivery_mechanisms = [mock_lpdm]
+        opds_api_fixture.mock_licensepool.available_delivery_mechanisms = [mock_lpdm]
         with pytest.raises(FormatNotAvailable):
             opds_api_fixture.api.fulfill(
                 opds_api_fixture.mock_patron,
@@ -2258,7 +2258,7 @@ class TestOPDSAPI:
 
         # This license pool has everything we need, so we can fulfill.
         mock_lpdm.resource.representation.public_url = "http://foo.com/bar.epub"
-        opds_api_fixture.mock_licensepool.delivery_mechanisms = [
+        opds_api_fixture.mock_licensepool.available_delivery_mechanisms = [
             MagicMock(),
             MagicMock(),
             mock_lpdm,


### PR DESCRIPTION
## Description

This PR introduces functionality to track available delivery mechanisms through a new flag in the `LicensePoolDeliveryMechanism` model. The main changes:

1. Added an `available` flag to `LicensePoolDeliveryMechanism` that defaults to `True`
2. Modified the `available_delivery_mechanisms` relationship in `LicensePool` to filter by the `available` flag
3. Maintained the original `delivery_mechanisms` relationship that returns all mechanisms regardless of availability

## Motivation and Context

This work is the basis for the changes in PP-2218 for Overdrive. This change allows us to mark delivery mechanisms as unavailable when we try to fulfill them and they turn out not to be available.

## How Has This Been Tested?

- Added new tests
- Ran tests in CI

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.