### PR TITLE
Add SIP2 dialect that sends SC Status message. (PP-2419)

### DIFF
--- a/src/palace/manager/api/sip/dialect.py
+++ b/src/palace/manager/api/sip/dialect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 from enum import Enum
 
@@ -8,21 +10,41 @@ class DialectConfig:
 
     send_end_session: bool
     tz_spaces: bool
+    send_sc_status: bool = False
 
 
 class Dialect(Enum):
     GENERIC_ILS = "GenericILS"
     AG_VERSO = "AutoGraphicsVerso"
     FOLIO = "TZSpaces"
+    SIP_V2 = "SipV2Compliant"
 
     @property
     def config(self) -> DialectConfig:
         """Return the configuration for this dialect."""
         if self == Dialect.GENERIC_ILS:
             return DialectConfig(send_end_session=True, tz_spaces=False)
+        elif self == Dialect.SIP_V2:
+            return DialectConfig(
+                send_end_session=True, tz_spaces=True, send_sc_status=True
+            )
         elif self == Dialect.AG_VERSO:
             return DialectConfig(send_end_session=False, tz_spaces=False)
         elif self == Dialect.FOLIO:
             return DialectConfig(send_end_session=True, tz_spaces=True)
         else:
             raise NotImplementedError(f"Unknown dialect: {self}")
+
+    @classmethod
+    def form_options(cls) -> dict[Dialect, str]:
+        return {
+            cls.SIP_V2: "SIP v2.00 Compliant",
+            cls.GENERIC_ILS: "Generic ILS",
+            cls.AG_VERSO: "Auto-Graphics VERSO",
+            cls.FOLIO: "Folio",
+        }
+
+    @classmethod
+    def preferred(cls) -> str:
+        """Return the preferred dialect."""
+        return cls.form_options()[cls.SIP_V2]

--- a/tests/mocks/sip.py
+++ b/tests/mocks/sip.py
@@ -23,6 +23,9 @@ class MockSIPClient(SIPClient):
             response = response.encode(Constants.DEFAULT_ENCODING)
         self.responses.append(response)
 
+    def dequeue_response(self):
+        return self.responses.pop(0)
+
     def connect(self):
         # Since there is no socket, do nothing but reset the local
         # connection-specific variables.


### PR DESCRIPTION
## Description

Adds a SIP2 dialect (SIP_V2 / "SIP v2.00 Compliant") that sends the SC Status (99) message before sending the Patron Information (63) message.

NB: Our other dialects, which do not send this message, are not compliant with the SIP v2.00 specification.

## Motivation and Context

Some SIP2 services (e.g., OCLC Wise) will not work properly if the SC Status (99) message is not sent (or, presumably, not sent in the proper sequence).

According to the SIP2 spec[1]:

> **SC Status**
> The SC status message sends SC status to the ACS. It requires an ACS Status Response message reply from the ACS. This message will be the first message sent by the SC to the ACS once a connection has been established (exception: the Login Message may be sent first to login to an ACS server program).
> The ACS will respond with a message that establishes some of the rules to be followed by the SC and establishes some parameters needed for further communication.
> `99<status code><max print width><protocol version>`

[1] https://developers.exlibrisgroup.com/wp-content/uploads/2020/01/3M-Standard-Interchange-Protocol-Version-2.00.pdf  Accessed 2025-04-24.

[Jira PP-2419]

## How Has This Been Tested?

- Manually tested in local development environment.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/14685037953) pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
