### PR TITLE
Bugfix for http verbose logging (PP-2319)

### DIFF
--- a/src/palace/manager/util/http.py
+++ b/src/palace/manager/util/http.py
@@ -300,9 +300,7 @@ class HTTP(LoggerMixin):
         try:
             if verbose:
                 logging.info(
-                    f"Sending {http_method} request to {url}: kwargs {kwargs!r}",
-                    url,
-                    kwargs,
+                    f"Sending {http_method} request to {url}: kwargs {kwargs!r}"
                 )
 
             request_start_time = time.time()
@@ -327,11 +325,7 @@ class HTTP(LoggerMixin):
 
             if verbose:
                 logging.info(
-                    "Response from %s: %s %r %r",
-                    url,
-                    response.status_code,
-                    response.headers,
-                    response.content,
+                    f"Response from {url}: {response.status_code} {response.headers!r} {response.content!r}"
                 )
         except requests.exceptions.Timeout as e:
             # Wrap the requests-specific Timeout exception

--- a/tests/manager/util/test_http.py
+++ b/tests/manager/util/test_http.py
@@ -134,6 +134,7 @@ class TestHTTP:
         ):
             HTTP._request_with_timeout("PUT", "http://url/", immediately_timeout)
 
+    @mock.patch("palace.manager.util.http.manager.__version__", None)
     def test_request_with_timeout_verbose(self, caplog: pytest.LogCaptureFixture):
         """
         When the verbose flag is set, we log the request and response.

--- a/tests/manager/util/test_http.py
+++ b/tests/manager/util/test_http.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping, Sequence
 from functools import partial
 from typing import Any
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 import requests
@@ -10,6 +10,7 @@ from requests import Response
 from requests_mock import Mocker
 
 from palace.manager.core.problem_details import INTEGRATION_ERROR, INVALID_INPUT
+from palace.manager.service.logging.configuration import LogLevel
 from palace.manager.util.http import (
     HTTP,
     BadResponseException,
@@ -132,6 +133,42 @@ class TestHTTP:
             RequestTimedOut, match="Timeout accessing http://url/: I give up"
         ):
             HTTP._request_with_timeout("PUT", "http://url/", immediately_timeout)
+
+    def test_request_with_timeout_verbose(self, caplog: pytest.LogCaptureFixture):
+        """
+        When the verbose flag is set, we log the request and response.
+        """
+        caplog.set_level(LogLevel.info)
+        mock_process_response = create_autospec(HTTP._process_response)
+        make_request = MagicMock(
+            return_value=MockRequestsResponse(
+                204, headers={"test": "response header"}, content="Success!"
+            )
+        )
+
+        response = HTTP._request_with_timeout(
+            "POST",
+            "http://url/",
+            make_request,
+            process_response_with=mock_process_response,
+            verbose=True,
+            headers={"header": "value"},
+        )
+
+        assert make_request.call_count == 1
+        assert make_request.call_args.args == ("POST", "http://url/")
+
+        assert mock_process_response.call_count == 1
+        assert response == mock_process_response.return_value
+
+        assert (
+            "Sending POST request to http://url/: kwargs {'headers': {'User-Agent':"
+            " 'Palace Manager/1.x.x', 'header': 'value'}, 'timeout': 20}"
+        ) in caplog.messages
+        assert (
+            "Response from http://url/: 204 {'test': 'response header'} b'Success!'"
+            in caplog.messages
+        )
 
     def test_request_with_network_failure(self) -> None:
         def immediately_fail(*args, **kwargs) -> Response:


### PR DESCRIPTION
## Description

Fix bug in our HTTP class that was causing an exception when making a request with `verbose=True`. It was causing the failures in PP-2319.

It was causing this exception to occur:
```
Log message could not be formatted. Exception: TypeError('not all arguments converted during string formatting')
```

## Motivation and Context

Was caused when I converted the logging statement to use a f-string in https://github.com/ThePalaceProject/circulation/pull/2366. After converting it, I forgot to remove the args to the log function 🤦🏻 

## How Has This Been Tested?

- Added a test for this case, since the verbose option wasn't being tested at all. This would have caught the issue. 

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
