### PR TITLE
Inventory reports exclude inactive collections. (PP-2237)

### DIFF
--- a/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
+++ b/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
@@ -37,6 +37,8 @@ def eligible_integrations(
     """Subset a list of integrations to only those that are eligible for the inventory report."""
 
     def is_eligible(integration: IntegrationConfiguration) -> bool:
+        if not integration.collection.is_active:
+            return False
         settings_cls = registry[integration.protocol].settings_class()
         return issubclass(settings_cls, OPDSImporterSettings)
 


### PR DESCRIPTION
## Description

Excludes otherwise eligible collections that are not active (e.g., subscription expired) from inclusion in the inventory reports.

## Motivation and Context

Books in inactive collections are not available for lending, so reporting them as available would be misleading.

[Jira PP-2237]

## How Has This Been Tested?

- Tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/13982806834/job/39151248655) pass.

NB: CI tests pass except for one Google Drive integration test with a known problem:
- `tests/manager/service/google_drive/test_google_drive.py::TestGoogleDriveService::test_share_document`

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
