### PR TITLE
Update OD API to not encode then decode settings strings (PP-2218)

### DIFF
--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -443,7 +443,7 @@ class OverdriveAPI(
         This header contains the collection's credentials that were configured
         through the admin interface for this specific collection.
         """
-        credentials = b"%s:%s" % (self.client_key(), self.client_secret())
+        credentials = f"{self.client_key()}:{self.client_secret()}"
         return "Basic " + base64.standard_b64encode(credentials).strip()
 
     @property
@@ -644,14 +644,14 @@ class OverdriveAPI(
         kwargs["timeout"] = 120
         return HTTP.post_with_timeout(url, payload, headers=headers, **kwargs)
 
-    def website_id(self) -> bytes:
-        return self.settings.overdrive_website_id.encode("utf-8")
+    def website_id(self) -> str:
+        return self.settings.overdrive_website_id
 
-    def client_key(self) -> bytes:
-        return self.settings.overdrive_client_key.encode("utf-8")
+    def client_key(self) -> str:
+        return self.settings.overdrive_client_key
 
-    def client_secret(self) -> bytes:
-        return self.settings.overdrive_client_secret.encode("utf-8")
+    def client_secret(self) -> str:
+        return self.settings.overdrive_client_secret
 
     def library_id(self) -> str:
         return self._library_id

--- a/src/palace/manager/api/overdrive/script.py
+++ b/src/palace/manager/api/overdrive/script.py
@@ -41,8 +41,8 @@ class GenerateOverdriveAdvantageAccountList(InputScript):
         query = Collection.by_protocol(self._db, protocol=OverdriveAPI.label())
         for collection in query.filter(Collection.parent_id == None):
             api = self._create_overdrive_api(collection=collection)
-            client_key = api.client_key().decode()
-            client_secret = api.client_secret().decode()
+            client_key = api.client_key()
+            client_secret = api.client_secret()
             library_id = api.library_id()
 
             try:


### PR DESCRIPTION
## Description

Remove some bytes conversions left over from the Python 2 -> 3 migration.

## Motivation and Context

Remove some unnecessary str -> bytes -> str conversions hanging around in the Overdrive API code.

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
