### PR TITLE
Address Integration and Deadlock errors in axis.import_identifiers and axis.reap_collection

### DIFF
--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -212,7 +212,7 @@ class Axis360API(
         return ""
 
     def __init__(
-        self, _db: Session, collection: Collection, bearer_token: str = None
+        self, _db: Session, collection: Collection, bearer_token: str | None = None
     ) -> None:
         super().__init__(_db, collection)
         settings = self.settings

--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -211,7 +211,9 @@ class Axis360API(
     def description(cls) -> str:
         return ""
 
-    def __init__(self, _db: Session, collection: Collection) -> None:
+    def __init__(
+        self, _db: Session, collection: Collection, bearer_token: str = None
+    ) -> None:
         super().__init__(_db, collection)
         settings = self.settings
         self.library_id = settings.external_account_id
@@ -229,7 +231,7 @@ class Axis360API(
         if not self.library_id or not self.username or not self.password:
             raise CannotLoadConfiguration("Axis 360 configuration is incomplete.")
 
-        self._cached_bearer_token: str | None = None
+        self._cached_bearer_token: str | None = bearer_token
         self.verify_certificate: bool = (
             settings.verify_certificate
             if settings.verify_certificate is not None

--- a/src/palace/manager/celery/tasks/axis.py
+++ b/src/palace/manager/celery/tasks/axis.py
@@ -28,6 +28,7 @@ from palace.manager.sqlalchemy.util import get_one_or_create
 from palace.manager.util.backoff import exponential_backoff
 from palace.manager.util.datetime_helpers import datetime_utc, utc_now
 from palace.manager.util.http import BadResponseException
+from palace.manager.util.log import pluralize
 
 DEFAULT_BATCH_SIZE: int = 25
 DEFAULT_START_TIME = datetime_utc(1970, 1, 1)
@@ -312,7 +313,7 @@ def import_identifiers(
         )
         task.log.info(
             f"Replacing task to continue importing remaining "
-            f"{identifiers_list_length} identifier{'' if identifiers_list_length == 1 else 's'} "
+            f'{pluralize(identifiers_list_length, "identifier")} '
             f"for collection ({collection_name}, id={collection_id})"
         )
 
@@ -396,7 +397,7 @@ def reap_all_collections(task: Task) -> None:
             )
             count += 1
 
-        task.log.info(f"Finished queuing reap collection tasks.")
+        task.log.info(f"Finished queuing all reap_collection tasks.")
 
 
 @shared_task(queue=QueueNames.default, bind=True, max_retries=4)

--- a/tests/manager/celery/tasks/test_axis.py
+++ b/tests/manager/celery/tasks/test_axis.py
@@ -315,7 +315,7 @@ def test_reap_all_collections(
             mock_reap_collection.apply_async.call_args_list[0].kwargs
             == reap_collection_args
         )
-        assert "Finished queuing reap collection tasks" in caplog.text
+        assert "Finished queuing all reap_collection tasks" in caplog.text
 
 
 def test_reap_collection_configuration_error(
@@ -446,13 +446,12 @@ def test_retry_import_identifiers(
     no_retry_expected: bool,
 ):
     set_caplog_level_to_info(caplog)
-    collection = db.collection(name="test_collection", protocol=Axis360API.label())
+    collection = db.collection(protocol=Axis360API.label())
 
     edition, licensepool = db.edition(
         collection=collection,
         with_license_pool=True,
         identifier_type=Identifier.AXIS_360_ID,
-        identifier_id="012345678",
     )
 
     mock_api = MagicMock()
@@ -505,7 +504,7 @@ def test_retry_reap_collection(
     no_retry_expected: bool,
 ):
     set_caplog_level_to_info(caplog)
-    collection = db.collection(name="test_collection", protocol=Axis360API.label())
+    collection = db.collection(protocol=Axis360API.label())
     db.edition(
         with_license_pool=True,
         identifier_type=Identifier.AXIS_360_ID,

--- a/tests/manager/celery/tasks/test_axis.py
+++ b/tests/manager/celery/tasks/test_axis.py
@@ -3,7 +3,9 @@ from datetime import timedelta
 from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
-from sqlalchemy.orm.exc import ObjectDeletedError
+from psycopg2.errors import DeadlockDetected
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 
 from palace.manager.api.axis import Axis360API
 from palace.manager.celery.task import Task
@@ -19,6 +21,7 @@ from palace.manager.celery.tasks.axis import (
     reap_collection,
     timestamp,
 )
+from palace.manager.core.exceptions import IntegrationException
 from palace.manager.core.metadata_layer import CirculationData, IdentifierData, Metadata
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.identifier import Identifier
@@ -380,11 +383,67 @@ def test_reap_collection_with_requeue(
         )
 
 
+def test_retry_import_identifiers_due_to_integration_exception(
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+    queue_collection_import_lock_fixture: QueueCollectionImportLockFixture,
+):
+    collection = db.collection(name="test_collection", protocol=Axis360API.label())
+
+    edition, licensepool = db.edition(
+        collection=collection,
+        with_license_pool=True,
+        identifier_type=Identifier.AXIS_360_ID,
+        identifier_id="012345678",
+    )
+
+    mock_api = MagicMock()
+    with patch.object(axis, "create_api") as mock_create_api:
+        mock_create_api.return_value = mock_api
+        edition, lp = db.edition(with_license_pool=True)
+
+        mock_api.availability_by_title_ids.side_effect = [
+            IntegrationException("not a 401 error"),
+            [
+                (
+                    {},
+                    {},
+                )
+            ],
+        ]
+
+        mock_api.update_book.return_value = (edition, False, licensepool, False)
+
+        import_identifiers.delay(
+            collection_id=collection.id,
+            identifiers=[edition.primary_identifier.identifier],
+        ).wait()
+
+        assert mock_api.availability_by_title_ids.call_count == 2
+        assert mock_api.update_book.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "error, update_count, no_retry_expected",
+    [
+        [ObjectDeletedError(None), 2, False],
+        [StaleDataError(None), 2, False],
+        [OperationalError(params={}, orig=DeadlockDetected(), statement=""), 2, False],
+        [
+            OperationalError(params={}, orig=Exception("other db issue"), statement=""),
+            1,
+            True,
+        ],
+    ],
+)
 def test_retry_import_identifiers(
     db: DatabaseTransactionFixture,
     celery_fixture: CeleryFixture,
     queue_collection_import_lock_fixture: QueueCollectionImportLockFixture,
     caplog: pytest.LogCaptureFixture,
+    error: Exception,
+    update_count: int,
+    no_retry_expected: bool,
 ):
     set_caplog_level_to_info(caplog)
     collection = db.collection(name="test_collection", protocol=Axis360API.label())
@@ -404,16 +463,72 @@ def test_retry_import_identifiers(
         mock_api.availability_by_title_ids.return_value = [({}, {})]
 
         mock_api.update_book.side_effect = [
-            ObjectDeletedError(None),
+            error,
             (edition, False, licensepool, False),
         ]
 
-        import_identifiers.delay(
-            collection_id=collection.id,
-            identifiers=[edition.primary_identifier.identifier],
-        ).wait()
+        if no_retry_expected:
+            # expect an exception if non-deadlock
+            with pytest.raises(Exception):
+                import_identifiers.delay(
+                    collection_id=collection.id,
+                    identifiers=[edition.primary_identifier.identifier],
+                ).wait()
+        else:
+            import_identifiers.delay(
+                collection_id=collection.id,
+                identifiers=[edition.primary_identifier.identifier],
+            ).wait()
 
-        assert mock_api.update_book.call_count == 2
+        assert mock_api.update_book.call_count == update_count
+
+
+@pytest.mark.parametrize(
+    "error, update_count, no_retry_expected",
+    [
+        [IntegrationException("non-auth issue"), 2, False],
+        [OperationalError(params={}, orig=DeadlockDetected(), statement=""), 2, False],
+        [
+            OperationalError(params={}, orig=Exception("other db issue"), statement=""),
+            1,
+            True,
+        ],
+    ],
+)
+def test_retry_reap_collection(
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+    queue_collection_import_lock_fixture: QueueCollectionImportLockFixture,
+    caplog: pytest.LogCaptureFixture,
+    error: Exception,
+    update_count: int,
+    no_retry_expected: bool,
+):
+    set_caplog_level_to_info(caplog)
+    collection = db.collection(name="test_collection", protocol=Axis360API.label())
+    db.edition(
+        with_license_pool=True,
+        identifier_type=Identifier.AXIS_360_ID,
+        collection=collection,
+    )
+
+    mock_api = MagicMock()
+    mock_api.update_licensepools_for_identifiers.side_effect = [
+        error,  # first time throw error
+        None,  # second call is successful
+    ]
+
+    with patch.object(axis, "create_api") as mock_create_api:
+        mock_create_api.return_value = mock_api
+
+        if no_retry_expected:
+            with pytest.raises(Exception):
+                reap_collection.delay(collection_id=collection.id, batch_size=1).wait()
+        else:
+            reap_collection.delay(collection_id=collection.id, batch_size=1).wait()
+
+        update_license_pools = mock_api.update_licensepools_for_identifiers
+        assert update_license_pools.call_count == update_count
 
 
 def test_process_item_creates_presentation_ready_work(


### PR DESCRIPTION
This is a follow on PR to the many PRs associated with PP-2233.   I think this should bring the number of errors down very close to zero. 

* Add support for sharing a bearer token among multiple axis api instances:  
    We are creating a new instance of the axis api for each transaction. Since we're updating a single book in each transaction, both in the reaper and the import_identifiers, we are also calling out to the axis token endpoint man times per task.  Multiply that by 200+ (vt and ga libraries for starters) and it's no surprise that we're getting 502s back from axis.  This change ensures that we reducing our calls to the axis api to a minimum.

* Add retry support for non-401 IntegrationException in the axis reaper and import_identifiers operations: 
   In the case when we are getting integration exceptions, we should retry a few times before failing.
* Add retry support for DeadlockDetected errors in the axis reaper and import_identifiers operations
   Deadlocks are infrequent, but should not result in task failure.  This change will hopefully remedy this issue since consecutive dealocks on retries for a  single task should never occur (or at least extremely rarely).
* Add new tests for the various retry cases.

## Description

<!--- Describe your changes -->
https://ebce-lyrasis.atlassian.net/browse/PP-2233
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2233
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
