### PR TITLE
[PP-1467] Convert nyt best seller update script to celery

### DIFF
--- a/bin/update_nyt_best_seller_lists
+++ b/bin/update_nyt_best_seller_lists
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-"""Bring in the entire history of all NYT best-seller lists."""
+"""Bring in the entire history of all NYT best-seller lists.
+This script kicks off the task and returns immediately."""
 import sys
 
 from palace.manager.scripts.nyt import NYTBestSellerListsScript

--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -18,7 +18,6 @@ HOME=/var/www/circulation
 # These scripts improve the bibliographic information associated with
 # the collections.
 #
-30 3 * * * root bin/run update_nyt_best_seller_lists >> /var/log/cron.log 2>&1
 
 # If any works are missing presentation editions, add them.
 0 */3 * * * root bin/run work_presentation_editions >> /var/log/cron.log 2>&1

--- a/src/palace/manager/api/metadata/nyt.py
+++ b/src/palace/manager/api/metadata/nyt.py
@@ -218,7 +218,6 @@ class NYTBestSellerAPI(
         """Update the given list with current and historical data."""
         for date in list.all_dates:
             self.update(list, date, self.HISTORICAL_LIST_MAX_AGE)
-            self._db.commit()
 
 
 class NYTBestSellerList(list["NYTBestSellerListTitle"], LoggerMixin):

--- a/src/palace/manager/celery/tasks/nyt.py
+++ b/src/palace/manager/celery/tasks/nyt.py
@@ -1,0 +1,32 @@
+from celery import shared_task
+
+from palace.manager.api.metadata.nyt import NYTBestSellerAPI
+from palace.manager.celery.task import Task
+from palace.manager.service.celery.celery import QueueNames
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def update_nyt_best_sellers_lists(task: Task, include_history: bool = False) -> None:
+
+    with task.session() as session:
+        api = NYTBestSellerAPI.from_config(session)
+        names = api.list_of_lists()
+    for l in sorted(names["results"], key=lambda x: x["list_name_encoded"]):
+        # run each list update in its own transaction to minimize transaction time and size
+        with task.transaction() as session:
+            api = NYTBestSellerAPI.from_config(session)
+            name = l["list_name_encoded"]
+            task.log.info(f"Handling list {name}")
+            best = api.best_seller_list(l)
+
+            if include_history:
+                api.fill_in_history(best)
+            else:
+                api.update(best)
+
+            # Mirror the list to the database.
+            custom_list = best.to_customlist(session)
+            task.log.info(
+                f'Now custom list named "{custom_list.name}" '
+                f"contains {len(custom_list.entries)} entries in the list."
+            )

--- a/src/palace/manager/scripts/nyt.py
+++ b/src/palace/manager/scripts/nyt.py
@@ -9,10 +9,6 @@ from palace.manager.scripts.base import Script
 class NYTBestSellerListsScript(Script):
     name = "Update New York Times best-seller lists by kicking off an asynchronous task"
 
-    def __init__(self, include_history=False):
-        super().__init__()
-        self.include_history = include_history
-
     @classmethod
     def arg_parser(cls) -> argparse.ArgumentParser:
         parser = argparse.ArgumentParser(
@@ -26,5 +22,6 @@ class NYTBestSellerListsScript(Script):
         )
         return parser
 
-    def do_run(self):
-        update_nyt_best_sellers_lists.delay(include_history=self.include_history)
+    def do_run(self, *args, **kwargs):
+        parsed = self.parse_command_line(self._db, *args, **kwargs)
+        update_nyt_best_sellers_lists.delay(include_history=parsed.include_history)

--- a/src/palace/manager/scripts/nyt.py
+++ b/src/palace/manager/scripts/nyt.py
@@ -25,3 +25,7 @@ class NYTBestSellerListsScript(Script):
     def do_run(self, *args, **kwargs):
         parsed = self.parse_command_line(self._db, *args, **kwargs)
         update_nyt_best_sellers_lists.delay(include_history=parsed.include_history)
+        self.log.info(
+            f"Successfully queued update_nyt_best_sellers_lists task "
+            f"(include_history={str(parsed.include_history)}"
+        )

--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -190,6 +190,13 @@ def beat_schedule() -> dict[str, Any]:
                 hour="8,20",
             ),  # Every 12 hours, but spaced after hour 8 to reduce job cluttering
         },
+        "update_nyt_best_sellers_lists": {
+            "task": "nyt.update_nyt_best_sellers_lists",
+            "schedule": crontab(
+                minute="30",
+                hour="3",
+            ),  # Every morning at 3:30 am.
+        },
     }
 
 

--- a/tests/manager/celery/tasks/test_nyt.py
+++ b/tests/manager/celery/tasks/test_nyt.py
@@ -1,0 +1,60 @@
+from unittest.mock import create_autospec, patch
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+from fixtures.celery import CeleryFixture
+from fixtures.database import DatabaseTransactionFixture
+
+from palace.manager.api.metadata.nyt import NYTBestSellerAPI, NYTBestSellerList
+from palace.manager.celery.tasks.nyt import update_nyt_best_sellers_lists
+
+
+@pytest.mark.parametrize(
+    "include_history",
+    [
+        pytest.param(
+            True,
+        ),
+        pytest.param(
+            False,
+        ),
+    ],
+)
+def test_update_nyt_best_sellers_lists(
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+    caplog: LogCaptureFixture,
+    include_history: bool,
+) -> None:
+    with patch("palace.manager.celery.tasks.nyt.NYTBestSellerAPI") as nyt_api:
+        list_b = {"list_name_encoded": "list b"}
+        list_a = {"list_name_encoded": "list a"}
+        mock_api = create_autospec(NYTBestSellerAPI)
+        mock_api.list_of_lists.return_value = {
+            "results": [
+                list_b,
+                list_a,
+            ]
+        }
+        nyt_api.from_config.return_value = mock_api
+
+        best_seller_list = create_autospec(NYTBestSellerList)
+        mock_api.best_seller_list.return_value = best_seller_list
+
+        update_nyt_best_sellers_lists.delay(include_history=include_history).wait()
+
+        assert mock_api.list_of_lists.call_count == 1
+        assert mock_api.best_seller_list.call_count == 2
+        # verify that best seller lists are retrieved in sorted order
+        assert [
+            x.args[0]["list_name_encoded"]
+            for x in mock_api.best_seller_list.call_args_list
+        ] == ["list a", "list b"]
+        if include_history:
+            assert mock_api.fill_in_history.call_count == 2
+            assert mock_api.update.call_count == 0
+        else:
+            assert mock_api.fill_in_history.call_count == 0
+            assert mock_api.update.call_count == 2
+
+        assert best_seller_list.to_customlist.call_count == 2

--- a/tests/manager/celery/tasks/test_nyt.py
+++ b/tests/manager/celery/tasks/test_nyt.py
@@ -1,7 +1,6 @@
 from unittest.mock import create_autospec, patch
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 
 from palace.manager.api.metadata.nyt import NYTBestSellerAPI, NYTBestSellerList
 from palace.manager.celery.tasks.nyt import update_nyt_best_sellers_lists
@@ -23,7 +22,6 @@ from tests.fixtures.database import DatabaseTransactionFixture
 def test_update_nyt_best_sellers_lists(
     db: DatabaseTransactionFixture,
     celery_fixture: CeleryFixture,
-    caplog: LogCaptureFixture,
     include_history: bool,
 ) -> None:
     with patch("palace.manager.celery.tasks.nyt.NYTBestSellerAPI") as nyt_api:

--- a/tests/manager/celery/tasks/test_nyt.py
+++ b/tests/manager/celery/tasks/test_nyt.py
@@ -2,11 +2,11 @@ from unittest.mock import create_autospec, patch
 
 import pytest
 from _pytest.logging import LogCaptureFixture
-from fixtures.celery import CeleryFixture
-from fixtures.database import DatabaseTransactionFixture
 
 from palace.manager.api.metadata.nyt import NYTBestSellerAPI, NYTBestSellerList
 from palace.manager.celery.tasks.nyt import update_nyt_best_sellers_lists
+from tests.fixtures.celery import CeleryFixture
+from tests.fixtures.database import DatabaseTransactionFixture
 
 
 @pytest.mark.parametrize(

--- a/tests/manager/scripts/test_update_nyt_best_sellers_lists.py
+++ b/tests/manager/scripts/test_update_nyt_best_sellers_lists.py
@@ -1,0 +1,22 @@
+from unittest.mock import patch
+
+import pytest
+
+from palace.manager.scripts.nyt import NYTBestSellerListsScript
+
+
+@pytest.mark.parametrize(
+    "include_history",
+    [
+        pytest.param(
+            True,
+        ),
+        pytest.param(
+            False,
+        ),
+    ],
+)
+def test_do_run(include_history: bool):
+    with patch("palace.manager.scripts.nyt.update_nyt_best_sellers_lists") as mock:
+        NYTBestSellerListsScript(include_history=include_history).do_run()
+        mock.delay.assert_called_once_with(include_history=include_history)

--- a/tests/manager/scripts/test_update_nyt_best_sellers_lists.py
+++ b/tests/manager/scripts/test_update_nyt_best_sellers_lists.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 import pytest
 
 from palace.manager.scripts.nyt import NYTBestSellerListsScript
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.services import ServicesFixture
 
 
 @pytest.mark.parametrize(
@@ -16,7 +18,16 @@ from palace.manager.scripts.nyt import NYTBestSellerListsScript
         ),
     ],
 )
-def test_do_run(include_history: bool):
+def test_do_run(
+    include_history: bool,
+    db: DatabaseTransactionFixture,
+    services_fixture: ServicesFixture,
+):
     with patch("palace.manager.scripts.nyt.update_nyt_best_sellers_lists") as mock:
-        NYTBestSellerListsScript(include_history=include_history).do_run()
+        command_args = []
+        if include_history:
+            command_args.append("--include-history")
+        NYTBestSellerListsScript(db.session, services_fixture.services).do_run(
+            command_args
+        )
         mock.delay.assert_called_once_with(include_history=include_history)


### PR DESCRIPTION
## Description

* Converts the NYT best seller update script to celery
* Updates manual script
* Removes the cron job
* Adds a scheduled task to the beat schedule
* Adds a tests for both the script and the task.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1467
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
New unit tests added.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
