### PR TITLE
Add additional sort column to playtime report

### DIFF
--- a/src/palace/manager/celery/tasks/playtime_entries.py
+++ b/src/palace/manager/celery/tasks/playtime_entries.py
@@ -348,6 +348,7 @@ def _fetch_report_records(
         combined_sq.c.collection_name,
         combined_sq.c.library_name,
         combined_sq.c.identifier_str,
+        combined_sq.c.title,
     )
 
 


### PR DESCRIPTION
## Description

Add an additional `order by` to the playtime report. 

## Motivation and Context

This shouldn't come into play in real reports very often, but it makes sure we have a consistent order of results in our tests. Should stop this flakey test failure: https://github.com/ThePalaceProject/circulation/actions/runs/14595662530/job/40940999621

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
