### PR TITLE
Stagger the execution of the collection import tasks to minimize dead…

### DIFF
--- a/src/palace/manager/celery/tasks/axis.py
+++ b/src/palace/manager/celery/tasks/axis.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from celery import shared_task
 from sqlalchemy import select
@@ -49,6 +49,13 @@ def import_all_collections(
             )
             list_identifiers_for_import.apply_async(
                 kwargs={"collection_id": collection.id},
+                eta=utc_now()
+                + timedelta(
+                    seconds=count * 5
+                ),  # stagger the execution of the collection import
+                # in order to minimize chance of deadlocks caused by
+                # simultaneous updates to the metadata when CM has multiple
+                # axis collections configured with overlapping content
                 link=import_identifiers.s(
                     collection_id=collection.id,
                     batch_size=batch_size,

--- a/src/palace/manager/celery/tasks/axis.py
+++ b/src/palace/manager/celery/tasks/axis.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from celery import shared_task
 from sqlalchemy import select
@@ -49,10 +49,7 @@ def import_all_collections(
             )
             list_identifiers_for_import.apply_async(
                 kwargs={"collection_id": collection.id},
-                eta=utc_now()
-                + timedelta(
-                    seconds=count * 5
-                ),  # stagger the execution of the collection import
+                countdown=count * 5,  # stagger the execution of the collection import
                 # in order to minimize chance of deadlocks caused by
                 # simultaneous updates to the metadata when CM has multiple
                 # axis collections configured with overlapping content
@@ -363,11 +360,19 @@ def reap_all_collections(task: Task) -> None:
     A shared task that  kicks off a reap collection task for each Axis 360 collection.
     """
     with task.session() as session:
+        count = 0
         for collection in get_collections_by_protocol(task, session, Axis360API):
             task.log.info(
                 f'Queued collection("{collection.name}" [id={collection.id}] for reaping...'
             )
-            reap_collection.delay(collection_id=collection.id)
+            reap_collection.apply_async(
+                kwargs={"collection_id": collection.id},
+                countdown=count * 5,  # stagger the execution of the collection import
+                # in order to minimize chance of deadlocks caused by
+                # simultaneous updates to the metadata when CM has multiple
+                # axis collections configured with overlapping content
+            )
+            count += 1
 
         task.log.info(f"Finished queuing reap collection tasks.")
 

--- a/tests/manager/celery/tasks/test_axis.py
+++ b/tests/manager/celery/tasks/test_axis.py
@@ -101,17 +101,17 @@ def test_import_all_collections(
         import_all_collections.delay().wait()
 
         assert mock_list_identifiers_for_import.apply_async.call_count == 1
+        import_args = {
+            "kwargs": {"collection_id": collection2.id},
+            "countdown": 0,
+            "link": import_identifiers.s(
+                collection_id=collection2.id,
+                batch_size=DEFAULT_BATCH_SIZE,
+            ),
+        }
         assert (
-            mock_list_identifiers_for_import.apply_async.call_args_list[0].kwargs[
-                "kwargs"
-            ]["collection_id"]
-            == collection2.id
-        )
-        assert mock_list_identifiers_for_import.apply_async.call_args_list[0].kwargs[
-            "link"
-        ] == import_identifiers.s(
-            collection_id=collection2.id,
-            batch_size=DEFAULT_BATCH_SIZE,
+            mock_list_identifiers_for_import.apply_async.call_args_list[0].kwargs
+            == import_args
         )
         assert "Finished queuing 1 collection." in caplog.text
 
@@ -300,10 +300,18 @@ def test_reap_all_collections(
     with patch.object(axis, "reap_collection") as mock_reap_collection:
         reap_all_collections.delay().wait()
 
-        assert mock_reap_collection.delay.call_count == 1
-        assert mock_reap_collection.delay.call_args_list[0].kwargs == {
-            "collection_id": collection2.id,
+        assert mock_reap_collection.apply_async.call_count == 1
+        reap_collection_args = {
+            "kwargs": {
+                "collection_id": collection2.id,
+            },
+            "countdown": 0,
         }
+
+        assert (
+            mock_reap_collection.apply_async.call_args_list[0].kwargs
+            == reap_collection_args
+        )
         assert "Finished queuing reap collection tasks" in caplog.text
 
 


### PR DESCRIPTION
…locks.

## Description
This update introduces a 5 second delay between the execution of each axis collection import task in order to reduce the probability of a simultaneous update of a particular book on CMs where there are multiple axis collections with overlapping contents.
<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2233
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
