### PR TITLE
Bump poetry version to match dependabot

### DIFF
--- a/.github/actions/poetry/action.yml
+++ b/.github/actions/poetry/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: "Version of poetry to install"
     required: false
-    default: "1.7.1"
+    default: "2.1.1"
   cache:
     description: "Cache poetry packages"
     required: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -375,7 +375,7 @@ jobs:
           bash -c "
             cat src/palace/manager/_version.py &&
             source env/bin/activate &&
-            poetry install --without ci --no-root --sync &&
+            poetry sync --without ci --no-root &&
             pytest --no-cov tests
           "
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,13 @@ jobs:
       exec-repo: ${{ steps.ghcr-repo.outputs.exec }}
       exec-meta: ${{ steps.meta-exec.outputs.json }}
 
+    # https://docs.docker.com/build/ci/github-actions/local-registry/
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
 # This build is heavily based on this example from the docker buildx documentation:
 # https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
 
@@ -85,6 +92,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
 
       # If the base image build was changed, we build it first, so we can test
       # using these changes throughout the rest of the build. If the base image
@@ -97,7 +106,7 @@ jobs:
             baseimage:
               - 'docker/Dockerfile.baseimage'
 
-      # Build the base image, only if needed, and load it into the local docker daemon.
+      # Build the base image, only if needed, and load it into the local registry.
       - name: Build base image
         id: build-baseimage
         uses: docker/build-push-action@v6
@@ -108,8 +117,8 @@ jobs:
           cache-from: |
             type=registry,ref=${{ steps.ghcr-repo.outputs.baseimage }}:latest
             type=registry,ref=ghcr.io/thepalaceproject/circ-baseimage:latest
-          load: true
-          tags: circ-baseimage:local-build
+          push: true
+          tags: localhost:5000/circ-baseimage:local-build
         if: steps.changes.outputs.baseimage == 'true'
 
       - name: Login to GitHub Container Registry
@@ -128,7 +137,7 @@ jobs:
           docker buildx imagetools inspect ${{ steps.ghcr-repo.outputs.baseimage }}:latest > /dev/null
           tag_exists=$?
           if [[ "${{ steps.changes.outputs.baseimage }}" == "true" ]]; then
-            tag="circ-baseimage:local-build"
+            tag="localhost:5000/circ-baseimage:local-build"
           elif [[ $tag_exists -eq 0 ]]; then
             tag="${{ steps.ghcr-repo.outputs.baseimage }}:latest"
           else

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ COPY --chmod=644 docker/services/logrotate /etc/
 # Copy our poetry files into the image and install our dependencies.
 COPY --chown=simplified:simplified poetry.lock pyproject.toml /var/www/circulation/
 RUN . env/bin/activate && \
-    poetry install --only main,pg --sync --no-root
+    poetry sync --only main,pg --no-root
 
 COPY --chown=simplified:simplified . /var/www/circulation
 

--- a/docker/Dockerfile.baseimage
+++ b/docker/Dockerfile.baseimage
@@ -18,7 +18,7 @@ RUN apt-get update && \
     apt-get upgrade -y --no-install-recommends -o Dpkg::Options::="--force-confold" && \
     /bd_build/cleanup.sh
 
-ARG POETRY_VERSION=1.7.1
+ARG POETRY_VERSION=2.1.1
 
 # Install required packages including python, pip, compiliers and libraries needed
 # to build the python wheels we need and poetry.
@@ -62,7 +62,7 @@ RUN python3 -m venv env && \
     echo "if [ -f $SIMPLIFIED_ENVIRONMENT ]; then source $SIMPLIFIED_ENVIRONMENT; fi" >> env/bin/activate && \
     . env/bin/activate && \
     pip install --upgrade pip && \
-    poetry install --only main,pg --sync --no-root && \
+    poetry sync --only main,pg --no-root && \
     # TODO: This can be removed once NLTK merges https://github.com/sloria/TextBlob/pull/469
     python3 -m nltk.downloader punkt_tab && \
     python3 -m textblob.download_corpora lite && \

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = true
 
 [testenv]
 commands_pre =
-    poetry install --without ci --sync -v
+    poetry sync --without ci -v
     # TODO: This can be removed once NLTK merges https://github.com/sloria/TextBlob/pull/469
     python -m nltk.downloader punkt_tab
     python -m textblob.download_corpora


### PR DESCRIPTION
## Description

Bump up the Poetry version we are using to match what dependabot uses.

## Motivation and Context

I've noticed some messages in our CI lately that the lock file version may not be supported, since dependabot has moved to a 2.x version of Poetry.

## How Has This Been Tested?

- Build in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
