### PR TITLE
Update our pre-commit linters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -17,7 +17,7 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args:
@@ -37,32 +37,32 @@ repos:
           - --remove-all-unused-imports
 
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 25.1.0
     hooks:
       - id: black
         name: Run black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         name: Run isort
 
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.29.2
+    rev: 0.33.0
     hooks:
       - id: check-github-workflows
       - id: check-github-actions
 
   - repo: https://github.com/pappasam/toml-sort
-    rev: v0.23.1
+    rev: v0.24.2
     hooks:
       - id: toml-sort
         args: []
         files: pyproject\.toml
 
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.23
+    rev: v0.9.29
     hooks:
       - id: pymarkdown
         args:

--- a/alembic/versions/20241127_c3458e1ef9aa_remove_unsafe_characters_summary.py
+++ b/alembic/versions/20241127_c3458e1ef9aa_remove_unsafe_characters_summary.py
@@ -21,9 +21,9 @@ def upgrade() -> None:
     # https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP
     op.execute(
         "UPDATE works SET summary_text = regexp_replace("
-        "  summary_text, '[^\u0020-\uD7FF\u0009\u000A\u000D\uE000-\uFFFD\U00010000-\U0010FFFF]+', '', 'g'"
+        "  summary_text, '[^\u0020-\ud7ff\u0009\u000a\u000d\ue000-\ufffd\U00010000-\U0010ffff]+', '', 'g'"
         ") WHERE "
-        "summary_text ~ '[^\u0020-\uD7FF\u0009\u000A\u000D\uE000-\uFFFD\U00010000-\U0010FFFF]'"
+        "summary_text ~ '[^\u0020-\ud7ff\u0009\u000a\u000d\ue000-\ufffd\U00010000-\U0010ffff]'"
     )
 
 

--- a/bin/custom_list_update_new_entries
+++ b/bin/custom_list_update_new_entries
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-"""Updates CustomLists with newly added entries if they are configured for it
-"""
+"""Updates CustomLists with newly added entries if they are configured for it"""
 from palace.manager.scripts.customlist import CustomListUpdateEntriesScript
 from palace.manager.sqlalchemy.session import production_session
 from palace.manager.util.cache import CachedData

--- a/bin/equivalent_identifiers_refresh
+++ b/bin/equivalent_identifiers_refresh
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-"""Re-index Equivalent identifiers
-"""
+"""Re-index Equivalent identifiers"""
 
 
 from palace.manager.core.equivalents_coverage import (

--- a/bin/work_classification
+++ b/bin/work_classification
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-"""Re-classify any Works that need it.
-"""
+"""Re-classify any Works that need it."""
 
 
 from palace.manager.core.coverage import WorkClassificationCoverageProvider

--- a/bin/work_presentation_editions
+++ b/bin/work_presentation_editions
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-"""Re-generate presentation editions of any Works that need it.
-"""
+"""Re-generate presentation editions of any Works that need it."""
 
 
 from palace.manager.core.coverage import WorkPresentationEditionCoverageProvider

--- a/src/palace/manager/api/admin/controller/library_settings.py
+++ b/src/palace/manager/api/admin/controller/library_settings.py
@@ -32,7 +32,9 @@ from palace.manager.sqlalchemy.listeners import site_configuration_has_changed
 from palace.manager.sqlalchemy.model.announcements import (
     SETTING_NAME as ANNOUNCEMENT_SETTING_NAME,
 )
-from palace.manager.sqlalchemy.model.announcements import Announcement
+from palace.manager.sqlalchemy.model.announcements import (
+    Announcement,
+)
 from palace.manager.sqlalchemy.model.library import Library, LibraryLogo
 from palace.manager.sqlalchemy.model.resource import Representation
 from palace.manager.sqlalchemy.session import json_serializer

--- a/src/palace/manager/api/web_publication_manifest.py
+++ b/src/palace/manager/api/web_publication_manifest.py
@@ -1,5 +1,4 @@
-"""Vendor-specific variants of the standard Web Publication Manifest classes.
-"""
+"""Vendor-specific variants of the standard Web Publication Manifest classes."""
 
 from palace.manager.sqlalchemy.model.licensing import DeliveryMechanism
 from palace.manager.sqlalchemy.model.resource import Representation

--- a/src/palace/manager/core/selftest.py
+++ b/src/palace/manager/core/selftest.py
@@ -1,5 +1,4 @@
-"""Define the interfaces used by integration self-tests.
-"""
+"""Define the interfaces used by integration self-tests."""
 
 from __future__ import annotations
 

--- a/src/palace/manager/search/external_search.py
+++ b/src/palace/manager/search/external_search.py
@@ -23,7 +23,12 @@ from opensearch_dsl.query import (
     Nested,
 )
 from opensearch_dsl.query import Query as BaseQuery
-from opensearch_dsl.query import Range, Regexp, Term, Terms
+from opensearch_dsl.query import (
+    Range,
+    Regexp,
+    Term,
+    Terms,
+)
 from spellchecker import SpellChecker
 
 from palace.manager.core.classifier import Classifier

--- a/src/palace/manager/sqlalchemy/model/identifier.py
+++ b/src/palace/manager/sqlalchemy/model/identifier.py
@@ -494,7 +494,7 @@ class Identifier(Base, IdentifierConstants, LoggerMixin):
         identifiers_by_urn = dict()
 
         def find_existing_identifiers(
-            identifier_details: list[tuple[str, str]]
+            identifier_details: list[tuple[str, str]],
         ) -> None:
             if not identifier_details:
                 return

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -7,7 +7,11 @@ import logging
 from enum import IntEnum, auto
 from typing import TYPE_CHECKING, Literal, overload
 
-from sqlalchemy import Boolean, Column, DateTime
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+)
 from sqlalchemy import Enum as AlchemyEnum
 from sqlalchemy import (
     ForeignKey,

--- a/tests/manager/api/admin/controller/test_library.py
+++ b/tests/manager/api/admin/controller/test_library.py
@@ -31,7 +31,10 @@ from palace.manager.sqlalchemy.model.admin import AdminRole
 from palace.manager.sqlalchemy.model.announcements import (
     SETTING_NAME as ANNOUNCEMENTS_SETTING_NAME,
 )
-from palace.manager.sqlalchemy.model.announcements import Announcement, AnnouncementData
+from palace.manager.sqlalchemy.model.announcements import (
+    Announcement,
+    AnnouncementData,
+)
 from palace.manager.sqlalchemy.model.library import Library, LibraryLogo
 from palace.manager.sqlalchemy.util import get_one
 from palace.manager.util.problem_detail import ProblemDetail, ProblemDetailException

--- a/tests/manager/api/discovery/test_opds_registration.py
+++ b/tests/manager/api/discovery/test_opds_registration.py
@@ -32,7 +32,10 @@ from palace.manager.sqlalchemy.util import create, get_one
 from palace.manager.util.problem_detail import (
     JSON_MEDIA_TYPE as PROBLEM_DETAIL_JSON_MEDIA_TYPE,
 )
-from palace.manager.util.problem_detail import ProblemDetail, ProblemDetailException
+from palace.manager.util.problem_detail import (
+    ProblemDetail,
+    ProblemDetailException,
+)
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.library import LibraryFixture
 from tests.fixtures.services import ServicesFixture

--- a/tests/manager/api/test_bibliotheca.py
+++ b/tests/manager/api/test_bibliotheca.py
@@ -957,7 +957,7 @@ class TestErrorParser:
             ),
             (
                 # Simulate an unexpected response, which cannot be decoded as a string.
-                b"\xDE\xAD\xBE\xEF",
+                b"\xde\xad\xbe\xef",
                 None,
                 "Unreadable error message (Unicode decode error).",
             ),

--- a/tests/manager/search/test_external_search.py
+++ b/tests/manager/search/test_external_search.py
@@ -19,7 +19,11 @@ from opensearch_dsl.query import (
     Nested,
 )
 from opensearch_dsl.query import Query as opensearch_dsl_query
-from opensearch_dsl.query import Range, Term, Terms
+from opensearch_dsl.query import (
+    Range,
+    Term,
+    Terms,
+)
 from psycopg2.extras import NumericRange
 
 from palace.manager.core.classifier import Classifier
@@ -344,7 +348,7 @@ class TestExternalSearchWithWorks:
         result.tiffany = _work(title="Breakfast at Tiffany's")
 
         result.les_mis = _work()
-        result.les_mis.presentation_edition.title = "Les Mis\u00E9rables"
+        result.les_mis.presentation_edition.title = "Les Mis\u00e9rables"
 
         result.modern_romance = _work(title="Modern Romance")
 

--- a/tests/manager/sqlalchemy/model/test_edition.py
+++ b/tests/manager/sqlalchemy/model/test_edition.py
@@ -419,7 +419,7 @@ class TestEdition:
             None,
             overdrive,
             "text/plain",
-            "\u0000💣ü🔥\u0001\u000C",
+            "\u0000💣ü🔥\u0001\u000c",
         )
         work.set_summary(l2.resource)
         assert work.summary_text == "💣ü🔥"

--- a/tests/manager/util/test_xml_parser.py
+++ b/tests/manager/util/test_xml_parser.py
@@ -48,7 +48,7 @@ class TestXMLProcessor:
         assert "Third" == tag3.text
 
     def test_invalid_characters_are_stripped(self) -> None:
-        data = b'<?xml version="1.0" encoding="utf-8"><tag>I enjoy invalid characters, such as \x00\x01 and \x1F. But I also like \xe2\x80\x9csmart quotes\xe2\x80\x9d.</tag>'
+        data = b'<?xml version="1.0" encoding="utf-8"><tag>I enjoy invalid characters, such as \x00\x01 and \x1f. But I also like \xe2\x80\x9csmart quotes\xe2\x80\x9d.</tag>'
         parser = MockProcessor("/tag")
         [tag] = parser.process_all(data)
         assert (


### PR DESCRIPTION
## Description

Updates our pre-commit linters. Figured I would do this while updating poetry.

## Motivation and Context

This PR was created by running:
```
pre-commit autoupdate
pre-commit run -a
```

So all the changes are automated from our linters. There are a few changes, but none that look problematic to me. 

## How Has This Been Tested?

- Running CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
