### PR TITLE
Refactor novelist integration to decouple from metadata layer (PP-2466)

### DIFF
--- a/tests/manager/metadata_layer/test_metadata.py
+++ b/tests/manager/metadata_layer/test_metadata.py
@@ -646,41 +646,6 @@ class TestMetadata:
         assert "123" == contributor.lc
         assert "Robert_Jordan" == contributor.wikipedia_name
 
-    def test_filter_recommendations(self, db: DatabaseTransactionFixture):
-        metadata = Metadata(DataSource.OVERDRIVE)
-        known_identifier = db.identifier()
-        unknown_identifier = IdentifierData(
-            type=Identifier.ISBN, identifier="hey there"
-        )
-
-        # Unknown identifiers are filtered out of the recommendations.
-        metadata.recommendations += [known_identifier, unknown_identifier]
-        metadata.filter_recommendations(db.session)
-        assert [known_identifier] == metadata.recommendations
-
-        # It works with IdentifierData as well.
-        known_identifier_data = IdentifierData(
-            type=known_identifier.type, identifier=known_identifier.identifier
-        )
-        metadata.recommendations = [known_identifier_data, unknown_identifier]
-        metadata.filter_recommendations(db.session)
-        [result] = metadata.recommendations
-        # The IdentifierData has been replaced by a bonafide Identifier.
-        assert isinstance(result, Identifier)
-        # The genuine article.
-        assert known_identifier == result
-
-        # Recommendations are filtered to make sure the primary identifier is not recommended.
-        primary_identifier = db.identifier()
-        metadata = Metadata(DataSource.OVERDRIVE, primary_identifier=primary_identifier)
-        metadata.recommendations = [
-            known_identifier_data,
-            unknown_identifier,
-            primary_identifier,
-        ]
-        metadata.filter_recommendations(db.session)
-        assert [known_identifier] == metadata.recommendations
-
     def test_metadata_can_be_deepcopied(self):
         # Check that we didn't put something in the metadata that
         # will prevent it from being copied. (e.g., self.log)


### PR DESCRIPTION
## Description

Refactor `NoveListAPI` to decouple it from the `Metadata` object from the metadata layer.

## Motivation and Context

The `NoveListAPI` integration used to capture all its data into a `Metadata` object. However this data was never stored in the database by calling the `apply` method on it. The `Metadata` object was just used to pass book recommendations into the `RecommendationLane`, which isn't a very good fit for the `Metadata` object. 

This refactor decouples `NoveListAPI` from the metadata layer, allowing it to return a list of recommendations directly. This removes some of the parsing of the `NoveListAPI` data that was parsed but never used. If we decide in the future that we want to capture this data and store it in the database we can bring back in some of this code. (I'm not sure if we are even allowed to store this data).

## How Has This Been Tested?

- Running unit tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
