### PR TITLE
Mark LCP content as deliverable (PP-2334)

### DIFF
--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -1867,11 +1867,13 @@ class DeliveryMechanism(Base, HasSessionCache):
         # EPUB books
         (MediaTypes.EPUB_MEDIA_TYPE, NO_DRM),
         (MediaTypes.EPUB_MEDIA_TYPE, ADOBE_DRM),
+        (MediaTypes.EPUB_MEDIA_TYPE, LCP_DRM),
         # PDF books
         (MediaTypes.PDF_MEDIA_TYPE, NO_DRM),
         # Various audiobook formats
         (None, FINDAWAY_DRM),
         (MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE, NO_DRM),
+        (MediaTypes.AUDIOBOOK_MANIFEST_MEDIA_TYPE, LCP_DRM),
         (MediaTypes.OVERDRIVE_AUDIOBOOK_MANIFEST_MEDIA_TYPE, LIBBY_DRM),
     }
 

--- a/tests/manager/core/test_opds2_import.py
+++ b/tests/manager/core/test_opds2_import.py
@@ -110,7 +110,7 @@ class OPDS2ImporterFixture:
     @staticmethod
     def get_delivery_mechanisms(
         license_pool: LicensePool,
-    ) -> set[tuple[str, str | None]]:
+    ) -> set[tuple[str | None, str | None]]:
         return {
             (dm.delivery_mechanism.content_type, dm.delivery_mechanism.drm_scheme)
             for dm in license_pool.delivery_mechanisms


### PR DESCRIPTION
## Description

Add LCP to the list of deliverable formats in the mobile clients.

## Motivation and Context

Eventually, I think this property should be removed, as we have different clients, and they can deliver different formats. For example the web catalog can only deliver some formats, and the mobile apps might differ for some time in their ability to deliver a format. 

However we need bigger changes for that, and this property is still used in one of the importers and the custom list code. So I'm going to leave it for now, but update it so that LCP is marked as supported.

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
