### PR TITLE
Optimize LibraryAnnotator NoveList config check. (PP-2491)

### DIFF
--- a/src/palace/manager/api/metadata/novelist.py
+++ b/src/palace/manager/api/metadata/novelist.py
@@ -136,7 +136,16 @@ class NoveListAPI(
         return cls.settings_load(integration)
 
     @classmethod
-    def is_configured(cls, library: Library) -> bool:
+    def is_configured_db_check(cls, library: Library) -> bool:
+        """Checks if a NoveList integration exists and is configured for the given library.
+
+        Note: This method performs a database query to find the relevant
+        integration. It should not be called repeatedly in performance-sensitive
+        code without considering caching strategies as appropriate.
+
+        :param library: The Library to check for a NoveList configuration.
+        :return: True if a NoveList integration is configured, False otherwise.
+        """
         integration = cls.integration(library)
         return integration is not None
 

--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -7,6 +7,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections import defaultdict
+from functools import cached_property
 from typing import Any
 
 from dependency_injector.wiring import Provide, inject
@@ -740,18 +741,15 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         self._top_level_title = top_level_title
         self.identifies_patrons = library_identifies_patrons
         self.facets = facets or None
-        self._is_novelist_configured: bool | None = None
 
-    @property
+    @cached_property
     def is_novelist_configured(self) -> bool:
         """Lazy load and cache NoveList's `is_configured` flag.
 
         This is an optimization to avoid a SQL query to check this
-        flag for every book in the feed.
+        flag for every entry in the feed.
         """
-        if self._is_novelist_configured is None:
-            self._is_novelist_configured = NoveListAPI.is_configured(self.library)
-        return self._is_novelist_configured
+        return NoveListAPI.is_configured(self.library)
 
     def top_level_title(self) -> str:
         return self._top_level_title

--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -749,7 +749,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         This is an optimization to avoid a SQL query to check this
         flag for every entry in the feed.
         """
-        return NoveListAPI.is_configured(self.library)
+        return NoveListAPI.is_configured_db_check(self.library)
 
     def top_level_title(self) -> str:
         return self._top_level_title
@@ -925,7 +925,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             )
 
         # Add a link for related books if available.
-        if self.related_books_available(work, self.library):
+        if self.may_have_related_works(work):
             entry.computed.other_links.append(
                 Link(
                     rel="related",
@@ -992,12 +992,14 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             )
         return super().active_licensepool_for(work=work, library=self.library)
 
-    @classmethod
-    def related_books_available(cls, work: Work, library: Library) -> bool:
-        """:return: bool asserting whether related books might exist for a particular Work"""
-        contributions = work.sort_author and work.sort_author != Edition.UNKNOWN_AUTHOR
+    def may_have_related_works(self, work: Work) -> bool:
+        """Could there be related works?
 
-        return bool(contributions or work.series or NoveListAPI.is_configured(library))
+        :param work: The Work to check.
+        :return: True if related works might exist for the Work. False otherwise.
+        """
+        contributions = work.sort_author and work.sort_author != Edition.UNKNOWN_AUTHOR
+        return bool(contributions or work.series or self.is_novelist_configured)
 
     def language_and_audience_key_from_work(
         self, work: Work

--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -740,6 +740,18 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         self._top_level_title = top_level_title
         self.identifies_patrons = library_identifies_patrons
         self.facets = facets or None
+        self._is_novelist_configured: bool | None = None
+
+    @property
+    def is_novelist_configured(self) -> bool:
+        """Lazy load and cache NoveList's `is_configured` flag.
+
+        This is an optimization to avoid a SQL query to check this
+        flag for every book in the feed.
+        """
+        if self._is_novelist_configured is None:
+            self._is_novelist_configured = NoveListAPI.is_configured(self.library)
+        return self._is_novelist_configured
 
     def top_level_title(self) -> str:
         return self._top_level_title
@@ -896,7 +908,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         if work.series:
             self.add_series_link(entry)
 
-        if NoveListAPI.is_configured(self.library):
+        if self.is_novelist_configured:
             # If NoveList Select is configured, there might be
             # recommendations, too.
             entry.computed.other_links.append(

--- a/src/palace/manager/scripts/novelist.py
+++ b/src/palace/manager/scripts/novelist.py
@@ -12,7 +12,7 @@ class NovelistSnapshotScript(TimestampScript, LibraryInputScript):
     def do_run(self, output=sys.stdout, *args, **kwargs):
         parsed = self.parse_command_line(self._db, *args, **kwargs)
         for library in parsed.libraries:
-            if not NoveListAPI.integration(library):
+            if not NoveListAPI.is_configured_db_check(library):
                 self.log.info(
                     f'The library name "{library.name}" is not associated with Novelist API integration and '
                     f"therefore will not be queued."

--- a/tests/manager/api/metadata/test_novelist.py
+++ b/tests/manager/api/metadata/test_novelist.py
@@ -81,11 +81,14 @@ class TestNoveListAPI:
 
     def test_is_configured(self, novelist_fixture: NoveListFixture):
         # If a IntegrationLibraryConfiguration exists, the API is_configured
-        assert NoveListAPI.is_configured(novelist_fixture.db.default_library()) is True
+        assert (
+            NoveListAPI.is_configured_db_check(novelist_fixture.db.default_library())
+            is True
+        )
 
         # If an integration doesn't exist for the library, it is not.
         library = novelist_fixture.db.library()
-        assert NoveListAPI.is_configured(library) is False
+        assert NoveListAPI.is_configured_db_check(library) is False
 
     def test_review_response(self, novelist_fixture: NoveListFixture):
         invalid_credential_response: HttpResponseTuple = (

--- a/tests/manager/feed/test_library_annotator.py
+++ b/tests/manager/feed/test_library_annotator.py
@@ -887,7 +887,7 @@ class TestLibraryAnnotator:
             partials_by_rel=expected_rel_and_partial,
         )
 
-    @patch.object(NoveListAPI, "is_configured", return_value=False)
+    @patch.object(NoveListAPI, "is_configured_db_check", return_value=False)
     def test_annotator_lazy_cache_novelist_is_configured(
         self,
         mock_is_configured: MagicMock,


### PR DESCRIPTION
## Description

- Lazy load and cache the value of `NoveList.is_configured` in the `LibraryAnnotator`. The previous behavior was to compute this value multiple times, once for every feed entry.
- Added test to ensure that `NoveList.is_configured` is called only once per feed generation, regardless of how many items are in the feed. Without the change this test was failing. After the change, it passes.

## Motivation and Context

Computing the value of `NoveList.is_configured` was contributing to slowness (1/5 to 1/4 of response time in my testing) when building our OPDS feeds because a database query is being run every time we check to see if NoveList is configured for a given library. However, the value should not change within a single feed build, so computing once and caching the result makes sense here.

## How Has This Been Tested?

- Added new test.
- All tests pass locally.
- Tested with profiling in local development environment.
  - After this change, calls to `NoveList.is_configured` were no longer contributing significantly to the response time and the response time improved.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/14845548918) pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
