### PR TITLE
Convert metadata layer models to use pydantic (PP-2466)

### DIFF
--- a/alembic/versions/20250505_d671b95566fb_make_contributor_aliases_not_nullable.py
+++ b/alembic/versions/20250505_d671b95566fb_make_contributor_aliases_not_nullable.py
@@ -1,0 +1,35 @@
+"""Make contributor.aliases not nullable
+
+Revision ID: d671b95566fb
+Revises: f36442df213d
+Create Date: 2025-05-05 17:03:57.699199+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "d671b95566fb"
+down_revision = "f36442df213d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "contributors",
+        "aliases",
+        existing_type=postgresql.ARRAY(sa.VARCHAR()),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "contributors",
+        "aliases",
+        existing_type=postgresql.ARRAY(sa.VARCHAR()),
+        nullable=True,
+    )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1602,45 +1602,51 @@ python-dateutil = ">=2.7"
 
 [[package]]
 name = "frozendict"
-version = "2.4.4"
+version = "2.4.6"
 description = "A simple immutable dictionary"
 optional = false
 python-versions = ">=3.6"
 groups = ["main"]
 files = [
-    {file = "frozendict-2.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4a59578d47b3949437519b5c39a016a6116b9e787bb19289e333faae81462e59"},
-    {file = "frozendict-2.4.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:12a342e439aef28ccec533f0253ea53d75fe9102bd6ea928ff530e76eac38906"},
-    {file = "frozendict-2.4.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f79c26dff10ce11dad3b3627c89bb2e87b9dd5958c2b24325f16a23019b8b94"},
-    {file = "frozendict-2.4.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2bd009cf4fc47972838a91e9b83654dc9a095dc4f2bb3a37c3f3124c8a364543"},
-    {file = "frozendict-2.4.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:87ebcde21565a14fe039672c25550060d6f6d88cf1f339beac094c3b10004eb0"},
-    {file = "frozendict-2.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:fefeb700bc7eb8b4c2dc48704e4221860d254c8989fb53488540bc44e44a1ac2"},
-    {file = "frozendict-2.4.4-cp310-cp310-win_arm64.whl", hash = "sha256:4297d694eb600efa429769125a6f910ec02b85606f22f178bafbee309e7d3ec7"},
-    {file = "frozendict-2.4.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:812ab17522ba13637826e65454115a914c2da538356e85f43ecea069813e4b33"},
-    {file = "frozendict-2.4.4-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fee9420475bb6ff357000092aa9990c2f6182b2bab15764330f4ad7de2eae49"},
-    {file = "frozendict-2.4.4-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:3148062675536724502c6344d7c485dd4667fdf7980ca9bd05e338ccc0c4471e"},
-    {file = "frozendict-2.4.4-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:78c94991944dd33c5376f720228e5b252ee67faf3bac50ef381adc9e51e90d9d"},
-    {file = "frozendict-2.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:1697793b5f62b416c0fc1d94638ec91ed3aa4ab277f6affa3a95216ecb3af170"},
-    {file = "frozendict-2.4.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:199a4d32194f3afed6258de7e317054155bc9519252b568d9cfffde7e4d834e5"},
-    {file = "frozendict-2.4.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85375ec6e979e6373bffb4f54576a68bf7497c350861d20686ccae38aab69c0a"},
-    {file = "frozendict-2.4.4-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:2d8536e068d6bf281f23fa835ac07747fb0f8851879dd189e9709f9567408b4d"},
-    {file = "frozendict-2.4.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:259528ba6b56fa051bc996f1c4d8b57e30d6dd3bc2f27441891b04babc4b5e73"},
-    {file = "frozendict-2.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:07c3a5dee8bbb84cba770e273cdbf2c87c8e035903af8f781292d72583416801"},
-    {file = "frozendict-2.4.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6874fec816b37b6eb5795b00e0574cba261bf59723e2de607a195d5edaff0786"},
-    {file = "frozendict-2.4.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8f92425686323a950337da4b75b4c17a3327b831df8c881df24038d560640d4"},
-    {file = "frozendict-2.4.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d58d9a8d9e49662c6dafbea5e641f97decdb3d6ccd76e55e79818415362ba25"},
-    {file = "frozendict-2.4.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:93a7b19afb429cbf99d56faf436b45ef2fa8fe9aca89c49eb1610c3bd85f1760"},
-    {file = "frozendict-2.4.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2b70b431e3a72d410a2cdf1497b3aba2f553635e0c0f657ce311d841bf8273b6"},
-    {file = "frozendict-2.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:e1b941132d79ce72d562a13341d38fc217bc1ee24d8c35a20d754e79ff99e038"},
-    {file = "frozendict-2.4.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:dc2228874eacae390e63fd4f2bb513b3144066a977dc192163c9f6c7f6de6474"},
-    {file = "frozendict-2.4.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63aa49f1919af7d45fb8fd5dec4c0859bc09f46880bd6297c79bb2db2969b63d"},
-    {file = "frozendict-2.4.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6bf9260018d653f3cab9bd147bd8592bf98a5c6e338be0491ced3c196c034a3"},
-    {file = "frozendict-2.4.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6eb716e6a6d693c03b1d53280a1947716129f5ef9bcdd061db5c17dea44b80fe"},
-    {file = "frozendict-2.4.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d13b4310db337f4d2103867c5a05090b22bc4d50ca842093779ef541ea9c9eea"},
-    {file = "frozendict-2.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:b3b967d5065872e27b06f785a80c0ed0a45d1f7c9b85223da05358e734d858ca"},
-    {file = "frozendict-2.4.4-cp39-cp39-win_arm64.whl", hash = "sha256:4ae8d05c8d0b6134bfb6bfb369d5fa0c4df21eabb5ca7f645af95fdc6689678e"},
-    {file = "frozendict-2.4.4-py311-none-any.whl", hash = "sha256:705efca8d74d3facbb6ace80ab3afdd28eb8a237bfb4063ed89996b024bc443d"},
-    {file = "frozendict-2.4.4-py312-none-any.whl", hash = "sha256:d9647563e76adb05b7cde2172403123380871360a114f546b4ae1704510801e5"},
-    {file = "frozendict-2.4.4.tar.gz", hash = "sha256:3f7c031b26e4ee6a3f786ceb5e3abf1181c4ade92dce1f847da26ea2c96008c7"},
+    {file = "frozendict-2.4.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c3a05c0a50cab96b4bb0ea25aa752efbfceed5ccb24c007612bc63e51299336f"},
+    {file = "frozendict-2.4.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f5b94d5b07c00986f9e37a38dd83c13f5fe3bf3f1ccc8e88edea8fe15d6cd88c"},
+    {file = "frozendict-2.4.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4c789fd70879ccb6289a603cdebdc4953e7e5dea047d30c1b180529b28257b5"},
+    {file = "frozendict-2.4.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da6a10164c8a50b34b9ab508a9420df38f4edf286b9ca7b7df8a91767baecb34"},
+    {file = "frozendict-2.4.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9a8a43036754a941601635ea9c788ebd7a7efbed2becba01b54a887b41b175b9"},
+    {file = "frozendict-2.4.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c9905dcf7aa659e6a11b8051114c9fa76dfde3a6e50e6dc129d5aece75b449a2"},
+    {file = "frozendict-2.4.6-cp310-cp310-win_amd64.whl", hash = "sha256:323f1b674a2cc18f86ab81698e22aba8145d7a755e0ac2cccf142ee2db58620d"},
+    {file = "frozendict-2.4.6-cp310-cp310-win_arm64.whl", hash = "sha256:eabd21d8e5db0c58b60d26b4bb9839cac13132e88277e1376970172a85ee04b3"},
+    {file = "frozendict-2.4.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:eddabeb769fab1e122d3a6872982c78179b5bcc909fdc769f3cf1964f55a6d20"},
+    {file = "frozendict-2.4.6-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:377a65be0a700188fc21e669c07de60f4f6d35fae8071c292b7df04776a1c27b"},
+    {file = "frozendict-2.4.6-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce1e9217b85eec6ba9560d520d5089c82dbb15f977906eb345d81459723dd7e3"},
+    {file = "frozendict-2.4.6-cp36-cp36m-musllinux_1_2_aarch64.whl", hash = "sha256:7291abacf51798d5ffe632771a69c14fb423ab98d63c4ccd1aa382619afe2f89"},
+    {file = "frozendict-2.4.6-cp36-cp36m-musllinux_1_2_x86_64.whl", hash = "sha256:e72fb86e48811957d66ffb3e95580af7b1af1e6fbd760ad63d7bd79b2c9a07f8"},
+    {file = "frozendict-2.4.6-cp36-cp36m-win_amd64.whl", hash = "sha256:622301b1c29c4f9bba633667d592a3a2b093cb408ba3ce578b8901ace3931ef3"},
+    {file = "frozendict-2.4.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a4e3737cb99ed03200cd303bdcd5514c9f34b29ee48f405c1184141bd68611c9"},
+    {file = "frozendict-2.4.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:49ffaf09241bc1417daa19362a2241a4aa435f758fd4375c39ce9790443a39cd"},
+    {file = "frozendict-2.4.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d69418479bfb834ba75b0e764f058af46ceee3d655deb6a0dd0c0c1a5e82f09"},
+    {file = "frozendict-2.4.6-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:c131f10c4d3906866454c4e89b87a7e0027d533cce8f4652aa5255112c4d6677"},
+    {file = "frozendict-2.4.6-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:fc67cbb3c96af7a798fab53d52589752c1673027e516b702ab355510ddf6bdff"},
+    {file = "frozendict-2.4.6-cp37-cp37m-win_amd64.whl", hash = "sha256:7730f8ebe791d147a1586cbf6a42629351d4597773317002181b66a2da0d509e"},
+    {file = "frozendict-2.4.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:807862e14b0e9665042458fde692c4431d660c4219b9bb240817f5b918182222"},
+    {file = "frozendict-2.4.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9647c74efe3d845faa666d4853cfeabbaee403b53270cabfc635b321f770e6b8"},
+    {file = "frozendict-2.4.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:665fad3f0f815aa41294e561d98dbedba4b483b3968e7e8cab7d728d64b96e33"},
+    {file = "frozendict-2.4.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f42e6b75254ea2afe428ad6d095b62f95a7ae6d4f8272f0bd44a25dddd20f67"},
+    {file = "frozendict-2.4.6-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:02331541611f3897f260900a1815b63389654951126e6e65545e529b63c08361"},
+    {file = "frozendict-2.4.6-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:18d50a2598350b89189da9150058191f55057581e40533e470db46c942373acf"},
+    {file = "frozendict-2.4.6-cp38-cp38-win_amd64.whl", hash = "sha256:1b4a3f8f6dd51bee74a50995c39b5a606b612847862203dd5483b9cd91b0d36a"},
+    {file = "frozendict-2.4.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a76cee5c4be2a5d1ff063188232fffcce05dde6fd5edd6afe7b75b247526490e"},
+    {file = "frozendict-2.4.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ba5ef7328706db857a2bdb2c2a17b4cd37c32a19c017cff1bb7eeebc86b0f411"},
+    {file = "frozendict-2.4.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:669237c571856be575eca28a69e92a3d18f8490511eff184937283dc6093bd67"},
+    {file = "frozendict-2.4.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0aaa11e7c472150efe65adbcd6c17ac0f586896096ab3963775e1c5c58ac0098"},
+    {file = "frozendict-2.4.6-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:b8f2829048f29fe115da4a60409be2130e69402e29029339663fac39c90e6e2b"},
+    {file = "frozendict-2.4.6-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:94321e646cc39bebc66954a31edd1847d3a2a3483cf52ff051cd0996e7db07db"},
+    {file = "frozendict-2.4.6-cp39-cp39-win_amd64.whl", hash = "sha256:74b6b26c15dddfefddeb89813e455b00ebf78d0a3662b89506b4d55c6445a9f4"},
+    {file = "frozendict-2.4.6-cp39-cp39-win_arm64.whl", hash = "sha256:7088102345d1606450bd1801a61139bbaa2cb0d805b9b692f8d81918ea835da6"},
+    {file = "frozendict-2.4.6-py311-none-any.whl", hash = "sha256:d065db6a44db2e2375c23eac816f1a022feb2fa98cbb50df44a9e83700accbea"},
+    {file = "frozendict-2.4.6-py312-none-any.whl", hash = "sha256:49344abe90fb75f0f9fdefe6d4ef6d4894e640fadab71f11009d52ad97f370b9"},
+    {file = "frozendict-2.4.6-py313-none-any.whl", hash = "sha256:7134a2bb95d4a16556bb5f2b9736dceb6ea848fa5b6f3f6c2d6dba93b44b4757"},
+    {file = "frozendict-2.4.6.tar.gz", hash = "sha256:df7cd16470fbd26fc4969a208efadc46319334eb97def1ddf48919b351192b8e"},
 ]
 
 [[package]]
@@ -2475,7 +2481,7 @@ files = [
     {file = "lxml-5.3.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:aa837e6ee9534de8d63bc4c1249e83882a7ac22bd24523f83fad68e6ffdf41ae"},
     {file = "lxml-5.3.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:da4c9223319400b97a2acdfb10926b807e51b69eb7eb80aad4942c0516934858"},
     {file = "lxml-5.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:dc0e9bdb3aa4d1de703a437576007d366b54f52c9897cae1a3716bb44fc1fc85"},
-    {file = "lxml-5.3.2-cp310-cp310-win32.win32.whl", hash = "sha256:dd755a0a78dd0b2c43f972e7b51a43be518ebc130c9f1a7c4480cf08b4385486"},
+    {file = "lxml-5.3.2-cp310-cp310-win32.whl", hash = "sha256:5f94909a1022c8ea12711db7e08752ca7cf83e5b57a87b59e8a583c5f35016ad"},
     {file = "lxml-5.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:d64ea1686474074b38da13ae218d9fde0d1dc6525266976808f41ac98d9d7980"},
     {file = "lxml-5.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9d61a7d0d208ace43986a92b111e035881c4ed45b1f5b7a270070acae8b0bfb4"},
     {file = "lxml-5.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:856dfd7eda0b75c29ac80a31a6411ca12209183e866c33faf46e77ace3ce8a79"},
@@ -3321,7 +3327,6 @@ files = [
     {file = "psycopg2-2.9.10-cp311-cp311-win_amd64.whl", hash = "sha256:0435034157049f6846e95103bd8f5a668788dd913a7c30162ca9503fdf542cb4"},
     {file = "psycopg2-2.9.10-cp312-cp312-win32.whl", hash = "sha256:65a63d7ab0e067e2cdb3cf266de39663203d38d6a8ed97f5ca0cb315c73fe067"},
     {file = "psycopg2-2.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:4a579d6243da40a7b3182e0430493dbd55950c493d8c68f4eec0b302f6bbf20e"},
-    {file = "psycopg2-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:91fd603a2155da8d0cfcdbf8ab24a2d54bca72795b90d2a3ed2b6da8d979dee2"},
     {file = "psycopg2-2.9.10-cp39-cp39-win32.whl", hash = "sha256:9d5b3b94b79a844a986d029eee38998232451119ad653aea42bb9220a8c5066b"},
     {file = "psycopg2-2.9.10-cp39-cp39-win_amd64.whl", hash = "sha256:88138c8dedcbfa96408023ea2b0c369eda40fe5d75002c0964c78f46f11fa442"},
     {file = "psycopg2-2.9.10.tar.gz", hash = "sha256:12ec0b40b0273f95296233e8750441339298e6a572f7039da5b260e3c8b60e11"},
@@ -3382,7 +3387,6 @@ files = [
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567"},
-    {file = "psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:eb09aa7f9cecb45027683bb55aebaaf45a0df8bf6de68801a6afdc7947bb09d4"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b73d6d7f0ccdad7bc43e6d34273f70d587ef62f824d7261c4ae9b8b1b6af90e8"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce5ab4bf46a211a8e924d307c1b1fcda82368586a19d0a24f8ae166f5c784864"},
@@ -5412,4 +5416,4 @@ lxml = ">=3.8"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "df7ccd7314d78a6e325ad6e596208dd09218c9dc1136040cc0f97262262a4adf"
+content-hash = "c719bcfb27439fec27a2bf3605a3332fdf8980dc2bac33866fed186fd2582727"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -239,6 +239,7 @@ firebase-admin = "^6.0.1"
 Flask = "^3.0"
 Flask-Babel = "^4.0"
 Flask-Cors = "5.0.1"
+frozendict = "^2.4.6"
 fuzzywuzzy = "0.18.0"  # fuzzywuzzy is for author name manipulations
 google-api-python-client = "^2.162.0"
 google-auth = "^2.38.0"

--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -656,7 +656,6 @@ class Axis360API(
             contributions=True,
             formats=True,
             links=True,
-            analytics=analytics,
         )
 
         bibliographic.apply(edition, self.collection, replace=policy, db=self._db)
@@ -859,7 +858,9 @@ class BibliographicParser(Axis360Parser[tuple[Metadata, CirculationData]], Logge
         ns: dict[str, str] | None,
     ) -> CirculationData:
         identifier = self.text_of_subtag(element, "axis:titleId", ns)
-        primary_identifier = IdentifierData(Identifier.AXIS_360_ID, identifier)
+        primary_identifier = IdentifierData(
+            type=Identifier.AXIS_360_ID, identifier=identifier
+        )
         if not circulation_data:
             circulation_data = CirculationData(
                 data_source=DataSource.AXIS_360,
@@ -1052,10 +1053,12 @@ class BibliographicParser(Axis360Parser[tuple[Metadata, CirculationData]], Logge
 
         # We don't use this for anything.
         # file_size = self.int_of_optional_subtag(element, 'axis:fileSize', ns)
-        primary_identifier = IdentifierData(Identifier.AXIS_360_ID, identifier)
+        primary_identifier = IdentifierData(
+            type=Identifier.AXIS_360_ID, identifier=identifier
+        )
         identifiers = []
         if isbn:
-            identifiers.append(IdentifierData(Identifier.ISBN, isbn))
+            identifiers.append(IdentifierData(type=Identifier.ISBN, identifier=isbn))
 
         formats = []
         seen_formats = []

--- a/src/palace/manager/api/metadata/novelist.py
+++ b/src/palace/manager/api/metadata/novelist.py
@@ -398,13 +398,15 @@ class NoveListAPI(
         audience_level = book_info.get("audience_level")
         if audience_level:
             metadata.subjects.append(
-                SubjectData(Subject.FREEFORM_AUDIENCE, audience_level)
+                SubjectData(type=Subject.FREEFORM_AUDIENCE, identifier=audience_level)
             )
 
         novelist_rating = book_info.get("rating")
         if novelist_rating:
             metadata.measurements.append(
-                MeasurementData(Measurement.RATING, novelist_rating)
+                MeasurementData(
+                    quantity_measured=Measurement.RATING, value=novelist_rating
+                )
             )
 
         # Extract feature content if it is available.
@@ -439,7 +441,7 @@ class NoveListAPI(
                 if genres:
                     for genre in genres:
                         metadata.subjects.append(
-                            SubjectData(Subject.TAG, genre["Name"])
+                            SubjectData(type=Subject.TAG, identifier=genre["Name"])
                         )
                         extracted_genres = True
                 if extracted_genres:
@@ -447,12 +449,15 @@ class NoveListAPI(
 
         if lexile_info:
             metadata.subjects.append(
-                SubjectData(Subject.LEXILE_SCORE, lexile_info["Lexile"])
+                SubjectData(type=Subject.LEXILE_SCORE, identifier=lexile_info["Lexile"])
             )
 
         if goodreads_info:
             metadata.measurements.append(
-                MeasurementData(Measurement.RATING, goodreads_info["average_rating"])
+                MeasurementData(
+                    quantity_measured=Measurement.RATING,
+                    value=goodreads_info["average_rating"],
+                )
             )
 
         metadata = self.get_recommendations(metadata, recommendations_info)
@@ -520,7 +525,7 @@ class NoveListAPI(
         for synonymous_id in synonymous_ids:
             isbn = synonymous_id.get("ISBN")
             if isbn:
-                isbn_data = IdentifierData(Identifier.ISBN, isbn)
+                isbn_data = IdentifierData(type=Identifier.ISBN, identifier=isbn)
                 isbns.append(isbn_data)
 
         return isbns

--- a/src/palace/manager/api/metadata/nyt.py
+++ b/src/palace/manager/api/metadata/nyt.py
@@ -368,11 +368,17 @@ class NYTBestSellerListTitle(TitleFromExternalList):
             for isbn in d.get("isbns", []):
                 isbn13 = isbn.get("isbn13", None)
                 if isbn13:
-                    other_isbns.append(IdentifierData(Identifier.ISBN, isbn13, 0.50))
+                    other_isbns.append(
+                        IdentifierData(
+                            type=Identifier.ISBN, identifier=isbn13, weight=0.50
+                        )
+                    )
 
         primary_isbn = primary_isbn13 or primary_isbn10
         if primary_isbn:
-            primary_isbn = IdentifierData(Identifier.ISBN, primary_isbn, 0.90)
+            primary_isbn = IdentifierData(
+                type=Identifier.ISBN, identifier=primary_isbn, weight=0.90
+            )
 
         contributors = []
         if display_author:

--- a/src/palace/manager/api/odl/importer.py
+++ b/src/palace/manager/api/odl/importer.py
@@ -346,7 +346,11 @@ class OPDS2WithODLImporter(OPDS2Importer):
                 f"info document ({parsed_license.expires}) setting license status "
                 f"to unavailable."
             )
-            parsed_license.status = LicenseStatus.unavailable
+            parsed_license = parsed_license.model_copy(
+                update={
+                    "status": LicenseStatus.unavailable,
+                }
+            )
 
         if parsed_license.terms_concurrency != feed_concurrency:
             cls.logger().error(
@@ -356,7 +360,11 @@ class OPDS2WithODLImporter(OPDS2Importer):
                 f"{parsed_license.terms_concurrency}) setting license status "
                 f"to unavailable."
             )
-            parsed_license.status = LicenseStatus.unavailable
+            parsed_license = parsed_license.model_copy(
+                update={
+                    "status": LicenseStatus.unavailable,
+                }
+            )
 
         return parsed_license
 

--- a/src/palace/manager/core/opds2_import.py
+++ b/src/palace/manager/core/opds2_import.py
@@ -696,9 +696,7 @@ class OPDS2Importer(BaseOPDSImporter[OPDS2ImporterSettings]):
         last_opds_update = publication.metadata.modified
 
         identifier = self._extract_identifier(publication)
-        identifier_data = IdentifierData(
-            type=identifier.type, identifier=identifier.identifier
-        )
+        identifier_data = IdentifierData.from_identifier(identifier)
 
         # FIXME: There are no measurements in OPDS 2.0
         measurements: list[Any] = []

--- a/src/palace/manager/metadata_layer/circulation.py
+++ b/src/palace/manager/metadata_layer/circulation.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 import datetime
 from collections.abc import Sequence
 from typing import Any
@@ -70,7 +69,7 @@ class CirculationData(LoggerMixin):
         if isinstance(primary_identifier, Identifier):
             self.primary_identifier_obj: Identifier | None = primary_identifier
             self._primary_identifier: IdentifierData | None = IdentifierData(
-                primary_identifier.type, primary_identifier.identifier
+                type=primary_identifier.type, identifier=primary_identifier.identifier
             )
         else:
             self.primary_identifier_obj = None
@@ -161,7 +160,7 @@ class CirculationData(LoggerMixin):
                     if format_found and format and not format.rights_uri:
                         self.formats.remove(format)
                         self.formats.append(
-                            dataclasses.replace(format, rights_uri=rights_uri)
+                            format.model_copy(update={"rights_uri": rights_uri})
                         )
                     if not format_found:
                         self.formats.append(

--- a/src/palace/manager/metadata_layer/contributor.py
+++ b/src/palace/manager/metadata_layer/contributor.py
@@ -43,11 +43,11 @@ class ContributorData(BaseFrozenData, LoggerMixin):
             self._cached_sort_name = self.sort_name
 
     @classmethod
-    def from_contribution(cls, contribution: Contribution) -> Self:
-        """Create a ContributorData object from a data-model Contribution
-        object.
-        """
-        contributor = contribution.contributor
+    def from_contributor(
+        cls, contributor: Contributor, *, roles: list[str] | None = None
+    ) -> Self:
+        if roles is None:
+            roles = []
         return cls(
             sort_name=contributor.sort_name,
             display_name=contributor.display_name,
@@ -57,8 +57,18 @@ class ContributorData(BaseFrozenData, LoggerMixin):
             viaf=contributor.viaf,
             biography=contributor.biography,
             aliases=contributor.aliases,
-            roles=[contribution.role],
+            roles=roles,
             extra=contributor.extra,
+        )
+
+    @classmethod
+    def from_contribution(cls, contribution: Contribution) -> Self:
+        """Create a ContributorData object from a data-model Contribution
+        object.
+        """
+        return cls.from_contributor(
+            contribution.contributor,
+            roles=[contribution.role],
         )
 
     @classmethod

--- a/src/palace/manager/metadata_layer/frozen_data.py
+++ b/src/palace/manager/metadata_layer/frozen_data.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BaseFrozenData(BaseModel):
+    model_config = ConfigDict(
+        frozen=True,
+    )

--- a/src/palace/manager/metadata_layer/identifier.py
+++ b/src/palace/manager/metadata_layer/identifier.py
@@ -1,24 +1,26 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from sqlalchemy.orm import Session
+from typing_extensions import Self
 
+from palace.manager.metadata_layer.frozen_data import BaseFrozenData
 from palace.manager.sqlalchemy.model.identifier import Identifier
 
 
-@dataclass(frozen=True)
-class IdentifierData:
+class IdentifierData(BaseFrozenData):
     type: str
     identifier: str
     weight: float = 1
 
-    def __repr__(self) -> str:
-        return '<IdentifierData type="{}" identifier="{}" weight="{}">'.format(
-            self.type,
-            self.identifier,
-            self.weight,
-        )
-
     def load(self, _db: Session) -> tuple[Identifier, bool]:
         return Identifier.for_foreign_id(_db, self.type, self.identifier)
+
+    @classmethod
+    def from_identifier(cls, identifier: Identifier | IdentifierData) -> Self:
+        """Create an IdentifierData object from a data-model Identifier
+        object.
+        """
+        if isinstance(identifier, cls):
+            return identifier
+
+        return cls(type=identifier.type, identifier=identifier.identifier)

--- a/src/palace/manager/metadata_layer/license.py
+++ b/src/palace/manager/metadata_layer/license.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import datetime
 
+from pydantic import NonNegativeInt
 from sqlalchemy.orm import Session
 
+from palace.manager.metadata_layer.frozen_data import BaseFrozenData
 from palace.manager.opds.odl.info import LicenseStatus
 from palace.manager.sqlalchemy.model.licensing import (
     License,
@@ -13,28 +15,16 @@ from palace.manager.sqlalchemy.model.licensing import (
 from palace.manager.sqlalchemy.util import get_one_or_create
 
 
-class LicenseData(LicenseFunctions):
-    def __init__(
-        self,
-        identifier: str,
-        checkout_url: str | None,
-        status_url: str,
-        status: LicenseStatus,
-        checkouts_available: int,
-        expires: datetime.datetime | None = None,
-        checkouts_left: int | None = None,
-        terms_concurrency: int | None = None,
-        content_types: list[str] | None = None,
-    ):
-        self.identifier = identifier
-        self.checkout_url = checkout_url
-        self.status_url = status_url
-        self.status = status
-        self.expires = expires
-        self.checkouts_left = checkouts_left
-        self.checkouts_available = checkouts_available
-        self.terms_concurrency = terms_concurrency
-        self.content_types = content_types
+class LicenseData(BaseFrozenData, LicenseFunctions):
+    identifier: str
+    checkout_url: str | None
+    status_url: str
+    status: LicenseStatus
+    checkouts_available: NonNegativeInt
+    expires: datetime.datetime | None = None
+    checkouts_left: int | None = None
+    terms_concurrency: int | None = None
+    content_types: tuple[str, ...] = tuple()
 
     def add_to_pool(self, db: Session, pool: LicensePool) -> License:
         license_obj, _ = get_one_or_create(

--- a/src/palace/manager/metadata_layer/link.py
+++ b/src/palace/manager/metadata_layer/link.py
@@ -1,41 +1,49 @@
 from __future__ import annotations
 
-from palace.manager.sqlalchemy.model.resource import Representation
+from functools import cached_property
+from typing import Annotated
+
+from frozendict import frozendict
+from pydantic import Field, constr, field_validator, model_validator
+from typing_extensions import Self
+
+from palace.manager.metadata_layer.frozen_data import BaseFrozenData
+from palace.manager.sqlalchemy.model.resource import Hyperlink, Representation
+from palace.manager.util.log import LoggerMixin
+from palace.manager.util.pydantic import FrozenDict
 
 
-class LinkData:
-    def __init__(
-        self,
-        rel: str | None,
-        href: str | None = None,
-        media_type: str | None = None,
-        content: bytes | str | None = None,
-        thumbnail: LinkData | None = None,
-        rights_uri: str | None = None,
-        rights_explanation: str | None = None,
-        original: LinkData | None = None,
-        transformation_settings: dict[str, str] | None = None,
-    ) -> None:
-        if not rel:
-            raise ValueError("rel is required")
+class LinkData(BaseFrozenData, LoggerMixin):
+    rel: Annotated[str, constr(min_length=1)]
+    href: str | None = None
+    media_type: str | None = None
+    content: bytes | str | None = Field(None, repr=False)
+    thumbnail: LinkData | None = Field(None, repr=False)
+    rights_uri: str | None = Field(None, repr=False)
+    rights_explanation: str | None = Field(None, repr=False)
+    original: LinkData | None = Field(None, repr=False)
+    transformation_settings: FrozenDict[str, str] = Field(
+        default_factory=frozendict, repr=False
+    )
 
-        if not href and not content:
-            raise ValueError("Either href or content is required")
-        self.rel = rel
-        self.href = href
-        self.media_type = media_type
-        self.content = content
-        self.thumbnail = thumbnail
-        # This handles content sources like unglue.it that have rights for each link
-        # rather than each edition, and rights for cover images.
-        self.rights_uri = rights_uri
-        self.rights_explanation = rights_explanation
-        # If this LinkData is a derivative, it may also contain the original link
-        # and the settings used to transform the original into the derivative.
-        self.original = original
-        self.transformation_settings = transformation_settings or {}
+    @model_validator(mode="after")
+    def _check_href_or_content(self) -> Self:
+        if not self.href and not self.content:
+            raise ValueError("Either 'href' or 'content' is required")
+        return self
 
-    @property
+    @field_validator("thumbnail")
+    @classmethod
+    def _thumbnail_has_correct_rel(cls, value: LinkData | None) -> LinkData | None:
+        if value is not None:
+            if value.rel != Hyperlink.THUMBNAIL_IMAGE:
+                cls.logger().error(
+                    f"Thumbnail link {value!r} does not have the thumbnail link relation! Not acceptable as a thumbnail."
+                )
+                return None
+        return value
+
+    @cached_property
     def guessed_media_type(self) -> str | None:
         """If the media type of a link is unknown, take a guess."""
         if self.media_type:
@@ -51,19 +59,5 @@ class LinkData:
         # content and the link relation.
         return None
 
-    def __repr__(self) -> str:
-        if self.content:
-            content = ", %d bytes content" % len(self.content)
-        else:
-            content = ""
-        if self.thumbnail:
-            thumbnail = ", has thumbnail"
-        else:
-            thumbnail = ""
-        return '<LinkData: rel="{}" href="{}" media_type={!r}{}{}>'.format(
-            self.rel,
-            self.href,
-            self.media_type,
-            thumbnail,
-            content,
-        )
+    def set_thumbnail(self, thumbnail: LinkData) -> Self:
+        return self.model_copy(update={"thumbnail": thumbnail})

--- a/src/palace/manager/metadata_layer/measurement.py
+++ b/src/palace/manager/metadata_layer/measurement.py
@@ -1,33 +1,13 @@
 from __future__ import annotations
 
-import datetime
+from pydantic import AwareDatetime, Field
 
+from palace.manager.metadata_layer.frozen_data import BaseFrozenData
 from palace.manager.util.datetime_helpers import utc_now
 
 
-class MeasurementData:
-    def __init__(
-        self,
-        quantity_measured: str,
-        value: float | int | str,
-        weight: float = 1,
-        taken_at: datetime.datetime | None = None,
-    ):
-        if not quantity_measured:
-            raise ValueError("quantity_measured is required.")
-        if value is None:
-            raise ValueError("measurement value is required.")
-        self.quantity_measured = quantity_measured
-        if not isinstance(value, float) and not isinstance(value, int):
-            value = float(value)
-        self.value = value
-        self.weight = weight
-        self.taken_at = taken_at or utc_now()
-
-    def __repr__(self) -> str:
-        return '<MeasurementData quantity="%s" value=%f weight=%d taken=%s>' % (
-            self.quantity_measured,
-            self.value,
-            self.weight,
-            self.taken_at,
-        )
+class MeasurementData(BaseFrozenData):
+    quantity_measured: str
+    value: float
+    weight: float = 1.0
+    taken_at: AwareDatetime = Field(default_factory=utc_now)

--- a/src/palace/manager/metadata_layer/policy/presentation.py
+++ b/src/palace/manager/metadata_layer/policy/presentation.py
@@ -2,85 +2,85 @@ from __future__ import annotations
 
 from typing_extensions import Self
 
+from palace.manager.metadata_layer.frozen_data import BaseFrozenData
 
-class PresentationCalculationPolicy:
+
+class PresentationCalculationPolicy(BaseFrozenData):
     """Which parts of the Work or Edition's presentation
     are we actually looking to update?
     """
 
-    DEFAULT_LEVELS = 3
-    DEFAULT_THRESHOLD = 0.5
-    DEFAULT_CUTOFF = 1000
+    choose_edition: bool = True
+    """
+    Should a new presentation edition be
+    chosen/created, or should we assume the old one is fine?
+    """
 
-    def __init__(
-        self,
-        *,
-        choose_edition: bool = True,
-        set_edition_metadata: bool = True,
-        classify: bool = True,
-        choose_summary: bool = True,
-        calculate_quality: bool = True,
-        choose_cover: bool = True,
-        update_search_index: bool = False,
-        verbose: bool = True,
-        equivalent_identifier_levels: int = DEFAULT_LEVELS,
-        equivalent_identifier_threshold: float = DEFAULT_THRESHOLD,
-        equivalent_identifier_cutoff: int = DEFAULT_CUTOFF,
-    ) -> None:
-        """Constructor.
+    set_edition_metadata: bool = True
+    """
+    Should we set new values for basic metadata such as title?
+    """
 
-        :param choose_edition: Should a new presentation edition be
-           chosen/created, or should we assume the old one is fine?
-        :param set_edition_metadata: Should we set new values for
-           basic metadata such as title?
-        :param classify: Should we reconsider which Genres under which
-           a Work should be filed?
-        :param choose_summary: Should we reconsider which of the
-           available summaries is the best?
-        :param calculate_quality: Should we recalculate the overall
-           quality of the Work?
-        :param choose_cover: Should we reconsider which of the
-           available cover images is the best?
-        :param update_search_index: Should we reindex this Work's
-           entry in the search index?
-        :param verbose: Should we print out information about the work we're
-           doing?
-        :param equivalent_identifier_levels: When determining which
-           identifiers refer to this Work (used when gathering
-           classifications, cover images, etc.), how many levels of
-           equivalency should we go down? E.g. for one level of
-           equivalency we will go from a proprietary vendor ID to the
-           equivalent ISBN.
-        :param equivalent_identifier_threshold: When determining which
-           identifiers refer to this Work, what is the probability
-           threshold for 'equivalency'? E.g. a value of 1 means that
-           we will not count two identifiers as equivalent unless we
-           are absolutely certain.
-        :param equivalent_identifier_cutoff: When determining which
-           identifiers refer to this work, how many Identifiers are
-           enough? Gathering _all_ the identifiers that identify an
-           extremely popular work can take an extraordinarily long time
-           for very little payoff, so it's useful to have a cutoff.
+    classify: bool = True
+    """
+    Should we reconsider which Genres under which a Work should be filed?
+    """
 
-           The cutoff is applied _per level_, so the total maximum
-           number of equivalent identifiers is
-           equivalent_identifier_cutoff * equivalent_identifier_levels.
-        """
-        self.choose_edition = choose_edition
-        self.set_edition_metadata = set_edition_metadata
-        self.classify = classify
-        self.choose_summary = choose_summary
-        self.calculate_quality = calculate_quality
-        self.choose_cover = choose_cover
+    choose_summary: bool = True
+    """
+    Should we reconsider which of the available summaries is the best?
+    """
 
-        # Similarly for update_search_index.
-        self.update_search_index = update_search_index
+    calculate_quality: bool = True
+    """
+    Should we recalculate the overall quality of the Work?
+    """
 
-        self.verbose = verbose
+    choose_cover: bool = True
+    """
+    Should we reconsider which of the available cover images is the best?
+    """
 
-        self.equivalent_identifier_levels = equivalent_identifier_levels
-        self.equivalent_identifier_threshold = equivalent_identifier_threshold
-        self.equivalent_identifier_cutoff = equivalent_identifier_cutoff
+    update_search_index: bool = False
+    """
+    Should we reindex this Work's entry in the search index?
+    """
+
+    verbose: bool = True
+    """
+    Should we print out information about the work we're doing?
+    """
+
+    equivalent_identifier_levels: int = 3
+    """
+    When determining which identifiers refer to this Work (used when gathering
+    classifications, cover images, etc.), how many levels of
+    equivalency should we go down? E.g. for one level of
+    equivalency we will go from a proprietary vendor ID to the
+    equivalent ISBN.
+    """
+
+    equivalent_identifier_threshold: float = 0.5
+    """
+    When determining which
+    identifiers refer to this Work, what is the probability
+    threshold for 'equivalency'? E.g. a value of 1 means that
+    we will not count two identifiers as equivalent unless we
+    are absolutely certain.
+    """
+
+    equivalent_identifier_cutoff: int = 1000
+    """
+    When determining which
+    identifiers refer to this work, how many Identifiers are
+    enough? Gathering _all_ the identifiers that identify an
+    extremely popular work can take an extraordinarily long time
+    for very little payoff, so it's useful to have a cutoff.
+
+    The cutoff is applied _per level_, so the total maximum
+    number of equivalent identifiers is
+    equivalent_identifier_cutoff * equivalent_identifier_levels.
+    """
 
     @classmethod
     def recalculate_everything(cls) -> Self:

--- a/src/palace/manager/metadata_layer/subject.py
+++ b/src/palace/manager/metadata_layer/subject.py
@@ -1,37 +1,14 @@
 from __future__ import annotations
 
+from typing import Annotated
 
-class SubjectData:
-    def __init__(
-        self,
-        type: str,
-        identifier: str | None,
-        name: str | None = None,
-        weight: int = 1,
-    ) -> None:
-        self.type = type
+from pydantic import StringConstraints
 
-        # Because subjects are sometimes evaluated according to keyword
-        # matching, it's important that any leading or trailing white
-        # space is removed during import.
-        self.identifier = identifier
-        if identifier:
-            self.identifier = identifier.strip()
+from palace.manager.metadata_layer.frozen_data import BaseFrozenData
 
-        self.name = name
-        if name:
-            self.name = name.strip()
 
-        self.weight = weight
-
-    @property
-    def key(self) -> tuple[str, str | None, str | None, int]:
-        return self.type, self.identifier, self.name, self.weight
-
-    def __repr__(self) -> str:
-        return '<SubjectData type="%s" identifier="%s" name="%s" weight=%d>' % (
-            self.type,
-            self.identifier,
-            self.name,
-            self.weight,
-        )
+class SubjectData(BaseFrozenData):
+    type: str
+    identifier: Annotated[str, StringConstraints(strip_whitespace=True)] | None
+    name: Annotated[str, StringConstraints(strip_whitespace=True)] | None = None
+    weight: int = 1

--- a/src/palace/manager/search/external_search.py
+++ b/src/palace/manager/search/external_search.py
@@ -44,7 +44,6 @@ from palace.manager.search.service import (
 )
 from palace.manager.sqlalchemy.model.contributor import Contributor
 from palace.manager.sqlalchemy.model.edition import Edition
-from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.lane import Pagination
 from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.model.work import Work
@@ -2273,9 +2272,7 @@ class Filter(SearchBase):
         into IdentifierData.
         """
         for i in identifiers:
-            if isinstance(i, Identifier):
-                i = IdentifierData(i.type, i.identifier)
-            yield i
+            yield IdentifierData.from_identifier(i)
 
     @classmethod
     def _chain_filters(cls, existing, new):

--- a/src/palace/manager/service/container.py
+++ b/src/palace/manager/service/container.py
@@ -91,7 +91,6 @@ def wire_container(container: Services) -> None:
             "palace.manager.api.overdrive",
             "palace.manager.feed.annotator.circulation",
             "palace.manager.feed.acquisition",
-            "palace.manager.metadata_layer.policy.replacement",
             "palace.manager.sqlalchemy.model.lane",
             "palace.manager.sqlalchemy.model.collection",
             "palace.manager.sqlalchemy.model.patron",

--- a/src/palace/manager/sqlalchemy/model/contributor.py
+++ b/src/palace/manager/sqlalchemy/model/contributor.py
@@ -41,7 +41,7 @@ class Contributor(Base):
     # This is the name by which this person is known in the original
     # catalog. It is sortable, e.g. "Twain, Mark".
     _sort_name = Column("sort_name", Unicode, index=True)
-    aliases = Column(ARRAY(Unicode), default=[])
+    aliases: Mapped[list[str]] = Column(ARRAY(Unicode), default=[], nullable=False)
 
     # This is the name we will display publicly. Ideally it will be
     # the name most familiar to readers.

--- a/src/palace/manager/sqlalchemy/model/identifier.py
+++ b/src/palace/manager/sqlalchemy/model/identifier.py
@@ -7,7 +7,7 @@ import random
 import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from functools import total_ordering
 from typing import TYPE_CHECKING, Literal, overload
 from urllib.parse import quote, unquote
@@ -803,7 +803,7 @@ class Identifier(Base, IdentifierConstants, LoggerMixin):
         rights_status_uri: str | None = None,
         rights_explanation: str | None = None,
         original_resource: Resource | None = None,
-        transformation_settings: dict[str, str] | None = None,
+        transformation_settings: Mapping[str, str] | None = None,
         db: Session | None = None,
     ) -> tuple[Hyperlink, bool]:
         """Create a link between this Identifier and a (potentially new)

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -65,7 +65,6 @@ class LicenseFunctions:
     checkouts_left: int | None
     checkouts_available: int | None
     terms_concurrency: int | None
-    content_types: list[str] | None
 
     @property
     def is_perpetual(self) -> bool:
@@ -635,9 +634,7 @@ class LicensePool(Base):
             # than creating an identical composite.
             self.presentation_edition = all_editions[0]
         else:
-            edition_identifier = IdentifierData(
-                self.identifier.type, self.identifier.identifier
-            )
+            edition_identifier = IdentifierData.from_identifier(self.identifier)
             metadata = Metadata(
                 data_source=DataSourceConstants.PRESENTATION_EDITION,
                 primary_identifier=edition_identifier,

--- a/src/palace/manager/sqlalchemy/model/resource.py
+++ b/src/palace/manager/sqlalchemy/model/resource.py
@@ -43,7 +43,7 @@ from palace.manager.sqlalchemy.model.licensing import (
     RightsStatus,
 )
 from palace.manager.sqlalchemy.util import (
-    MutableDictFrozenDict,
+    MutableDict,
     get_one,
     get_one_or_create,
 )
@@ -403,7 +403,7 @@ class ResourceTransformation(Base):
 
     # The settings used for the transformation.
     settings: Mapped[dict[str, str]] = Column(
-        MutableDictFrozenDict.as_mutable(JSON), default={}, nullable=False
+        MutableDict.as_mutable(JSON), default={}, nullable=False
     )
 
 

--- a/src/palace/manager/sqlalchemy/model/resource.py
+++ b/src/palace/manager/sqlalchemy/model/resource.py
@@ -27,7 +27,6 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSON
-from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, relationship
 from sqlalchemy.orm.session import Session
 
@@ -43,7 +42,11 @@ from palace.manager.sqlalchemy.model.licensing import (
     LicensePoolDeliveryMechanism,
     RightsStatus,
 )
-from palace.manager.sqlalchemy.util import get_one, get_one_or_create
+from palace.manager.sqlalchemy.util import (
+    MutableDictFrozenDict,
+    get_one,
+    get_one_or_create,
+)
 from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.http import HTTP
 
@@ -400,7 +403,7 @@ class ResourceTransformation(Base):
 
     # The settings used for the transformation.
     settings: Mapped[dict[str, str]] = Column(
-        MutableDict.as_mutable(JSON), default={}, nullable=False
+        MutableDictFrozenDict.as_mutable(JSON), default={}, nullable=False
     )
 
 

--- a/src/palace/manager/sqlalchemy/util.py
+++ b/src/palace/manager/sqlalchemy/util.py
@@ -10,7 +10,7 @@ from psycopg2._range import NumericRange
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError, MultipleResultsFound, NoResultFound
-from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.ext import mutable
 from sqlalchemy.orm import Session
 from typing_extensions import Self
 
@@ -195,7 +195,7 @@ def tuple_to_numericrange(t: NumericRangeTuple | None) -> NumericRange | None:
     return NumericRange(t[0], t[1], "[]")
 
 
-class MutableDictFrozenDict(MutableDict):
+class MutableDict(mutable.MutableDict):
     """
     A MutableDict that will accept a frozen dictionary as a value coercing
     it to a regular dictionary.

--- a/tests/manager/api/odl/test_importer.py
+++ b/tests/manager/api/odl/test_importer.py
@@ -971,7 +971,7 @@ class TestOPDS2WithODLImporter:
         parsed = OPDS2WithODLImporter.parse_license_info(
             json.dumps(license_dict), info_link, checkout_link
         )
-        assert parsed.content_types == ["single format"]
+        assert parsed.content_types == ("single format",)
 
         # Format list
         license_dict = license_info_dict()
@@ -979,7 +979,7 @@ class TestOPDS2WithODLImporter:
         parsed = OPDS2WithODLImporter.parse_license_info(
             json.dumps(license_dict), info_link, checkout_link
         )
-        assert parsed.content_types == ["format1", "format2"]
+        assert parsed.content_types == ("format1", "format2")
 
     def test_fetch_license_info(self):
         """Ensure that OPDS2WithODLImporter correctly retrieves license data from an OPDS2 feed."""

--- a/tests/manager/api/overdrive/test_representation.py
+++ b/tests/manager/api/overdrive/test_representation.py
@@ -196,7 +196,7 @@ class TestOverdriveRepresentationExtractor:
         [author] = metadata.contributors
         assert "Rüping, Andreas" == author.sort_name
         assert "Andreas Rüping" == author.display_name
-        assert [Contributor.Role.AUTHOR] == author.roles
+        assert (Contributor.Role.AUTHOR,) == author.roles
 
         subjects = sorted(metadata.subjects, key=lambda x: x.identifier)
 

--- a/tests/manager/api/test_axis.py
+++ b/tests/manager/api/test_axis.py
@@ -567,9 +567,7 @@ class TestAxis360API:
                 for i, identifier in enumerate(identifiers):
                     # The first identifer in the list is still
                     # available.
-                    identifier_data = IdentifierData(
-                        type=identifier.type, identifier=identifier.identifier
-                    )
+                    identifier_data = IdentifierData.from_identifier(identifier)
                     metadata = Metadata(
                         data_source=DataSource.AXIS_360,
                         primary_identifier=identifier_data,
@@ -982,18 +980,18 @@ class TestParsers:
         # same format as author information.
         [cont1, cont2, narrator] = bib1.contributors
         assert "McCain, John" == cont1.sort_name
-        assert [Contributor.Role.PRIMARY_AUTHOR] == cont1.roles
+        assert (Contributor.Role.PRIMARY_AUTHOR,) == cont1.roles
 
         assert "Salter, Mark" == cont2.sort_name
-        assert [Contributor.Role.AUTHOR] == cont2.roles
+        assert (Contributor.Role.AUTHOR,) == cont2.roles
 
         assert "McCain, John S. III" == narrator.sort_name
-        assert [Contributor.Role.NARRATOR] == narrator.roles
+        assert (Contributor.Role.NARRATOR,) == narrator.roles
 
         # Book #2 only has a primary author.
         [cont] = bib2.contributors
         assert "Pollero, Rhonda" == cont.sort_name
-        assert [Contributor.Role.PRIMARY_AUTHOR] == cont.roles
+        assert (Contributor.Role.PRIMARY_AUTHOR,) == cont.roles
 
         axis_id, isbn = sorted(bib1.identifiers, key=lambda x: x.identifier)
         assert "0003642860" == axis_id.identifier
@@ -1123,23 +1121,23 @@ class TestParsers:
         parse = BibliographicParser.parse_contributor
         c = parse(author)
         assert "Dyssegaard, Elisabeth Kallick" == c.sort_name
-        assert [Contributor.Role.TRANSLATOR] == c.roles
+        assert (Contributor.Role.TRANSLATOR,) == c.roles
 
         # A corporate author is given a normal author role.
         author = "Bob, Inc. (COR)"
         c = parse(author, primary_author_found=False)
         assert "Bob, Inc." == c.sort_name
-        assert [Contributor.Role.PRIMARY_AUTHOR] == c.roles
+        assert (Contributor.Role.PRIMARY_AUTHOR,) == c.roles
 
         c = parse(author, primary_author_found=True)
         assert "Bob, Inc." == c.sort_name
-        assert [Contributor.Role.AUTHOR] == c.roles
+        assert (Contributor.Role.AUTHOR,) == c.roles
 
         # An unknown author type is given an unknown role
         author = "Eve, Mallory (ZZZ)"
         c = parse(author, primary_author_found=False)
         assert "Eve, Mallory" == c.sort_name
-        assert [Contributor.Role.UNKNOWN] == c.roles
+        assert (Contributor.Role.UNKNOWN,) == c.roles
 
         # force_role overwrites whatever other role might be
         # assigned.
@@ -1147,7 +1145,7 @@ class TestParsers:
         c = parse(
             author, primary_author_found=False, force_role=Contributor.Role.NARRATOR
         )
-        assert [Contributor.Role.NARRATOR] == c.roles
+        assert (Contributor.Role.NARRATOR,) == c.roles
 
     def test_availability_parser(self, axis360: Axis360Fixture):
         """Make sure the availability information gets properly

--- a/tests/manager/api/test_bibliotheca.py
+++ b/tests/manager/api/test_bibliotheca.py
@@ -47,7 +47,6 @@ from palace.manager.api.circulation_exceptions import (
 )
 from palace.manager.api.web_publication_manifest import FindawayManifest
 from palace.manager.core.monitor import TimestampData
-from palace.manager.metadata_layer.policy.replacement import ReplacementPolicy
 from palace.manager.scripts.coverage_provider import RunCollectionCoverageProviderScript
 from palace.manager.service.analytics.analytics import Analytics
 from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
@@ -206,15 +205,6 @@ class TestBibliothecaAPI:
         request = bibliotheca_fixture.api.requests[-1]
         headers = request[-1]["headers"]
         assert headers["3mcl-Authorization"] != expect
-
-    def test_replacement_policy(self, bibliotheca_fixture: BibliothecaAPITestFixture):
-        db = bibliotheca_fixture.db
-        mock_analytics = object()
-        policy = bibliotheca_fixture.api.replacement_policy(
-            db.session, analytics=mock_analytics
-        )
-        assert isinstance(policy, ReplacementPolicy)
-        assert mock_analytics == policy.analytics
 
     def test_bibliographic_lookup_request(
         self, bibliotheca_fixture: BibliothecaAPITestFixture
@@ -1805,8 +1795,8 @@ class TestItemListParser:
             "Sayers, Dorothy L.",
         ]
         assert [x.roles for x in authors] == [
-            [Contributor.Role.AUTHOR],
-            [Contributor.Role.AUTHOR],
+            (Contributor.Role.AUTHOR,),
+            (Contributor.Role.AUTHOR,),
         ]
 
         # Parentheticals are stripped.
@@ -1835,7 +1825,7 @@ class TestItemListParser:
             )
         )
         for narrator in narrators:
-            assert [Contributor.Role.NARRATOR] == narrator.roles
+            assert (Contributor.Role.NARRATOR,) == narrator.roles
         assert ["Callow, Simon", "Mann, Bruce", "Hagon, Garrick"] == [
             narrator.sort_name for narrator in narrators
         ]
@@ -1885,7 +1875,7 @@ class TestItemListParser:
 
         [author] = cooked.contributors
         assert "Rowland, Laura Joh" == author.sort_name
-        assert [Contributor.Role.AUTHOR] == author.roles
+        assert (Contributor.Role.AUTHOR,) == author.roles
 
         subjects = [x.name for x in cooked.subjects if x.name is not None]
         assert ["Children's Health", "Mystery & Detective"] == sorted(subjects)

--- a/tests/manager/api/test_enki.py
+++ b/tests/manager/api/test_enki.py
@@ -719,7 +719,7 @@ class TestBibliographicParser:
         # One contributor
         [contributor] = m.contributors
         assert "Hoffmeister, David" == contributor.sort_name
-        assert [Contributor.Role.AUTHOR] == contributor.roles
+        assert (Contributor.Role.AUTHOR,) == contributor.roles
 
         # Two links -- full-sized image and description.
         image, description = sorted(m.links, key=lambda x: x.rel)

--- a/tests/manager/core/test_coverage.py
+++ b/tests/manager/core/test_coverage.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import cast
 
 import pytest
 
@@ -1587,7 +1588,7 @@ class TestCollectionCoverageProvider:
         edition, pool = db.edition(with_license_pool=True)
         identifier = edition.primary_identifier
 
-        class Tripwire(PresentationCalculationPolicy):
+        class Tripwire:
             # This class sets a variable if one of its properties is
             # accessed.
             def __init__(self, *args, **kwargs):
@@ -1602,8 +1603,10 @@ class TestCollectionCoverageProvider:
                 return True
 
         presentation_calculation_policy = Tripwire()
-        replacement_policy = ReplacementPolicy(
-            presentation_calculation_policy=presentation_calculation_policy,
+        replacement_policy = ReplacementPolicy.model_construct(
+            presentation_calculation_policy=cast(
+                PresentationCalculationPolicy, presentation_calculation_policy
+            ),
         )
 
         provider = AlwaysSuccessfulCollectionCoverageProvider(

--- a/tests/manager/core/test_opds_import.py
+++ b/tests/manager/core/test_opds_import.py
@@ -455,7 +455,7 @@ class TestOPDSImporter:
 
         [contributor] = book["contributors"]
         assert "Thoreau, Henry David" == contributor.sort_name
-        assert [Contributor.Role.AUTHOR] == contributor.roles
+        assert (Contributor.Role.AUTHOR,) == contributor.roles
 
         subjects = book["subjects"]
         assert ["LCSH", "LCSH", "LCSH", "LCC"] == [x.type for x in subjects]
@@ -1203,6 +1203,7 @@ class TestOPDSImporter:
         t1, i1, t2, i2 = links
         links = OPDSImporter.consolidate_links(links)
         assert [Hyperlink.IMAGE, Hyperlink.IMAGE] == [x.rel for x in links]
+        i1, i2 = links
         assert t1 == i1.thumbnail
         assert t2 == i2.thumbnail
 
@@ -1213,6 +1214,7 @@ class TestOPDSImporter:
         t1, i1, i2 = links
         links = OPDSImporter.consolidate_links(links)
         assert [Hyperlink.IMAGE, Hyperlink.IMAGE] == [x.rel for x in links]
+        i1, i2 = links
         assert t1 == i1.thumbnail
         assert None == i2.thumbnail
 

--- a/tests/manager/metadata_layer/test_circulation.py
+++ b/tests/manager/metadata_layer/test_circulation.py
@@ -29,7 +29,7 @@ class TestCirculationData:
         object, it might or might not be possible to call apply()
         without providing a Collection.
         """
-        identifier = IdentifierData(Identifier.OVERDRIVE_ID, "1")
+        identifier = IdentifierData(type=Identifier.OVERDRIVE_ID, identifier="1")
         format = FormatData(
             content_type=Representation.EPUB_MEDIA_TYPE,
             drm_scheme=DeliveryMechanism.NO_DRM,
@@ -66,10 +66,10 @@ class TestCirculationData:
         # Check that we didn't put something in the CirculationData that
         # will prevent it from being copied. (e.g., self.log)
 
-        subject = SubjectData(Subject.TAG, "subject")
+        subject = SubjectData(type=Subject.TAG, identifier="subject")
         contributor = ContributorData()
-        identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
-        link = LinkData(Hyperlink.OPEN_ACCESS_DOWNLOAD, "example.epub")
+        identifier = IdentifierData(type=Identifier.GUTENBERG_ID, identifier="1")
+        link = LinkData(rel=Hyperlink.OPEN_ACCESS_DOWNLOAD, href="example.epub")
         format = FormatData(
             content_type=Representation.EPUB_MEDIA_TYPE,
             drm_scheme=DeliveryMechanism.NO_DRM,
@@ -95,7 +95,7 @@ class TestCirculationData:
 
     def test_links_filtered(self):
         # Tests that passed-in links filter down to only the relevant ones.
-        link1 = LinkData(Hyperlink.OPEN_ACCESS_DOWNLOAD, "example.epub")
+        link1 = LinkData(rel=Hyperlink.OPEN_ACCESS_DOWNLOAD, href="example.epub")
         link2 = LinkData(rel=Hyperlink.IMAGE, href="http://example.com/")
         link3 = LinkData(rel=Hyperlink.DESCRIPTION, content="foo")
         link4 = LinkData(
@@ -111,7 +111,7 @@ class TestCirculationData:
         )
         links = [link1, link2, link3, link4, link5]
 
-        identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
+        identifier = IdentifierData(type=Identifier.GUTENBERG_ID, identifier="1")
         circulation_data = CirculationData(
             DataSource.GUTENBERG,
             primary_identifier=identifier,
@@ -392,7 +392,7 @@ class TestCirculationData:
         actually licensed, but a LicensePool can be created anyway,
         so we can store format information.
         """
-        identifier = IdentifierData(Identifier.OVERDRIVE_ID, "1")
+        identifier = IdentifierData(type=Identifier.OVERDRIVE_ID, identifier="1")
         drm_format = FormatData(
             content_type=Representation.PDF_MEDIA_TYPE,
             drm_scheme=DeliveryMechanism.ADOBE_DRM,
@@ -467,8 +467,8 @@ class TestCirculationData:
         self, db: DatabaseTransactionFixture
     ):
         identifier = IdentifierData(
-            Identifier.GUTENBERG_ID,
-            "abcd",
+            type=Identifier.GUTENBERG_ID,
+            identifier="abcd",
         )
         link = LinkData(
             rel=Hyperlink.DRM_ENCRYPTED_DOWNLOAD,
@@ -500,8 +500,8 @@ class TestCirculationData:
         self, db: DatabaseTransactionFixture
     ):
         identifier = IdentifierData(
-            Identifier.GUTENBERG_ID,
-            "abcd",
+            type=Identifier.GUTENBERG_ID,
+            identifier="abcd",
         )
         link = LinkData(
             rel=Hyperlink.DRM_ENCRYPTED_DOWNLOAD,
@@ -541,8 +541,8 @@ class TestCirculationData:
         self, db
     ):
         identifier = IdentifierData(
-            Identifier.GUTENBERG_ID,
-            "abcd",
+            type=Identifier.GUTENBERG_ID,
+            identifier="abcd",
         )
 
         # Here's a CirculationData that will create an open-access
@@ -584,8 +584,8 @@ class TestCirculationData:
         # open-access link we will give it a RightsStatus of
         # IN_COPYRIGHT.
         identifier = IdentifierData(
-            Identifier.OVERDRIVE_ID,
-            "abcd",
+            type=Identifier.OVERDRIVE_ID,
+            identifier="abcd",
         )
         link = LinkData(
             rel=Hyperlink.OPEN_ACCESS_DOWNLOAD,
@@ -614,8 +614,8 @@ class TestCirculationData:
         self, db: DatabaseTransactionFixture
     ):
         identifier = IdentifierData(
-            Identifier.OVERDRIVE_ID,
-            "abcd",
+            type=Identifier.OVERDRIVE_ID,
+            identifier="abcd",
         )
         link = LinkData(
             rel=Hyperlink.OPEN_ACCESS_DOWNLOAD,
@@ -645,8 +645,8 @@ class TestCirculationData:
         self, db: DatabaseTransactionFixture
     ):
         identifier = IdentifierData(
-            Identifier.OVERDRIVE_ID,
-            "abcd",
+            type=Identifier.OVERDRIVE_ID,
+            identifier="abcd",
         )
         link = LinkData(
             rel=Hyperlink.DRM_ENCRYPTED_DOWNLOAD,

--- a/tests/manager/metadata_layer/test_contributor.py
+++ b/tests/manager/metadata_layer/test_contributor.py
@@ -52,28 +52,20 @@ class TestContributorData:
         lookup = partial(ContributorData.lookup, db.session)
 
         # We know very little about this person.
-        db.contributor(
+        db_al, _ = db.contributor(
             display_name="Ann Leckie",
             sort_name="Leckie, Ann",
         )
-        al = ContributorData(
-            display_name="Ann Leckie", sort_name="Leckie, Ann", roles=[]
-        )
+        al = ContributorData.from_contributor(db_al)
 
         # We know a lot about this person.
-        db.contributor(
+        db_pkd, _ = db.contributor(
             sort_name="Dick, Phillip K.",
             display_name="Phillip K. Dick",
             viaf="27063583",
             lc="n79018147",
         )
-        pkd = ContributorData(
-            sort_name="Dick, Phillip K.",
-            display_name="Phillip K. Dick",
-            viaf="27063583",
-            lc="n79018147",
-            roles=[],
-        )
+        pkd = ContributorData.from_contributor(db_pkd)
 
         # If there's no Contributor that matches the request, the method
         # returns None.

--- a/tests/manager/metadata_layer/test_format.py
+++ b/tests/manager/metadata_layer/test_format.py
@@ -1,10 +1,15 @@
 from palace.manager.metadata_layer.format import FormatData
+from palace.manager.metadata_layer.link import LinkData
 from palace.manager.sqlalchemy.model.licensing import DeliveryMechanism, RightsStatus
 from palace.manager.sqlalchemy.model.resource import Representation
 from tests.fixtures.database import DatabaseTransactionFixture
 
 
 class TestFormatData:
+    def test_hash(self) -> None:
+        # Test that FormatData is hashable
+        hash(FormatData(content_type="foo", drm_scheme="bar"))
+
     def test_apply_to_loan(self, db: DatabaseTransactionFixture) -> None:
         # Here's a LicensePool with one non-open-access delivery mechanism.
         session = db.session
@@ -44,3 +49,31 @@ class TestFormatData:
         # Calling apply_to_loan() again with the same arguments does nothing.
         format_data.apply_to_loan(session, loan)
         assert len(pool.delivery_mechanisms) == 2
+
+    def test_gather_data_from_link(self) -> None:
+        link = LinkData(
+            rel="test",
+            href="http://example.com",
+            media_type="application/pdf",
+            rights_uri=RightsStatus.IN_COPYRIGHT,
+        )
+
+        # If FormatData is created with rights_uri and content_type
+        # they are used directly.
+        format_data = FormatData(
+            content_type="application/epub+zip",
+            drm_scheme=DeliveryMechanism.ADOBE_DRM,
+            link=link,
+            rights_uri=RightsStatus.CC0,
+        )
+        assert format_data.content_type == "application/epub+zip"
+        assert format_data.drm_scheme == DeliveryMechanism.ADOBE_DRM
+        assert format_data.rights_uri == RightsStatus.CC0
+
+        # However, if FormatData is created with a LinkData object
+        # and no content_type or rights_uri, the content_type and
+        # rights_uri are taken from the LinkData object.
+        format_data = FormatData(content_type=None, drm_scheme=None, link=link)
+        assert format_data.content_type == "application/pdf"
+        assert format_data.drm_scheme is None
+        assert format_data.rights_uri == RightsStatus.IN_COPYRIGHT

--- a/tests/manager/metadata_layer/test_identifier.py
+++ b/tests/manager/metadata_layer/test_identifier.py
@@ -1,10 +1,26 @@
 from palace.manager.metadata_layer.identifier import IdentifierData
 from palace.manager.sqlalchemy.model.identifier import Identifier
+from tests.fixtures.database import DatabaseTransactionFixture
 
 
 class TestIdentifierData:
-    def test_constructor(self):
-        data = IdentifierData(Identifier.ISBN, "foo", 0.5)
-        assert Identifier.ISBN == data.type
-        assert "foo" == data.identifier
-        assert 0.5 == data.weight
+    def test_hash(self) -> None:
+        # Test that IdentifierData is hashable
+        hash(IdentifierData(type=Identifier.ISBN, identifier="foo"))
+
+    def test_constructor(self) -> None:
+        data = IdentifierData(type=Identifier.ISBN, identifier="foo", weight=0.5)
+        assert data.type == Identifier.ISBN
+        assert data.identifier == "foo"
+        assert data.weight == 0.5
+
+    def test_from_identifier(self, db: DatabaseTransactionFixture) -> None:
+        identifier = db.identifier()
+
+        data = IdentifierData.from_identifier(identifier)
+        assert data.type == identifier.type
+        assert data.identifier == identifier.identifier
+
+        # Calling from_identifier() on an IdentifierData object is a no-op
+        # and returns the same object.
+        assert IdentifierData.from_identifier(data) is data

--- a/tests/manager/metadata_layer/test_license.py
+++ b/tests/manager/metadata_layer/test_license.py
@@ -1,0 +1,15 @@
+from palace.manager.metadata_layer.license import LicenseData
+from palace.manager.opds.odl.info import LicenseStatus
+
+
+class TestLicense:
+    def test_hash(self) -> None:
+        """That LicenseData is hashable."""
+        license_data = LicenseData(
+            identifier="12345",
+            checkout_url="http://example.com/checkout",
+            status_url="http://example.com/status",
+            status=LicenseStatus.available,
+            checkouts_available=5,
+        )
+        assert hash(license_data)

--- a/tests/manager/metadata_layer/test_link.py
+++ b/tests/manager/metadata_layer/test_link.py
@@ -1,26 +1,70 @@
+from functools import partial
+
+import pytest
+from pydantic import ValidationError
+
 from palace.manager.metadata_layer.link import LinkData
 from palace.manager.sqlalchemy.model.resource import Hyperlink, Representation
 
 
 class TestLinkData:
+    def test_hash(self) -> None:
+        """Test that the hash of a LinkData object is consistent."""
+        link1 = LinkData(rel=Hyperlink.IMAGE, href="http://example.com/image.jpg")
+        link2 = LinkData(rel=Hyperlink.IMAGE, href="http://example.com/image.jpg")
+        assert hash(link1) == hash(link2)
+
     def test_guess_media_type(self):
         rel = Hyperlink.IMAGE
 
         # Sometimes we have no idea what media type is at the other
         # end of a link.
-        unknown = LinkData(rel, href="http://foo/bar.unknown")
+        unknown = LinkData(rel=rel, href="http://foo/bar.unknown")
         assert None == unknown.guessed_media_type
 
         # Sometimes we can guess based on the file extension.
-        jpeg = LinkData(rel, href="http://foo/bar.jpeg")
+        jpeg = LinkData(rel=rel, href="http://foo/bar.jpeg")
         assert Representation.JPEG_MEDIA_TYPE == jpeg.guessed_media_type
 
         # An explicitly known media type takes precedence over
         # something we guess from the file extension.
         png = LinkData(
-            rel, href="http://foo/bar.jpeg", media_type=Representation.PNG_MEDIA_TYPE
+            rel=rel,
+            href="http://foo/bar.jpeg",
+            media_type=Representation.PNG_MEDIA_TYPE,
         )
         assert Representation.PNG_MEDIA_TYPE == png.guessed_media_type
 
-        description = LinkData(Hyperlink.DESCRIPTION, content="Some content")
+        description = LinkData(rel=Hyperlink.DESCRIPTION, content="Some content")
         assert None == description.guessed_media_type
+
+    def test__thumbnail_has_correct_rel(self):
+        # Test that the thumbnail link has the correct rel
+        image = partial(
+            LinkData, rel=Hyperlink.IMAGE, href="http://example.com/image.jpg"
+        )
+
+        # Create a image link with a correct thumbnail
+        correct_thumbnail = image(
+            thumbnail=LinkData(
+                rel=Hyperlink.THUMBNAIL_IMAGE, href="http://example.com/thumbnail.jpg"
+            )
+        )
+        assert correct_thumbnail.thumbnail.href == "http://example.com/thumbnail.jpg"
+        assert correct_thumbnail.href == "http://example.com/image.jpg"
+
+        # We set the thumbnail to none if there is an incorrect rel
+        incorrect_thumbnail = image(
+            thumbnail=LinkData(
+                rel="non_thumbnail", href="http://example.com/non_thumbnail.jpg"
+            )
+        )
+        assert incorrect_thumbnail.thumbnail is None
+        assert incorrect_thumbnail.href == "http://example.com/image.jpg"
+
+    def test_require_href_or_content(self):
+        # Test that a LinkData object requires either href or content
+        with pytest.raises(
+            ValidationError, match="Either 'href' or 'content' is required"
+        ):
+            LinkData(rel=Hyperlink.IMAGE)

--- a/tests/manager/metadata_layer/test_measurement.py
+++ b/tests/manager/metadata_layer/test_measurement.py
@@ -1,0 +1,38 @@
+import datetime
+
+from freezegun import freeze_time
+
+from palace.manager.metadata_layer.measurement import MeasurementData
+from palace.manager.util.datetime_helpers import utc_now
+
+
+class TestMeasurementData:
+    def test_taken_at(self) -> None:
+        """Test that the taken_at is set correctly."""
+
+        # If taken_at is given, it's converted to a datetime.datetime with the correct date
+        measurement = MeasurementData.model_validate(
+            {
+                "quantity_measured": "quality",
+                "value": 25.0,
+                "taken_at": "2023-10-01T00:00:00+00:00",
+            }
+        )
+        assert measurement.taken_at == datetime.datetime.fromisoformat(
+            "2023-10-01T00:00:00+00:00"
+        )
+
+        # It taken_at is not given, then it is set to the current time
+        with freeze_time():
+            measurement = MeasurementData.model_validate(
+                {"quantity_measured": "quality", "value": 25.0}
+            )
+            assert measurement.taken_at == utc_now()
+
+    def test_hash(self) -> None:
+        """Test that MeasurementData is hashable."""
+        hash(
+            MeasurementData.model_validate(
+                {"quantity_measured": "quality", "value": 25.0}
+            )
+        )

--- a/tests/manager/metadata_layer/test_metadata.py
+++ b/tests/manager/metadata_layer/test_metadata.py
@@ -314,7 +314,7 @@ class TestMetadata:
         coverage = CoverageRecord.lookup(edition, data_source)
         assert older_last_update == coverage.timestamp
 
-    def test_defaults(self):
+    def test_defaults(self) -> None:
         # Verify that a Metadata object doesn't make any assumptions
         # about an item's medium.
         m = Metadata(data_source=DataSource.OCLC)
@@ -327,7 +327,7 @@ class TestMetadata:
 
         edition, pool = db.edition(with_license_pool=True)
         edition.series = "Harry Otter and the Mollusk of Infamy"
-        edition.series_position = "14"
+        edition.series_position = 14
         edition.primary_identifier.add_link(
             Hyperlink.IMAGE, "image", edition.data_source
         )
@@ -486,7 +486,7 @@ class TestMetadata:
         # We then learn about a subject under which the work
         # is classified.
         metadata.title = None
-        metadata.subjects = [SubjectData(Subject.TAG, "subject")]
+        metadata.subjects = [SubjectData(type=Subject.TAG, identifier="subject")]
         metadata.apply(edition, None)
 
         # The work is now slated to have its presentation completely
@@ -649,7 +649,9 @@ class TestMetadata:
     def test_filter_recommendations(self, db: DatabaseTransactionFixture):
         metadata = Metadata(DataSource.OVERDRIVE)
         known_identifier = db.identifier()
-        unknown_identifier = IdentifierData(Identifier.ISBN, "hey there")
+        unknown_identifier = IdentifierData(
+            type=Identifier.ISBN, identifier="hey there"
+        )
 
         # Unknown identifiers are filtered out of the recommendations.
         metadata.recommendations += [known_identifier, unknown_identifier]
@@ -658,7 +660,7 @@ class TestMetadata:
 
         # It works with IdentifierData as well.
         known_identifier_data = IdentifierData(
-            known_identifier.type, known_identifier.identifier
+            type=known_identifier.type, identifier=known_identifier.identifier
         )
         metadata.recommendations = [known_identifier_data, unknown_identifier]
         metadata.filter_recommendations(db.session)
@@ -683,11 +685,11 @@ class TestMetadata:
         # Check that we didn't put something in the metadata that
         # will prevent it from being copied. (e.g., self.log)
 
-        subject = SubjectData(Subject.TAG, "subject")
+        subject = SubjectData(type=Subject.TAG, identifier="subject")
         contributor = ContributorData()
-        identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
-        link = LinkData(Hyperlink.OPEN_ACCESS_DOWNLOAD, "example.epub")
-        measurement = MeasurementData(Measurement.RATING, 5)
+        identifier = IdentifierData(type=Identifier.GUTENBERG_ID, identifier="1")
+        link = LinkData(rel=Hyperlink.OPEN_ACCESS_DOWNLOAD, href="example.epub")
+        measurement = MeasurementData(quantity_measured=Measurement.RATING, value=5)
         circulation = CirculationData(
             data_source=DataSource.GUTENBERG,
             primary_identifier=identifier,
@@ -731,7 +733,7 @@ class TestMetadata:
 
     def test_links_filtered(self):
         # test that filter links to only metadata-relevant ones
-        link1 = LinkData(Hyperlink.OPEN_ACCESS_DOWNLOAD, "example.epub")
+        link1 = LinkData(rel=Hyperlink.OPEN_ACCESS_DOWNLOAD, href="example.epub")
         link2 = LinkData(rel=Hyperlink.IMAGE, href="http://example.com/")
         link3 = LinkData(rel=Hyperlink.DESCRIPTION, content="foo")
         link4 = LinkData(
@@ -747,7 +749,7 @@ class TestMetadata:
         )
         links = [link1, link2, link3, link4, link5]
 
-        identifier = IdentifierData(Identifier.GUTENBERG_ID, "1")
+        identifier = IdentifierData(type=Identifier.GUTENBERG_ID, identifier="1")
         metadata = Metadata(
             data_source=DataSource.GUTENBERG,
             primary_identifier=identifier,
@@ -776,9 +778,7 @@ class TestMetadata:
         # Here's an Metadata object for a second print book with the
         # same PWID.
         identifier = db.identifier()
-        identifierdata = IdentifierData(
-            type=identifier.type, identifier=identifier.identifier
-        )
+        identifierdata = IdentifierData.from_identifier(identifier)
         metadata = Metadata(
             DataSource.GUTENBERG,
             primary_identifier=identifierdata,

--- a/tests/manager/metadata_layer/test_subject.py
+++ b/tests/manager/metadata_layer/test_subject.py
@@ -1,0 +1,23 @@
+from palace.manager.metadata_layer.subject import SubjectData
+
+
+class TestSubjectData:
+    def test_identifier(self) -> None:
+        """Test that we strip whitespace from the identifier."""
+        subject = SubjectData.model_validate({"type": "test", "identifier": " 12345 "})
+        assert subject.type == "test"
+        assert subject.identifier == "12345"
+
+    def test_name(self) -> None:
+        """Test that we strip whitespace from the name."""
+        subject = SubjectData.model_validate(
+            {"type": "test", "identifier": None, "name": "  Test Name  "}
+        )
+        assert subject.type == "test"
+        assert subject.identifier is None
+        assert subject.name == "Test Name"
+
+    def test_hash(self) -> None:
+        """Test that SubjectData is hashable."""
+        subject = SubjectData.model_validate({"type": "test", "identifier": "12345"})
+        assert hash(subject)

--- a/tests/manager/sqlalchemy/model/test_edition.py
+++ b/tests/manager/sqlalchemy/model/test_edition.py
@@ -198,7 +198,7 @@ class TestEdition:
             edition.equivalent_identifiers(policy=policy)
         )
 
-        policy.equivalent_identifier_threshold = 0.7
+        policy = PresentationCalculationPolicy(equivalent_identifier_threshold=0.7)
         assert {edition.primary_identifier} == set(
             edition.equivalent_identifiers(policy=policy)
         )

--- a/tests/manager/sqlalchemy/model/test_identifier.py
+++ b/tests/manager/sqlalchemy/model/test_identifier.py
@@ -436,7 +436,11 @@ class TestIdentifier:
         assert 3 == len(equivs[identifier.id])
 
         # Increase the cutoff, and we get more identifiers.
-        with_cutoff.equivalent_identifier_cutoff = 5
+        with_cutoff = PresentationCalculationPolicy(
+            equivalent_identifier_levels=5,
+            equivalent_identifier_threshold=0.1,
+            equivalent_identifier_cutoff=5,
+        )
         equivs = Identifier.recursively_equivalent_identifier_ids(
             db.session, [identifier.id], policy=with_cutoff
         )


### PR DESCRIPTION
## Description

Update the following classes:
- `ContributorData`
- `FormatData`
- `IdentifierData`
- `LicenseData`
- `LinkData`
- `MeasurementData`
- `PresentationCalculationPolicy`
- `ReplacementPolicy`
- `SubjectData`

To:
- Use pydantic for serialization / deserialization
- immutable and hashable
- Use pydantic for their `repr`

Because Pydantic models don't allow the model to be created with positional args, a bunch of the changes in this PR are updating calls to use named args to construct the models.

This is the first phase of this work. `CirculationData` and `Metadata` still need to be converted.

## Motivation and Context

Working towards getting all of our metadata layer classes to be serializable and deserializable via pydantic, so its easier to add them to celery queues.

See: PP-2466

## How Has This Been Tested?

- Tests run in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
