### PR TITLE
Fix borrow method type hint (PP-2218)

### DIFF
--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -434,8 +434,13 @@ class Axis360API(
         patron: Patron,
         pin: str | None,
         licensepool: LicensePool,
-        delivery_mechanism: LicensePoolDeliveryMechanism,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
     ) -> LoanInfo:
+        # Because we have SET_DELIVERY_MECHANISM_AT set to BORROW_STEP,
+        # delivery mechanism should always be set, but mypy doesn't know
+        # that, so we assert it here for type safety.
+        assert delivery_mechanism is not None
+
         title_id = licensepool.identifier.identifier
         patron_id = patron.authorization_identifier
         response = self._checkout(

--- a/src/palace/manager/api/bibliotheca.py
+++ b/src/palace/manager/api/bibliotheca.py
@@ -439,7 +439,7 @@ class BibliothecaAPI(
         patron_obj: Patron,
         patron_password: str | None,
         licensepool: LicensePool,
-        delivery_mechanism: LicensePoolDeliveryMechanism,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
     ) -> LoanInfo:
         """Check out a book on behalf of a patron.
 

--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -684,7 +684,7 @@ class BaseCirculationAPI(
         patron: Patron,
         pin: str | None,
         licensepool: LicensePool,
-        delivery_mechanism: LicensePoolDeliveryMechanism,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
     ) -> LoanInfo | HoldInfo:
         """Check out a book on behalf of a patron.
 
@@ -1066,7 +1066,7 @@ class CirculationAPI(LoggerMixin):
         # last looked.
         try:
             checkout_result = api.checkout(
-                patron, pin, licensepool, delivery_mechanism=delivery_mechanism  # type: ignore[arg-type]
+                patron, pin, licensepool, delivery_mechanism=delivery_mechanism
             )
 
             if isinstance(checkout_result, HoldInfo):

--- a/src/palace/manager/api/enki.py
+++ b/src/palace/manager/api/enki.py
@@ -401,7 +401,7 @@ class EnkiAPI(
         patron: Patron,
         pin: str | None,
         licensepool: LicensePool,
-        delivery_mechanism: LicensePoolDeliveryMechanism,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
     ) -> LoanInfo:
         identifier = licensepool.identifier
         enki_id = identifier.identifier

--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -287,7 +287,7 @@ class OPDS2WithODLApi(
         patron: Patron,
         pin: str | None,
         licensepool: LicensePool,
-        delivery_mechanism: LicensePoolDeliveryMechanism,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
     ) -> LoanInfo:
         """Create a new loan."""
         _db = Session.object_session(patron)

--- a/src/palace/manager/api/opds_for_distributors.py
+++ b/src/palace/manager/api/opds_for_distributors.py
@@ -271,7 +271,7 @@ class OPDSForDistributorsAPI(
         patron: Patron,
         pin: str | None,
         licensepool: LicensePool,
-        delivery_mechanism: LicensePoolDeliveryMechanism,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
     ) -> LoanInfo:
         now = utc_now()
         return LoanInfo.from_license_pool(

--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -839,7 +839,7 @@ class OverdriveAPI(
         patron: Patron,
         pin: str | None,
         licensepool: LicensePool,
-        delivery_mechanism: LicensePoolDeliveryMechanism,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
     ) -> LoanInfo:
         """Check out a book on behalf of a patron.
 

--- a/src/palace/manager/core/opds_import.py
+++ b/src/palace/manager/core/opds_import.py
@@ -341,7 +341,7 @@ class BaseOPDSAPI(
         patron: Patron,
         pin: str | None,
         licensepool: LicensePool,
-        delivery_mechanism: LicensePoolDeliveryMechanism,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
     ) -> LoanInfo:
         return LoanInfo.from_license_pool(licensepool, end_date=None)
 

--- a/tests/mocks/circulation.py
+++ b/tests/mocks/circulation.py
@@ -67,7 +67,7 @@ class MockBaseCirculationAPI(BaseCirculationAPI):
         patron: Patron,
         pin: str | None,
         licensepool: LicensePool,
-        delivery_mechanism: LicensePoolDeliveryMechanism,
+        delivery_mechanism: LicensePoolDeliveryMechanism | None,
     ) -> LoanInfo | HoldInfo:
         # Should be a LoanInfo.
         return self._return_or_raise("checkout")


### PR DESCRIPTION
## Description

Remove a type ignore comment from our circulation API implementation, and update the type hints to match in all the classes inheriting from `BaseCirculationApi`.

## Motivation and Context

Ran into this incorrect type hint when working on the Overdrive API, I had assumed it was set because of the type hint, but it was `None`.

## How Has This Been Tested?

- Running mypy

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
