### PR TITLE
Update names for Overdrive token functions (PP-2218)

### DIFF
--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -714,6 +714,10 @@ class OverdriveAPI(
     ) -> Response:
         """
         Make an HTTP request on behalf of a patron.
+
+        If palace_context==True, then the request will be performed in the context of
+        privileged palace credentials. Otherwise, it will be performed in the context of
+        the collections configured credentials.
         """
         patron_credential = self._get_patron_oauth_credential(
             patron, pin, palace_context=palace_context

--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -777,9 +777,9 @@ class OverdriveAPI(
             self._db,
             DataSource.OVERDRIVE,
             (
-                "Palace Scope OAuth Token"
+                "Palace Context Patron OAuth Token"
                 if palace_context
-                else "Collection Scope OAuth Token"
+                else "Collection Context Patron OAuth Token"
             ),
             patron,
             refresh,

--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -713,11 +713,11 @@ class OverdriveAPI(
         palace_context: bool = False,
     ) -> Response:
         """
-        Make an HTTP request on behalf of a patron.
+        Make an HTTP request on behalf of a patron to Overdrive's API.
 
-        If palace_context==True, then the request will be performed in the context of
-        privileged palace credentials. Otherwise, it will be performed in the context of
-        the collections configured credentials.
+        If palace_context == True, the request will be performed using privileged
+        Palace Project credentials, which provide extended API access. Otherwise,
+        it will use the collection's configured credentials.
         """
         patron_credential = self._get_patron_oauth_credential(
             patron, pin, palace_context=palace_context
@@ -790,8 +790,8 @@ class OverdriveAPI(
         """Create the Overdrive scope string for the given library.
 
         This is used when setting up Patron Authentication, and when
-        generating the X-Overdrive-Scope header used by SimplyE to set up
-        its own Patron Authentication.
+        generating the X-Overdrive-Scope header used by apps to set up
+        their own Patron Authentication.
         """
         return "websiteid:{} authorizationname:{}".format(
             self.settings.overdrive_website_id,

--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -317,8 +317,11 @@ class OverdriveAPI(
     @property
     def _client_oauth_token(self) -> str:
         """
-        Get the oauth bearer token used to authenticate with Overdrive
-        for this collection.
+        The client oauth bearer token used for authentication with
+        Overdrive for this collection.
+
+        This token is refreshed as needed and cached for reuse
+        by this property.
 
         See: https://developer.overdrive.com/docs/api-security
              https://developer.overdrive.com/apis/client-auth
@@ -435,18 +438,22 @@ class OverdriveAPI(
     @property
     def _collection_context_basic_auth_header(self) -> str:
         """
-        The basic auth header used to acquire an oauth bearer token
-        using the collections credentials, configured for each
-        collection through the admin interface.
+        Returns the Basic Auth header used to acquire an OAuth bearer token.
+
+        This header contains the collection's credentials that were configured
+        through the admin interface for this specific collection.
         """
-        s = b"%s:%s" % (self.client_key(), self.client_secret())
-        return "Basic " + base64.standard_b64encode(s).strip()
+        credentials = b"%s:%s" % (self.client_key(), self.client_secret())
+        return "Basic " + base64.standard_b64encode(credentials).strip()
 
     @property
     def _palace_context_basic_auth_header(self) -> str:
         """
-        The basic auth header used to acquire an oauth bearer token
-        using the palace credentials passed into the CM via env vars.
+        Returns the Basic Auth header used to acquire an OAuth bearer token.
+
+        This header contains the Palace Project credentials passed into the
+        Circulation Manager via environment variables. This is used to acquire
+        a privileged token that has extra permissions for the Overdrive API.
         """
         is_test_mode = (
             True

--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -5,6 +5,7 @@ import json
 import re
 import urllib.parse
 from collections.abc import Callable, Generator, Iterable, Mapping
+from functools import partial
 from json import JSONDecodeError
 from threading import RLock
 from typing import Any, NamedTuple, cast
@@ -278,8 +279,8 @@ class OverdriveAPI(
 
         self._hosts = self._determine_hosts(server_nickname=self._server_nickname)
 
-        # This is set by access to .token
-        self._token: OverdriveToken | None = None
+        # This is set by access to ._collection_oauth_token
+        self._collection_oauth_token_cache: OverdriveToken | None = None
 
         # This is set by an access to .collection_token
         self._collection_token: str | None = None
@@ -314,26 +315,37 @@ class OverdriveAPI(
         return url % kwargs
 
     @property
-    def token(self) -> str:
-        if (token := self._token) is not None and utc_now() < token.expires:
+    def _client_oauth_token(self) -> str:
+        """
+        Get the oauth bearer token used to authenticate with Overdrive
+        for this collection.
+
+        See: https://developer.overdrive.com/docs/api-security
+             https://developer.overdrive.com/apis/client-auth
+        """
+        if (
+            token := self._collection_oauth_token_cache
+        ) is not None and utc_now() < token.expires:
             return token.token
 
-        return self._refresh_token().token
+        return self._refresh_client_oauth_token().token
 
-    def _refresh_token(self) -> OverdriveToken:
-        """Get an overdrive bearer token."""
+    def _refresh_client_oauth_token(self) -> OverdriveToken:
         with self.lock:
-            response = self.token_post(
+            response = self._do_post(
                 self.TOKEN_ENDPOINT,
                 dict(grant_type="client_credentials"),
+                {"Authorization": self._collection_context_basic_auth_header},
                 allowed_response_codes=[200],
             )
             data = response.json()
             access_token = data["access_token"]
             expires_in = data["expires_in"] * 0.9
             expires = utc_now() + datetime.timedelta(seconds=expires_in)
-            self._token = OverdriveToken(token=access_token, expires=expires)
-            return self._token
+            self._collection_oauth_token_cache = OverdriveToken(
+                token=access_token, expires=expires
+            )
+            return self._collection_oauth_token_cache
 
     @property
     def collection_token(self) -> str:
@@ -394,7 +406,7 @@ class OverdriveAPI(
         exception_on_401: bool = False,
     ) -> tuple[int, CaseInsensitiveDict[str], bytes]:
         """Make an HTTP GET request using the active Bearer Token."""
-        request_headers = dict(Authorization="Bearer %s" % self.token)
+        request_headers = dict(Authorization="Bearer %s" % self._client_oauth_token)
         if extra_headers:
             request_headers.update(extra_headers)
 
@@ -415,18 +427,27 @@ class OverdriveAPI(
                 )
             else:
                 # Force a refresh of the token and try again.
-                self._refresh_token()
+                self._refresh_client_oauth_token()
                 return self.get(url, extra_headers, True)
         else:
             return status_code, headers, content
 
     @property
-    def token_authorization_header(self) -> str:
+    def _collection_context_basic_auth_header(self) -> str:
+        """
+        The basic auth header used to acquire an oauth bearer token
+        using the collections credentials, configured for each
+        collection through the admin interface.
+        """
         s = b"%s:%s" % (self.client_key(), self.client_secret())
         return "Basic " + base64.standard_b64encode(s).strip()
 
     @property
-    def fulfillment_authorization_header(self) -> str:
+    def _palace_context_basic_auth_header(self) -> str:
+        """
+        The basic auth header used to acquire an oauth bearer token
+        using the palace credentials passed into the CM via env vars.
+        """
         is_test_mode = (
             True
             if self._server_nickname == OverdriveConstants.TESTING_SERVERS
@@ -444,23 +465,6 @@ class OverdriveAPI(
             client_credentials["secret"].encode(),
         )
         return "Basic " + base64.standard_b64encode(s).strip()
-
-    def token_post(
-        self,
-        url: str,
-        payload: dict[str, str],
-        is_fulfillment: bool = False,
-        headers: dict[str, str] | None = None,
-        **kwargs: Any,
-    ) -> Response:
-        """Make an HTTP POST request for purposes of getting an OAuth token."""
-        headers = dict(headers) if headers is not None else {}
-        headers["Authorization"] = (
-            self.token_authorization_header
-            if not is_fulfillment
-            else self.fulfillment_authorization_header
-        )
-        return self._do_post(url, payload, headers, **kwargs)
 
     @staticmethod
     def _update_credential(
@@ -651,7 +655,7 @@ class OverdriveAPI(
     def _run_self_tests(self, _db: Session) -> Generator[SelfTestResult]:
         result = self.run_test(
             "Checking global Client Authentication privileges",
-            self._refresh_token,
+            self._refresh_client_oauth_token,
         )
         yield result
         if not result.success:
@@ -686,7 +690,9 @@ class OverdriveAPI(
                     "Checking Patron Authentication privileges, using test patron for library %s"
                     % library.name
                 )
-                yield self.run_test(task, self.get_patron_credential, patron, pin)
+                yield self.run_test(
+                    task, self._get_patron_oauth_credential, patron, pin
+                )
 
     def patron_request(
         self,
@@ -697,18 +703,13 @@ class OverdriveAPI(
         data: str | None = None,
         exception_on_401: bool = False,
         method: str | None = None,
-        is_fulfillment: bool = False,
+        palace_context: bool = False,
     ) -> Response:
-        """Make an HTTP request on behalf of a patron.
-
-        If is_fulfillment==True, then the request will be performed in the context of our
-        fulfillment client credentials. Otherwise, it will be performed in the context of
-        the collection client credentials.
-
-        The results are never cached.
         """
-        patron_credential = self.get_patron_credential(
-            patron, pin, is_fulfillment=is_fulfillment
+        Make an HTTP request on behalf of a patron.
+        """
+        patron_credential = self._get_patron_oauth_credential(
+            patron, pin, palace_context=palace_context
         )
         headers = dict(Authorization="Bearer %s" % patron_credential.credential)
         if extra_headers:
@@ -730,7 +731,9 @@ class OverdriveAPI(
                 )
             else:
                 # Refresh the token and try again.
-                self.refresh_patron_access_token(patron_credential, patron, pin)
+                self._refresh_patron_oauth_token(
+                    patron_credential, patron, pin, palace_context=palace_context
+                )
                 return self.patron_request(patron, pin, url, extra_headers, data, True)
         else:
             # This is commented out because it may expose patron
@@ -739,25 +742,34 @@ class OverdriveAPI(
             # self.log.debug("%s: %s", url, response.status_code)
             return response
 
-    def get_patron_credential(
-        self, patron: Patron, pin: str | None, is_fulfillment: bool = False
+    def _get_patron_oauth_credential(
+        self, patron: Patron, pin: str | None, palace_context: bool = False
     ) -> Credential:
-        """Create an OAuth token for the given patron.
+        """Get an Overdrive OAuth token for the given patron.
+
+        See: https://developer.overdrive.com/apis/patron-auth
 
         :param patron: The patron for whom to fetch the credential.
         :param pin: The patron's PIN or password.
-        :param is_fulfillment: Boolean indicating whether we need a fulfillment credential.
+        :param palace_context: Determines if the oauth token is fetched
+           using the palace credentials or the collections credentials.
         """
 
-        def refresh(credential: Credential) -> Credential:
-            return self.refresh_patron_access_token(
-                credential, patron, pin, is_fulfillment=is_fulfillment
-            )
+        refresh = partial(
+            self._refresh_patron_oauth_token,
+            patron=patron,
+            pin=pin,
+            palace_context=palace_context,
+        )
 
         return Credential.lookup(
             self._db,
             DataSource.OVERDRIVE,
-            "Fulfillment OAuth Token" if is_fulfillment else "OAuth Token",
+            (
+                "Palace Scope OAuth Token"
+                if palace_context
+                else "Collection Scope OAuth Token"
+            ),
             patron,
             refresh,
             collection=self.collection,
@@ -775,12 +787,12 @@ class OverdriveAPI(
             self.ils_name(library),
         )
 
-    def refresh_patron_access_token(
+    def _refresh_patron_oauth_token(
         self,
         credential: Credential,
         patron: Patron,
         pin: str | None,
-        is_fulfillment: bool = False,
+        palace_context: bool = False,
     ) -> Credential:
         """Request an OAuth bearer token that allows us to act on
         behalf of a specific patron.
@@ -803,10 +815,16 @@ class OverdriveAPI(
             payload["password_required"] = "false"
             payload["password"] = "[ignore]"
         try:
-            response = self.token_post(
+            response = self._do_post(
                 self.PATRON_TOKEN_ENDPOINT,
                 payload,
-                is_fulfillment=is_fulfillment,
+                {
+                    "Authorization": (
+                        self._palace_context_basic_auth_header
+                        if palace_context
+                        else self._collection_context_basic_auth_header
+                    ),
+                },
                 allowed_response_codes=["2xx"],
             )
         except BadResponseException as e:
@@ -823,7 +841,7 @@ class OverdriveAPI(
                 "error_description", "Failed to authenticate with Overdrive"
             )
             debug_message = (
-                f"refresh_patron_access_token failed. Status code: '{e.response.status_code}'. "
+                f"_refresh_patron_oauth_token failed. Status code: '{e.response.status_code}'. "
                 f"Error: '{error_code}'. Description: '{error_description}'."
             )
             self.log.info(debug_message + f" Response: '{e.response.text}'")
@@ -1067,7 +1085,7 @@ class OverdriveAPI(
         :return: Information about the loan.
         """
         url = f"{self.CHECKOUTS_ENDPOINT}/{overdrive_id.upper()}"
-        data = self.patron_request(patron, pin, url, is_fulfillment=True).json()
+        data = self.patron_request(patron, pin, url, palace_context=True).json()
         self.raise_exception_on_error(data)
         return data  # type: ignore[no-any-return]
 
@@ -1186,10 +1204,10 @@ class OverdriveAPI(
                 # The client must authenticate using its own
                 # credentials to fulfill this URL; we can't do it.
                 scope_string = self.scope_string(patron.library)
-                fulfillment_access_token = self.get_patron_credential(
+                fulfillment_access_token = self._get_patron_oauth_credential(
                     patron,
                     pin,
-                    is_fulfillment=True,
+                    palace_context=True,
                 ).credential
                 # The credential should never be None, but mypy doesn't know that, so
                 # we assert to be safe.
@@ -1290,7 +1308,7 @@ class OverdriveAPI(
         :return: Information about the patron's loans.
         """
         data = self.patron_request(
-            patron, pin, self.CHECKOUTS_ENDPOINT, is_fulfillment=True
+            patron, pin, self.CHECKOUTS_ENDPOINT, palace_context=True
         ).json()
         self.raise_exception_on_error(data)
         return data  # type: ignore[no-any-return]

--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -279,8 +279,8 @@ class OverdriveAPI(
 
         self._hosts = self._determine_hosts(server_nickname=self._server_nickname)
 
-        # This is set by access to ._collection_oauth_token
-        self._collection_oauth_token_cache: OverdriveToken | None = None
+        # This is set by access to ._client_oauth_token
+        self._cached_client_oauth_token: OverdriveToken | None = None
 
         # This is set by an access to .collection_token
         self._collection_token: str | None = None
@@ -324,7 +324,7 @@ class OverdriveAPI(
              https://developer.overdrive.com/apis/client-auth
         """
         if (
-            token := self._collection_oauth_token_cache
+            token := self._cached_client_oauth_token
         ) is not None and utc_now() < token.expires:
             return token.token
 
@@ -342,10 +342,10 @@ class OverdriveAPI(
             access_token = data["access_token"]
             expires_in = data["expires_in"] * 0.9
             expires = utc_now() + datetime.timedelta(seconds=expires_in)
-            self._collection_oauth_token_cache = OverdriveToken(
+            self._cached_client_oauth_token = OverdriveToken(
                 token=access_token, expires=expires
             )
-            return self._collection_oauth_token_cache
+            return self._cached_client_oauth_token
 
     @property
     def collection_token(self) -> str:

--- a/tests/manager/api/overdrive/test_api.py
+++ b/tests/manager/api/overdrive/test_api.py
@@ -329,8 +329,8 @@ class TestOverdriveAPI:
         assert len(api.access_token_requests) == 1
 
         # However if the token expires we will get a new one
-        assert api._collection_oauth_token_cache is not None
-        api._collection_oauth_token_cache = api._collection_oauth_token_cache._replace(
+        assert api._cached_client_oauth_token is not None
+        api._cached_client_oauth_token = api._cached_client_oauth_token._replace(
             expires=utc_now() - timedelta(seconds=1)
         )
 

--- a/tests/manager/api/overdrive/test_api.py
+++ b/tests/manager/api/overdrive/test_api.py
@@ -135,12 +135,18 @@ class TestOverdriveAPI:
         collection = MockOverdriveAPI.mock_collection(session, library)
 
         exception_message = "This is a unit test, you can't make HTTP requests!"
-        api = OverdriveAPI(session, collection)
         with (
-            patch.object(api, "_do_get", side_effect=Exception(exception_message)),
-            patch.object(api, "_do_post", side_effect=Exception(exception_message)),
+            patch.object(
+                OverdriveAPI, "_do_get", side_effect=Exception(exception_message)
+            ),
+            patch.object(
+                OverdriveAPI, "_do_post", side_effect=Exception(exception_message)
+            ),
         ):
-            # Attempting to access .token or .collection_token _will_
+            # Make sure that the constructor doesn't make any requests.
+            api = OverdriveAPI(session, collection)
+
+            # Attempting to access ._client_oauth_token or .collection_token _will_
             # try to make an HTTP request.
             with pytest.raises(Exception, match=exception_message):
                 api.collection_token

--- a/tests/manager/api/overdrive/test_api.py
+++ b/tests/manager/api/overdrive/test_api.py
@@ -134,24 +134,19 @@ class TestOverdriveAPI:
         # make any HTTP requests.
         collection = MockOverdriveAPI.mock_collection(session, library)
 
-        class NoRequests(OverdriveAPI):
-            MSG = "This is a unit test, you can't make HTTP requests!"
+        exception_message = "This is a unit test, you can't make HTTP requests!"
+        api = OverdriveAPI(session, collection)
+        with (
+            patch.object(api, "_do_get", side_effect=Exception(exception_message)),
+            patch.object(api, "_do_post", side_effect=Exception(exception_message)),
+        ):
+            # Attempting to access .token or .collection_token _will_
+            # try to make an HTTP request.
+            with pytest.raises(Exception, match=exception_message):
+                api.collection_token
 
-            def no_requests(self, *args, **kwargs):
-                raise Exception(self.MSG)
-
-            _do_get = no_requests
-            _do_post = no_requests
-            _make_request = no_requests
-
-        api = NoRequests(session, collection)
-
-        # Attempting to access .token or .collection_token _will_
-        # try to make an HTTP request.
-        for field in "token", "collection_token":
-            with pytest.raises(Exception) as excinfo:
-                getattr(api, field)
-            assert api.MSG in str(excinfo.value)
+            with pytest.raises(Exception, match=exception_message):
+                api._client_oauth_token
 
     def test_ils_name(self, overdrive_api_fixture: OverdriveAPIFixture):
         fixture = overdrive_api_fixture
@@ -224,30 +219,21 @@ class TestOverdriveAPI:
             result + "%3A", extra="something else"
         )
 
-    def test_token_authorization_header(
+    def test__collection_context_basic_auth_header(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ):
         fixture = overdrive_api_fixture
 
         # Verify that the Authorization header needed to get an access
         # token for a given collection is encoded properly.
-        assert fixture.api.token_authorization_header == "Basic YTpi"
+        assert fixture.api._collection_context_basic_auth_header == "Basic YTpi"
         assert (
-            fixture.api.token_authorization_header
+            fixture.api._collection_context_basic_auth_header
             == "Basic "
             + base64.standard_b64encode(
                 b"%s:%s" % (fixture.api.client_key(), fixture.api.client_secret())
             ).decode("utf8")
         )
-
-    def test_token_post_success(self, overdrive_api_fixture: OverdriveAPIFixture):
-        fixture = overdrive_api_fixture
-        transaction = fixture.db
-
-        fixture.api.queue_response(200, content="some content")
-        response = fixture.api.token_post(transaction.fresh_url(), "the payload")
-        assert 200 == response.status_code
-        assert fixture.api.access_token_response.content == response.content
 
     def test_get_success(self, overdrive_api_fixture: OverdriveAPIFixture):
         fixture = overdrive_api_fixture
@@ -302,14 +288,13 @@ class TestOverdriveAPI:
         transaction = fixture.db
 
         # We have a token.
-        assert "bearer token" == fixture.api.token
+        assert "bearer token" == fixture.api._client_oauth_token
 
         # But then we try to GET, and receive a 401.
         fixture.api.queue_response(401)
 
-        # We refresh the bearer token. (This happens in
-        # MockOverdriveAPI.token_post, so we don't mock the response
-        # in the normal way.)
+        # We refresh the bearer token. (This is special cased in MockOverdriveAPI
+        # so we don't mock the response in the normal way.)
         fixture.api.access_token_response = fixture.api.mock_access_token_response(
             "new bearer token"
         )
@@ -323,9 +308,9 @@ class TestOverdriveAPI:
         assert b"at last, the content" == content
 
         # The bearer token has been updated.
-        assert "new bearer token" == fixture.api.token
+        assert "new bearer token" == fixture.api._client_oauth_token
 
-    def test_token(self, overdrive_api_fixture: OverdriveAPIFixture):
+    def test__client_oauth_token(self, overdrive_api_fixture: OverdriveAPIFixture):
         """Verify the process of refreshing the Overdrive bearer token."""
         api = overdrive_api_fixture.api
 
@@ -333,31 +318,33 @@ class TestOverdriveAPI:
         assert len(api.access_token_requests) == 0
 
         # Accessing the token triggers a refresh
-        assert api.token == "bearer token"
+        assert api._client_oauth_token == "bearer token"
         assert len(api.access_token_requests) == 1
 
         # Mock the token response
         api.access_token_response = api.mock_access_token_response("new bearer token")
 
         # Accessing the token again won't refresh, because the old token is still valid
-        assert api.token == "bearer token"
+        assert api._client_oauth_token == "bearer token"
         assert len(api.access_token_requests) == 1
 
         # However if the token expires we will get a new one
-        assert api._token is not None
-        api._token = api._token._replace(expires=utc_now() - timedelta(seconds=1))
+        assert api._collection_oauth_token_cache is not None
+        api._collection_oauth_token_cache = api._collection_oauth_token_cache._replace(
+            expires=utc_now() - timedelta(seconds=1)
+        )
 
-        assert api.token == "new bearer token"
+        assert api._client_oauth_token == "new bearer token"
         assert len(api.access_token_requests) == 2
 
-    def test_401_after_token_refresh_raises_error(
+    def test_401_after__refresh_client_oauth_token_raises_error(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ):
         fixture = overdrive_api_fixture
         api = fixture.api
 
         # Our initial token value is "bearer token".
-        assert api.token == "bearer token"
+        assert api._client_oauth_token == "bearer token"
 
         # We try to GET and receive a 401.
         api.queue_response(401)
@@ -376,12 +363,12 @@ class TestOverdriveAPI:
             api.get_library()
 
         # We refreshed the token in the process.
-        assert fixture.api.token == "new bearer token"
+        assert fixture.api._client_oauth_token == "new bearer token"
 
         # We made two requests
         assert len(api.requests) == 2
 
-    def test_401_during__refresh_token_raises_error(
+    def test_401_during__refresh_client_oauth_token_raises_error(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ):
         fixture = overdrive_api_fixture
@@ -394,7 +381,7 @@ class TestOverdriveAPI:
             BadResponseException,
             match="Got status code 401 .* can only continue on: 200.",
         ):
-            fixture.api._refresh_token()
+            fixture.api._refresh_client_oauth_token()
 
     def test_advantage_differences(self, overdrive_api_fixture: OverdriveAPIFixture):
         db = overdrive_api_fixture.db
@@ -526,9 +513,9 @@ class TestOverdriveAPI:
         # Mock every method used by OverdriveAPI._run_self_tests.
         api = MockOverdriveAPI(db.session, overdrive_api_fixture.collection)
 
-        # First we will call get_token
-        mock_refresh_token = create_autospec(api._refresh_token)
-        api._refresh_token = mock_refresh_token
+        # First we will call _refresh_collection_oauth_token
+        mock_refresh_token = create_autospec(api._refresh_client_oauth_token)
+        api._refresh_client_oauth_token = mock_refresh_token
 
         # Then we will call get_advantage_accounts().
         mock_get_advantage_accounts = create_autospec(
@@ -545,8 +532,8 @@ class TestOverdriveAPI:
         # Finally, for every library associated with this
         # collection, we'll call get_patron_credential() using
         # the credentials of that library's test patron.
-        mock_get_patron_credential = create_autospec(api.get_patron_credential)
-        api.get_patron_credential = mock_get_patron_credential
+        mock_get_patron_credential = create_autospec(api._get_patron_oauth_credential)
+        api._get_patron_oauth_credential = mock_get_patron_credential
 
         # Now let's make sure two Libraries have access to this
         # Collection -- one library with a default patron and one
@@ -623,8 +610,8 @@ class TestOverdriveAPI:
         """
 
         api = overdrive_api_fixture.api
-        api._refresh_token = create_autospec(
-            api._refresh_token, side_effect=Exception("Failure!")
+        api._refresh_client_oauth_token = create_autospec(
+            api._refresh_client_oauth_token, side_effect=Exception("Failure!")
         )
 
         # Only one test will be run.
@@ -1964,7 +1951,7 @@ class TestOverdriveAPI:
         assert 10 == pool.patrons_in_hold_queue
         assert True == changed
 
-    def test_refresh_patron_access_token(
+    def test__refresh_patron_oauth_token(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ):
         """Verify that patron information is included in the request
@@ -1975,21 +1962,18 @@ class TestOverdriveAPI:
         patron.authorization_identifier = "barcode"
         credential = db.credential(patron=patron)
 
-        data, raw = overdrive_api_fixture.sample_json("patron_token.json")
-        overdrive_api_fixture.api.queue_response(200, content=raw)
-
         # Try to refresh the patron access token with a PIN, and
         # then without a PIN.
-        overdrive_api_fixture.api.refresh_patron_access_token(
+        overdrive_api_fixture.api._refresh_patron_oauth_token(
             credential, patron, "a pin"
         )
 
-        overdrive_api_fixture.api.refresh_patron_access_token(credential, patron, None)
+        overdrive_api_fixture.api._refresh_patron_oauth_token(credential, patron, None)
 
         # Verify that the requests that were made correspond to what
         # Overdrive is expecting.
         with_pin, without_pin = overdrive_api_fixture.api.access_token_requests
-        url, payload, headers, kwargs = with_pin
+        url, (payload, headers), kwargs = with_pin
         assert "https://oauth-patron.overdrive.com/patrontoken" == url
         assert "barcode" == payload["username"]
         expect_scope = "websiteid:{} authorizationname:{}".format(
@@ -2000,14 +1984,14 @@ class TestOverdriveAPI:
         assert "a pin" == payload["password"]
         assert not "password_required" in payload
 
-        url, payload, headers, kwargs = without_pin
+        url, (payload, headers), kwargs = without_pin
         assert "https://oauth-patron.overdrive.com/patrontoken" == url
         assert "barcode" == payload["username"]
         assert expect_scope == payload["scope"]
         assert "false" == payload["password_required"]
         assert "[ignore]" == payload["password"]
 
-    def test_test_refresh_patron_access_token_failure(
+    def test__refresh_patron_oauth_token_failure(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ) -> None:
         db = overdrive_api_fixture.db
@@ -2023,7 +2007,7 @@ class TestOverdriveAPI:
         with pytest.raises(
             PatronAuthorizationFailedException, match="Invalid Library Card"
         ):
-            overdrive_api_fixture.api.refresh_patron_access_token(
+            overdrive_api_fixture.api._refresh_patron_oauth_token(
                 credential, patron, "a pin"
             )
 
@@ -2037,11 +2021,11 @@ class TestOverdriveAPI:
             PatronAuthorizationFailedException,
             match="Failed to authenticate with Overdrive",
         ):
-            overdrive_api_fixture.api.refresh_patron_access_token(
+            overdrive_api_fixture.api._refresh_patron_oauth_token(
                 credential, patron, "a pin"
             )
 
-    def test_refresh_patron_access_token_is_fulfillment(
+    def test__refresh_patron_oauth_token_palace_context(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ):
         """Verify that patron information is included in the request
@@ -2064,8 +2048,8 @@ class TestOverdriveAPI:
             return_value=MockRequestsResponse(200, content=post_response)
         )
         od_api._do_get = MagicMock()
-        response_credential = od_api.refresh_patron_access_token(
-            credential, patron, "a pin", is_fulfillment=True
+        response_credential = od_api._refresh_patron_oauth_token(
+            credential, patron, "a pin", palace_context=True
         )
 
         # Posted once, no gets
@@ -2104,7 +2088,7 @@ class TestOverdriveAPI:
             f"{Configuration.OD_PREFIX_TESTING_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}"
         )
         with pytest.raises(CannotFulfill):
-            od_api.fulfillment_authorization_header
+            od_api._palace_context_basic_auth_header
 
     def test_no_drm_fulfillment(self, overdrive_api_fixture: OverdriveAPIFixture):
         db = overdrive_api_fixture.db
@@ -2192,9 +2176,8 @@ class TestOverdriveAPI:
 
 class TestOverdriveAPICredentials:
     def test_patron_correct_credentials_for_multiple_overdrive_collections(
-        self, overdrive_api_fixture: OverdriveAPIFixture
+        self, db: DatabaseTransactionFixture
     ):
-        db = overdrive_api_fixture.db
         # Verify that the correct credential will be used
         # when a library has more than one OverDrive collection.
 
@@ -2205,9 +2188,7 @@ class TestOverdriveAPICredentials:
             return f"{grant_type}|{scope}|{username}|{password}"
 
         class MockAPI(MockOverdriveAPI):
-            def token_post(
-                self, url, payload, is_fulfillment=False, headers={}, **kwargs
-            ):
+            def _do_post(self, url, payload, headers, **kwargs):
                 url = self.endpoint(url)
                 self.access_token_requests.append((url, payload, headers, kwargs))
                 token = _make_token(
@@ -2283,21 +2264,23 @@ class TestOverdriveAPICredentials:
         for name in list(expected_credentials.keys()) + list(
             reversed(list(expected_credentials.keys()))
         ):
-            credential = od_apis[name].get_patron_credential(patron, pin)
+            credential = od_apis[name]._get_patron_oauth_credential(patron, pin)
             assert expected_credentials[name] == credential.credential
 
     def test_fulfillment_credentials_testing_keys(
-        self, overdrive_api_fixture: OverdriveAPIFixture
-    ):
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         test_key = "tk"
         test_secret = "ts"
 
-        os.environ[
-            f"{Configuration.OD_PREFIX_TESTING_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}"
-        ] = test_key
-        os.environ[
-            f"{Configuration.OD_PREFIX_TESTING_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_SECRET_SUFFIX}"
-        ] = test_secret
+        monkeypatch.setenv(
+            f"{Configuration.OD_PREFIX_TESTING_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}",
+            test_key,
+        )
+        monkeypatch.setenv(
+            f"{Configuration.OD_PREFIX_TESTING_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_SECRET_SUFFIX}",
+            test_secret,
+        )
 
         testing_credentials = Configuration.overdrive_fulfillment_keys(testing=True)
         assert testing_credentials["key"] == test_key
@@ -2306,27 +2289,31 @@ class TestOverdriveAPICredentials:
         prod_key = "pk"
         prod_secret = "ps"
 
-        os.environ[
-            f"{Configuration.OD_PREFIX_PRODUCTION_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}"
-        ] = prod_key
-        os.environ[
-            f"{Configuration.OD_PREFIX_PRODUCTION_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_SECRET_SUFFIX}"
-        ] = prod_secret
+        monkeypatch.setenv(
+            f"{Configuration.OD_PREFIX_PRODUCTION_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}",
+            prod_key,
+        )
+        monkeypatch.setenv(
+            f"{Configuration.OD_PREFIX_PRODUCTION_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_SECRET_SUFFIX}",
+            prod_secret,
+        )
 
         prod_credentials = Configuration.overdrive_fulfillment_keys()
         assert prod_credentials["key"] == prod_key
         assert prod_credentials["secret"] == prod_secret
 
     def test_fulfillment_credentials_cannot_load(
-        self, overdrive_api_fixture: OverdriveAPIFixture
-    ):
-        os.environ.pop(
-            f"{Configuration.OD_PREFIX_PRODUCTION_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}"
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(
+            f"{Configuration.OD_PREFIX_PRODUCTION_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}",
+            raising=False,
         )
         pytest.raises(CannotLoadConfiguration, Configuration.overdrive_fulfillment_keys)
 
-        os.environ.pop(
-            f"{Configuration.OD_PREFIX_TESTING_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}"
+        monkeypatch.delenv(
+            f"{Configuration.OD_PREFIX_TESTING_PREFIX}_{Configuration.OD_FULFILLMENT_CLIENT_KEY_SUFFIX}",
+            raising=False,
         )
         pytest.raises(
             CannotLoadConfiguration,


### PR DESCRIPTION
## Description

This PR refactors function names related to Overdrive token handling to improve clarity and consistency. The changes focus on renaming methods that handle various aspects of OAuth token management in the Overdrive API integration.

Specifically, this includes renaming functions that manage:
- Client OAuth tokens
- Collection tokens
- Patron OAuth tokens
- Authentication headers

These changes are purely naming refactors and do not alter the functionality of the code.

## Motivation and Context

While working on PP-2218, I was struggling with the naming of the various authentication functions and properties in the Overdrive API class. The current naming of token-related functions in the Overdrive API integration lacks consistency and clarity. Hoping that this makes it easier to work with this code and understand the authentication flow.

## How Has This Been Tested?

The existing test suite, including all tests in `tests/manager/api/overdrive/test_api.py`, has been run to ensure that the renamed functions continue to operate correctly. All tests pass with the new function names.

No functional changes were made to the code, only renames, so the existing tests verify that the functionality remains intact.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.