### PR TITLE
Clean up unnecessary analytics provider injections

### DIFF
--- a/src/palace/manager/api/axis.py
+++ b/src/palace/manager/api/axis.py
@@ -15,7 +15,6 @@ from typing import Any, Generic, Literal, Optional, TypeVar, Union, cast
 from urllib.parse import urlparse
 
 import certifi
-from dependency_injector.wiring import Provide, inject
 from flask_babel import lazy_gettext as _
 from lxml import etree
 from lxml.etree import _Element, _ElementTree
@@ -70,8 +69,6 @@ from palace.manager.metadata_layer.link import LinkData
 from palace.manager.metadata_layer.metadata import Metadata
 from palace.manager.metadata_layer.policy.replacement import ReplacementPolicy
 from palace.manager.metadata_layer.subject import SubjectData
-from palace.manager.service.analytics.analytics import Analytics
-from palace.manager.service.container import Services
 from palace.manager.sqlalchemy.constants import LinkRelations, MediaTypes
 from palace.manager.sqlalchemy.model.classification import Classification, Subject
 from palace.manager.sqlalchemy.model.collection import Collection
@@ -629,11 +626,9 @@ class Axis360API(
         for removed_identifier in remainder:
             self._reap(removed_identifier)
 
-    @inject
     def update_book(
         self,
         bibliographic: Metadata,
-        analytics: Analytics = Provide[Services.analytics.analytics],
     ) -> tuple[Edition, bool, LicensePool, bool]:
         """Create or update a single book based on bibliographic
         and availability data from the Axis 360 API.

--- a/src/palace/manager/api/enki.py
+++ b/src/palace/manager/api/enki.py
@@ -6,7 +6,6 @@ import time
 from collections.abc import Callable, Generator, Mapping
 from typing import Any, cast
 
-from dependency_injector.wiring import Provide
 from flask_babel import lazy_gettext as _
 from requests import Response as RequestsResponse
 from sqlalchemy.orm import Session
@@ -50,8 +49,6 @@ from palace.manager.metadata_layer.link import LinkData
 from palace.manager.metadata_layer.metadata import Metadata
 from palace.manager.metadata_layer.policy.replacement import ReplacementPolicy
 from palace.manager.metadata_layer.subject import SubjectData
-from palace.manager.service.analytics.analytics import Analytics
-from palace.manager.service.container import Services
 from palace.manager.sqlalchemy.model.classification import Classification, Subject
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.datasource import DataSource
@@ -796,7 +793,6 @@ class EnkiImport(CollectionMonitor, TimelineMonitor):
         _db: Session,
         collection: Collection,
         api_class: EnkiAPI | Callable[..., EnkiAPI] = EnkiAPI,
-        analytics: Analytics = Provide[Services.analytics.analytics],
     ):
         """Constructor."""
         super().__init__(_db, collection)
@@ -807,7 +803,6 @@ class EnkiImport(CollectionMonitor, TimelineMonitor):
             api = api_class
         self.api = api
         self.collection_id = collection.id
-        self.analytics = analytics
 
     @property
     def collection(self) -> Collection | None:

--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -7,7 +7,6 @@ import uuid
 from collections.abc import Callable
 from functools import cached_property, partial
 
-from dependency_injector.wiring import Provide, inject
 from flask import url_for
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
@@ -53,8 +52,6 @@ from palace.manager.core.lcp.credential import LCPCredentialFactory
 from palace.manager.opds.lcp.license import LicenseDocument
 from palace.manager.opds.lcp.status import LoanStatus
 from palace.manager.opds.types.link import BaseLink
-from palace.manager.service.analytics.analytics import Analytics
-from palace.manager.service.container import Services
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.licensing import (
@@ -100,12 +97,10 @@ class OPDS2WithODLApi(
     def description(cls) -> str:
         return "Import books from a distributor that uses OPDS2 + ODL (Open Distribution to Libraries)."
 
-    @inject
     def __init__(
         self,
         _db: Session,
         collection: Collection,
-        analytics: Analytics = Provide[Services.analytics.analytics],
     ) -> None:
         super().__init__(_db, collection)
 
@@ -119,7 +114,6 @@ class OPDS2WithODLApi(
         self.data_source_name = settings.data_source
         # Create the data source if it doesn't exist yet.
         DataSource.lookup(_db, self.data_source_name, autocreate=True)
-        self.analytics = analytics
 
         self._hasher_factory = HasherFactory()
         self._credential_factory = LCPCredentialFactory()

--- a/src/palace/manager/api/overdrive/monitor.py
+++ b/src/palace/manager/api/overdrive/monitor.py
@@ -6,7 +6,6 @@ from collections.abc import Generator
 from typing import Any
 
 import dateutil
-from dependency_injector.wiring import Provide, inject
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 from tenacity import (
@@ -23,8 +22,6 @@ from palace.manager.core.monitor import (
     TimelineMonitor,
     TimestampData,
 )
-from palace.manager.service.analytics.analytics import Analytics
-from palace.manager.service.container import Services
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.identifier import Identifier
@@ -40,18 +37,15 @@ class OverdriveCirculationMonitor(CollectionMonitor, TimelineMonitor):
     PROTOCOL = OverdriveAPI.label()
     OVERLAP = datetime.timedelta(minutes=1)
 
-    @inject
     def __init__(
         self,
         _db: Session,
         collection: Collection,
         api_class: type[OverdriveAPI] = OverdriveAPI,
-        analytics: Analytics = Provide[Services.analytics.analytics],
     ) -> None:
         """Constructor."""
         super().__init__(_db, collection)
         self.api = api_class(_db, collection)
-        self.analytics = analytics
 
     def recently_changed_ids(
         self, start: datetime.datetime, cutoff: datetime.datetime | None

--- a/src/palace/manager/service/container.py
+++ b/src/palace/manager/service/container.py
@@ -83,12 +83,7 @@ class Services(DeclarativeContainer):
 def wire_container(container: Services) -> None:
     container.wire(
         modules=[
-            "palace.manager.api.axis",
-            "palace.manager.api.bibliotheca",
             "palace.manager.api.circulation_manager",
-            "palace.manager.api.enki",
-            "palace.manager.api.odl.api",
-            "palace.manager.api.overdrive",
             "palace.manager.feed.annotator.circulation",
             "palace.manager.feed.acquisition",
             "palace.manager.sqlalchemy.model.lane",

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -894,9 +894,7 @@ class LicensePool(Base):
                 new_value=new_value,
             )
 
-    def update_availability_from_delta(
-        self, event_type, event_date, delta, analytics=None
-    ):
+    def update_availability_from_delta(self, event_type, event_date, delta):
         """Call update_availability based on a single change seen in the
         distributor data, rather than a complete snapshot of
         distributor information as of a certain time.

--- a/tests/manager/api/test_enki.py
+++ b/tests/manager/api/test_enki.py
@@ -29,7 +29,6 @@ from palace.manager.api.overdrive.api import OverdriveAPI
 from palace.manager.core.monitor import TimestampData
 from palace.manager.metadata_layer.circulation import CirculationData
 from palace.manager.metadata_layer.metadata import Metadata
-from palace.manager.service.analytics.analytics import Analytics
 from palace.manager.sqlalchemy.model.classification import Subject
 from palace.manager.sqlalchemy.model.contributor import Contributor
 from palace.manager.sqlalchemy.model.datasource import DataSource
@@ -1021,16 +1020,11 @@ class TestEnkiImport:
         api.queue_response(200, content=json.dumps(circ_data))
         api.queue_response(200, content=json.dumps(bib_data))
 
-        from tests.mocks.analytics_provider import MockAnalyticsProvider
-
-        analytics = MockAnalyticsProvider()
         monitor = EnkiImport(
             db.session,
             enki_test_fixture.collection,
             api_class=api,
-            analytics=cast(Analytics, analytics),
         )
-        end = utc_now()
 
         # Ask for circulation events from one hour in 1970.
         start = datetime_utc(1970, 1, 1, 0, 0, 0)
@@ -1072,10 +1066,6 @@ class TestEnkiImport:
         assert "A book" == work.title
         assert 1 == licensepool.licenses_owned
         assert 0 == licensepool.licenses_available
-
-        # An analytics event was sent out for the newly discovered book.
-        # No more DISTRIBUTOR events
-        assert 0 == analytics.count
 
         # Now let's see what update_circulation does when the work
         # already exists.


### PR DESCRIPTION
## Description

Clean up some leftover dependency injections that are never actually used.

## Motivation and Context

I noticed this while working on: https://github.com/ThePalaceProject/circulation/pull/2458. Since these are unnecessary, we might as well remove them as it will speed up dependency injection.

Looks like this was leftover after https://github.com/ThePalaceProject/circulation/pull/214 went in.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
