### PR TITLE
Additional information in SIP2 self test (PP-2418)

### DIFF
--- a/src/palace/manager/api/sip/__init__.py
+++ b/src/palace/manager/api/sip/__init__.py
@@ -354,12 +354,7 @@ class SIP2AuthenticationProvider(
 
         # Log in was successful so test patron's test credentials
         if login.success:
-            results = [
-                r for r in super(SIP2AuthenticationProvider, self)._run_self_tests(_db)
-            ]
-            yield from results
-
-            if results[0].success:
+            if self.test_username:
 
                 def raw_patron_information():
                     info = sip.patron_information(
@@ -377,6 +372,8 @@ class SIP2AuthenticationProvider(
                 yield self.run_test(
                     ("Raw test patron information"), raw_patron_information
                 )
+
+            yield from super()._run_self_tests(_db)
 
     def info_to_patrondata(
         self, info: dict[str, Any] | ProblemDetail, validate_password: bool = True

--- a/tests/manager/api/sip/test_authentication_provider.py
+++ b/tests/manager/api/sip/test_authentication_provider.py
@@ -778,25 +778,25 @@ class TestSIP2AuthenticationProvider:
         )
         assert results[1].success == True
 
-        assert results[2].name == "Authenticating test patron"
+        assert results[2].name == "Patron information request"
         assert results[2].success == True
-
-        # Since test patron authentication is true, we can now see self
-        # test results for syncing metadata and the raw data from `patron_information`
-        assert results[3].name == "Syncing patron metadata"
-        assert results[3].success == True
-
-        assert results[4].name == "Patron information request"
-        assert results[4].success == True
-        assert results[4].result == provider.client.patron_information_request(
+        assert results[2].result == provider.client.patron_information_request(
             "usertest1", "userpassword1"
         )
 
-        assert results[5].name == "Raw test patron information"
-        assert results[5].success == True
-        assert results[5].result == json.dumps(
+        assert results[3].name == "Raw test patron information"
+        assert results[3].success == True
+        assert results[3].result == json.dumps(
             client.patron_information_parser(
                 TestSIP2AuthenticationProvider.sierra_valid_login
             ),
             indent=1,
         )
+
+        assert results[4].name == "Authenticating test patron"
+        assert results[4].success == True
+
+        # Since test patron authentication is true, we can now see self
+        # test results for syncing metadata and the raw data from `patron_information`
+        assert results[5].name == "Syncing patron metadata"
+        assert results[5].success == True


### PR DESCRIPTION
## Description

Run all the SIP2 self tests, even if there is a failure, as long as we have a test barcode configured.

## Motivation and Context

Running all the tests outputs helpful debug information that can help to figure out a failure such as the raw patron information. This also makes it more clear when requests are timing out.

See PP-2418

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
