### PR TITLE
Remove type ignore from playtime entries task

### DIFF
--- a/src/palace/manager/celery/tasks/playtime_entries.py
+++ b/src/palace/manager/celery/tasks/playtime_entries.py
@@ -230,8 +230,7 @@ def generate_playtime_report(
                     file_name=linked_file_name,
                     parent_folder_id=leaf_folder["id"],
                     content_type="text/csv",
-                    stream=temp,  # type: ignore[arg-type]
-                    # I strove to avoid this type: ignore statement but couldn't find a good workaround.
+                    stream=temp,
                 )
                 task.log.info(
                     f"Stored {'/'.join(nested_folders + [linked_file_name])} in Google Drive"

--- a/src/palace/manager/service/google_drive/google_drive.py
+++ b/src/palace/manager/service/google_drive/google_drive.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from io import IOBase
-from typing import TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, cast
 
 from googleapiclient.http import MediaIoBaseUpload
 
@@ -42,7 +42,7 @@ class GoogleDriveService(LoggerMixin):
     def create_file(
         self,
         file_name: str,
-        stream: IOBase,
+        stream: IO[bytes],
         content_type: str,
         parent_folder_id: str | None = None,
     ) -> File:
@@ -55,7 +55,9 @@ class GoogleDriveService(LoggerMixin):
                 f'A file named "{file_name}" already exists in folder(id={parent_folder_id}'
             )
 
-        media = MediaIoBaseUpload(stream, mimetype=content_type)
+        # We cast this to IOBase, because the type hints for MediaIoBaseUpload
+        # specify this as a IOBase, but it will accept the more generic IO[bytes]
+        media = MediaIoBaseUpload(cast(IOBase, stream), mimetype=content_type)
         parents = [parent_folder_id] if parent_folder_id else []
         file_metadata: File = {"name": file_name, "parents": parents}
         file = (


### PR DESCRIPTION
## Description

Small fix to remove type ignore from playtime entries, and add a better type hint for `GoogleDriveService.create_file`.

## Motivation and Context

I did this after @dbernstein asked about type hinting https://github.com/ThePalaceProject/circulation/pull/2415. Since the work is already done, it would be nice to get it merged. Looks like you --force pushed over my changes in https://github.com/ThePalaceProject/circulation/pull/2415, so I'll break this out to a separate PR.

## How Has This Been Tested?

- Running mypy locally.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
