### PR TITLE
Move the LicenseStatus enum into OPDS package

### DIFF
--- a/src/palace/manager/api/odl/importer.py
+++ b/src/palace/manager/api/odl/importer.py
@@ -19,16 +19,12 @@ from palace.manager.core.opds2_import import OPDS2Importer, OPDS2ImportMonitor
 from palace.manager.opds import opds2, rwpm
 from palace.manager.opds.lcp.status import LoanStatus
 from palace.manager.opds.odl import odl
-from palace.manager.opds.odl.info import LicenseInfo
+from palace.manager.opds.odl.info import LicenseInfo, LicenseStatus
 from palace.manager.opds.odl.odl import Opds2OrOpds2WithOdlPublication
 from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.edition import Edition
-from palace.manager.sqlalchemy.model.licensing import (
-    DeliveryMechanism,
-    LicenseStatus,
-    RightsStatus,
-)
+from palace.manager.sqlalchemy.model.licensing import DeliveryMechanism, RightsStatus
 from palace.manager.sqlalchemy.model.resource import Hyperlink
 from palace.manager.util.http import HTTP, GetRequestCallable
 

--- a/src/palace/manager/core/metadata_layer.py
+++ b/src/palace/manager/core/metadata_layer.py
@@ -33,6 +33,7 @@ from sqlalchemy.sql.expression import and_, or_
 from typing_extensions import Self, TypedDict, Unpack
 
 from palace.manager.core.classifier import NO_NUMBER, NO_VALUE
+from palace.manager.opds.odl.info import LicenseStatus
 from palace.manager.service.analytics.analytics import Analytics
 from palace.manager.sqlalchemy.constants import LinkRelations
 from palace.manager.sqlalchemy.model.classification import Classification, Subject
@@ -48,7 +49,6 @@ from palace.manager.sqlalchemy.model.licensing import (
     LicenseFunctions,
     LicensePool,
     LicensePoolDeliveryMechanism,
-    LicenseStatus,
     RightsStatus,
 )
 from palace.manager.sqlalchemy.model.resource import Hyperlink, Representation, Resource

--- a/src/palace/manager/opds/odl/info.py
+++ b/src/palace/manager/opds/odl/info.py
@@ -19,7 +19,7 @@ class LicenseStatus(Enum):
     unavailable = "unavailable"
 
     @classmethod
-    def get(cls, value: str):
+    def get(cls, value: str) -> LicenseStatus:
         return cls.__members__.get(value.lower(), cls.unavailable)
 
 

--- a/src/palace/manager/opds/odl/info.py
+++ b/src/palace/manager/opds/odl/info.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from collections.abc import Sequence
+from enum import Enum
 from functools import cached_property
 
 from pydantic import AwareDatetime, Field, NonNegativeInt
@@ -8,7 +11,16 @@ from palace.manager.opds.odl.protection import Protection
 from palace.manager.opds.odl.terms import Terms
 from palace.manager.opds.opds2 import Price
 from palace.manager.opds.util import StrOrTuple, obj_or_tuple_to_tuple
-from palace.manager.sqlalchemy.model.licensing import LicenseStatus
+
+
+class LicenseStatus(Enum):
+    preorder = "preorder"
+    available = "available"
+    unavailable = "unavailable"
+
+    @classmethod
+    def get(cls, value: str):
+        return cls.__members__.get(value.lower(), cls.unavailable)
 
 
 class Loan(BaseOpdsModel):

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-from enum import Enum as PythonEnum
 from enum import IntEnum, auto
 from typing import TYPE_CHECKING, Literal, overload
 
@@ -27,6 +26,7 @@ from sqlalchemy.orm.session import Session
 
 from palace.manager.api.circulation_exceptions import CannotHold, CannotLoan
 from palace.manager.core.exceptions import BasePalaceException
+from palace.manager.opds.odl.info import LicenseStatus
 from palace.manager.sqlalchemy.constants import (
     DataSourceConstants,
     EditionConstants,
@@ -52,16 +52,6 @@ if TYPE_CHECKING:
 
 class PolicyException(BasePalaceException):
     pass
-
-
-class LicenseStatus(PythonEnum):
-    preorder = "preorder"
-    available = "available"
-    unavailable = "unavailable"
-
-    @classmethod
-    def get(cls, value: str):
-        return cls.__members__.get(value.lower(), cls.unavailable)
 
 
 class LicenseFunctions:

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -57,6 +57,7 @@ from palace.manager.integration.base import SettingsType as TIntegrationSettings
 from palace.manager.integration.configuration.library import LibrarySettings
 from palace.manager.integration.goals import Goals
 from palace.manager.integration.settings import BaseSettings
+from palace.manager.opds.odl.info import LicenseStatus
 from palace.manager.service.integration_registry.base import IntegrationRegistry
 from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.classification import (
@@ -83,7 +84,6 @@ from palace.manager.sqlalchemy.model.licensing import (
     License,
     LicensePool,
     LicensePoolDeliveryMechanism,
-    LicenseStatus,
     RightsStatus,
 )
 from palace.manager.sqlalchemy.model.patron import Patron

--- a/tests/manager/api/odl/test_importer.py
+++ b/tests/manager/api/odl/test_importer.py
@@ -22,6 +22,7 @@ from palace.manager.api.odl.importer import (
 from palace.manager.api.odl.settings import OPDS2AuthType, OPDS2WithODLSettings
 from palace.manager.core.coverage import CoverageFailure
 from palace.manager.core.metadata_layer import LicenseData
+from palace.manager.opds.odl.info import LicenseStatus
 from palace.manager.sqlalchemy.constants import (
     EditionConstants,
     IdentifierConstants,
@@ -29,11 +30,7 @@ from palace.manager.sqlalchemy.constants import (
 )
 from palace.manager.sqlalchemy.model.contributor import Contribution, Contributor
 from palace.manager.sqlalchemy.model.edition import Edition
-from palace.manager.sqlalchemy.model.licensing import (
-    DeliveryMechanism,
-    LicensePool,
-    LicenseStatus,
-)
+from palace.manager.sqlalchemy.model.licensing import DeliveryMechanism, LicensePool
 from palace.manager.sqlalchemy.model.resource import Hyperlink
 from palace.manager.sqlalchemy.model.work import Work
 from palace.manager.util import datetime_helpers

--- a/tests/manager/celery/tasks/test_generate_inventory_and_hold_reports.py
+++ b/tests/manager/celery/tasks/test_generate_inventory_and_hold_reports.py
@@ -16,11 +16,11 @@ from palace.manager.celery.tasks.generate_inventory_and_hold_reports import (
     library_report_integrations,
 )
 from palace.manager.core.opds_import import OPDSImporterSettings
+from palace.manager.opds.odl.info import LicenseStatus
 from palace.manager.service.logging.configuration import LogLevel
 from palace.manager.sqlalchemy.model.classification import Genre
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.library import Library
-from palace.manager.sqlalchemy.model.licensing import LicenseStatus
 from palace.manager.sqlalchemy.model.patron import Hold
 from palace.manager.sqlalchemy.util import get_one_or_create
 from palace.manager.util.datetime_helpers import utc_now

--- a/tests/manager/core/test_circulation_data.py
+++ b/tests/manager/core/test_circulation_data.py
@@ -13,14 +13,11 @@ from palace.manager.core.metadata_layer import (
     ReplacementPolicy,
     SubjectData,
 )
+from palace.manager.opds.odl.info import LicenseStatus
 from palace.manager.sqlalchemy.model.classification import Subject
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.identifier import Identifier
-from palace.manager.sqlalchemy.model.licensing import (
-    DeliveryMechanism,
-    LicenseStatus,
-    RightsStatus,
-)
+from palace.manager.sqlalchemy.model.licensing import DeliveryMechanism, RightsStatus
 from palace.manager.sqlalchemy.model.resource import Hyperlink, Representation
 from palace.manager.util.datetime_helpers import utc_now
 from tests.fixtures.database import DatabaseTransactionFixture

--- a/tests/manager/sqlalchemy/model/test_licensing.py
+++ b/tests/manager/sqlalchemy/model/test_licensing.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError
 
 from palace.manager.api.circulation_exceptions import CannotHold, CannotLoan
 from palace.manager.integration.configuration.formats import FormatPriorities
+from palace.manager.opds.odl.info import LicenseStatus
 from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
 from palace.manager.sqlalchemy.model.collection import CollectionMissing
@@ -23,7 +24,6 @@ from palace.manager.sqlalchemy.model.licensing import (
     Hold,
     LicensePool,
     LicensePoolDeliveryMechanism,
-    LicenseStatus,
     Loan,
     RightsStatus,
 )


### PR DESCRIPTION
## Description

Move the `LicenseStatus` enum into OPDS package

## Motivation and Context

This enum is really part of our OPDS model, so it should be in the OPDS package. Having it there also means that importing the OPDS models, doesn't mean importing all of our sqlalchemy models. This is helpful for this PR: https://github.com/ThePalaceProject/palace-tools/pull/107

## How Has This Been Tested?

- Ran unit tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
