### PR TITLE
Removes cause for divide by zero error in axis task.

### DIFF
--- a/src/palace/manager/celery/tasks/axis.py
+++ b/src/palace/manager/celery/tasks/axis.py
@@ -274,8 +274,7 @@ def import_identifiers(
 
     task.log.info(
         f'Imported {total_imported_in_current_task} books into collection(name="{collection_name}", '
-        f"id={collection_id} in {elapsed_seconds:.2f} secs or "
-        f"{(elapsed_seconds/total_imported_in_current_task):.2f} secs / book"
+        f"id={collection_id} in {elapsed_seconds:.2f} secs"
     )
 
     processed_count += total_imported_in_current_task


### PR DESCRIPTION
## Description
Removes the part of the log message that was causing the ZeroDivisionError in the axis import_identifiers task (of which there were 76 in the last 24 hours).  I removed the calculation rather than writing it because I thought it would be of limited value.

<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2233
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
