### PR TITLE
[PP-2504] change playtime report name

### DIFF
--- a/src/palace/manager/celery/tasks/playtime_entries.py
+++ b/src/palace/manager/celery/tasks/playtime_entries.py
@@ -214,7 +214,7 @@ def generate_playtime_report(
 
                 nested_folders = [
                     data_source_name,
-                    "Usage Report",
+                    "Usage Reports",
                     reporting_name,
                     str(start.year),
                 ]

--- a/src/palace/manager/celery/tasks/playtime_entries.py
+++ b/src/palace/manager/celery/tasks/playtime_entries.py
@@ -135,7 +135,7 @@ class Writer(Protocol):
     def writerow(self, row: Iterable[Any]) -> Any: ...
 
 
-REPORT_DATE_FORMAT = "%Y-%m-%d"
+REPORT_DATE_FORMAT = "%m-%d-%Y"
 
 
 @shared_task(queue=QueueNames.default, bind=True)

--- a/tests/manager/celery/tasks/test_playtime_entries.py
+++ b/tests/manager/celery/tasks/test_playtime_entries.py
@@ -732,7 +732,9 @@ class TestGeneratePlaytimeReport:
 
         cutoff = date1m(0).replace(day=1)
         until = utc_now().date().replace(day=1)
-        column1 = f"{cutoff} - {until}"
+        column1 = (
+            f"{REPORT_DATE_FORMAT.format(cutoff)} - {REPORT_DATE_FORMAT.format(until)}"
+        )
         headers = [
             "date",
             "urn",

--- a/tests/manager/celery/tasks/test_playtime_entries.py
+++ b/tests/manager/celery/tasks/test_playtime_entries.py
@@ -852,7 +852,7 @@ class TestGeneratePlaytimeReport:
             "parent_folder_id": parent_folder_id,
             "folders": [
                 "ds_a",
-                "Usage Report",
+                "Usage Reports",
                 "test cm",
                 "2025",
             ],
@@ -861,7 +861,7 @@ class TestGeneratePlaytimeReport:
             "parent_folder_id": parent_folder_id,
             "folders": [
                 "ds_b",
-                "Usage Report",
+                "Usage Reports",
                 "test cm",
                 "2025",
             ],

--- a/tests/manager/celery/tasks/test_playtime_entries.py
+++ b/tests/manager/celery/tasks/test_playtime_entries.py
@@ -732,9 +732,7 @@ class TestGeneratePlaytimeReport:
 
         cutoff = date1m(0).replace(day=1)
         until = utc_now().date().replace(day=1)
-        column1 = (
-            f"{REPORT_DATE_FORMAT.format(cutoff)} - {REPORT_DATE_FORMAT.format(until)}"
-        )
+        column1 = f"{cutoff.strftime(REPORT_DATE_FORMAT)} - {until.strftime(REPORT_DATE_FORMAT)}"
         headers = [
             "date",
             "urn",


### PR DESCRIPTION
## Description

Now that we are writing production reports to google drive,  Tara and I discovered a couple of minor bugs that were resulting in reports not landing in quite the right place with the right file naming conventions.  This PR addresses those mismatches. 

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2504
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests updated and manually tested in the production google drive.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
