### PR TITLE
Holds report includes only books with holds. (PP-2317)

### DIFF
--- a/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
+++ b/src/palace/manager/celery/tasks/generate_inventory_and_hold_reports.py
@@ -347,7 +347,10 @@ class GenerateInventoryAndHoldsReportsJob(Job):
                 FROM integration_library_configurations ilc
                 WHERE ilc.parent_id = ic.id
             ) collection_sharing ON TRUE
-            WHERE lib.id = :library_id AND ic.id IN :integration_ids
+            WHERE lib.id = :library_id
+              AND ic.id IN :integration_ids
+              -- Only include items with holds in this library
+              AND COALESCE(lib_holds.active_hold_count, 0) > 0
             ORDER BY ed.sort_title, ed.sort_author, d.name, ic.name
         """
 


### PR DESCRIPTION
## Description

Fixes holds reports to include only titles with at least one hold.

NB: The overall associated inventory report should include all books.

## Motivation and Context

[Jira PP-2317]

## How Has This Been Tested?

- Updates a test to ensure that books with and without holds continue to be included in inventory reports; and that books without holds are excluded from the holds report.
- Tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/14365660091) pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
