### PR TITLE
[PP-1471] convert novelist script to celery tasks

### DIFF
--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -29,9 +29,6 @@ HOME=/var/www/circulation
 # those works.
 30 22 * * * root bin/run work_classify_unchecked_subjects >> /var/log/cron.log 2>&1
 
-# Sync a library's collection with NoveList
-0 0 * * 0 root bin/run -d 60 novelist_update >> /var/log/cron.log 2>&1
-
 # The remaining scripts keep the circulation manager in sync with
 # specific types of collections.
 

--- a/src/palace/manager/celery/tasks/novelist.py
+++ b/src/palace/manager/celery/tasks/novelist.py
@@ -1,0 +1,45 @@
+from celery import shared_task
+
+from palace.manager.api.metadata.novelist import NoveListAPI
+from palace.manager.celery.task import Task
+from palace.manager.service.celery.celery import QueueNames
+from palace.manager.sqlalchemy.model.library import Library
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def update_novelists_for_all_libraries(task: Task) -> None:
+    with task.session() as session:
+        libraries = session.query(Library).all()
+        for library in libraries:
+            update_novelists_by_library.delay(library_id=library.id)
+            task.log.info(
+                f"Queued update task for library('{library.name}' (id={library.id})"
+            )
+
+        task.log.info(
+            f"update_novelists_for_all_libraries task completed successfully."
+        )
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def update_novelists_by_library(task: Task, library_id: int) -> None:
+
+    with task.session() as session:
+        library = Library.by_id(session, id=library_id)
+
+        if not library:
+            task.log.error(
+                f"Library with id={library_id} not found. Unable to process task."
+            )
+            return
+
+        api = NoveListAPI.from_config(library)
+
+        task.log.info(
+            f"Beginning update for library('{library.name}' (id={library.id})"
+        )
+        response = api.put_items_novelist(library)
+        task.log.info(
+            f"Update complete for  library('{library.name}' (id={library.id}). "
+            f"Novelist API Response:\n{response}"
+        )

--- a/src/palace/manager/celery/tasks/novelist.py
+++ b/src/palace/manager/celery/tasks/novelist.py
@@ -1,19 +1,39 @@
 from celery import shared_task
+from sqlalchemy import select
 
 from palace.manager.api.metadata.novelist import NoveListAPI
 from palace.manager.celery.task import Task
 from palace.manager.service.celery.celery import QueueNames
+from palace.manager.sqlalchemy.model.integration import (
+    IntegrationConfiguration,
+    IntegrationLibraryConfiguration,
+)
 from palace.manager.sqlalchemy.model.library import Library
 
 
 @shared_task(queue=QueueNames.default, bind=True)
 def update_novelists_for_all_libraries(task: Task) -> None:
     with task.session() as session:
-        libraries = session.query(Library).all()
-        for library in libraries:
-            update_novelists_by_library.delay(library_id=library.id)
+        registry = task.services.integration_registry.metadata()
+        novelist_protocol = registry.get_protocol(NoveListAPI)
+        all_libraries_with_novelist_config = (
+            select(Library.id, Library.name)
+            .join(IntegrationLibraryConfiguration)
+            .join(IntegrationConfiguration)
+            .where(IntegrationConfiguration.protocol == novelist_protocol)
+        )
+        libraries = session.execute(all_libraries_with_novelist_config).all()
+        if libraries:
+            for library in libraries:
+                update_novelists_by_library.delay(library_id=library.id)
+                task.log.info(
+                    f"Queued update task for library('{library.name}' (id={library.id})"
+                )
+        else:
+
             task.log.info(
-                f"Queued update task for library('{library.name}' (id={library.id})"
+                f"No libraries in this CM are configured with the Novelist metatadata integration. "
+                f"No update tasks queued."
             )
 
         task.log.info(

--- a/src/palace/manager/scripts/novelist.py
+++ b/src/palace/manager/scripts/novelist.py
@@ -2,18 +2,24 @@ from __future__ import annotations
 
 import sys
 
+from palace.manager.api.metadata.novelist import NoveListAPI
 from palace.manager.celery.tasks.novelist import update_novelists_by_library
 from palace.manager.scripts.input import LibraryInputScript
 from palace.manager.scripts.timestamp import TimestampScript
 
 
 class NovelistSnapshotScript(TimestampScript, LibraryInputScript):
-    def do_run(
-        self, output=sys.stdout, update_novelists_by_collection=None, *args, **kwargs
-    ):
+    def do_run(self, output=sys.stdout, *args, **kwargs):
         parsed = self.parse_command_line(self._db, *args, **kwargs)
         for library in parsed.libraries:
-            update_novelists_by_library.delay(library_id=library.id)
-            self.log.info(
-                f'Queued novelist_update task for library: name="{library.name}", id={library.id}'
-            )
+            if not NoveListAPI.integration(library):
+                self.log.info(
+                    f'The library name "{library.name}" is not associated with Novelist API integration and '
+                    f"therefore will not be queued."
+                )
+            else:
+                # only queue up libraries associated with
+                update_novelists_by_library.delay(library_id=library.id)
+                self.log.info(
+                    f'Queued novelist_update task for library: name="{library.name}", id={library.id}'
+                )

--- a/src/palace/manager/scripts/novelist.py
+++ b/src/palace/manager/scripts/novelist.py
@@ -2,26 +2,18 @@ from __future__ import annotations
 
 import sys
 
-from palace.manager.api.metadata.novelist import NoveListAPI
-from palace.manager.core.config import CannotLoadConfiguration
+from palace.manager.celery.tasks.novelist import update_novelists_by_library
 from palace.manager.scripts.input import LibraryInputScript
 from palace.manager.scripts.timestamp import TimestampScript
 
 
 class NovelistSnapshotScript(TimestampScript, LibraryInputScript):
-    def do_run(self, output=sys.stdout, *args, **kwargs):
+    def do_run(
+        self, output=sys.stdout, update_novelists_by_collection=None, *args, **kwargs
+    ):
         parsed = self.parse_command_line(self._db, *args, **kwargs)
         for library in parsed.libraries:
-            try:
-                api = NoveListAPI.from_config(library)
-            except CannotLoadConfiguration as e:
-                self.log.info(str(e))
-                continue
-            if api:
-                response = api.put_items_novelist(library)
-
-                if response:
-                    result = "NoveList API Response\n"
-                    result += str(response)
-
-                    output.write(result)
+            update_novelists_by_library.delay(library_id=library.id)
+            self.log.info(
+                f'Queued novelist_update task for library: name="{library.name}", id={library.id}'
+            )

--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -197,6 +197,12 @@ def beat_schedule() -> dict[str, Any]:
                 hour="3",
             ),  # Every morning at 3:30 am.
         },
+        "update_novelists_for_all_libraries": {
+            "task": "novelist.update_novelists_for_all_libraries",
+            "schedule": crontab(
+                minute="0", hour="0", day_of_week="0"
+            ),  # Every Sundary at midnight
+        },
     }
 
 

--- a/tests/manager/celery/tasks/test_novelist.py
+++ b/tests/manager/celery/tasks/test_novelist.py
@@ -1,0 +1,71 @@
+from unittest.mock import create_autospec, patch
+
+import pytest
+
+from palace.manager.api.metadata.novelist import NoveListAPI
+from palace.manager.celery.tasks.novelist import (
+    update_novelists_by_library,
+    update_novelists_for_all_libraries,
+)
+from palace.manager.service.logging.configuration import LogLevel
+from tests.fixtures.celery import CeleryFixture
+from tests.fixtures.database import DatabaseTransactionFixture
+
+
+def test_update_novelists_for_all_libraries(
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+    caplog: pytest.LogCaptureFixture,
+):
+    caplog.set_level(LogLevel.info)
+
+    lib1 = db.library(name="lib1", short_name="lib1")
+    lib2 = db.library(name="lib2", short_name="lib2")
+
+    with patch(
+        "palace.manager.celery.tasks.novelist.update_novelists_by_library"
+    ) as update:
+        update_novelists_for_all_libraries.delay().wait()
+
+        assert update.delay.call_count == 2
+        assert [x.kwargs["library_id"] for x in update.delay.call_args_list] == [
+            lib1.id,
+            lib2.id,
+        ]
+
+    for lib in [lib1, lib2]:
+        assert (
+            f"Queued update task for library('{lib.name}' (id={lib.id})" in caplog.text
+        )
+
+    assert "task completed successfully" in caplog.text
+
+
+def test_update_novelists_by_library(
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+    caplog: pytest.LogCaptureFixture,
+):
+    caplog.set_level(LogLevel.info)
+
+    lib1 = db.library(name="lib1", short_name="lib1")
+    with patch("palace.manager.celery.tasks.novelist.NoveListAPI") as api_class:
+        mock_api = create_autospec(NoveListAPI)
+        response = "test response"
+        mock_api.put_items_novelist.return_value = response
+        api_class.from_config.return_value = mock_api
+        update_novelists_by_library.delay(library_id=lib1.id).wait()
+
+        api_class.from_config.assert_called_once_with(lib1)
+        mock_api.put_items_novelist.assert_called_once_with(lib1)
+        assert f"Novelist API Response:\n{response}" in caplog.text
+
+
+def test_update_novelists_by_library_library_not_found(
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+    caplog: pytest.LogCaptureFixture,
+):
+    caplog.set_level(LogLevel.info)
+    update_novelists_by_library.delay(library_id=100).wait()
+    assert f"Library with id=100 not found. Unable to process task." in caplog.text

--- a/tests/manager/scripts/test_novelist.py
+++ b/tests/manager/scripts/test_novelist.py
@@ -1,30 +1,39 @@
 from __future__ import annotations
 
-from palace.manager.api.metadata.novelist import NoveListAPI
+from unittest.mock import patch
+
+import pytest
+
 from palace.manager.scripts.novelist import NovelistSnapshotScript
+from palace.manager.service.logging.configuration import LogLevel
 from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.services import ServicesFixture
 
 
 class TestNovelistSnapshotScript:
     def mockNoveListAPI(self, *args, **kwargs):
         self.called_with = (args, kwargs)
 
-    def test_do_run(self, db: DatabaseTransactionFixture):
-        """Test that NovelistSnapshotScript.do_run() calls the NoveList api."""
-
-        class MockNovelistSnapshotScript(NovelistSnapshotScript):
-            pass
-
-        oldNovelistConfig = NoveListAPI.from_config
-        NoveListAPI.from_config = self.mockNoveListAPI
-
+    def test_do_run(
+        self,
+        db: DatabaseTransactionFixture,
+        services_fixture: ServicesFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test that NovelistSnapshotScript.do_run() queues the update_novelists_by_library task."""
+        caplog.set_level(LogLevel.info)
         l1 = db.library()
         cmd_args = [l1.name]
-        script = MockNovelistSnapshotScript(db.session)
-        script.do_run(cmd_args=cmd_args)
 
-        (params, args) = self.called_with
-
-        assert params[0] == l1
-
-        NoveListAPI.from_config = oldNovelistConfig
+        with patch(
+            "palace.manager.scripts.novelist.update_novelists_by_library"
+        ) as update:
+            script = NovelistSnapshotScript(
+                db.session,
+            )
+            script.do_run(cmd_args=cmd_args)
+            update.delay.assert_called_once_with(library_id=l1.id)
+            assert (
+                f'Queued novelist_update task for library: name="{l1.name}", id={l1.id}'
+                in caplog.text
+            )


### PR DESCRIPTION
## Description
This update replaces the implementation of the NovelistSnapshotScript to spawn a celery task for each library we want to update.  On the celery side, there are two tasks. One  spawns tasks for each library while the other handles the novelist updates by library.

Additionally I removed the cron job from docker/services/cron/circulation and moved it to a celery scheduled task executing at the same time: ie Midnight on Sunday. 

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-1471

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests added.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
