### PR TITLE
Handle case of hold on unsupported Overdrive content (PP-2415)

### DIFF
--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -1072,16 +1072,10 @@ class CirculationAPI(LoggerMixin):
                 on_multiple="interchangeable",
             )
             if existing_hold:
-                # The book was on hold, and now we have a loan.
-                # collect cm event to commemorate the conversion:
-                self._collect_event(
-                    patron=patron,
-                    licensepool=licensepool,
-                    name=CirculationEvent.CM_HOLD_CONVERTED_TO_LOAN,
-                )
+                # The book was on hold, and now we have a loan. Call
+                # collect cm event and delete the record of the hold.
+                existing_hold.collect_event_and_delete(self.analytics)
 
-                # Delete the record of the hold.
-                self._db.delete(existing_hold)
             __transaction.commit()
 
             if loan and new_loan:

--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -953,6 +953,7 @@ class OverdriveAPI(
                 already_checked_out = True
             except NoActiveLoan:
                 # Reraise the original exception.
+                self.log.info(f"No active loan found. Raising {e.__class__.__name__}.")
                 raise e from None
 
         # At this point we know all available formats for this book.

--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -998,7 +998,7 @@ class OverdriveAPI(
                 # If this was a hold, we remove the hold record from the database before
                 # we raise the exception, since the hold has been converted to a checkout.
                 if existing_hold:
-                    self._db.delete(existing_hold)
+                    existing_hold.collect_event_and_delete()
 
                 msg = (
                     "This book is not available in a format supported by the Palace app. "
@@ -1006,7 +1006,7 @@ class OverdriveAPI(
                 )
 
                 if not do_early_return:
-                    msg += " You may be able to read this book by logging into the Overdrive website."
+                    msg += " You may be able to read this book by logging into the OverDrive website."
 
                 raise CannotLoan(msg)
 

--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -999,11 +999,15 @@ class OverdriveAPI(
                 if existing_hold:
                     self._db.delete(existing_hold)
 
-                # TODO: Should we suggest that the patron can use Libby to read the book?
-                raise CannotLoan(
+                msg = (
                     "This book is not available in a format supported by the Palace app. "
                     "We apologize for the inconvenience."
                 )
+
+                if not do_early_return:
+                    msg += " You may be able to read this book by logging into the Overdrive website."
+
+                raise CannotLoan(msg)
 
         # Create the loan info.
         return LoanInfo.from_license_pool(

--- a/src/palace/manager/service/analytics/analytics.py
+++ b/src/palace/manager/service/analytics/analytics.py
@@ -9,13 +9,13 @@ from palace.manager.service.analytics.eventdata import AnalyticsEventData
 from palace.manager.service.analytics.local import LocalAnalyticsProvider
 from palace.manager.service.analytics.provider import AnalyticsProvider
 from palace.manager.service.analytics.s3 import S3AnalyticsProvider
-from palace.manager.sqlalchemy.model.library import Library
-from palace.manager.sqlalchemy.model.licensing import LicensePool
-from palace.manager.sqlalchemy.model.patron import Patron
 from palace.manager.util.log import LoggerMixin
 
 if TYPE_CHECKING:
     from palace.manager.service.storage.s3 import S3Service
+    from palace.manager.sqlalchemy.model.library import Library
+    from palace.manager.sqlalchemy.model.licensing import LicensePool
+    from palace.manager.sqlalchemy.model.patron import Patron
 
 
 class Analytics(LoggerMixin, AnalyticsProvider):

--- a/src/palace/manager/service/analytics/eventdata.py
+++ b/src/palace/manager/service/analytics/eventdata.py
@@ -2,17 +2,20 @@ from __future__ import annotations
 
 from datetime import datetime
 from functools import cached_property
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 import flask
 from pydantic import AwareDatetime, BaseModel, ConfigDict, computed_field
 from typing_extensions import Self
 
-from palace.manager.sqlalchemy.model.library import Library
-from palace.manager.sqlalchemy.model.licensing import LicensePool
-from palace.manager.sqlalchemy.model.patron import Patron
 from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.log import LoggerMixin
+
+if TYPE_CHECKING:
+    from palace.manager.sqlalchemy.model.library import Library
+    from palace.manager.sqlalchemy.model.licensing import LicensePool
+    from palace.manager.sqlalchemy.model.patron import Patron
 
 
 class AnalyticsEventData(BaseModel, LoggerMixin):

--- a/src/palace/manager/service/container.py
+++ b/src/palace/manager/service/container.py
@@ -94,6 +94,7 @@ def wire_container(container: Services) -> None:
             "palace.manager.sqlalchemy.model.lane",
             "palace.manager.core.metadata_layer",
             "palace.manager.sqlalchemy.model.collection",
+            "palace.manager.sqlalchemy.model.patron",
             "palace.manager.sqlalchemy.model.work",
         ]
     )

--- a/tests/manager/api/overdrive/test_api.py
+++ b/tests/manager/api/overdrive/test_api.py
@@ -971,7 +971,10 @@ class TestOverdriveAPI:
             match="This book is not available in a format supported by the Palace app",
         ):
             api.checkout(patron, pin, pool, None)
-        services_fixture_wired.analytics_fixture.analytics_mock.collect_event.assert_called_once_with(
+        mock_collect = (
+            services_fixture_wired.analytics_fixture.analytics_mock.collect_event
+        )
+        mock_collect.assert_called_once_with(
             db.default_library(),
             pool,
             CirculationEvent.CM_HOLD_CONVERTED_TO_LOAN,

--- a/tests/manager/api/overdrive/test_api.py
+++ b/tests/manager/api/overdrive/test_api.py
@@ -18,6 +18,7 @@ from palace.manager.api.circulation_exceptions import (
     FormatNotAvailable,
     FulfilledOnIncompatiblePlatform,
     NoAcceptableFormat,
+    NoAvailableCopies,
     NotCheckedOut,
     PatronAuthorizationFailedException,
     PatronHoldLimitReached,
@@ -40,6 +41,7 @@ from palace.manager.sqlalchemy.model.licensing import (
     LicensePool,
     RightsStatus,
 )
+from palace.manager.sqlalchemy.model.patron import Hold
 from palace.manager.sqlalchemy.model.resource import Representation
 from palace.manager.util import base64
 from palace.manager.util.datetime_helpers import utc_now
@@ -806,39 +808,50 @@ class TestOverdriveAPI:
         with pytest.raises(CannotLoan, match="Some error details"):
             api.checkout(patron, pin, pool, None)
 
-        # If the error is "TitleAlreadyCheckedOut", we know that somehow we already have this title
+        # If the error is "TitleAlreadyCheckedOut" or "NoCopiesAvailable", we know that somehow we already have this title
         # checked out. In that case we make a second request to get the loan information, and return a LoanInfo object.
-        http.queue_response(
-            400, content=overdrive_api_fixture.error_message("TitleAlreadyCheckedOut")
-        )
-        http.queue_response(
-            201,
-            content=overdrive_api_fixture.data.sample_data(
-                "checkout_response_no_format_locked_in.json"
-            ),
-        )
-        loan = api.checkout(patron, pin, pool, None)
-
-        # During the checkout process, we get information about the books formats and update them correctly
-        assert {
-            (
-                dm.delivery_mechanism.content_type,
-                dm.delivery_mechanism.drm_scheme,
-                dm.available,
+        for err in ["TitleAlreadyCheckedOut", "NoCopiesAvailable"]:
+            http.queue_response(400, content=overdrive_api_fixture.error_message(err))
+            http.queue_response(
+                201,
+                content=overdrive_api_fixture.data.sample_data(
+                    "checkout_response_no_format_locked_in.json"
+                ),
             )
-            for dm in pool.delivery_mechanisms
-        } == {
-            (Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM, True),
-            (Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM, False),
-        }
+            loan = api.checkout(patron, pin, pool, None)
 
-        # The return value is a LoanInfo object with all relevant info.
-        assert isinstance(loan, LoanInfo)
-        assert loan.collection_id == pool.collection.id
-        assert loan.identifier_type == identifier.type
-        assert loan.identifier == identifier.identifier
-        assert loan.start_date is None
-        assert loan.end_date == datetime(2014, 11, 26, 14, 22, 00, tzinfo=timezone.utc)
+            # During the checkout process, we get information about the books formats and update them correctly
+            assert {
+                (
+                    dm.delivery_mechanism.content_type,
+                    dm.delivery_mechanism.drm_scheme,
+                    dm.available,
+                )
+                for dm in pool.delivery_mechanisms
+            } == {
+                (Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.ADOBE_DRM, True),
+                (Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM, False),
+            }
+
+            # The return value is a LoanInfo object with all relevant info.
+            assert isinstance(loan, LoanInfo)
+            assert loan.collection_id == pool.collection.id
+            assert loan.identifier_type == identifier.type
+            assert loan.identifier == identifier.identifier
+            assert loan.start_date is None
+            assert loan.end_date == datetime(
+                2014, 11, 26, 14, 22, 00, tzinfo=timezone.utc
+            )
+
+        # If we don't actually have an active loan, we raise the original exception.
+        http.queue_response(
+            400, content=overdrive_api_fixture.error_message("NoCopiesAvailable")
+        )
+        http.queue_response(
+            400, content=overdrive_api_fixture.error_message("TitleNotCheckedOut")
+        )
+        with pytest.raises(NoAvailableCopies):
+            api.checkout(patron, pin, pool, None)
 
     @pytest.mark.parametrize(
         "response_file",
@@ -876,7 +889,7 @@ class TestOverdriveAPI:
         http.queue_response(200, content="")
         with pytest.raises(
             CannotLoan,
-            match="This book is not available in a supported format",
+            match="This book is not available in a format supported by the Palace app",
         ):
             api.checkout(patron, pin, pool, None)
 
@@ -921,7 +934,7 @@ class TestOverdriveAPI:
         )
         with pytest.raises(
             CannotLoan,
-            match="This book is not available in a supported format",
+            match="This book is not available in a format supported by the Palace app",
         ):
             api.checkout(patron, pin, pool, None)
 
@@ -939,6 +952,24 @@ class TestOverdriveAPI:
         assert (
             "patron.api.overdrive.com/v1/patrons/me/checkouts/" in loan_info_request_url
         )
+
+        # If the patron has a hold on the book, but after checkout it is in an unsupported format,
+        # we don't return the book, but we delete the hold since its been converted to a loan and
+        # we return an error.
+        pool.on_hold_to(patron, position=0)
+        assert db.session.query(Hold).count() == 1
+        http.reset_mock()
+        http.queue_response(
+            201,
+            content=overdrive_api_fixture.data.sample_data(response_file),
+        )
+        with pytest.raises(
+            CannotLoan,
+            match="This book is not available in a format supported by the Palace app",
+        ):
+            api.checkout(patron, pin, pool, None)
+
+        assert db.session.query(Hold).count() == 0
 
     def test_place_hold(
         self, overdrive_api_fixture: OverdriveAPIFixture, db: DatabaseTransactionFixture


### PR DESCRIPTION
## Description

- Handle the case where a hold on unsupported Overdrive content is converted into a loan.
- Handle an edge case that comes up when we have a loan, but the book has a holds queue. In this case Overdrive API returns `NoCopiesAvailable` rather then the loan. When we see this, check to see if we actually have a loan for the content.
- Reword the problem detail returned to the app when this occurs.
  - Note: I've got a question in the ticket about the wording of this case.

## Motivation and Context

See: PP-2415.

## How Has This Been Tested?

- Tested locally with content in this state
- Added units tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
