### PR TITLE
Type hints for HTTP request kwargs

### DIFF
--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -63,7 +63,7 @@ from palace.manager.sqlalchemy.model.patron import Hold, Loan, Patron
 from palace.manager.sqlalchemy.model.resource import Resource
 from palace.manager.sqlalchemy.util import get_one
 from palace.manager.util.datetime_helpers import utc_now
-from palace.manager.util.http import HTTP, BadResponseException
+from palace.manager.util.http import HTTP, BadResponseException, ResponseCodesT
 from palace.manager.util.log import LoggerMixin
 
 
@@ -277,7 +277,7 @@ class FetchFulfillment(UrlFulfillment, LoggerMixin):
         content_type: str | None = None,
         *,
         include_headers: dict[str, str] | None = None,
-        allowed_response_codes: list[str | int] | None = None,
+        allowed_response_codes: ResponseCodesT = None,
     ) -> None:
         super().__init__(content_link, content_type)
         self.include_headers = include_headers or {}

--- a/src/palace/manager/api/discovery/opds_registration.py
+++ b/src/palace/manager/api/discovery/opds_registration.py
@@ -12,6 +12,7 @@ from html_sanitizer import Sanitizer
 from requests import Response
 from sqlalchemy import select
 from sqlalchemy.orm.session import Session
+from typing_extensions import Unpack
 
 from palace.manager.api.config import Configuration
 from palace.manager.api.problem_details import (
@@ -34,7 +35,7 @@ from palace.manager.sqlalchemy.model.discovery_service_registration import (
 from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
 from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.util import get_one, get_one_or_create
-from palace.manager.util.http import HTTP
+from palace.manager.util.http import HTTP, RequestKwargs
 from palace.manager.util.problem_detail import ProblemDetailException
 from palace.manager.util.pydantic import HttpUrl
 
@@ -136,9 +137,10 @@ class OpdsRegistrationService(
 
     @staticmethod
     def post_request(
-        url: str, payload: str | dict[str, Any], **kwargs: Any
+        url: str,
+        **kwargs: Unpack[RequestKwargs],
     ) -> Response:
-        return HTTP.debuggable_post(url, payload, **kwargs)
+        return HTTP.debuggable_post(url, **kwargs)
 
     @classmethod
     def for_protocol_goal_and_url(
@@ -434,7 +436,7 @@ class OpdsRegistrationService(
         response = cls.post_request(
             register_url,
             headers=headers,
-            payload=payload,
+            data=payload,
             timeout=60,
             allowed_response_codes=["2xx", "3xx"],
         )

--- a/src/palace/manager/api/kansas_patron.py
+++ b/src/palace/manager/api/kansas_patron.py
@@ -135,7 +135,7 @@ class KansasAuthenticationAPI(
         """
         return HTTP.post_with_timeout(
             self.base_url,
-            data,
+            data=data,
             headers={"Content-Type": "application/xml"},
             max_retry_count=0,
             allowed_response_codes=["2xx"],

--- a/src/palace/manager/api/metadata/novelist.py
+++ b/src/palace/manager/api/metadata/novelist.py
@@ -752,9 +752,8 @@ class NoveListAPI(
         }
 
     def put(self, url: str, headers: Mapping[str, str], **kwargs: Any) -> Response:
-        data = kwargs.pop("data", None)
         # This might take a very long time -- disable the normal
         # timeout.
         kwargs["timeout"] = None
-        response = HTTP.put_with_timeout(url, data, headers=headers, **kwargs)
+        response = HTTP.put_with_timeout(url, headers=headers, **kwargs)
         return response

--- a/src/palace/manager/api/odl/auth.py
+++ b/src/palace/manager/api/odl/auth.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any, Literal, NamedTuple
 
@@ -11,7 +11,12 @@ from palace.manager.api.odl.settings import OPDS2AuthType
 from palace.manager.core.exceptions import IntegrationException, PalaceValueError
 from palace.manager.opds.authentication import AuthenticationDocument
 from palace.manager.util.datetime_helpers import utc_now
-from palace.manager.util.http import HTTP, BadResponseException, BearerAuth
+from palace.manager.util.http import (
+    HTTP,
+    BadResponseException,
+    BearerAuth,
+    ResponseCodesT,
+)
 from palace.manager.util.log import LoggerMixin
 from palace.manager.util.problem_detail import ProblemDetail
 
@@ -140,8 +145,8 @@ class OdlAuthenticatedRequest(LoggerMixin, ABC):
     ) -> Response:
         # If the request restricts allowed response codes, we need to add 401 to the allowed response codes
         # so that we can handle the 401 response and refresh the token, if necessary.
-        original_allowed_response_codes: Sequence[int | str] = kwargs.get(
-            "allowed_response_codes", []
+        original_allowed_response_codes: ResponseCodesT = (
+            kwargs.get("allowed_response_codes") or []
         )
         if (
             original_allowed_response_codes

--- a/src/palace/manager/api/odl/importer.py
+++ b/src/palace/manager/api/odl/importer.py
@@ -30,7 +30,7 @@ from palace.manager.sqlalchemy.model.licensing import (
     RightsStatus,
 )
 from palace.manager.sqlalchemy.model.resource import Hyperlink
-from palace.manager.util.http import HTTP
+from palace.manager.util.http import HTTP, GetRequestCallable
 
 
 class OPDS2WithODLImporter(OPDS2Importer):
@@ -59,7 +59,7 @@ class OPDS2WithODLImporter(OPDS2Importer):
         db: Session,
         collection: Collection,
         data_source_name: str | None = None,
-        http_get: Callable[..., Response] | None = None,
+        http_get: GetRequestCallable | None = None,
     ):
         """Initialize a new instance of OPDS2WithODLImporter class.
 

--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -642,7 +642,7 @@ class OverdriveAPI(
         url = self.endpoint(url)
         kwargs["max_retry_count"] = self.settings.max_retry_count
         kwargs["timeout"] = 120
-        return HTTP.post_with_timeout(url, payload, headers=headers, **kwargs)
+        return HTTP.post_with_timeout(url, data=payload, headers=headers, **kwargs)
 
     def website_id(self) -> str:
         return self.settings.overdrive_website_id

--- a/src/palace/manager/core/opds_import.py
+++ b/src/palace/manager/core/opds_import.py
@@ -1703,14 +1703,15 @@ class OPDSImportMonitor(CollectionMonitor):
         """
 
         headers = self._update_headers(headers)
-        kwargs = dict(
+        if not url.startswith("http"):
+            url = urljoin(self._feed_base_url, url)
+        return HTTP.get_with_timeout(
+            url,
+            headers=headers,
             timeout=120,
             max_retry_count=self._max_retry_count,
             allowed_response_codes=["2xx", "3xx"],
         )
-        if not url.startswith("http"):
-            url = urljoin(self._feed_base_url, url)
-        return HTTP.get_with_timeout(url, headers=headers, **kwargs)
 
     def _get_accept_header(self) -> str:
         return ",".join(
@@ -1862,7 +1863,7 @@ class OPDSImportMonitor(CollectionMonitor):
         """
         self.log.info("Following next link: %s", url)
         get = do_get or self._get
-        resp = get(url, {})
+        resp = get(url, headers={})
         feed = resp.content
 
         self._verify_media_type(url, resp)

--- a/src/palace/manager/sqlalchemy/model/resource.py
+++ b/src/palace/manager/sqlalchemy/model/resource.py
@@ -1050,10 +1050,7 @@ class Representation(Base, MediaTypes):
     @classmethod
     def simple_http_post(cls, url, headers, **kwargs):
         """The most simple HTTP-based POST."""
-        data = kwargs.get("data")
-        if "data" in kwargs:
-            del kwargs["data"]
-        response = HTTP.post_with_timeout(url, data, headers=headers, **kwargs)
+        response = HTTP.post_with_timeout(url, headers=headers, **kwargs)
         return response.status_code, response.headers, response.content
 
     @classmethod

--- a/src/palace/manager/util/http.py
+++ b/src/palace/manager/util/http.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from io import BytesIO, StringIO
 from json import JSONDecodeError
-from typing import Any
+from typing import Any, Literal, Protocol, TypedDict
 from urllib.parse import urlparse
 
 import requests
@@ -12,7 +13,7 @@ from flask_babel import lazy_gettext as _
 from requests import PreparedRequest, sessions
 from requests.adapters import HTTPAdapter, Response
 from requests.auth import AuthBase
-from typing_extensions import Self
+from typing_extensions import Self, Unpack
 from urllib3 import Retry
 
 from palace import manager
@@ -145,6 +146,59 @@ class RequestTimedOut(RequestNetworkException, requests.exceptions.Timeout):
     internal_message = "Timeout accessing %s: %s"
 
 
+_ResponseCodesLiteral = Literal["2xx", "3xx", "4xx", "5xx"]
+ResponseCodesT = Sequence[_ResponseCodesLiteral | int] | None
+
+
+class GetRequestKwargs(TypedDict, total=False):
+    params: Mapping[str, str | int | float | None] | None
+    headers: Mapping[str, str | None] | None
+    auth: tuple[str, str] | AuthBase | None
+    timeout: float | int | None
+    allow_redirects: bool
+    stream: bool | None
+    verify: bool | None
+
+    allowed_response_codes: ResponseCodesT
+    disallowed_response_codes: ResponseCodesT
+    verbose: bool
+    max_retry_count: int
+    backoff_factor: float
+
+
+class RequestKwargs(GetRequestKwargs, total=False):
+    data: Iterable[bytes] | str | bytes | Mapping[str, Any] | None
+    files: Mapping[str, BytesIO | StringIO | str | bytes] | None
+    json: Mapping[str, Any] | None
+
+
+class GetRequestCallable(Protocol):
+    def __call__(
+        self,
+        url: str,
+        **kwargs: Unpack[GetRequestKwargs],
+    ) -> Response: ...
+
+
+class MakeRequestCallable(Protocol):
+    def __call__(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Unpack[RequestKwargs],
+    ) -> Response: ...
+
+
+class _ProcessResponseCallable(Protocol):
+    def __call__(
+        self,
+        url: str,
+        response: Response,
+        allowed_response_codes: ResponseCodesT = None,
+        disallowed_response_codes: ResponseCodesT = None,
+    ) -> Response: ...
+
+
 class HTTP(LoggerMixin):
     """A helper for the `requests` module."""
 
@@ -162,35 +216,37 @@ class HTTP(LoggerMixin):
         cls.DEFAULT_REQUEST_TIMEOUT = 5
 
     @classmethod
-    def get_with_timeout(cls, url: str, *args: Any, **kwargs: Any) -> Response:
+    def get_with_timeout(cls, url: str, **kwargs: Unpack[GetRequestKwargs]) -> Response:
         """Make a GET request with timeout handling."""
-        return cls.request_with_timeout("GET", url, *args, **kwargs)
+        return cls.request_with_timeout("GET", url, **kwargs)
 
     @classmethod
     def post_with_timeout(
-        cls, url: str, payload: str | Mapping[str, Any], *args: Any, **kwargs: Any
+        cls,
+        url: str,
+        **kwargs: Unpack[RequestKwargs],
     ) -> Response:
         """Make a POST request with timeout handling."""
-        kwargs["data"] = payload
-        return cls.request_with_timeout("POST", url, *args, **kwargs)
+        return cls.request_with_timeout("POST", url, **kwargs)
 
     @classmethod
     def put_with_timeout(
-        cls, url: str, payload: str | Mapping[str, Any], *args: Any, **kwargs: Any
+        cls,
+        url: str,
+        **kwargs: Unpack[RequestKwargs],
     ) -> Response:
         """Make a PUT request with timeout handling."""
-        kwargs["data"] = payload
-        return cls.request_with_timeout("PUT", url, *args, **kwargs)
+        return cls.request_with_timeout("PUT", url, **kwargs)
 
     @classmethod
     def request_with_timeout(
-        cls, http_method: str, url: str, *args: Any, **kwargs: Any
+        cls, http_method: str, url: str, **kwargs: Unpack[RequestKwargs]
     ) -> Response:
         """Call requests.request and turn a timeout into a RequestTimedOut
         exception.
         """
         return cls._request_with_timeout(
-            url, sessions.Session.request, http_method, *args, **kwargs
+            http_method, url, sessions.Session.request, **kwargs
         )
 
     # The set of status codes on which a retry will be attempted (if the number of retries requested is non-zero).
@@ -199,10 +255,11 @@ class HTTP(LoggerMixin):
     @classmethod
     def _request_with_timeout(
         cls,
+        http_method: str,
         url: str,
         make_request_with: Callable[..., Response],
-        *args: Any,
-        **kwargs: Any,
+        process_response_with: _ProcessResponseCallable | None = None,
+        **kwargs: Unpack[RequestKwargs],
     ) -> Response:
         """Call some kind of method and turn a timeout into a RequestTimedOut
         exception.
@@ -215,9 +272,8 @@ class HTTP(LoggerMixin):
         :param args: Positional arguments for the request function.
         :param kwargs: Keyword arguments for the request function.
         """
-        process_response_with = kwargs.pop(
-            "process_response_with", cls._process_response
-        )
+        process_response_with = process_response_with or cls._process_response
+
         allowed_response_codes = kwargs.pop("allowed_response_codes", [])
         disallowed_response_codes = kwargs.pop("disallowed_response_codes", [])
         verbose = kwargs.pop("verbose", False)
@@ -230,39 +286,24 @@ class HTTP(LoggerMixin):
         )
         backoff_factor: float = float(kwargs.pop("backoff_factor", 1.0))
 
-        # Unicode data can't be sent over the wire. Convert it to UTF-8.
-        if "data" in kwargs and isinstance(kwargs["data"], str):
-            kwdata: str = kwargs["data"]
-            kwargs["data"] = kwdata.encode("utf8")
-
         # Set a user-agent if not already present
         version = (
             manager.__version__
             if manager.__version__
             else cls.DEFAULT_USER_AGENT_VERSION
         )
-        ua_header = {"User-Agent": f"Palace Manager/{version}"}
-        headers = ua_header | (kwargs.get("headers") or {})
-
-        # Make sure headers are encoded as utf-8
-        kwargs["headers"] = {
-            k.encode() if isinstance(k, str) else k: (
-                v.encode() if isinstance(v, str) else v
-            )
-            for k, v in headers.items()
-        }
+        headers: dict[str, str | None] = {"User-Agent": f"Palace Manager/{version}"}
+        if (additional_headers := kwargs.get("headers")) is not None:
+            headers.update(additional_headers)
+        kwargs["headers"] = headers
 
         try:
             if verbose:
                 logging.info(
-                    "Sending request to %s: args %r kwargs %r", url, args, kwargs
+                    f"Sending {http_method} request to {url}: kwargs {kwargs!r}",
+                    url,
+                    kwargs,
                 )
-            if len(args) == 1:
-                # requests.request takes two positional arguments,
-                # an HTTP method and a URL. In most cases, the URL
-                # gets added on here. But if you do pass in both
-                # arguments, it will still work.
-                args = args + (url,)
 
             request_start_time = time.time()
             if make_request_with == sessions.Session.request:
@@ -277,9 +318,9 @@ class HTTP(LoggerMixin):
                     session.mount("http://", adapter)
                     session.mount("https://", adapter)
 
-                    response = session.request(*args, **kwargs)
+                    response = session.request(http_method, url, **kwargs)  # type: ignore[misc]
             else:
-                response = make_request_with(*args, **kwargs)
+                response = make_request_with(http_method, url, **kwargs)
             cls.logger().info(
                 f"Request time for {url} took {time.time() - request_start_time:.2f} seconds"
             )
@@ -301,7 +342,7 @@ class HTTP(LoggerMixin):
             # a generic RequestNetworkException.
             raise RequestNetworkException(url, str(e)) from e
 
-        return process_response_with(  # type: ignore[no-any-return]
+        return process_response_with(
             url,
             response,
             allowed_response_codes,
@@ -313,8 +354,8 @@ class HTTP(LoggerMixin):
         cls,
         url: str,
         response: Response,
-        allowed_response_codes: Sequence[int | str] | None = None,
-        disallowed_response_codes: Sequence[int | str] | None = None,
+        allowed_response_codes: ResponseCodesT = None,
+        disallowed_response_codes: ResponseCodesT = None,
     ) -> Response:
         """Raise a RequestNetworkException if the response code indicates a
         server-side failure, or behavior so unpredictable that we can't
@@ -380,12 +421,12 @@ class HTTP(LoggerMixin):
             raise RequestNetworkException(url, str(e)) from e
 
     @classmethod
-    def series(cls, status_code: int) -> str:
+    def series(cls, status_code: int) -> _ResponseCodesLiteral:
         """Return the HTTP series for the given status code."""
-        return "%sxx" % (int(status_code) // 100)
+        return "%sxx" % (int(status_code) // 100)  # type: ignore[return-value]
 
     @classmethod
-    def debuggable_get(cls, url: str, **kwargs: Any) -> Response:
+    def debuggable_get(cls, url: str, **kwargs: Unpack[GetRequestKwargs]) -> Response:
         """Make a GET request that returns a detailed problem
         detail document on error.
         """
@@ -393,12 +434,13 @@ class HTTP(LoggerMixin):
 
     @classmethod
     def debuggable_post(
-        cls, url: str, payload: str | dict[str, Any], **kwargs: Any
+        cls,
+        url: str,
+        **kwargs: Unpack[RequestKwargs],
     ) -> Response:
         """Make a POST request that returns a detailed problem
         detail document on error.
         """
-        kwargs["data"] = payload
         return cls.debuggable_request("POST", url, **kwargs)
 
     @classmethod
@@ -407,7 +449,7 @@ class HTTP(LoggerMixin):
         http_method: str,
         url: str,
         make_request_with: Callable[..., Response] | None = None,
-        **kwargs: Any,
+        **kwargs: Unpack[RequestKwargs],
     ) -> Response:
         """Make a request that raises a ProblemError with a detailed problem detail
         document on error, rather than a generic "an integration error occurred"
@@ -425,9 +467,9 @@ class HTTP(LoggerMixin):
         )
         make_request_with = make_request_with or requests.request
         return cls._request_with_timeout(
-            url,
-            make_request_with,
             http_method,
+            url,
+            make_request_with=make_request_with,
             process_response_with=cls.process_debuggable_response,
             **kwargs,
         )
@@ -437,14 +479,12 @@ class HTTP(LoggerMixin):
         cls,
         url: str,
         response: Response,
-        allowed_response_codes: list[str | int] | None = None,
-        disallowed_response_codes: list[str | int] | None = None,
+        allowed_response_codes: ResponseCodesT = None,
+        disallowed_response_codes: ResponseCodesT = None,
     ) -> Response:
         """If there was a problem with an integration request,
         raise ProblemError with an appropriate ProblemDetail. Otherwise, return the
         response to the original request.
-
-        :param response: A Response object from the requests library.
         """
 
         allowed_response_codes = allowed_response_codes or ["2xx", "3xx"]

--- a/src/palace/manager/util/http.py
+++ b/src/palace/manager/util/http.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping
 from io import BytesIO, StringIO
 from json import JSONDecodeError
 from typing import Any, Literal, Protocol, TypedDict
@@ -147,7 +147,7 @@ class RequestTimedOut(RequestNetworkException, requests.exceptions.Timeout):
 
 
 _ResponseCodesLiteral = Literal["2xx", "3xx", "4xx", "5xx"]
-ResponseCodesT = Sequence[_ResponseCodesLiteral | int] | None
+ResponseCodesT = Iterable[_ResponseCodesLiteral | int] | None
 
 
 class GetRequestKwargs(TypedDict, total=False):

--- a/tests/manager/api/metadata/test_novelist.py
+++ b/tests/manager/api/metadata/test_novelist.py
@@ -745,5 +745,5 @@ class TestNoveListAPI:
 
         novelist_fixture.novelist.put("http://apiendpoint.com", headers, data=data)
         mock_put.assert_called_once_with(
-            "http://apiendpoint.com", data, headers=headers, timeout=None
+            "http://apiendpoint.com", data=data, headers=headers, timeout=None
         )

--- a/tests/manager/api/test_circulation.py
+++ b/tests/manager/api/test_circulation.py
@@ -84,7 +84,7 @@ class TestFetchFulfillment:
         assert response.get_data(as_text=True) == "Other content."
         assert response.content_type == "application/xyz"
         assert http.requests == ["http://some.other.location"]
-        [(args, kwargs)] = http.requests_args
+        [kwargs] = http.requests_args
         assert kwargs["allow_redirects"] is True
 
         # If the content type is not set on the fulfillment, and the response does not have a content type,
@@ -115,7 +115,8 @@ class TestFetchFulfillment:
         assert response.content_type == "foo/bar"
         assert "X-Test" not in response.headers
         assert http.requests == ["http://some.location"]
-        [(args, kwargs)] = http.requests_args
+        [kwargs] = http.requests_args
+        assert kwargs["headers"] is not None
         assert kwargs["headers"]["X-Test"] == "test"
 
     def test_fetch_fulfillment_allowed_response_codes(


### PR DESCRIPTION
## Description

  This PR adds proper type hints to HTTP-related keyword arguments across the application. It introduces typed dictionaries for HTTP request keyword arguments, ensuring type safety when making HTTP requests.

  The changes include:

  - Added `GetRequestKwargs` and `RequestKwargs` typed dictionaries in http.py
  - Updated method signatures to use `Unpack[RequestKwargs]` for proper typing of kwargs
  - Created protocol classes for request callables to improve type checking
  - Updated tests to maintain compatibility with the new typing

## Motivation and Context

  This change improves type safety by properly typing HTTP request keyword arguments. Previously, these were untyped, which could lead to subtle bugs where incorrect parameter types were passed to HTTP requests. With these changes:

  - Static type checkers can catch errors at development time
  - IDE autocompletion provides better suggestions for available parameters
  - Code becomes more self-documenting through explicit parameter types

I am always forgetting what the param names for the http methods are, especially the palace specific ones, so the IDE autocomplete is really helpful here.

## How Has This Been Tested?

  The changes have been tested through:

  - Running the existing test suite to ensure all tests still pass
  - Manual verification of type checking using mypy
  - Ensuring IDE autocompletion correctly identifies parameter types

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
