### PR TITLE
This update fixes a bug that was causing google drive failures when t…

### DIFF
--- a/src/palace/manager/service/google_drive/google_drive.py
+++ b/src/palace/manager/service/google_drive/google_drive.py
@@ -29,6 +29,7 @@ class GoogleDriveService(LoggerMixin):
                 q=query,
                 pageSize=10,
                 fields="nextPageToken, files(*)",
+                supportsAllDrives=True,
             )
             .execute()
         )
@@ -62,7 +63,9 @@ class GoogleDriveService(LoggerMixin):
         file_metadata: File = {"name": file_name, "parents": parents}
         file = (
             self.api_client.files()
-            .create(body=file_metadata, media_body=media, fields="*")
+            .create(
+                body=file_metadata, media_body=media, fields="*", supportsAllDrives=True
+            )
             .execute()
         )
 
@@ -89,7 +92,11 @@ class GoogleDriveService(LoggerMixin):
             folder = self.get_file(name=folder_name, parent_folder_id=parent_id)
 
             if not folder:
-                folder = self.api_client.files().create(body=body).execute()
+                folder = (
+                    self.api_client.files()
+                    .create(body=body, supportsAllDrives=True)
+                    .execute()
+                )
 
             results.append(folder)
             parent_id = folder["id"]


### PR DESCRIPTION
…he GOOGLE_DRIVE_PARENT_FOLDER_ID refers to a shared drive.

## Description
The production reports were not being uploaded to the shared google drive. 
<!--- Describe your changes -->

## Motivation and Context

Tara Carpenter was not seeing the files land in the EBCE Partner Success Team shared drive.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I generated a report from my local instance using  the production google drive credentials and parent folder id and verified that the report landed.  I also tested that it still works when the folder id is not in a shared drive.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
