### PR TITLE
[PP-2405] This update optimizes the axis identifiers import and reape…

### DIFF
--- a/bin/axis_import
+++ b/bin/axis_import
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+"""Import an Axis Collection by name"""
+
+from palace.manager.scripts.axis_import import ImportCollection
+
+ImportCollection().run()

--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -662,7 +662,7 @@ class Axis360API(
             analytics=analytics,
         )
 
-        # NOTE: availability is bibliographic.circulation, so it's a
+        # NOTE: availability is bibliographic.circulation, so it is
         # unnecessary to call availability.apply() -- it's taken
         # care of inside bibliographic.apply().
         bibliographic.apply(edition, self.collection, replace=policy, db=self._db)

--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -663,10 +663,9 @@ class Axis360API(
         )
 
         # NOTE: availability is bibliographic.circulation, so it's a
-        # little redundant to call availability.apply() -- it's taken
+        # unnecessary to call availability.apply() -- it's taken
         # care of inside bibliographic.apply().
         bibliographic.apply(edition, self.collection, replace=policy, db=self._db)
-        availability.apply(self._db, self.collection, replace=policy)
         return edition, new_edition, license_pool, new_license_pool
 
     def _fetch_remote_availability(

--- a/src/palace/manager/celery/tasks/axis.py
+++ b/src/palace/manager/celery/tasks/axis.py
@@ -16,7 +16,7 @@ from palace.manager.api.circulation import (
 )
 from palace.manager.celery.task import Task
 from palace.manager.core.exceptions import IntegrationException
-from palace.manager.core.metadata_layer import CirculationData, Metadata
+from palace.manager.core.metadata_layer import Metadata
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.redis.models.lock import RedisLock
 from palace.manager.service.redis.redis import Redis
@@ -288,7 +288,7 @@ def import_identifiers(
             collection = Collection.by_id(session, id=collection_id)
             api = create_api(session=session, collection=collection, bearer_token=bearer_token)  # type: ignore[arg-type]
             try:
-                process_book(task, session, api, metadata, circulation)
+                process_book(task, session, api, metadata)
                 total_imported_in_current_task += 1
             except (ObjectDeletedError, StaleDataError, OperationalError) as e:
                 _check_if_deadlock(e)
@@ -355,10 +355,9 @@ def process_book(
     _db: Session,
     api: Axis360API,
     metadata: Metadata,
-    circulation: CirculationData,
 ) -> None:
     edition, new_edition, license_pool, new_license_pool = api.update_book(
-        bibliographic=metadata, availability=circulation
+        bibliographic=metadata,
     )
 
     task.log.info(

--- a/src/palace/manager/celery/tasks/axis.py
+++ b/src/palace/manager/celery/tasks/axis.py
@@ -30,7 +30,7 @@ from palace.manager.util.datetime_helpers import datetime_utc, utc_now
 from palace.manager.util.http import BadResponseException
 from palace.manager.util.log import pluralize
 
-DEFAULT_BATCH_SIZE: int = 10
+DEFAULT_BATCH_SIZE: int = 50
 DEFAULT_START_TIME = datetime_utc(1970, 1, 1)
 MAX_DELAY_IN_SECONDS_BETWEEN_REAP_TASKS = 20
 
@@ -311,9 +311,14 @@ def import_identifiers(
 
     elapsed_seconds = time.perf_counter() - start_seconds
 
+    average_secs_per_book = (
+        ""
+        if total_imported_in_current_task == 0
+        else f" or {(elapsed_seconds/total_imported_in_current_task):.3f} secs per book"
+    )
     task.log.info(
         f'Imported {total_imported_in_current_task} books into collection(name="{collection_name}", '
-        f"id={collection_id} in {elapsed_seconds:.2f} secs"
+        f"id={collection_id} in {elapsed_seconds:.2f} secs {average_secs_per_book}"
     )
 
     processed_count += total_imported_in_current_task

--- a/src/palace/manager/scripts/axis_import.py
+++ b/src/palace/manager/scripts/axis_import.py
@@ -29,7 +29,11 @@ class ImportCollection(Script):
     def do_run(self, *args, **kwargs):
         parsed = self.parse_command_line(self._db, *args, **kwargs)
         collection_name = parsed.collection_name
+
         collection = Collection.by_name(self._db, collection_name)
+        if not collection:
+            raise ValueError(f'No collection found named "{collection_name}".')
+
         list_identifiers_for_import.apply_async(
             kwargs={"collection_id": collection.id, "import_all": parsed.import_all},
             link=import_identifiers.s(

--- a/src/palace/manager/scripts/axis_import.py
+++ b/src/palace/manager/scripts/axis_import.py
@@ -1,0 +1,38 @@
+import argparse
+
+from palace.manager.celery.tasks.axis import (
+    import_identifiers,
+    list_identifiers_for_import,
+)
+from palace.manager.scripts.base import Script
+from palace.manager.sqlalchemy.model.collection import Collection
+
+
+class ImportCollection(Script):
+    """A convenient script for manually kicking off an axis collection import"""
+
+    @classmethod
+    def arg_parser(cls):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "--collection-name",
+            type=str,
+            help="Collection Name",
+        ),
+        parser.add_argument(
+            "--import-all",
+            action="store_true",
+            help="Import all identifiers rather not just recently changed ones.",
+        ),
+        return parser
+
+    def do_run(self, *args, **kwargs):
+        parsed = self.parse_command_line(self._db, *args, **kwargs)
+        collection_name = parsed.collection_name
+        collection = Collection.by_name(self._db, collection_name)
+        list_identifiers_for_import.apply_async(
+            kwargs={"collection_id": collection.id, "import_all": parsed.import_all},
+            link=import_identifiers.s(
+                collection_id=collection.id,
+            ),
+        )

--- a/tests/manager/api/test_axis.py
+++ b/tests/manager/api/test_axis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import datetime
 import json
 import socket
@@ -89,9 +90,15 @@ def axis_files_fixture() -> AxisFilesFixture:
     return AxisFilesFixture()
 
 
+primary_identifier = IdentifierData(
+    type=Identifier.AXIS_360_ID, identifier="0003642860"
+)
+
+
 class Axis360Fixture:
     # Sample bibliographic and availability data you can use in a test
     # without having to parse it from an XML file.
+
     BIBLIOGRAPHIC_DATA = Metadata(
         DataSource.AXIS_360,
         publisher="Random House Inc",
@@ -99,9 +106,7 @@ class Axis360Fixture:
         title="Faith of My Fathers : A Family Memoir",
         imprint="Random House Inc2",
         published=datetime_utc(2000, 3, 7, 0, 0),
-        primary_identifier=IdentifierData(
-            type=Identifier.AXIS_360_ID, identifier="0003642860"
-        ),
+        primary_identifier=primary_identifier,
         identifiers=[IdentifierData(type=Identifier.ISBN, identifier="9780375504587")],
         contributors=[
             ContributorData(
@@ -115,16 +120,15 @@ class Axis360Fixture:
             ),
             SubjectData(type=Subject.FREEFORM_AUDIENCE, identifier="Adult"),
         ],
-    )
-
-    AVAILABILITY_DATA = CirculationData(
-        data_source=DataSource.AXIS_360,
-        primary_identifier=BIBLIOGRAPHIC_DATA.primary_identifier,
-        licenses_owned=9,
-        licenses_available=8,
-        licenses_reserved=0,
-        patrons_in_hold_queue=0,
-        last_checked=datetime_utc(2015, 5, 20, 2, 9, 8),
+        circulation=CirculationData(
+            data_source=DataSource.AXIS_360,
+            primary_identifier=primary_identifier,
+            licenses_owned=9,
+            licenses_available=8,
+            licenses_reserved=0,
+            patrons_in_hold_queue=0,
+            last_checked=datetime_utc(2015, 5, 20, 2, 9, 8),
+        ),
     )
 
     def __init__(self, db: DatabaseTransactionFixture, files: AxisFilesFixture):
@@ -134,7 +138,6 @@ class Axis360Fixture:
             db.session, db.default_library()
         )
         self.api = MockAxis360API(db.session, self.collection)
-        self.BIBLIOGRAPHIC_DATA.circulation = self.AVAILABILITY_DATA
 
     def sample_data(self, filename):
         return self.files.sample_data(filename)
@@ -741,7 +744,6 @@ class TestAxis360API:
         api = MockAxis360API(axis360.db.session, axis360.collection)
         e, e_new, lp, lp_new = api.update_book(
             axis360.BIBLIOGRAPHIC_DATA,
-            axis360.AVAILABILITY_DATA,
             analytics=cast(Analytics, analytics),
         )
         # A new LicensePool and Edition were created.
@@ -777,11 +779,11 @@ class TestAxis360API:
             licenses_available=7,
         )
 
-        axis360.BIBLIOGRAPHIC_DATA.circulation = new_circulation
+        bibliographic = copy.deepcopy(axis360.BIBLIOGRAPHIC_DATA)
+        bibliographic.circulation = new_circulation
 
         e2, e_new, lp2, lp_new = api.update_book(
-            axis360.BIBLIOGRAPHIC_DATA,
-            new_circulation,
+            bibliographic=bibliographic,
             analytics=cast(Analytics, analytics),
         )
 

--- a/tests/manager/api/test_axis.py
+++ b/tests/manager/api/test_axis.py
@@ -134,6 +134,7 @@ class Axis360Fixture:
             db.session, db.default_library()
         )
         self.api = MockAxis360API(db.session, self.collection)
+        self.BIBLIOGRAPHIC_DATA.circulation = self.AVAILABILITY_DATA
 
     def sample_data(self, filename):
         return self.files.sample_data(filename)
@@ -578,6 +579,8 @@ class TestAxis360API:
                         licenses_owned=7,
                         licenses_available=6,
                     )
+
+                    metadata.circulation = availability
                     yield metadata, availability
 
                     # The rest have been 'forgotten' by Axis 360.
@@ -773,6 +776,8 @@ class TestAxis360API:
             licenses_owned=8,
             licenses_available=7,
         )
+
+        axis360.BIBLIOGRAPHIC_DATA.circulation = new_circulation
 
         e2, e_new, lp2, lp_new = api.update_book(
             axis360.BIBLIOGRAPHIC_DATA,

--- a/tests/manager/api/test_axis.py
+++ b/tests/manager/api/test_axis.py
@@ -779,7 +779,9 @@ class TestAxis360API:
             licenses_available=7,
         )
 
-        bibliographic = copy.deepcopy(axis360.BIBLIOGRAPHIC_DATA)
+        # deepcopy would be preferable here, but I was running into low level errors.
+        # A shallow copy should be sufficient here.
+        bibliographic = copy.copy(axis360.BIBLIOGRAPHIC_DATA)
         bibliographic.circulation = new_circulation
 
         e2, e_new, lp2, lp_new = api.update_book(

--- a/tests/manager/scripts/test_axis_import.py
+++ b/tests/manager/scripts/test_axis_import.py
@@ -1,12 +1,12 @@
 from unittest.mock import patch
 
 import pytest
-from fixtures.database import DatabaseTransactionFixture
 
 from palace.manager.api.axis import Axis360API
 from palace.manager.celery.tasks.axis import import_identifiers
 from palace.manager.scripts import axis_import
 from palace.manager.scripts.axis_import import ImportCollection
+from tests.fixtures.database import DatabaseTransactionFixture
 
 
 class TestAxisCollectionImportScript:

--- a/tests/manager/scripts/test_axis_import.py
+++ b/tests/manager/scripts/test_axis_import.py
@@ -23,11 +23,11 @@ class TestAxisCollectionImportScript:
 
             assert list_import.apply_async.call_args[1] == {
                 "kwargs": {"collection_id": collection.id, "import_all": True},
-                "link": import_identifiers.s(collection_id=1),
+                "link": import_identifiers.s(collection_id=collection.id),
             }
 
     def test_axis_import_collection_not_found(self, db: DatabaseTransactionFixture):
         collection_name = "test_collection"
         with pytest.raises(ValueError) as e:
             ImportCollection(db.session).do_run(["--collection-name", collection_name])
-            assert f'No collection found named "{collection_name}".' in e.value
+            assert f'No collection found named "{collection_name}".' in str(e.value)

--- a/tests/manager/scripts/test_axis_import.py
+++ b/tests/manager/scripts/test_axis_import.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+import pytest
+from fixtures.database import DatabaseTransactionFixture
+
+from palace.manager.api.axis import Axis360API
+from palace.manager.celery.tasks.axis import import_identifiers
+from palace.manager.scripts import axis_import
+from palace.manager.scripts.axis_import import ImportCollection
+
+
+class TestAxisCollectionImportScript:
+
+    def test_axis_import(self, db: DatabaseTransactionFixture):
+
+        collection_name = "test_collection"
+        collection = db.collection(collection_name, protocol=Axis360API)
+        with patch.object(axis_import, "list_identifiers_for_import") as list_import:
+            ImportCollection(db.session).do_run(
+                ["--collection-name", collection.name, "--import-all"]
+            )
+            assert list_import.apply_async.assert_called_once
+
+            assert list_import.apply_async.call_args[1] == {
+                "kwargs": {"collection_id": collection.id, "import_all": True},
+                "link": import_identifiers.s(collection_id=1),
+            }
+
+    def test_axis_import_collection_not_found(self, db: DatabaseTransactionFixture):
+        collection_name = "test_collection"
+        with pytest.raises(ValueError) as e:
+            ImportCollection(db.session).do_run(["--collection-name", collection_name])
+            assert f'No collection found named "{collection_name}".' in e.value


### PR DESCRIPTION
…r tasks by reducing the number of unnecessary calls to both CirculationData.apply and LicensePool.set_open_access_status. This call is particularly expensive when a CM has many licensepools associated with each identifier due to having many collections configured with the same set of books. Since the performance is significantly improved I have upped the default batch size for axis tasks from 10 to 50 to reduce the number of calls for token renewal. Finally this commit includes a new convenience script for manually kicking off an axis import.

## Description

<!--- Describe your changes -->

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2405
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tested this locally with the Georgia data.   The change reduced the average time per book from 1 second to .20 seconds.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
