### PR TITLE
Better parsing for BCP 47 language tags

### DIFF
--- a/src/palace/manager/opds/rwpm.py
+++ b/src/palace/manager/opds/rwpm.py
@@ -10,7 +10,7 @@ from typing import Literal, TypeVar
 from pydantic import AwareDatetime, Field, NonNegativeInt, PositiveFloat, PositiveInt
 
 from palace.manager.opds.base import BaseOpdsModel
-from palace.manager.opds.types.language import LanguageCode, LanguageMap
+from palace.manager.opds.types.language import LanguageMap, LanguageTag
 from palace.manager.opds.types.link import BaseLink, CompactCollection
 from palace.manager.opds.util import (
     StrModelOrTuple,
@@ -117,10 +117,10 @@ class Link(BaseLink):
     width: PositiveInt | None = None
     bitrate: PositiveFloat | None = None
     duration: PositiveFloat | None = None
-    language: StrOrTuple[LanguageCode] | None = None
+    language: StrOrTuple[LanguageTag] | None = None
 
     @cached_property
-    def languages(self) -> Sequence[LanguageCode]:
+    def languages(self) -> Sequence[LanguageTag]:
         return obj_or_tuple_to_tuple(self.language)
 
     alternate: CompactCollection[Link] = Field(default_factory=CompactCollection)
@@ -271,10 +271,10 @@ class Metadata(BaseOpdsModel):
 
     modified: AwareDatetime | None = None
     published: AwareDatetime | date | None = None
-    language: StrOrTuple[LanguageCode] | None = None
+    language: StrOrTuple[LanguageTag] | None = None
 
     @cached_property
-    def languages(self) -> Sequence[LanguageCode]:
+    def languages(self) -> Sequence[LanguageTag]:
         return obj_or_tuple_to_tuple(self.language)
 
     author: StrModelOrTuple[Contributor] | None = None

--- a/src/palace/manager/opds/types/language.py
+++ b/src/palace/manager/opds/types/language.py
@@ -39,7 +39,9 @@ class LanguageTag(str):
             return value
 
         if not isinstance(value, str):
-            raise ValueError(f"Expected str, got {type(value).__name__}")
+            raise ValueError(
+                f"Language tag must be a string, got {type(value).__name__}"
+            )
 
         if len(value) == 0:
             raise ValueError("Language tag cannot be empty")

--- a/src/palace/manager/opds/types/language.py
+++ b/src/palace/manager/opds/types/language.py
@@ -9,34 +9,58 @@ from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
 
 
-class LanguageCode(str):
+class LanguageTag(str):
     """
-    LanguageCode parses 2-letter or 3-letter ISO 639-2 language codes. Making sure
-    they are valid language codes and normalizing them to 3-letter codes.
+    Parses a subset of IETF BCP 47 language tags.
+
+    https://datatracker.ietf.org/doc/bcp47/
+
+    The class expects the `primary language` to be a 2-letter or 3-letter ISO 639-2 language
+    code. It splits the language tag into its sub-tags, parses the primary language tag,
+    validates it's a valid language code, and normalizes it to a 3-letter code.
+
+    This handles the most common cases that we see in feeds we parse.
+
+    TODO: We may want to replace this with a more complete implementation of
+      BCP 47. Especially if we are able to find a library that we can leverage.
+      I did some research, but at the time of writing, I wasn't able to find one.
     """
 
-    __slots__ = ()
+    __slots__ = ("_original", "_subtags")
+
+    _original: str
+    _subtags: tuple[str, ...]
 
     def __new__(
         cls,
-        value: str,
-    ) -> LanguageCode:
-        if isinstance(value, LanguageCode):
+        value: str | LanguageTag,
+    ) -> LanguageTag:
+        if isinstance(value, LanguageTag):
             return value
-        return super().__new__(cls, cls._validate_language_code(value))
 
-    @staticmethod
-    def _validate_language_code(language_code: str) -> str:
-        language = None
-        if len(language_code) == 2:
-            language = pycountry.languages.get(alpha_2=language_code)
-        elif len(language_code) == 3:
-            language = pycountry.languages.get(alpha_3=language_code)
+        if not isinstance(value, str):
+            raise ValueError(f"Expected str, got {type(value).__name__}")
 
-        if language is None:
-            raise ValueError(f"Invalid language code '{language_code}'")
+        if len(value) == 0:
+            raise ValueError("Language tag cannot be empty")
 
-        return language.alpha_3  # type: ignore[no-any-return]
+        # First we split the language tag into its sub-tags.
+        subtags = tuple([t.lower() for t in value.replace("_", "-").split("-")])
+        primary_language = subtags[0]
+
+        code = None
+        if len(primary_language) == 2:
+            code = pycountry.languages.get(alpha_2=primary_language)
+        elif len(primary_language) == 3:
+            code = pycountry.languages.get(alpha_3=primary_language)
+
+        if code is None:
+            raise ValueError(f"Invalid language code '{primary_language}'")
+
+        language_code = super().__new__(cls, code.alpha_3)
+        language_code._original = value
+        language_code._subtags = subtags
+        return language_code
 
     @classmethod
     def __get_pydantic_core_schema__(
@@ -47,8 +71,43 @@ class LanguageCode(str):
         """
         return core_schema.no_info_after_validator_function(
             cls,
-            core_schema.str_schema(min_length=2, max_length=3),
+            core_schema.str_schema(
+                serialization=core_schema.plain_serializer_function_ser_schema(
+                    lambda t: t.original, when_used="json"
+                ),
+            ),
         )
+
+    @property
+    def original(self) -> str:
+        """
+        Return the original language tag that was passed to the constructor.
+        """
+        return self._original
+
+    @property
+    def subtags(self) -> tuple[str, ...]:
+        """
+        Return the sub-tags of the language tag.
+        """
+        return self._subtags
+
+    @property
+    def primary_language(self) -> str:
+        """
+        Return the primary language of the language tag.
+        """
+        return self._subtags[0]
+
+    @property
+    def code(self) -> str:
+        """
+        Return the 3-letter ISO 639-2 language code.
+        """
+        return str(self)
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {self._original}>"
 
 
 T = TypeVar("T")
@@ -71,7 +130,7 @@ class LanguageMap(Mapping[str, str]):
         :param value: Either a string or a dictionary with language codes as keys
             and translations as values.
         """
-        self._mapping: dict[LanguageCode | None, str] = {}
+        self._mapping: dict[LanguageTag | None, str] = {}
         self._hash: int | None = None
 
         if isinstance(value, str):
@@ -81,12 +140,12 @@ class LanguageMap(Mapping[str, str]):
                 raise ValueError("Must provide at least one translation")
 
             self._mapping = {
-                LanguageCode(lang): translation for lang, translation in value.items()
+                LanguageTag(lang): translation for lang, translation in value.items()
             }
         self._default_language = next(iter(self._mapping.keys()))
 
     @property
-    def default_language(self) -> LanguageCode | None:
+    def default_language(self) -> LanguageTag | None:
         return self._default_language
 
     @staticmethod
@@ -152,7 +211,7 @@ class LanguageMap(Mapping[str, str]):
 
         :raises ValueError: If the language code is invalid.
         """
-        language_code = LanguageCode(language) if language else self.default_language
+        language_code = LanguageTag(language) if language else self.default_language
         return self._mapping.get(language_code, default)
 
     def __getitem__(self, language: str | None) -> str:

--- a/tests/manager/opds/types/test_language.py
+++ b/tests/manager/opds/types/test_language.py
@@ -3,16 +3,18 @@ import json
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
-from palace.manager.opds.types.language import LanguageCode, LanguageMap
+from palace.manager.opds.types.language import LanguageMap, LanguageTag
 
 
-class TestLanguageCode:
+class TestLanguageTag:
 
     @pytest.mark.parametrize(
         "language_code, expected",
         [
             ("ENG", "eng"),
             ("en", "eng"),
+            ("en-CA", "eng"),
+            ("en_uk", "eng"),
             ("fra", "fra"),
             ("fR", "fra"),
         ],
@@ -21,11 +23,10 @@ class TestLanguageCode:
         """
         Languages are always normalized to the 3-letter ISO 639-2 code.
         """
-        assert LanguageCode._validate_language_code(language_code) == expected
-        assert LanguageCode(language_code) == expected
-        assert TypeAdapter(LanguageCode).validate_python(language_code) == expected
+        assert LanguageTag(language_code) == expected
+        assert TypeAdapter(LanguageTag).validate_python(language_code) == expected
         assert (
-            TypeAdapter(LanguageCode).validate_json(json.dumps(language_code))
+            TypeAdapter(LanguageTag).validate_json(json.dumps(language_code))
             == expected
         )
 
@@ -33,30 +34,44 @@ class TestLanguageCode:
         language_code = "foo"
 
         with pytest.raises(ValueError, match="Invalid language code 'foo'"):
-            LanguageCode(language_code)
-
-        with pytest.raises(ValueError, match="Invalid language code 'foo'"):
-            LanguageCode._validate_language_code(language_code)
+            LanguageTag(language_code)
 
         with pytest.raises(
             ValidationError, match="Value error, Invalid language code 'foo'"
         ):
-            TypeAdapter(LanguageCode).validate_python(language_code)
+            TypeAdapter(LanguageTag).validate_python(language_code)
 
         with pytest.raises(
             ValidationError, match="Value error, Invalid language code 'foo'"
         ):
-            TypeAdapter(LanguageCode).validate_json(json.dumps(language_code))
+            TypeAdapter(LanguageTag).validate_json(json.dumps(language_code))
+
+    def test_serialization(self) -> None:
+        language_code = LanguageTag("en-CA")
+        assert language_code == "eng"
+        assert isinstance(language_code, LanguageTag)
+        assert json.loads(TypeAdapter(LanguageTag).dump_json(language_code)) == "en-CA"
 
     def test_constructor(self) -> None:
-        language_code = LanguageCode("eng")
+        language_code = LanguageTag("eng")
         assert language_code == "eng"
         assert isinstance(language_code, str)
-        assert isinstance(language_code, LanguageCode)
+        assert isinstance(language_code, LanguageTag)
 
         # Can be constructed with a LanguageCode, which is a no-op
-        new_language_code = LanguageCode(language_code)
+        new_language_code = LanguageTag(language_code)
         assert new_language_code is language_code
+
+    def test_repr(self) -> None:
+        language_code = LanguageTag("eng-UK")
+        assert repr(language_code) == "<LanguageCode: eng-UK>"
+
+    def test_properties(self) -> None:
+        language_code = LanguageTag("en-Latn-GB-x-private")
+        assert language_code.primary_language == "en"
+        assert language_code.code == str(language_code) == "eng"
+        assert language_code.subtags == ("en", "latn", "gb", "x", "private")
+        assert language_code.original == "en-Latn-GB-x-private"
 
 
 class TestLanguageMap:
@@ -196,7 +211,7 @@ class TestLanguageMap:
         # Test round-trip to json
         assert (
             json.loads(ta.dump_json(test_map))
-            == {LanguageCode(l): v for l, v in string.items()}
+            == {LanguageTag(l): v for l, v in string.items()}
             if isinstance(string, dict)
             else string
         )

--- a/tests/manager/opds/types/test_language.py
+++ b/tests/manager/opds/types/test_language.py
@@ -62,6 +62,14 @@ class TestLanguageTag:
         new_language_code = LanguageTag(language_code)
         assert new_language_code is language_code
 
+        # Empty strings should raise an error
+        with pytest.raises(ValueError, match="Language tag cannot be empty"):
+            LanguageTag("")
+
+        # Other types should raise an error
+        with pytest.raises(ValueError, match="Language tag must be a string, got int"):
+            LanguageTag(123)
+
     def test_repr(self) -> None:
         language_code = LanguageTag("eng-UK")
         assert repr(language_code) == "<LanguageCode: eng-UK>"


### PR DESCRIPTION
## Description

OPDS technically allows BCP-47 language tags. Previously we were parsing these as ISO language codes. This is a subset of language tags, but doesn't account for any subtags. 

We now allow subtags, although we don't actually parse them, just validate the primary language as a language code.

## Motivation and Context

There were some technically valid language codes being used in the Palace Bookshelf feed ("en-US", and "en_UK"). I'm not sure these tags are adding a lot of value, but they are valid in a feed, so we should parse them. 

## How Has This Been Tested?

- Updated unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
