### PR TITLE
Alphabetize items in admin UI (PP-2351)

### DIFF
--- a/alembic/versions/20250409_b96d67e65177_sort_library_languages.py
+++ b/alembic/versions/20250409_b96d67e65177_sort_library_languages.py
@@ -1,0 +1,59 @@
+"""Sort library languages
+
+Revision ID: b96d67e65177
+Revises: df27b4867e56
+Create Date: 2025-04-09 14:24:59.558570+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from palace.manager.sqlalchemy.session import json_serializer
+
+# revision identifiers, used by Alembic.
+revision = "b96d67e65177"
+down_revision = "df27b4867e56"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    results = conn.execute(
+        sa.text(
+            """
+            SELECT id, settings_dict
+            FROM libraries WHERE settings_dict ?|
+            array['large_collection_languages', 'small_collection_languages', 'tiny_collection_languages']
+            FOR UPDATE
+            """
+        )
+    )
+    for library_id, settings_dict in results:
+        # Sort the language lists
+        for key in [
+            "large_collection_languages",
+            "small_collection_languages",
+            "tiny_collection_languages",
+        ]:
+            if key in settings_dict:
+                settings_dict[key] = sorted(settings_dict[key])
+
+        # Update the library's settings
+        conn.execute(
+            sa.text(
+                """
+                UPDATE libraries
+                SET settings_dict = :settings_dict
+                WHERE id = :library_id
+                """
+            ),
+            settings_dict=json_serializer(settings_dict),
+            library_id=library_id,
+        )
+
+
+def downgrade() -> None:
+    # No need to unsort the languages
+    pass

--- a/src/palace/manager/api/admin/controller/integration_settings.py
+++ b/src/palace/manager/api/admin/controller/integration_settings.py
@@ -144,7 +144,9 @@ class IntegrationSettingsController(ABC, Generic[T], LoggerMixin):
             api = self.registry[service.protocol]
             if issubclass(api, HasLibraryIntegrationConfiguration):
                 libraries = []
-                for library_settings in service.library_configurations:
+                for library_settings in sorted(
+                    service.library_configurations, key=lambda x: x.library.name
+                ):
                     library_info = self.configured_service_library_info(
                         library_settings
                     )

--- a/src/palace/manager/integration/configuration/library.py
+++ b/src/palace/manager/integration/configuration/library.py
@@ -605,7 +605,6 @@ class LibrarySettings(BaseSettings):
                             f'"{field_label}": "{language}" is not a valid language code.'
                         )
                     )
-                if validated_language not in languages:
-                    languages.add(validated_language)
+                languages.add(validated_language)
             return sorted(languages)
         return value

--- a/src/palace/manager/integration/configuration/library.py
+++ b/src/palace/manager/integration/configuration/library.py
@@ -10,7 +10,6 @@ from pydantic import (
     PositiveFloat,
     PositiveInt,
     ValidationInfo,
-    field_serializer,
     field_validator,
     model_validator,
 )
@@ -596,7 +595,7 @@ class LibrarySettings(BaseSettings):
     ) -> list[str] | None:
         """Verify that collection languages are valid."""
         if value is not None:
-            languages = []
+            languages = set()
             for language in value:
                 validated_language = LanguageCodes.string_to_alpha_3(language)
                 if validated_language is None:
@@ -607,19 +606,6 @@ class LibrarySettings(BaseSettings):
                         )
                     )
                 if validated_language not in languages:
-                    languages.append(validated_language)
-            return languages
+                    languages.add(validated_language)
+            return sorted(languages)
         return value
-
-    @field_serializer(
-        "large_collection_languages",
-        "small_collection_languages",
-        "tiny_collection_languages",
-    )
-    def serialize_languages(self, languages: list[str] | None) -> list[str] | None:
-        """
-        Sort the list of languages in alphabetical order before sending it to the client.
-        """
-        if languages is None:
-            return None
-        return sorted(languages)

--- a/src/palace/manager/integration/configuration/library.py
+++ b/src/palace/manager/integration/configuration/library.py
@@ -616,9 +616,7 @@ class LibrarySettings(BaseSettings):
         "small_collection_languages",
         "tiny_collection_languages",
     )
-    def serialize_courses_in_order(
-        self, languages: list[str] | None
-    ) -> list[str] | None:
+    def serialize_languages(self, languages: list[str] | None) -> list[str] | None:
         """
         Sort the list of languages in alphabetical order before sending it to the client.
         """

--- a/src/palace/manager/integration/configuration/library.py
+++ b/src/palace/manager/integration/configuration/library.py
@@ -10,6 +10,7 @@ from pydantic import (
     PositiveFloat,
     PositiveInt,
     ValidationInfo,
+    field_serializer,
     field_validator,
     model_validator,
 )
@@ -609,3 +610,18 @@ class LibrarySettings(BaseSettings):
                     languages.append(validated_language)
             return languages
         return value
+
+    @field_serializer(
+        "large_collection_languages",
+        "small_collection_languages",
+        "tiny_collection_languages",
+    )
+    def serialize_courses_in_order(
+        self, languages: list[str] | None
+    ) -> list[str] | None:
+        """
+        Sort the list of languages in alphabetical order before sending it to the client.
+        """
+        if languages is None:
+            return None
+        return sorted(languages)

--- a/tests/manager/api/test_config.py
+++ b/tests/manager/api/test_config.py
@@ -58,7 +58,7 @@ class TestConfiguration:
         library.update_settings(
             LibrarySettings.model_construct(large_collection_languages=["spa", "jpn"])
         )
-        assert C.large_collection_languages(library) == ["spa", "jpn"]
+        assert C.large_collection_languages(library) == ["jpn", "spa"]
 
     def test_estimate_language_collection_for_library(
         self, db: DatabaseTransactionFixture, library_fixture: LibraryFixture

--- a/tests/manager/integration/configuration/test_library.py
+++ b/tests/manager/integration/configuration/test_library.py
@@ -53,3 +53,17 @@ def test_validate_language_codes_error(
 
     assert excinfo.value.problem_detail.detail is not None
     assert '"xyz" is not a valid language code' in excinfo.value.problem_detail.detail
+
+
+def test_serialize_language(library_settings: LibrarySettingsFixture) -> None:
+    settings = library_settings(
+        large_collection_languages=["fre", "eng"],
+        small_collection_languages=["ja", "chi"],
+        tiny_collection_languages=["eng", "chi"],
+    )
+
+    # When serialized, they are normalized to alpha-3 codes and sorted
+    serialized = settings.model_dump()
+    assert serialized["large_collection_languages"] == ["eng", "fre"]
+    assert serialized["small_collection_languages"] == ["chi", "jpn"]
+    assert serialized["tiny_collection_languages"] == ["chi", "eng"]

--- a/tests/manager/integration/configuration/test_library.py
+++ b/tests/manager/integration/configuration/test_library.py
@@ -58,8 +58,8 @@ def test_validate_language_codes_error(
 def test_serialize_language(library_settings: LibrarySettingsFixture) -> None:
     settings = library_settings(
         large_collection_languages=["fre", "eng"],
-        small_collection_languages=["ja", "chi"],
-        tiny_collection_languages=["eng", "chi"],
+        small_collection_languages=["ja", "chinese"],
+        tiny_collection_languages=["english", "chi"],
     )
 
     # When serialized, they are normalized to alpha-3 codes and sorted

--- a/tests/migration/test_20250409_b96d67e65177_sort_library_languages.py
+++ b/tests/migration/test_20250409_b96d67e65177_sort_library_languages.py
@@ -1,0 +1,42 @@
+from pytest_alembic import MigrationContext
+
+from tests.migration.conftest import AlembicDatabaseFixture
+
+
+def test_sort_languages(
+    alembic_runner: MigrationContext,
+    alembic_database: AlembicDatabaseFixture,
+) -> None:
+    alembic_runner.migrate_down_to("b96d67e65177")
+    alembic_runner.migrate_down_one()
+
+    no_languages = alembic_database.library()
+    large = alembic_database.library(
+        settings={"large_collection_languages": ["spa", "jpn", "chi"]}
+    )
+    small = alembic_database.library(
+        settings={"small_collection_languages": ["ger", "eng", "fre"]}
+    )
+    tiny = alembic_database.library(
+        settings={"tiny_collection_languages": ["rus", "ita"]}
+    )
+
+    alembic_runner.migrate_up_one()
+
+    # Check that the languages are sorted
+    no_languages_settings_dict = alembic_database.fetch_library(
+        no_languages
+    ).settings_dict
+    assert "large_collection_languages" not in no_languages_settings_dict
+    assert "small_collection_languages" not in no_languages_settings_dict
+    assert "tiny_collection_languages" not in no_languages_settings_dict
+
+    assert alembic_database.fetch_library(large).settings_dict[
+        "large_collection_languages"
+    ] == ["chi", "jpn", "spa"]
+    assert alembic_database.fetch_library(small).settings_dict[
+        "small_collection_languages"
+    ] == ["eng", "fre", "ger"]
+    assert alembic_database.fetch_library(tiny).settings_dict[
+        "tiny_collection_languages"
+    ] == ["ita", "rus"]


### PR DESCRIPTION
## Description

Implements:
- System Configuration - Collections | When adding/editing a shared collection - Under Libraries - alphabetize list of libraries associated with that collection
- System Configuration - Patron Authentication | When adding/editing a shared ILS - Under Libraries - alphabetize list of libraries associated with that ILS
- System Configuration - Libraries | When adding/editing a library - Under Languages > Click Add > Alphabetize the list that pops up

## Motivation and Context

Admin UI improvement requests. See: PP-2351.

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
