### PR TITLE
Bump admin UI to v1.29.0

### DIFF
--- a/src/palace/manager/api/admin/config.py
+++ b/src/palace/manager/api/admin/config.py
@@ -60,7 +60,7 @@ class OperationalMode(str, Enum):
 class Configuration(LoggerMixin):
     APP_NAME = "Palace Collection Manager"
     PACKAGE_NAME = "@thepalaceproject/circulation-admin"
-    PACKAGE_VERSION = "1.28.1"
+    PACKAGE_VERSION = "1.29.0"
 
     STATIC_ASSETS = {
         "admin_js": "circulation-admin.js",


### PR DESCRIPTION
## Description

Configure Palace Manager to default to [Admin UI v1.29.0](https://github.com/ThePalaceProject/circulation-admin/releases/tag/v1.29.0).

## Motivation and Context

PP-2398

## How Has This Been Tested?

N/A

## Checklist

N/A