### PR TITLE
Parse Overdrive hold and patron responses with Pydantic models

### DIFF
--- a/src/palace/manager/api/overdrive/api.py
+++ b/src/palace/manager/api/overdrive/api.py
@@ -66,7 +66,11 @@ from palace.manager.api.overdrive.model import (
     Checkouts,
     ErrorResponse,
     Format,
+    Hold as HoldResponse,
+    Holds as HoldsResponse,
+    PatronInformation,
     PatronRequestCallable,
+    _overdrive_field_request,
 )
 from palace.manager.api.overdrive.representation import OverdriveRepresentationExtractor
 from palace.manager.api.overdrive.settings import (
@@ -96,7 +100,7 @@ from palace.manager.sqlalchemy.model.licensing import (
 from palace.manager.sqlalchemy.model.patron import Patron
 from palace.manager.sqlalchemy.model.resource import Representation
 from palace.manager.util import base64
-from palace.manager.util.datetime_helpers import strptime_utc, utc_now
+from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.http import HTTP, BadResponseException, RequestKwargs
 
 
@@ -919,19 +923,14 @@ class OverdriveAPI(
 
         identifier = licensepool.identifier
         overdrive_id = identifier.identifier
-        headers = {"Content-Type": "application/json"}
-        payload_dict = dict(fields=[dict(name="reserveId", value=overdrive_id)])
-        payload = json.dumps(payload_dict)
 
         already_checked_out = False
         try:
-            checkout = self.patron_request(
-                patron,
-                pin,
-                self.CHECKOUTS_ENDPOINT,
-                extra_headers=headers,
-                data=payload,
-                response_type=Checkout,
+            make_request: PatronRequestCallable[Checkout] = partial(
+                self.patron_request, patron, pin, response_type=Checkout
+            )
+            checkout = _overdrive_field_request(
+                make_request, self.CHECKOUTS_ENDPOINT, {"reserveId": overdrive_id}
             )
         except OverdriveResponseException as e:
             code = e.error_message
@@ -1020,13 +1019,6 @@ class OverdriveAPI(
             )
         except OverdriveResponseException as e:
             raise CannotReturn(e.error_message) from e
-
-    def fill_out_form(self, **values: str) -> tuple[dict[str, str], str]:
-        fields = []
-        for k, v in list(values.items()):
-            fields.append(dict(name=k, value=v))
-        headers = {"Content-Type": "application/json; charset=utf-8"}
-        return headers, json.dumps(dict(fields=fields))
 
     def get_loan(self, patron: Patron, pin: str | None, overdrive_id: str) -> Checkout:
         """Get patron's loan information for the identified item.
@@ -1171,28 +1163,6 @@ class OverdriveAPI(
             raise CannotFulfill(f"Could not lock in format {format_type}") from e
         return format_data
 
-    @classmethod
-    def extract_data_from_hold_response(
-        cls, hold_response_json: dict[str, Any]
-    ) -> tuple[int, datetime.datetime | None]:
-        position = hold_response_json["holdListPosition"]
-        placed = cls._extract_date(hold_response_json, "holdPlacedDate")
-        return position, placed
-
-    @classmethod
-    def _extract_date(
-        cls, data: dict[str, Any] | Any, field_name: str
-    ) -> datetime.datetime | None:
-        if not isinstance(data, dict):
-            return None
-        if not field_name in data:
-            return None
-        try:
-            return strptime_utc(data[field_name], cls.TIME_FORMAT)
-        except ValueError as e:
-            # Wrong format
-            return None
-
     def get_patron_checkouts(self, patron: Patron, pin: str | None) -> Checkouts:
         """Get information for the given patron's loans.
 
@@ -1207,19 +1177,10 @@ class OverdriveAPI(
             response_type=Checkouts,
         )
 
-    def get_patron_holds(self, patron: Patron, pin: str | None) -> dict[str, Any]:
-        return self.patron_request(patron, pin, self.HOLDS_ENDPOINT).json()  # type: ignore[no-any-return]
-
-    @classmethod
-    def _pd(cls, d: str | None) -> datetime.datetime | None:
-        """Stupid method to parse a date.
-
-        TIME_FORMAT mentions "Z" for Zulu time, which is the same as
-        UTC.
-        """
-        if not d:
-            return None
-        return strptime_utc(d, cls.TIME_FORMAT)
+    def get_patron_holds(self, patron: Patron, pin: str | None) -> HoldsResponse:
+        return self.patron_request(
+            patron, pin, self.HOLDS_ENDPOINT, response_type=HoldsResponse
+        )
 
     def patron_activity(
         self, patron: Patron, pin: str | None
@@ -1232,7 +1193,7 @@ class OverdriveAPI(
 
         try:
             checkouts = self.get_patron_checkouts(patron, pin).checkouts
-            holds = self.get_patron_holds(patron, pin)
+            holds = self.get_patron_holds(patron, pin).holds
         except PatronAuthorizationFailedException as e:
             # This frequently happens because Overdrive performs
             # checks for blocked or expired accounts upon initial
@@ -1246,21 +1207,19 @@ class OverdriveAPI(
                 "Overdrive authentication failed, assuming no loans.", exc_info=e
             )
             checkouts = []
-            holds = {}
+            holds = []
 
         for checkout in checkouts:
             loan_info = self.process_checkout_data(checkout, collection.id)
             if loan_info is not None:
                 yield loan_info
 
-        for hold in holds.get("holds", []):
-            overdrive_identifier = hold["reserveId"].lower()
-            start = self._pd(hold.get("holdPlacedDate"))
-            end = self._pd(hold.get("holdExpires"))
-            position = hold.get("holdListPosition")
-            if position is not None:
-                position = int(position)
-            if "checkout" in hold.get("actions", {}):
+        for hold in holds:
+            overdrive_identifier = hold.reserve_id.lower()
+            start = hold.hold_placed_date
+            end = hold.hold_expires
+            position = hold.hold_list_position
+            if "checkout" in hold.actions:
                 # This patron needs to decide whether to check the
                 # book out. By our reckoning, the patron's position is
                 # 0, not whatever position Overdrive had for them.
@@ -1388,10 +1347,13 @@ class OverdriveAPI(
         # preferred email address for notifications.
         address = None
         try:
-            data = self.patron_request(
-                patron, pin, self.PATRON_INFORMATION_ENDPOINT
-            ).json()
-            address = data.get("lastHoldEmail")
+            patron_information = self.patron_request(
+                patron,
+                pin,
+                self.PATRON_INFORMATION_ENDPOINT,
+                response_type=PatronInformation,
+            )
+            address = patron_information.last_hold_email
 
             # Great! Except, it's possible that this address is the
             # 'trash everything' address, because we _used_ to send
@@ -1431,18 +1393,21 @@ class OverdriveAPI(
         else:
             form_fields["ignoreHoldEmail"] = True
 
-        headers, document = self.fill_out_form(**form_fields)
         try:
-            data = self.patron_request(
-                patron, pin, self.HOLDS_ENDPOINT, headers, document
-            ).json()
+            make_request: PatronRequestCallable[HoldResponse] = partial(
+                self.patron_request, patron, pin, response_type=HoldResponse
+            )
+            hold = _overdrive_field_request(
+                make_request,
+                self.HOLDS_ENDPOINT,
+                form_fields,
+            )
         except OverdriveResponseException as e:
             raise CannotHold(e.error_code) from e
-        position, date = self.extract_data_from_hold_response(data)
         return HoldInfo.from_license_pool(
             licensepool,
-            start_date=date,
-            hold_position=position,
+            start_date=hold.hold_placed_date,
+            hold_position=hold.hold_list_position,
         )
 
     def release_hold(

--- a/src/palace/manager/api/overdrive/model.py
+++ b/src/palace/manager/api/overdrive/model.py
@@ -449,12 +449,13 @@ class Hold(BaseOverdriveModel):
     hold_list_position: NonNegativeInt | None = Field(None, alias="holdListPosition")
     number_of_holds: NonNegativeInt | None = Field(None, alias="numberOfHolds")
     hold_placed_date: AwareDatetime = Field(..., alias="holdPlacedDate")
-    # XXX: This is not referenced in the API documentation but our old parser
-    # used to look for this field in the hold data, so I included it here. We
-    # should validate if this is actually provided by the API response.
-    hold_expires: AwareDatetime | None = Field(None, alias="holdExpires")
     links: dict[str, Link] = Field(default_factory=dict)
     actions: dict[str, Action] = Field(default_factory=dict)
+
+    # This field isn't referenced in the API docs, but it is present when a
+    # hold is available, and gives the date when the hold will expire if
+    # it is not checked out.
+    hold_expires: AwareDatetime | None = Field(None, alias="holdExpires")
 
 
 class Holds(BaseOverdriveModel):

--- a/src/palace/manager/api/overdrive/model.py
+++ b/src/palace/manager/api/overdrive/model.py
@@ -5,7 +5,14 @@ from functools import cached_property
 from typing import Protocol, overload
 from urllib.parse import quote_plus
 
-from pydantic import AliasChoices, AwareDatetime, BaseModel, ConfigDict, Field
+from pydantic import (
+    AliasChoices,
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    NonNegativeInt,
+)
 from pydantic.alias_generators import to_camel
 from requests import Response
 from typing_extensions import Self
@@ -194,6 +201,34 @@ class PatronRequestCallable(Protocol, typing.Generic[T]):
     ) -> T: ...
 
 
+def _overdrive_field_request(
+    make_request: PatronRequestCallable[T],
+    url: str,
+    fields: typing.Mapping[str, str | bool | int],
+    *,
+    method: str | None = None,
+) -> T:
+    if fields:
+        data = json.dumps(
+            {
+                "fields": [
+                    {"name": name, "value": value} for name, value in fields.items()
+                ]
+            }
+        )
+    else:
+        data = None
+
+    headers = {"Content-Type": "application/json"}
+
+    return make_request(
+        method=method,
+        url=url,
+        data=data,
+        extra_headers=headers,
+    )
+
+
 class Action(BaseOverdriveModel):
     href: str
     method: str
@@ -262,21 +297,11 @@ class Action(BaseOverdriveModel):
         if camel_kwargs:
             raise ExtraFieldsError(camel_kwargs.keys())
 
-        if field_data:
-            data = json.dumps(
-                {
-                    "fields": [
-                        {"name": name, "value": value}
-                        for name, value in field_data.items()
-                    ]
-                }
-            )
-        else:
-            data = None
-
-        headers = {"Content-Type": "application/json"}
-        return make_request(
-            method=self.method.upper(), url=self.href, data=data, extra_headers=headers
+        return _overdrive_field_request(
+            make_request,
+            method=self.method.upper(),
+            url=self.href,
+            fields=field_data,
         )
 
 
@@ -411,3 +436,60 @@ class Checkouts(BaseOverdriveModel):
     total_checkouts: int = Field(..., alias="totalCheckouts")
     links: dict[str, Link] = Field(default_factory=dict)
     checkouts: list[Checkout] = Field(default_factory=list)
+
+
+class Hold(BaseOverdriveModel):
+    """
+    See: https://developer.overdrive.com/apis/holds
+    """
+
+    reserve_id: str = Field(..., alias="reserveId")
+    cross_ref_id: int | None = Field(None, alias="crossRefId")
+    email_address: str | None = Field(None, alias="emailAddress")
+    hold_list_position: NonNegativeInt | None = Field(None, alias="holdListPosition")
+    number_of_holds: NonNegativeInt | None = Field(None, alias="numberOfHolds")
+    hold_placed_date: AwareDatetime = Field(..., alias="holdPlacedDate")
+    # XXX: This is not referenced in the API documentation but our old parser
+    # used to look for this field in the hold data, so I included it here. We
+    # should validate if this is actually provided by the API response.
+    hold_expires: AwareDatetime | None = Field(None, alias="holdExpires")
+    links: dict[str, Link] = Field(default_factory=dict)
+    actions: dict[str, Action] = Field(default_factory=dict)
+
+
+class Holds(BaseOverdriveModel):
+    """
+    See: https://developer.overdrive.com/apis/holds
+    """
+
+    total_items: int = Field(..., alias="totalItems")
+    links: dict[str, Link] = Field(default_factory=dict)
+    holds: list[Hold] = Field(default_factory=list)
+
+
+class LendingPeriod(BaseOverdriveModel):
+    """Model for a lending period for a format type."""
+
+    format_type: str = Field(..., alias="formatType")
+    lending_period: NonNegativeInt = Field(..., alias="lendingPeriod")
+    units: str
+
+
+class PatronInformation(BaseOverdriveModel):
+    """
+    See: https://developer.overdrive.com/apis/patron-auth
+    """
+
+    patron_id: int = Field(..., alias="patronId")
+    website_id: int = Field(..., alias="websiteId")
+    existing_patron: bool = Field(..., alias="existingPatron")
+    collection_token: str = Field(..., alias="collectionToken")
+    hold_limit: NonNegativeInt = Field(..., alias="holdLimit")
+    last_hold_email: str | None = Field(None, alias="lastHoldEmail")
+    checkout_limit: NonNegativeInt = Field(..., alias="checkoutLimit")
+    lending_periods: list[LendingPeriod] = Field(..., alias="lendingPeriods")
+    links: dict[str, Link] = Field(default_factory=dict)
+    link_templates: dict[str, LinkTemplate] = Field(
+        default_factory=dict, alias="linkTemplates"
+    )
+    actions: list[dict[str, Action]] = Field(default_factory=list)

--- a/tests/manager/api/overdrive/test_api.py
+++ b/tests/manager/api/overdrive/test_api.py
@@ -8,6 +8,7 @@ import pytest
 
 from palace.manager.api.circulation import (
     FetchFulfillment,
+    HoldInfo,
     LoanInfo,
     RedirectFulfillment,
 )
@@ -948,86 +949,107 @@ class TestOverdriveAPI:
         #
         # The request will include different form fields depending on
         # whether default_notification_email_address returns something.
-        http = overdrive_api_fixture.mock_http
+        patron = db.patron()
+        pin = "1234"
         api = overdrive_api_fixture.api
+        http = overdrive_api_fixture.mock_http
+        pool = db.licensepool(edition=None, collection=overdrive_api_fixture.collection)
 
         # First, test the case where no notification email address is
         # provided and there is no default.
-        patron = MagicMock()
-        pin = MagicMock()
-        pool = db.licensepool(edition=None, collection=overdrive_api_fixture.collection)
-
-        # Mock out some functions
-        # TODO: Replace this test with one that doesn't rely so heavily on mocking.
-        mock_fill_out_form = create_autospec(
-            api.fill_out_form, return_value=("headers", "filled-out form")
-        )
-        api.fill_out_form = mock_fill_out_form
-
         mock_default_notification_email_address = create_autospec(
             api.default_notification_email_address, return_value=None
         )
         api.default_notification_email_address = mock_default_notification_email_address
 
-        mock_patron_request = create_autospec(api.patron_request)
-        api.patron_request = mock_patron_request
-
-        mock_extract_data_from_hold_response = create_autospec(
-            api.extract_data_from_hold_response, return_value=("position", "date")
+        overdrive_api_fixture.queue_access_token_response()
+        http.queue_response(
+            201,
+            content=overdrive_api_fixture.data.sample_data("successful_hold.json"),
         )
-        api.extract_data_from_hold_response = mock_extract_data_from_hold_response
 
-        # Make call
         response = api.place_hold(patron, pin, pool, None)
-
-        # Now we can trace the path of the input through the method calls.
+        assert isinstance(response, HoldInfo)
+        assert response.identifier_type == pool.identifier.type
+        assert response.identifier == pool.identifier.identifier
 
         # The patron and PIN were passed into
         # default_notification_email_address.
         mock_default_notification_email_address.assert_called_once_with(patron, pin)
 
         # The return value was None, and so 'ignoreHoldEmail' was
-        # added to the form to be filled out, rather than
-        # 'emailAddress' being added.
-        mock_fill_out_form.assert_called_once_with(
-            ignoreHoldEmail=True, reserveId=str(pool.identifier.identifier)
-        )
+        # sent in the request data.
 
-        # patron_request was called with the filled-out form and other
-        # information necessary to authenticate the request.
-        mock_patron_request.assert_called_once_with(
-            patron, pin, api.HOLDS_ENDPOINT, "headers", "filled-out form"
-        )
+        [hold_request_method] = http.requests_methods[1:]
+        [hold_request_url] = http.requests[1:]
+        [hold_request_args] = http.requests_args[1:]
 
-        # Finally, extract_data_from_hold_response was called on
-        # the return value of patron_request
-        mock_extract_data_from_hold_response.assert_called_once_with(
-            mock_patron_request.return_value.json.return_value
+        assert hold_request_method == "post"
+        assert hold_request_url.endswith("/me/holds")
+        assert hold_request_args["data"] == json.dumps(
+            {
+                "fields": [
+                    {"name": "reserveId", "value": pool.identifier.identifier},
+                    {"name": "ignoreHoldEmail", "value": True},
+                ]
+            }
         )
 
         # Now we need to test two more cases.
         #
         # First, the patron has a holds notification address
         # registered with Overdrive.
-        mock_default_notification_email_address.reset_mock()
-        mock_fill_out_form.reset_mock()
+        http.reset_mock()
         email = "holds@patr.on"
         mock_default_notification_email_address.return_value = email
+
+        http.queue_response(
+            201,
+            content=overdrive_api_fixture.data.sample_data("successful_hold.json"),
+        )
+
         api.place_hold(patron, pin, pool, None)
 
-        # Different variables were passed in to fill_out_form.
-        mock_fill_out_form.assert_called_once_with(
-            emailAddress=email, reserveId=str(pool.identifier.identifier)
+        [hold_request_method] = http.requests_methods
+        [hold_request_url] = http.requests
+        [hold_request_args] = http.requests_args
+
+        assert hold_request_method == "post"
+        assert hold_request_url.endswith("/me/holds")
+        assert hold_request_args["data"] == json.dumps(
+            {
+                "fields": [
+                    {"name": "reserveId", "value": pool.identifier.identifier},
+                    {"name": "emailAddress", "value": email},
+                ]
+            }
         )
 
         # Finally, test that when a specific address is passed in, it
         # takes precedence over the patron's holds notification address.
-        mock_default_notification_email_address.reset_mock()
-        mock_fill_out_form.reset_mock()
+        http.reset_mock()
         mock_default_notification_email_address.return_value = email
+
+        http.queue_response(
+            201,
+            content=overdrive_api_fixture.data.sample_data("successful_hold.json"),
+        )
+
         api.place_hold(patron, pin, pool, "another@addre.ss")
-        mock_fill_out_form.assert_called_once_with(
-            emailAddress="another@addre.ss", reserveId=str(pool.identifier.identifier)
+
+        [hold_request_method] = http.requests_methods
+        [hold_request_url] = http.requests
+        [hold_request_args] = http.requests_args
+
+        assert hold_request_method == "post"
+        assert hold_request_url.endswith("/me/holds")
+        assert hold_request_args["data"] == json.dumps(
+            {
+                "fields": [
+                    {"name": "reserveId", "value": pool.identifier.identifier},
+                    {"name": "emailAddress", "value": "another@addre.ss"},
+                ]
+            }
         )
 
     def test_checkin(


### PR DESCRIPTION
## Description

Update our Overdrive API to parse responses from these endpoints with pydantic models:

- hold
- holds
- patron info

## Motivation and Context

Some follow on work to https://github.com/ThePalaceProject/circulation/pull/2359. On Friday I spent some time going through the hold responses that Overdrive provides to see if we got any useful format information in them. While I was at it I converted the responses to parse with Pydantic.

## How Has This Been Tested?

- Testing in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
