### PR TITLE
Mitigate axis reaper task buildup

### DIFF
--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -88,9 +88,10 @@ def beat_schedule() -> dict[str, Any]:
         "axis_reap_all_collections": {
             "task": "axis.reap_all_collections",
             "schedule": crontab(
+                day_of_month=30,
                 minute="0",
                 hour="4",
-            ),  # Once a day at 4:00 AM
+            ),  # Once a month (the 30th) at 4:00 AM
         },
         "credential_reaper": {
             "task": "reaper.credential_reaper",


### PR DESCRIPTION
## Description
Here are some changes that I'd like to try rolling out to the  Vermont and Georgia scripts instances to see if we can bring the default queues back to zero.

The first change is to reduce the frequency of the axis.reap_all_collections  task this should stop the growth of the queue. 
The second is to increase the maximum number of celery workers to 8 from 4. 
## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2232
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
