### PR TITLE
Respond to Cache-Control headers (PP-2380)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,6 @@ Celery and caching, we recommend that you use a separate database for each purpo
    be a single hostname (`http://catalog.library.org`) or a pipe-separated list of hostnames
    (`http://catalog.library.org|https://beta.library.org`). You can also set this to `*` to allow access from any host,
    but you must not do this in a production environment -- only during development. (optional)
-- `PALACE_AUTHENTICATION_DOCUMENT_CACHE_TIME`: Cache time for authentication documents (in seconds). The default is
-   3600 (optional).
 
 #### Storage Service
 

--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -6,6 +6,7 @@ from flask_cors.core import get_cors_options, set_cors_headers
 
 from palace.manager.api.app import app
 from palace.manager.core.app_server import (
+    cache_control_headers,
     compressible,
     raises_problem_detail,
     returns_problem_detail,
@@ -216,6 +217,7 @@ def library_dir_route(path, *args, **kwargs):
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@cache_control_headers(default_max_age=3600)
 @compressible
 def index():
     return app.manager.index_controller()
@@ -224,6 +226,7 @@ def index():
 @library_route("/authentication_document")
 @has_library
 @returns_problem_detail
+@cache_control_headers(default_max_age=3600)
 @compressible
 def authentication_document():
     return app.manager.index_controller.authentication_document()
@@ -234,6 +237,7 @@ def authentication_document():
 @has_library
 @allows_patron_web
 @returns_problem_detail
+@cache_control_headers()
 @compressible
 def acquisition_groups(lane_identifier):
     return app.manager.opds_feeds.groups(lane_identifier)

--- a/src/palace/manager/core/app_server.py
+++ b/src/palace/manager/core/app_server.py
@@ -105,7 +105,7 @@ def raises_problem_detail(f: Callable[P, T]) -> Callable[P, T | Response]:
     return decorated
 
 
-def _parse_cache_control(cache_control_header: str | None) -> dict[str, str | None]:
+def _parse_cache_control(cache_control_header: str | None) -> dict[str, int | None]:
     """
     Parse the Cache-Control header into a dictionary of directives.
 

--- a/src/palace/manager/core/app_server.py
+++ b/src/palace/manager/core/app_server.py
@@ -138,8 +138,13 @@ def cache_control_headers(
     """
     Decorator that manages Cache-Control headers on Flask responses based on request and configuration.
 
-    This decorator processes both incoming request Cache-Control headers and adds
-    appropriate Cache-Control headers to responses.
+    This decorator processes incoming request Cache-Control headers and adds appropriate Cache-Control
+    headers to responses.
+
+    Note: This decorator allows incoming requests to override cache settings, potentially bypassing
+          the cache. This could enable malicious users to cause excessive load on the server. Use
+          with caution.
+    Todo: Consider restricting this functionality to authenticated users in the future.
 
     :param default_max_age: Optional integer specifying the default max-age in seconds
             to set on responses that don't already have Cache-Control headers

--- a/src/palace/manager/core/app_server.py
+++ b/src/palace/manager/core/app_server.py
@@ -105,6 +105,75 @@ def raises_problem_detail(f: Callable[P, T]) -> Callable[P, T | Response]:
     return decorated
 
 
+def _parse_cache_control(cache_control_header: str | None) -> dict[str, str | None]:
+    """
+    Parse the Cache-Control header into a dictionary of directives.
+
+    https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control
+    """
+    cache_control_header = cache_control_header or ""
+
+    directives: dict[str, int | None] = {}
+    for directive in cache_control_header.split(","):
+        directive = directive.strip().lower()
+        if not directive:
+            continue
+
+        if "=" in directive:
+            key, value = directive.split("=", 1)
+            try:
+                int_val = int(value)
+            except ValueError:
+                continue
+            directives[key] = int_val
+        else:
+            directives[directive] = None
+
+    return directives
+
+
+def cache_control_headers(
+    default_max_age: int | None = None,
+) -> Callable[[Callable[P, Response]], Callable[P, Response]]:
+    """
+    Decorator that manages Cache-Control headers on Flask responses based on request and configuration.
+
+    This decorator processes both incoming request Cache-Control headers and adds
+    appropriate Cache-Control headers to responses.
+
+    :param default_max_age: Optional integer specifying the default max-age in seconds
+            to set on responses that don't already have Cache-Control headers
+    """
+
+    def decorator(f: Callable[P, Response]) -> Callable[P, Response]:
+        @wraps(f)
+        def decorated(*args: P.args, **kwargs: P.kwargs) -> Response:
+            """Set cache control headers on the response."""
+            response = f(*args, **kwargs)
+
+            # Check if the incoming request has a Cache-Control header
+            directives = _parse_cache_control(
+                flask.request.headers.get("Cache-Control")
+            )
+
+            if "no-cache" in directives or "no-store" in directives:
+                # Set the response to be non-cacheable.
+                response.headers["Cache-Control"] = "no-store"
+            elif "max-age" in directives and directives["max-age"]:
+                # Set the response to be cacheable for the specified max-age.
+                response.headers["Cache-Control"] = f"max-age={directives['max-age']}"
+            elif (
+                "Cache-Control" not in response.headers and default_max_age is not None
+            ):
+                # If no Cache-Control header is set, use the default max-age.
+                response.headers["Cache-Control"] = f"max-age={default_max_age}"
+            return response
+
+        return decorated
+
+    return decorator
+
+
 def compressible(f):
     """Decorate a function to make it transparently handle whatever
     compression the client has announced it supports.

--- a/src/palace/manager/service/sitewide.py
+++ b/src/palace/manager/service/sitewide.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Literal
 from urllib.parse import urlparse
 
-from pydantic import NonNegativeInt, field_validator
+from pydantic import field_validator
 
 from palace.manager.service.configuration.service_configuration import (
     ServiceConfiguration,
@@ -14,7 +14,6 @@ from palace.manager.util.pydantic import HttpUrl
 class SitewideConfiguration(ServiceConfiguration):
     base_url: HttpUrl | None = None
     patron_web_hostnames: list[HttpUrl] | Literal["*"] = []
-    authentication_document_cache_time: NonNegativeInt = 3600
     quicksight_authorized_arns: dict[str, list[str]] | None = None
 
     @field_validator("patron_web_hostnames", mode="before")

--- a/tests/manager/api/controller/test_index.py
+++ b/tests/manager/api/controller/test_index.py
@@ -106,25 +106,3 @@ class TestIndexController:
             # Make sure we got the A4OPDS document for the right library.
             doc = json.loads(data)
             assert library_name == doc["title"]
-
-        # Verify that the authentication document cache is working.
-        circulation_fixture.manager.authentication_for_opds_documents[library_name] = (
-            "Cached value"
-        )
-        with circulation_fixture.request_context_with_library(
-            "/", headers=dict(Authorization=circulation_fixture.invalid_auth)
-        ):
-            response = (
-                circulation_fixture.manager.index_controller.authentication_document()
-            )
-            assert response.get_data(as_text=True) == "Cached value"
-
-        # Verify what happens when the cache is disabled.
-        circulation_fixture.manager.authentication_for_opds_documents.max_age = 0
-        with circulation_fixture.request_context_with_library(
-            "/", headers=dict(Authorization=circulation_fixture.invalid_auth)
-        ):
-            response = (
-                circulation_fixture.manager.index_controller.authentication_document()
-            )
-            assert response.get_data(as_text=True) != "Cached value"

--- a/tests/manager/api/test_controller_cm.py
+++ b/tests/manager/api/test_controller_cm.py
@@ -30,9 +30,6 @@ class TestCirculationManager:
         # configuration settings.
         mock_db = MagicMock()
 
-        services_fixture.set_sitewide_config_option(
-            "authentication_document_cache_time", 12
-        )
         mock_load_settings = create_autospec(CirculationManager.load_settings)
         mock_setup_controllers = create_autospec(
             CirculationManager.setup_one_time_controllers
@@ -48,7 +45,6 @@ class TestCirculationManager:
         assert mock_load_settings.called
         assert mock_setup_controllers.called
 
-        assert manager.authentication_for_opds_documents.max_age == 12
         assert manager.services is services_fixture.services
         assert manager.analytics is services_fixture.analytics_fixture.analytics_mock
         assert manager.external_search is services_fixture.search_fixture.index_mock
@@ -75,10 +71,6 @@ class TestCirculationManager:
         assert 1 == len(manager.top_level_lanes)
         assert 1 == len(manager.circulation_apis)
 
-        # The authentication document cache has a default value for
-        # max_age.
-        assert 3600 == manager.authentication_for_opds_documents.max_age
-
         # Now let's create a brand new library, never before seen.
         library = circulation_fixture.db.library()
         circulation_fixture.library_setup(library)
@@ -99,10 +91,6 @@ class TestCirculationManager:
             web_client="http://registration",
         )
 
-        # And a library-specific configuration setting.
-        manager.authentication_for_opds_documents["test"] = "document"
-        assert len(manager.authentication_for_opds_documents) == 1
-
         # Then reload the CirculationManager...
         circulation_fixture.manager.load_settings()
 
@@ -121,9 +109,6 @@ class TestCirculationManager:
 
         # So have the patron web domains
         assert {"http://sitewide", "http://registration"} == manager.patron_web_domains
-
-        # The authentication document cache has been cleared
-        assert len(manager.authentication_for_opds_documents) == 0
 
         # Controllers that don't depend on site configuration
         # have not been reloaded.

--- a/tests/manager/service/test_sitewide.py
+++ b/tests/manager/service/test_sitewide.py
@@ -122,32 +122,6 @@ class TestSitewideConfiguration:
             assert config.patron_web_hostnames == expected
 
     @pytest.mark.parametrize(
-        "authentication_document_cache_time, expected",
-        [
-            (None, 3600),
-            ("12", 12),
-            ("0", 0),
-            ("foo", CannotLoadConfiguration),
-            ("-12", CannotLoadConfiguration),
-        ],
-    )
-    def test_authentication_document_cache_time(
-        self,
-        sitewide_configuration_fixture: SitewideConfigurationFixture,
-        authentication_document_cache_time: str | None,
-        expected: int | type[Exception],
-    ):
-        sitewide_configuration_fixture.set(
-            "PALACE_AUTHENTICATION_DOCUMENT_CACHE_TIME",
-            authentication_document_cache_time,
-        )
-
-        context = sitewide_configuration_fixture.get_context_manager(expected)
-        with context:
-            config = SitewideConfiguration()
-            assert config.authentication_document_cache_time == expected
-
-    @pytest.mark.parametrize(
         "quicksight_authorized_arns, expected",
         [
             ("invalid json", CannotLoadConfiguration),


### PR DESCRIPTION
## Description

- Remove the internal CM authentication document cache
  - We are caching the authentication documents in cloudfront, so no need to have an additional cache within the CM
- Add a new decorator that responds to cache control headers and apply it to `authentication_document` and `groups` urls.

## Motivation and Context

This PR is the first step to resolve both PP-2380 and PP-2398. When we know we need to load a fresh document without caching the client will be responsible for setting the headers appropriately.

This will need 3 additional PRs to fully function:
- Library registry to make sure it sets the headers when requesting auth document
  - PR: https://github.com/ThePalaceProject/library-registry/pull/821 
- Admin UI to make sure it sets the headers when requesting groups feed
  - https://github.com/ThePalaceProject/web-opds-client/pull/44
  - https://github.com/ThePalaceProject/circulation-admin/pull/157
- Cloudfront to make sure our cache keys take into account the cache-control header 
  - PR: https://github.com/ThePalaceProject/hosting-playbook/pull/811

However this PR can be reviewed and merged before those follow ups are in place.

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
