### PR TITLE
Alphabetize lists and lanes (PP-2351)

### DIFF
--- a/src/palace/manager/api/admin/controller/custom_lists.py
+++ b/src/palace/manager/api/admin/controller/custom_lists.py
@@ -84,7 +84,7 @@ class CustomListsController(
             for list in library.shared_custom_lists:
                 custom_lists.append(self._list_as_json(list, is_owner=False))
 
-            return dict(custom_lists=custom_lists)
+            return dict(custom_lists=sorted(custom_lists, key=lambda x: x["name"]))
 
         if flask.request.method == "POST":
             list_ = CustomListPostRequest.model_validate(

--- a/src/palace/manager/sqlalchemy/model/customlist.py
+++ b/src/palace/manager/sqlalchemy/model/customlist.py
@@ -23,6 +23,7 @@ from sqlalchemy.sql.expression import or_
 
 from palace.manager.sqlalchemy.model.base import Base
 from palace.manager.sqlalchemy.model.datasource import DataSource
+from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import LicensePool
 from palace.manager.sqlalchemy.model.work import Work
@@ -31,7 +32,6 @@ from palace.manager.util.datetime_helpers import utc_now
 
 if TYPE_CHECKING:
     from palace.manager.sqlalchemy.model.collection import Collection
-    from palace.manager.sqlalchemy.model.edition import Edition
     from palace.manager.sqlalchemy.model.lane import Lane
     from palace.manager.sqlalchemy.model.library import Library
 
@@ -136,9 +136,10 @@ class CustomList(Base):
     def entries_having_works(cls, _db: Session, list_id: int):
         return (
             _db.query(Work)
-            .join(Work.custom_list_entries)
+            .join(CustomListEntry)
+            .join(Edition)
             .filter(CustomListEntry.list_id == list_id)
-            .order_by(Work.id)
+            .order_by(Edition.sort_title)
         )
 
     @classmethod


### PR DESCRIPTION
## Description

Sort alphabetically the following:
- Lists | When creating/editing a manual list - Under List Entries - Alphabetize list of titles configured with the list by title
- Lanes | Under Available Lists - Alphabetize list of available lists (for Show: All, Owned, and Subscribed results)

## Motivation and Context

Better UX. See PP-2351.

## How Has This Been Tested?

Tested locally.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
