### PR TITLE
Fixes for Overdrive Integration

### DIFF
--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -785,9 +785,8 @@ class OverdriveAPI(
                 # We were unable to validate the response as the expected type. Log some relevant details and
                 # raise a BadResponseException.
                 self.log.exception(
-                    "Unable to validate Overdrive response as type %s: %s",
-                    response_type.__name__,
-                    e.errors(),
+                    "Unable to validate Overdrive response. %s",
+                    str(e),
                 )
                 raise OverdriveValidationError(
                     response.url,

--- a/src/palace/manager/api/overdrive/exception.py
+++ b/src/palace/manager/api/overdrive/exception.py
@@ -50,6 +50,14 @@ class OverdriveModelError(BasePalaceException):
     ...
 
 
+class OverdriveValidationError(BadResponseException, OverdriveModelError):
+    """
+    Raise when we are unable to validate a response from Overdrive.
+    """
+
+    ...
+
+
 class MissingSubstitutionsError(OverdriveModelError):
     """
     Raised when templating a LinkTemplate, and some of the required

--- a/src/palace/manager/api/overdrive/model.py
+++ b/src/palace/manager/api/overdrive/model.py
@@ -314,7 +314,7 @@ class Checkout(BaseOverdriveModel):
     cross_ref_id: int | None = Field(None, alias="crossRefId")
     expires: AwareDatetime
     locked_in: bool = Field(..., alias="isFormatLockedIn")
-    links: dict[str, Link] = Field(default_factory=dict)
+    links: dict[str, Link | list[Link]] = Field(default_factory=dict)
     actions: dict[str, Action] = Field(default_factory=dict)
     checkout_date: AwareDatetime | None = Field(None, alias="checkoutDate")
     formats: list[Format] = Field(default_factory=list)

--- a/tests/files/overdrive/checkout_response_bundled_children.json
+++ b/tests/files/overdrive/checkout_response_bundled_children.json
@@ -1,0 +1,69 @@
+{
+  "reserveId" : "6a600b7a-afda-4f0f-a32c-5be178267b0e",
+  "crossRefId" : 505744,
+  "expires" : "2025-03-29T18:13:30Z",
+  "isFormatLockedIn" : false,
+  "formats" : [ {
+    "reserveId" : "6a600b7a-afda-4f0f-a32c-5be178267b0e",
+    "crossRefId" : 505744,
+    "formatType" : "audiobook-overdrive",
+    "links" : {
+      "self" : {
+        "href" : "https://patron.api.overdrive.com/v1/patrons/me/checkouts/6a600b7a-afda-4f0f-a32c-5be178267b0e/formats/audiobook-overdrive",
+        "type" : "application/vnd.overdrive.circulation.api+json"
+      }
+    },
+    "linkTemplates" : {
+      "downloadLink" : {
+        "href" : "https://patron.api.overdrive.com/v1/patrons/me/checkouts/6a600b7a-afda-4f0f-a32c-5be178267b0e/formats/audiobook-overdrive/downloadlink?errorpageurl={errorpageurl}&odreadauthurl={odreadauthurl}",
+        "type" : "application/vnd.overdrive.circulation.api+json"
+      },
+      "downloadLinkV2" : {
+        "href" : "https://patron.api.overdrive.com/v1/patrons/me/checkouts/6a600b7a-afda-4f0f-a32c-5be178267b0e/formats/audiobook-overdrive/downloadlink?errorurl={errorurl}&successurl={successurl}",
+        "type" : "application/vnd.overdrive.circulation.api+json"
+      }
+    }
+  } ],
+  "links" : {
+    "self" : {
+      "href" : "https://patron.api.overdrive.com/v1/patrons/me/checkouts/6a600b7a-afda-4f0f-a32c-5be178267b0e",
+      "type" : "application/vnd.overdrive.circulation.api+json"
+    },
+    "metadata" : {
+      "href" : "https://api.overdrive.com/v1/collections/v1P3BBQ0AAN8VAAB1GQAA0n/products/6a600b7a-afda-4f0f-a32c-5be178267b0e/metadata",
+      "type" : "application/vnd.overdrive.api+json"
+    },
+    "bundledChildren" : [ {
+      "href" : "https://patron.api.overdrive.com/v1/patrons/me/checkouts/5BC2C0AB-A195-4751-9745-624E9365945D",
+      "type" : "application/vnd.overdrive.circulation.api+json"
+    }, {
+      "href" : "https://patron.api.overdrive.com/v1/patrons/me/checkouts/EBFE8CD2-B9E7-43B8-8A95-243E5EE395FB",
+      "type" : "application/vnd.overdrive.circulation.api+json"
+    } ],
+    "downloadRedirect" : {
+      "href" : "https://patron.api.overdrive.com/v1/patrons/me/checkouts/6a600b7a-afda-4f0f-a32c-5be178267b0e/formats/downloadredirect",
+      "type" : "application/vnd.overdrive.circulation.api+json"
+    }
+  },
+  "actions" : {
+    "format" : {
+      "href" : "https://patron.api.overdrive.com/v1/patrons/me/checkouts/6a600b7a-afda-4f0f-a32c-5be178267b0e/formats",
+      "type" : "application/json",
+      "method" : "POST",
+      "fields" : [ {
+        "name" : "reserveId",
+        "type" : "text",
+        "value" : "6a600b7a-afda-4f0f-a32c-5be178267b0e"
+      }, {
+        "name" : "formatType",
+        "type" : "text",
+        "options" : [ "audiobook-mp3" ]
+      } ]
+    },
+    "earlyReturn" : {
+      "href" : "https://patron.api.overdrive.com/v1/patrons/me/checkouts/6a600b7a-afda-4f0f-a32c-5be178267b0e",
+      "method" : "DELETE"
+    }
+  },
+  "checkoutDate" : "2025-03-28T18:13:30Z"
+}

--- a/tests/manager/api/overdrive/test_api.py
+++ b/tests/manager/api/overdrive/test_api.py
@@ -379,9 +379,10 @@ class TestOverdriveAPI:
         overdrive_api_fixture.queue_access_token_response("bearer token")
         http.queue_response(401)
         overdrive_api_fixture.queue_access_token_response("new bearer token")
-        http.queue_response(200, content=json.dumps("at last, the content"))
+        http.queue_response(200, content="at last, the content")
         assert (
-            api.patron_request(patron, "pin", db.fresh_url()) == "at last, the content"
+            api.patron_request(patron, "pin", db.fresh_url()).text
+            == "at last, the content"
         )
 
         # The bearer token has been updated.
@@ -873,7 +874,7 @@ class TestOverdriveAPI:
         # Finally, extract_data_from_hold_response was called on
         # the return value of patron_request
         mock_extract_data_from_hold_response.assert_called_once_with(
-            mock_patron_request.return_value
+            mock_patron_request.return_value.json.return_value
         )
 
         # Now we need to test two more cases.

--- a/tests/manager/api/overdrive/test_api.py
+++ b/tests/manager/api/overdrive/test_api.py
@@ -422,6 +422,7 @@ class TestOverdriveAPI:
             excinfo.value.problem_detail.detail
             == "The server made a request to url, and got an unexpected or invalid response."
         )
+        assert excinfo.value.problem_detail.debug_message is not None
         assert "Invalid JSON" in excinfo.value.problem_detail.debug_message
         assert "1 validation error for Checkout" in caplog.text
 

--- a/tests/manager/api/overdrive/test_model.py
+++ b/tests/manager/api/overdrive/test_model.py
@@ -395,6 +395,12 @@ class TestCheckout:
         )
         assert checkout.reserve_id == "2BF132F7-215E-461B-B103-007CCED1915A"
 
+        checkout = Checkout.model_validate_json(
+            overdrive_files_fixture.sample_data(
+                "checkout_response_bundled_children.json"
+            )
+        )
+
     def test_get_format(self, checkouts_fixture: CheckoutsFixture) -> None:
         checkout = Checkout.model_validate_json(
             checkouts_fixture.files.sample_data(


### PR DESCRIPTION
## Description

Fixes two issues I found while testing the changes in https://github.com/ThePalaceProject/circulation/pull/2359 with the mobile apps:
- Early returns were causing an exception because they return a blank response, not JSON
- Some checkout responses return links that are `dict[str, list[Link]]` rather then `dict[str, Link]`

## Motivation and Context

- Updated type hint to cover both cases of links, and added a test (and fixture file) based on the response I was seeing
- Updated the `patron_request` function to return a `Response` if the request isn't validated
- Add some more error handling when we can't validate the response we get from Overdrive

## How Has This Been Tested?

- Tested locally
- Added tests to CI

I'll need to do another round of testing with this using the mobile apps once this is merged.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
