### PR TITLE
Add pydantic serialization / deserialization to celery (kombu) (PP-2468)

### DIFF
--- a/src/palace/manager/celery/tasks/marc.py
+++ b/src/palace/manager/celery/tasks/marc.py
@@ -237,6 +237,10 @@ def marc_export_collection(
             collection_name=collection_name,
             start_time=start_time,
             libraries=libraries,
+            # We pass context as a list of tuples instead of a dict, because the json serializer
+            # converts all dict keys to strings, so we lose the integer keys. We convert it back
+            # to a dict on the other side.
+            # See the note here: https://docs.celeryq.dev/en/stable/userguide/calling.html#serializers
             context=[
                 (library.library_id, upload.context)
                 for library, upload in uploads.items()

--- a/src/palace/manager/service/celery/configuration.py
+++ b/src/palace/manager/service/celery/configuration.py
@@ -98,7 +98,7 @@ class CeleryConfiguration(ServiceConfiguration):
             new_dict[key.replace(prefix, "")] = value
 
 
-# Allow Celery to accept pydantic classes via the json serializer.
+# Allow Celery (via Kombu) to accept pydantic classes via the json serializer.
 #
 # This is a custom serializer for Pydantic models. It serializes the model to a
 # dictionary containing the module and class name, and the model data. The

--- a/src/palace/manager/service/celery/configuration.py
+++ b/src/palace/manager/service/celery/configuration.py
@@ -124,7 +124,7 @@ def _deserialize_pydantic(obj: dict[str, Any]) -> BaseModel:
     model_data = obj["__model__"]
     module = importlib.import_module(module_path)
     cls = getattr(module, qualname)
-    return cls.model_validate(model_data)
+    return cls.model_validate(model_data)  # type: ignore[no-any-return]
 
 
 register_type(

--- a/src/palace/manager/service/celery/configuration.py
+++ b/src/palace/manager/service/celery/configuration.py
@@ -127,4 +127,6 @@ def _deserialize_pydantic(obj: dict[str, Any]) -> BaseModel:
     return cls.model_validate(model_data)
 
 
-register_type(BaseModel, "pydantic", _serialize_pydantic, _deserialize_pydantic)
+register_type(
+    BaseModel, "pydantic_base_model", _serialize_pydantic, _deserialize_pydantic
+)

--- a/tests/manager/celery/tasks/test_marc.py
+++ b/tests/manager/celery/tasks/test_marc.py
@@ -91,10 +91,7 @@ class TestMarcExport:
             ]
             libraries_kwarg = delta_call.kwargs["libraries"]
             assert len(libraries_kwarg) == 1
-            assert (
-                libraries_kwarg[0].get("library_id")
-                == marc_exporter_fixture.library1.id
-            )
+            assert libraries_kwarg[0].library_id == marc_exporter_fixture.library1.id
 
     def test_skip_collections(
         self,
@@ -176,8 +173,9 @@ class MarcExportCollectionFixture:
     def export_collection(self, collection: Collection, delta: bool = False) -> None:
         service = self.services_fixture.services.integration_registry.catalog_services()
         assert collection.id is not None
-        info = MarcExporter.enabled_libraries(self.db.session, service, collection.id)
-        libraries = [l.model_dump() for l in info]
+        libraries = MarcExporter.enabled_libraries(
+            self.db.session, service, collection.id
+        )
         marc.marc_export_collection.delay(
             collection.id,
             collection_name=collection.name,


### PR DESCRIPTION
## Description

This PR allows you to pass pydantic models into celery function calls, and have them automatically serialized and deserialized, so they are transparently passed into the function.

This PR also updates the marc exporter task to use this new functionality. Previously it was manually dumping the loading the pydantic models it was using.

## Motivation and Context

As part of PP-2468 we are going to be passing more pydantic models into celery tasks, so this is an effort to make that easier.

## How Has This Been Tested?

- Added unit test
- Converted marc exporter to use new functionality

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
