### PR TITLE
Configurable SIP2 timeout (PP-2418)

### DIFF
--- a/src/palace/manager/api/sip/__init__.py
+++ b/src/palace/manager/api/sip/__init__.py
@@ -178,6 +178,21 @@ class SIP2Settings(BasicAuthProviderSettings):
             },
         ),
     )
+    timeout: int = FormField(
+        3,
+        form=ConfigurationFormItem(
+            label="Timeout",
+            description=(
+                "The number of seconds to wait for a response from the SIP2 server "
+                "before timing out. The default is 3 seconds. <em>Use caution</em> when increasing "
+                "this value, as it can slow down the authentication process. Value must be "
+                "between 1 and 9 seconds."
+            ),
+            type=ConfigurationFormItemType.NUMBER,
+        ),
+        ge=1,
+        le=9,
+    )
 
 
 class SIP2LibrarySettings(BasicAuthProviderLibrarySettings):
@@ -238,6 +253,7 @@ class SIP2AuthenticationProvider(
         self.ssl_verification = settings.ssl_verification
         self.dialect = settings.ils
         self.institution_id = library_settings.institution_id
+        self.timeout = settings.timeout
         self._client = client
 
         # Check if patrons should be blocked based on SIP status
@@ -270,6 +286,7 @@ class SIP2AuthenticationProvider(
             ssl_verification=self.ssl_verification,
             encoding=self.encoding.lower(),
             dialect=self.dialect,
+            timeout=self.timeout,
         )
 
     @classmethod

--- a/src/palace/manager/api/sip/client.py
+++ b/src/palace/manager/api/sip/client.py
@@ -232,6 +232,9 @@ class SIPClient(Constants, LoggerMixin):
     # Maximum retries of a SIP message before failing.
     MAXIMUM_RETRIES = 5
 
+    # Default timeout in seconds for socket connections.
+    DEFAULT_TIMEOUT = 3
+
     # These are the subfield names associated with the 'patron status'
     # field as specified in the SIP2 spec.
     CHARGE_PRIVILEGES_DENIED = "charge privileges denied"
@@ -330,7 +333,7 @@ class SIPClient(Constants, LoggerMixin):
         self.ssl_contexts = ssl_contexts
         self.ssl_verification = ssl_verification
         self.encoding = encoding
-        self.timeout = timeout or 3
+        self.timeout = timeout or self.DEFAULT_TIMEOUT
 
         # Turn the separator string into a regular expression that splits
         # field name/field value pairs on the separator string.

--- a/tests/manager/api/sip/test_authentication_provider.py
+++ b/tests/manager/api/sip/test_authentication_provider.py
@@ -143,6 +143,7 @@ class TestSIP2AuthenticationProvider:
             ils=Dialect.AG_VERSO,
             encoding=Sip2Encoding.utf8,
             patron_status_block=False,
+            timeout=9,
         )
         library_settings = create_library_settings(institution_id="MAIN")
         provider = create_provider(settings=settings, library_settings=library_settings)
@@ -158,6 +159,7 @@ class TestSIP2AuthenticationProvider:
         assert Dialect.AG_VERSO == provider.dialect
         assert Sip2Encoding.utf8.value == provider.encoding
         assert provider.patron_status_should_block is False
+        assert 9 == provider.timeout
 
         # And it's possible to get a SIP2Client that's configured
         # based on the same values.
@@ -168,6 +170,7 @@ class TestSIP2AuthenticationProvider:
         assert "MAIN" == client.institution_id
         assert "server.com" == client.target_server
         assert 1234 == client.target_port
+        assert 9 == client.timeout
 
     def test_initialize_from_settings_defaults(
         self,

--- a/tests/manager/api/sip/test_client.py
+++ b/tests/manager/api/sip/test_client.py
@@ -144,22 +144,17 @@ class TestSIPClient:
     network connections.
     """
 
-    def test_connect(self):
+    @pytest.mark.parametrize("timeout", [None, 1, 10])
+    def test_connect(self, timeout: int | None):
         target_server = object()
-        sip = SIPClient(target_server, 999)
+        sip = SIPClient(target_server, 999, timeout=timeout)
 
-        old_socket = socket.socket
-
-        # Mock the socket.socket function.
-        socket.socket = MockSocket
-
-        # Call connect() and make sure timeout is set properly.
-        try:
+        with patch.object(socket, "socket", MockSocket):
+            # Call connect() and make sure timeout is set properly.
             sip.connect()
-            assert 3 == sip.connection.timeout
-        finally:
-            # Un-mock the socket.socket function
-            socket.socket = old_socket
+            if timeout is None:
+                timeout = 3
+            assert sip.connection.timeout == timeout
 
     def test_secure_connect_insecure(self, mock_socket: MockSocketFixture):
         self.context: MagicMock | None = None


### PR DESCRIPTION
## Description

Allow configuration of SIP2 connection timeout.

## Motivation and Context

We set the SIP2 connection timeout fairly low, because it has impacts on all the performance for all libraries on a CM. A single slow library, can slow the rest of them down. Libraries with slow authentication should cause less of a performance impact now that we have token auth rolled out everywhere, as we don't have to call out to the ILS as often, so I think adding a configuration that allows us to increase the timeout makes sense.

## How Has This Been Tested?

- Added tests
- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
