### PR TITLE
Add celery tasks to mark unavailable identifiers (PP-2469)

### DIFF
--- a/src/palace/manager/celery/tasks/apply.py
+++ b/src/palace/manager/celery/tasks/apply.py
@@ -6,6 +6,7 @@ from palace.manager.celery.task import Task
 from palace.manager.celery.utils import load_from_id
 from palace.manager.core.exceptions import PalaceValueError
 from palace.manager.data_layer.bibliographic import BibliographicData
+from palace.manager.data_layer.circulation import CirculationData
 from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.data_layer.policy.replacement import ReplacementPolicy
 from palace.manager.service.celery.celery import QueueNames
@@ -28,6 +29,50 @@ def _lock(client: Redis, identifier: IdentifierData) -> RedisLock:
     )
 
 
+def _validate_primary_identifier(
+    primary_identifier: IdentifierData | None,
+) -> IdentifierData:
+    """
+    Validate that the primary identifier is not None.
+    """
+    if primary_identifier is None:
+        raise PalaceValueError(
+            "No primary identifier provided! (primary_identifier_data is None)."
+        )
+
+    return primary_identifier
+
+
+@shared_task(
+    queue=QueueNames.apply,
+    bind=True,
+    autoretry_for=(LockNotAcquired,),
+    max_retries=4,
+    retry_backoff=30,
+)
+def circulation_apply(
+    task: Task,
+    circulation: CirculationData,
+    collection_id: int,
+    replace: ReplacementPolicy | None = None,
+) -> None:
+    """
+    Call CirculationData.apply() on the given collection.
+    """
+
+    redis_client = task.services.redis().client()
+    primary_identifier = _validate_primary_identifier(
+        circulation.primary_identifier_data
+    )
+
+    with (
+        _lock(redis_client, primary_identifier).lock(),
+        task.transaction() as session,
+    ):
+        collection = load_from_id(session, Collection, collection_id)
+        circulation.apply(session, collection, replace)
+
+
 @shared_task(
     queue=QueueNames.apply,
     bind=True,
@@ -47,12 +92,9 @@ def bibliographic_apply(
     """
 
     redis_client = task.services.redis().client()
-    primary_identifier = bibliographic.primary_identifier_data
-
-    if primary_identifier is None:
-        raise PalaceValueError(
-            "No primary identifier provided! (primary_identifier_data is None)."
-        )
+    primary_identifier = _validate_primary_identifier(
+        bibliographic.primary_identifier_data
+    )
 
     with (
         _lock(redis_client, primary_identifier).lock(),

--- a/src/palace/manager/celery/tasks/apply.py
+++ b/src/palace/manager/celery/tasks/apply.py
@@ -1,10 +1,10 @@
 from datetime import timedelta
+from functools import partial
 
 from celery import shared_task
 
 from palace.manager.celery.task import Task
-from palace.manager.celery.utils import load_from_id
-from palace.manager.core.exceptions import PalaceValueError
+from palace.manager.celery.utils import load_from_id, validate_not_none
 from palace.manager.data_layer.bibliographic import BibliographicData
 from palace.manager.data_layer.circulation import CirculationData
 from palace.manager.data_layer.identifier import IdentifierData
@@ -29,18 +29,10 @@ def _lock(client: Redis, identifier: IdentifierData) -> RedisLock:
     )
 
 
-def _validate_primary_identifier(
-    primary_identifier: IdentifierData | None,
-) -> IdentifierData:
-    """
-    Validate that the primary identifier is not None.
-    """
-    if primary_identifier is None:
-        raise PalaceValueError(
-            "No primary identifier provided! (primary_identifier_data is None)."
-        )
-
-    return primary_identifier
+_validate_primary_identifier = partial(
+    validate_not_none,
+    message="No primary identifier provided! (primary_identifier_data is None).",
+)
 
 
 @shared_task(

--- a/src/palace/manager/celery/tasks/identifiers.py
+++ b/src/palace/manager/celery/tasks/identifiers.py
@@ -1,0 +1,159 @@
+from functools import partial
+
+from celery import shared_task
+from celery.canvas import Signature, chord
+from sqlalchemy import select
+from sqlalchemy.orm import raiseload
+
+from palace.manager.celery.task import Task
+from palace.manager.celery.tasks.apply import circulation_apply
+from palace.manager.celery.utils import load_from_id
+from palace.manager.core.exceptions import PalaceValueError
+from palace.manager.data_layer.circulation import CirculationData
+from palace.manager.service.celery.celery import QueueNames
+from palace.manager.service.redis.models.set import (
+    IdentifierSet,
+    RedisSetKwargs,
+)
+from palace.manager.sqlalchemy.model.collection import Collection
+from palace.manager.sqlalchemy.model.identifier import Identifier
+from palace.manager.sqlalchemy.model.licensing import LicensePool
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def existing_available_identifiers(task: Task, collection_id: int) -> IdentifierSet:
+    """
+    Get all the identifiers that have licensepools that are available (licenses_available > 0
+    and licenses_owned > 0) in the given collection and return them as a Redis IdentifierSet.
+
+    This is meant to be used as part of a chord that marks any identifiers not found in
+    a distributors feed as unavailable.
+
+    See: mark_unavailable_chord.
+    """
+
+    redis_client = task.services.redis().client()
+    identifier_set = IdentifierSet(redis_client, [task.name, task.request.id])
+
+    try:
+        with task.session() as session:
+            identifiers_query = (
+                select(Identifier)
+                .join(LicensePool)
+                .where(
+                    LicensePool.collection_id == collection_id,
+                    LicensePool.licenses_available != 0,
+                    LicensePool.licenses_owned != 0,
+                )
+                .options(raiseload("*"))
+            )
+
+            for identifiers in (
+                session.execute(identifiers_query).yield_per(100).scalars().partitions()
+            ):
+                identifier_set.add(*identifiers)
+    except:
+        identifier_set.delete()
+        raise
+
+    return identifier_set
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def mark_identifiers_unavailable(
+    task: Task,
+    identifiers: list[RedisSetKwargs],
+    *,
+    collection_id: int,
+) -> None:
+    """
+    Takes two IdentiferSets as the first positional arg. The first set is the existing identifiers
+    that are available in the collection. The second set is the active identifiers that we have
+    received from the distributor.
+
+    Any identifiers that are in the first set but not in the second set will be marked as
+    unavailable in the collection. This is done by sending a circulation_apply task that sets
+    the licenses_available and licenses_owned to 0 for the identifier in the collection.
+
+    This is meant to be used as the body of a chord that is created by `mark_unavailable_chord`.
+    """
+    redis_client = task.services.redis().client()
+
+    existing_identifiers, active_identifiers = identifiers
+    existing_set = IdentifierSet(redis_client, **existing_identifiers)
+    active_set = IdentifierSet(redis_client, **active_identifiers)
+
+    try:
+        if not existing_set.exists():
+            task.log.warning(
+                "Existing identifiers set does not exist in Redis. No identifiers to mark as unavailable."
+            )
+            return
+
+        if not active_set.exists():
+            task.log.error(
+                "Active identifiers set does not exist in Redis. Refusing to mark all identifiers as unavailable."
+            )
+            raise PalaceValueError("Active identifiers set does not exist in Redis.")
+
+        with task.session() as session:
+            collection = load_from_id(session, Collection, collection_id)
+            data_source = collection.data_source
+            if data_source is None:
+                raise PalaceValueError(
+                    "Collection has no data source! (data_source is None)."
+                )
+            data_source_name = data_source.name
+            collection_name = collection.name
+
+        create_circulation_data = partial(
+            CirculationData,
+            data_source_name=data_source_name,
+            licenses_owned=0,
+            licenses_available=0,
+        )
+        identifiers_to_mark = existing_set - active_set
+        for identifier in identifiers_to_mark:
+            task.log.info(
+                f"Marking identifier {identifier} as unavailable in collection {collection_name} ({collection_id})"
+            )
+            circulation_apply.delay(
+                circulation=create_circulation_data(primary_identifier_data=identifier),
+                collection_id=collection_id,
+            )
+
+        task.log.info(
+            f"Sent tasks to mark {len(identifiers_to_mark)} identifiers as unavailable"
+        )
+    finally:
+        existing_set.delete()
+        active_set.delete()
+
+
+def create_mark_unavailable_chord(
+    collection_id: int, active_identifiers_sig: Signature
+) -> Signature:
+    """
+    Create a celery chord that marks any identifiers that were not found in the distributors feed
+    as unavailable for a given collection.
+
+    This chord will first call the `existing_available_identifiers` task to get all the
+    identifiers that are available in the collection.
+
+    In parallel, it will call the `active_identifiers_sig` task to get the identifiers
+    that are available in the distributors feed.
+
+    Finally, it will call the `mark_identifiers_unavailable` task to mark any identifiers
+    that are in the existing identifiers set but not in the active identifiers set as
+    unavailable in the collection.
+
+    The `active_identifiers_sig` task must be a celery signature that returns an IdentifierSet
+    that contains the identifiers that are available in the distributors feed. The task can
+    requeue itself if necessary, as long as it returns an IdentifierSet once it is done.
+    """
+    existing_identifiers_sig = existing_available_identifiers.s(collection_id)
+    mark_identifiers_sig = mark_identifiers_unavailable.s(collection_id=collection_id)
+
+    chord_header = [existing_identifiers_sig, active_identifiers_sig]
+
+    return chord(chord_header, body=mark_identifiers_sig)

--- a/src/palace/manager/celery/tasks/identifiers.py
+++ b/src/palace/manager/celery/tasks/identifiers.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import raiseload
 
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks.apply import circulation_apply
-from palace.manager.celery.utils import load_from_id
+from palace.manager.celery.utils import load_from_id, validate_not_none
 from palace.manager.core.exceptions import PalaceValueError
 from palace.manager.data_layer.circulation import CirculationData
 from palace.manager.service.celery.celery import QueueNames
@@ -98,12 +98,10 @@ def mark_identifiers_unavailable(
 
         with task.session() as session:
             collection = load_from_id(session, Collection, collection_id)
-            data_source = collection.data_source
-            if data_source is None:
-                raise PalaceValueError(
-                    "Collection has no data source! (data_source is None)."
-                )
-            data_source_name = data_source.name
+            data_source_name = validate_not_none(
+                collection.data_source,
+                message="Collection has no data source! (data_source is None).",
+            ).name
             collection_name = collection.name
 
         create_circulation_data = partial(

--- a/src/palace/manager/celery/utils.py
+++ b/src/palace/manager/celery/utils.py
@@ -24,6 +24,15 @@ def load_from_id(db: Session, model: type[T], id: int) -> T:
     """
 
     instance = get_one(db, model, id=id)
-    if instance is None:
-        raise PalaceValueError(f"{model.__name__} with id '{id}' not found.")
-    return instance
+    return validate_not_none(instance, f"{model.__name__} with id '{id}' not found.")
+
+
+def validate_not_none(value: T | None, message: str) -> T:
+    """
+    Validate that a value is not None.
+
+    Raises a PalaceValueError if the value is None.
+    """
+    if value is None:
+        raise PalaceValueError(message)
+    return value

--- a/src/palace/manager/data_layer/identifier.py
+++ b/src/palace/manager/data_layer/identifier.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pydantic import Field
 from sqlalchemy.orm import Session
 from typing_extensions import Self
 
@@ -11,7 +12,7 @@ from palace.manager.sqlalchemy.model.identifier import Identifier
 class IdentifierData(BaseFrozenData):
     type: str
     identifier: str
-    weight: float = 1
+    weight: float = Field(1.0, repr=False)
 
     def load(self, _db: Session) -> tuple[Identifier, bool]:
         return Identifier.for_foreign_id(_db, self.type, self.identifier)
@@ -27,7 +28,14 @@ class IdentifierData(BaseFrozenData):
         return cls(type=identifier.type, identifier=identifier.identifier)
 
     def redis_key(self) -> str:
+        """
+        String representation of the IdentifierData object suitable for use
+        as a redis key.
+        """
         return (
             f"{self.__class__.__name__}{RedisKeyGenerator.SEPERATOR}"
             f"{self.type}{RedisKeyGenerator.SEPERATOR}{self.identifier}"
         )
+
+    def __str__(self) -> str:
+        return f"{self.type}/{self.identifier}"

--- a/src/palace/manager/service/redis/models/set.py
+++ b/src/palace/manager/service/redis/models/set.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Generator
+from datetime import timedelta
+from functools import partial
+from typing import Any, Generic, TypedDict, TypeVar, cast
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from palace.manager.core.exceptions import PalaceValueError
+from palace.manager.data_layer.identifier import IdentifierData
+from palace.manager.service.redis.key import RedisKeyType
+from palace.manager.service.redis.redis import Redis
+from palace.manager.sqlalchemy.model.identifier import Identifier
+from palace.manager.util.log import LoggerMixin
+
+
+class RedisSetKwargs(TypedDict):
+    key: list[RedisKeyType]
+    expire_time: int
+
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class RedisSet(Generic[T], LoggerMixin):
+    """
+    A set of Pydantic models stored in Redis.
+
+    This class provides methods to add, remove, and retrieve models from the set.
+    Sets expire after a specified time (default is 12 hours).
+    """
+
+    def __init__(
+        self,
+        redis_client: Redis,
+        model_cls: type[T],
+        key: str | list[RedisKeyType] | None = None,
+        expire_time: timedelta | int = timedelta(hours=12),
+    ):
+        self._model_cls = model_cls
+        self._redis_client = redis_client
+        if key is None:
+            key = [str(uuid4())]
+        elif isinstance(key, str):
+            key = [key]
+        self._supplied_key = key
+        self._key = self._redis_client.get_key(
+            self.__class__.__name__, *self._supplied_key
+        )
+        if isinstance(expire_time, int):
+            expire_time = timedelta(seconds=expire_time)
+        self.expire_time = expire_time
+
+    def _str_from_model(self, model: T, /) -> str:
+        return model.model_dump_json(exclude_defaults=True)
+
+    def _strs_from_models(self, *models: T) -> list[str]:
+        return [self._str_from_model(model) for model in models]
+
+    def _model_from_str(self, _str: str, /) -> T:
+        return self._model_cls.model_validate_json(_str)
+
+    def _models_from_strs(
+        self,
+        *strings: str | bytes | float | int,
+    ) -> set[T]:
+        return {self._model_from_str(str(str_)) for str_ in strings}
+
+    def add(self, *models: T) -> int:
+        """
+        Add models to the set. This method will also set an expiration time for the set,
+        resetting the expiration time if the set already exists.
+        """
+        with self._redis_client.pipeline() as pipe:
+            pipe.sadd(self._key, *self._strs_from_models(*models))
+            pipe.expire(self._key, self.expire_time)
+            sadd_result, _ = pipe.execute()
+
+        return cast(int, sadd_result)
+
+    def remove(self, *models: T) -> int:
+        """
+        Remove models from the set.
+        """
+        return self._redis_client.srem(self._key, *self._strs_from_models(*models))
+
+    def get(self) -> set[T]:
+        """
+        Returns a set containing all the models in the redis set.
+        """
+        return self._models_from_strs(*self._redis_client.smembers(self._key))
+
+    def len(self) -> int:
+        """
+        Get the number of models in the set.
+        """
+        return self._redis_client.scard(self._key)
+
+    def pop(self, size: int) -> set[T]:
+        """
+        Pop a specified number of models from the set. This method will remove the models
+        from the set.
+        """
+        return self._models_from_strs(*self._redis_client.spop(self._key, size))
+
+    def delete(self) -> bool:
+        """
+        Delete the set. This method will remove the set from Redis and return True if the set was
+        deleted, or False if the set did not exist.
+        """
+        return self._redis_client.delete(self._key) > 0
+
+    def exists(self) -> bool:
+        """
+        Check if the set exists in Redis.
+        """
+        return self._redis_client.exists(self._key) > 0
+
+    def __json__(self) -> RedisSetKwargs:
+        """
+        Serialize the RedisSet object to a JSON-compatible dictionary, so we can
+        use it in the Celery task queue.
+
+        The serialized dict contains the same arguments as the constructor, except
+        the redis_client, which is not serializable. This makes it easy to recreate
+        the object from the serialized dict:
+            RedisSet(client, **redis_set.__json__())
+        """
+        return RedisSetKwargs(
+            key=self._supplied_key,
+            expire_time=int(self.expire_time.total_seconds()),
+        )
+
+    def __len__(self) -> int:
+        """
+        Just an alias for len().
+        """
+        return self.len()
+
+    def __iter__(self) -> Generator[T]:
+        """
+        Iterate over the models in the set.
+
+        Note: Redis guarantees that all the elements in the set will be returned, but it
+        does not guarantee that the elements will only be returned once. So this iterator
+        may return the same element multiple times if the set is modified while iterating.
+
+        This should not be a problem, as we are working with a set anyway, but it's important
+        for the consumer to be aware of this.
+        """
+        cursor = None
+        sscan = partial(
+            self._redis_client.sscan,
+            self._key,
+        )
+
+        while cursor != 0:
+            cursor, identifiers = sscan() if cursor is None else sscan(cursor=cursor)
+            for identifier in identifiers:
+                yield self._model_from_str(identifier)
+
+    def __contains__(self, model: T) -> bool:
+        """
+        Check if the set contains the given model.
+        """
+        return (
+            self._redis_client.sismember(
+                self._key,
+                self._str_from_model(model),
+            )
+            == 1
+        )
+
+    def __repr__(self) -> str:
+        """
+        Representation of the RedisSet object.
+        """
+        return f"{self.__class__.__name__}({self.get()!r})"
+
+    def __sub__(self, other: Any) -> set[T]:
+        """
+        Set difference operation for RedisSet.
+        """
+        if not isinstance(other, (self.__class__, set)):
+            return NotImplemented
+
+        if isinstance(other, set):
+            return self.get() - other
+
+        if self._redis_client is not other._redis_client:
+            raise PalaceValueError(
+                f"Cannot subtract {self.__class__.__name__}s from different Redis clients."
+            )
+
+        return self._models_from_strs(*self._redis_client.sdiff(self._key, other._key))
+
+    def __rsub__(self, other: Any) -> set[T]:
+        """
+        Set difference operation for RedisSet when the other operand is a set.
+        """
+
+        if not isinstance(other, set):
+            return NotImplemented
+
+        return other - self.get()
+
+
+U = TypeVar("U")
+
+
+class TypeConversionRedisSet(ABC, Generic[T, U], RedisSet[T]):
+    @abstractmethod
+    def _convert(
+        self,
+        data: T | U,
+    ) -> T: ...
+
+    def add(self, *models: T | U) -> int:
+        return super().add(*[self._convert(model) for model in models])
+
+    def remove(self, *models: T | U) -> int:
+        return super().remove(*[self._convert(model) for model in models])
+
+    def __contains__(self, model: T | U) -> bool:
+        return super().__contains__(self._convert(model))
+
+
+class IdentifierSet(TypeConversionRedisSet[IdentifierData, Identifier]):
+    """
+    A set of identifiers stored in Redis.
+
+    Identifiers can be supplied as either IdentifierData or Identifier objects.
+    """
+
+    def __init__(
+        self,
+        redis_client: Redis,
+        key: str | list[RedisKeyType] | None = None,
+        expire_time: timedelta | int = timedelta(hours=12),
+    ):
+        super().__init__(redis_client, IdentifierData, key, expire_time)
+
+    def _convert(
+        self,
+        data: IdentifierData | Identifier,
+    ) -> IdentifierData:
+        return (
+            data
+            if isinstance(data, IdentifierData)
+            else IdentifierData.from_identifier(data)
+        )

--- a/src/palace/manager/service/redis/redis.py
+++ b/src/palace/manager/service/redis/redis.py
@@ -93,9 +93,13 @@ class RedisPrefixCheckMixin(ABC):
             RedisCommandArgs("WATCH"),
             RedisCommandArgs("SRANDMEMBER"),
             RedisCommandArgs("SREM"),
+            RedisCommandArgs("SMEMBERS"),
+            RedisCommandArgs("SSCAN"),
+            RedisCommandArgs("SISMEMBER"),
             RedisCommandArgs("DEL", args_end=None),
             RedisCommandArgs("MGET", args_end=None),
             RedisCommandArgs("EXISTS", args_end=None),
+            RedisCommandArgs("SDIFF", args_end=None),
             RedisCommandArgs("EXPIRETIME"),
             RedisVariableCommandArgs("EVALSHA", key_index=1),
         ]

--- a/tests/fixtures/redis.py
+++ b/tests/fixtures/redis.py
@@ -34,8 +34,14 @@ class RedisFixture:
         )
         self.client: Redis = self.services_fixture.services.redis.client()
 
+    def keys(self) -> list[str]:
+        """
+        Get all keys in the Redis database created by the test.
+        """
+        return self.client.keys(f"{self.key_prefix}*")
+
     def close(self):
-        keys = self.client.keys(f"{self.key_prefix}*")
+        keys = self.keys()
         if keys:
             self.client.delete(*keys)
 

--- a/tests/manager/celery/tasks/test_apply.py
+++ b/tests/manager/celery/tasks/test_apply.py
@@ -20,7 +20,6 @@ class TestCirculationApply:
     ) -> None:
         collection = db.collection()
         pool = db.licensepool(None, collection=collection)
-        title = db.fresh_str()
         data = CirculationData(
             data_source_name=pool.data_source.name,
             primary_identifier_data=IdentifierData.from_identifier(pool.identifier),

--- a/tests/manager/celery/tasks/test_identifiers.py
+++ b/tests/manager/celery/tasks/test_identifiers.py
@@ -1,0 +1,286 @@
+from typing import Literal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from celery import shared_task
+from celery.exceptions import ChordError
+
+from palace.manager.celery.task import Task
+from palace.manager.celery.tasks import identifiers
+from palace.manager.core.exceptions import PalaceValueError
+from palace.manager.data_layer.identifier import IdentifierData
+from palace.manager.service.logging.configuration import LogLevel
+from palace.manager.service.redis.models.set import IdentifierSet, RedisSetKwargs
+from palace.manager.sqlalchemy.model.collection import Collection
+from palace.manager.sqlalchemy.model.licensing import LicensePool
+from tests.fixtures.celery import CeleryFixture
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.redis import RedisFixture
+
+
+class IdentifierTasksFixture:
+    def __init__(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        redis_fixture: RedisFixture,
+    ) -> None:
+        self._db = db
+        self._celery = celery_fixture
+        self._redis = redis_fixture
+        self.redis_client = self._redis.client
+
+    def license_pools(
+        self, collection: Collection, count: int = 10
+    ) -> list[LicensePool]:
+        return [
+            self._db.licensepool(edition=None, collection=collection)
+            for _ in range(count)
+        ]
+
+    @staticmethod
+    def identifiers(licensepools: list[LicensePool]) -> set[IdentifierData]:
+        return {IdentifierData.from_identifier(lp.identifier) for lp in licensepools}
+
+    def set_from_response(self, response: RedisSetKwargs) -> IdentifierSet:
+        return IdentifierSet(
+            self.redis_client,
+            **response,
+        )
+
+    @staticmethod
+    def identifiers_from_mock_calls(mock: MagicMock) -> set[IdentifierData]:
+        """
+        Get the identifiers from the mock calls.
+        """
+        return {
+            IdentifierData.from_identifier(
+                call.kwargs["circulation"].primary_identifier_data
+            )
+            for call in mock.call_args_list
+        }
+
+
+@pytest.fixture
+def identifier_tasks_fixture(
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+    redis_fixture: RedisFixture,
+) -> IdentifierTasksFixture:
+    return IdentifierTasksFixture(
+        db=db,
+        celery_fixture=celery_fixture,
+        redis_fixture=redis_fixture,
+    )
+
+
+class TestExistingAvailableIdentifiers:
+    def test_normal_run(
+        self,
+        db: DatabaseTransactionFixture,
+        identifier_tasks_fixture: IdentifierTasksFixture,
+    ) -> None:
+        collection = db.collection()
+        license_pools = identifier_tasks_fixture.license_pools(
+            collection=collection, count=10
+        )
+
+        # Some decoy license pools in a different collection, to make sure we are
+        # filtering the license pools by collection properly.
+        other_collection = db.collection()
+        identifier_tasks_fixture.license_pools(collection=other_collection, count=5)
+
+        response = identifiers.existing_available_identifiers.delay(
+            collection.id
+        ).wait()
+        identifier_set = identifier_tasks_fixture.set_from_response(response)
+
+        assert len(identifier_set) == len(license_pools)
+        assert identifier_set.get() == identifier_tasks_fixture.identifiers(
+            license_pools
+        )
+
+    def test_cleanup_on_exception(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        redis_fixture: RedisFixture,
+    ) -> None:
+        """
+        Make sure that if an exception is raised, the identifier set is deleted.
+        """
+
+        with (
+            patch.object(identifiers, "select", side_effect=PalaceValueError("Bang")),
+            pytest.raises(PalaceValueError, match="Bang"),
+        ):
+            identifiers.existing_available_identifiers.delay(db.collection().id).wait()
+
+        # Check that the identifier set was deleted
+        assert redis_fixture.keys() == []
+
+
+class TestMarkIdentifiersUnavailable:
+    def test_normal_run(
+        self,
+        db: DatabaseTransactionFixture,
+        identifier_tasks_fixture: IdentifierTasksFixture,
+    ) -> None:
+        collection = db.collection()
+        license_pools = identifier_tasks_fixture.license_pools(
+            collection=collection, count=10
+        )
+
+        existing_set = IdentifierSet(identifier_tasks_fixture.redis_client)
+        existing_set.add(*identifier_tasks_fixture.identifiers(license_pools))
+
+        active_set = IdentifierSet(identifier_tasks_fixture.redis_client)
+        active_set.add(*identifier_tasks_fixture.identifiers(license_pools[:5]))
+
+        expected_marked = existing_set - active_set
+
+        with patch.object(identifiers, "circulation_apply") as mock_apply:
+            identifiers.mark_identifiers_unavailable.delay(
+                [existing_set, active_set],
+                collection_id=collection.id,
+            ).wait()
+
+        assert mock_apply.delay.call_count == 5
+        assert (
+            identifier_tasks_fixture.identifiers_from_mock_calls(mock_apply.delay)
+            == expected_marked
+        )
+
+        # Check that we didn't leave any redis keys behind
+        assert existing_set.exists() is False
+        assert active_set.exists() is False
+
+    def test_run_with_nonexistent_sets(
+        self,
+        db: DatabaseTransactionFixture,
+        identifier_tasks_fixture: IdentifierTasksFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(LogLevel.info)
+
+        collection = db.collection()
+        existing_set = IdentifierSet(identifier_tasks_fixture.redis_client)
+        active_set = IdentifierSet(identifier_tasks_fixture.redis_client)
+
+        # If the existing set doesn't exist, or doesn't contain any identifiers
+        # (which are treated the same in redis), we exit early and log a message.
+        identifiers.mark_identifiers_unavailable.delay(
+            [existing_set, active_set],
+            collection_id=collection.id,
+        ).wait()
+        assert "Existing identifiers set does not exist in Redis" in caplog.text
+
+        # Add an identifier to the existing set, so it now exists
+        existing_set.add(IdentifierData.from_identifier(db.identifier()))
+
+        # If the active set doesn't exist, we raise an error instead of deleting every
+        # identifier in the existing set.
+        with pytest.raises(
+            PalaceValueError, match="Active identifiers set does not exist in Redis"
+        ):
+            identifiers.mark_identifiers_unavailable.delay(
+                [existing_set, active_set],
+                collection_id=collection.id,
+            ).wait()
+
+        # In the error case we still clean up the existing set
+        assert existing_set.exists() is False
+
+
+@shared_task(bind=True)
+def identifiers_test_task(
+    task: Task,
+    identifiers: RedisSetKwargs,
+    *,
+    do_iterations: int | Literal[False] = False,
+    iterations: int = 0,
+    raise_exception: bool = False,
+) -> IdentifierSet:
+    redis_client = task.services.redis().client()
+    redis_set = IdentifierSet(redis_client, **identifiers)
+    if raise_exception:
+        redis_set.delete()
+        raise PalaceValueError("Kaboom!")
+    if do_iterations and iterations < do_iterations:
+        iterations += 1
+        raise task.replace(
+            identifiers_test_task.s(
+                identifiers, iterations=iterations, do_iterations=do_iterations
+            )
+        )
+    return redis_set
+
+
+class TestCreateMarkUnavailableChord:
+    @pytest.mark.parametrize(
+        "do_iterations",
+        [
+            pytest.param(False, id="no iterations"),
+            pytest.param(10, id="10 iterations"),
+        ],
+    )
+    def test_normal_run(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        identifier_tasks_fixture: IdentifierTasksFixture,
+        do_iterations: int | Literal[False],
+    ) -> None:
+        collection = db.collection()
+        license_pools = identifier_tasks_fixture.license_pools(
+            collection=collection, count=10
+        )
+
+        all_identifiers = identifier_tasks_fixture.identifiers(license_pools)
+
+        active_set = IdentifierSet(identifier_tasks_fixture.redis_client)
+        active_set.add(*identifier_tasks_fixture.identifiers(license_pools[:5]))
+
+        expect_to_be_marked = all_identifiers - active_set
+
+        with patch.object(identifiers, "circulation_apply") as mock_apply:
+            identifiers.create_mark_unavailable_chord(
+                collection.id,
+                identifiers_test_task.s(active_set, do_iterations=do_iterations),
+            ).delay().wait()
+
+        # We queued tasks to mark the identifiers as unavailable
+        assert mock_apply.delay.call_count == 5
+        assert (
+            identifier_tasks_fixture.identifiers_from_mock_calls(mock_apply.delay)
+            == expect_to_be_marked
+        )
+
+        # Check that we didn't leave any redis keys behind
+        assert redis_fixture.keys() == []
+
+    def test_exception(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        identifier_tasks_fixture: IdentifierTasksFixture,
+    ) -> None:
+        collection = db.collection()
+        license_pools = identifier_tasks_fixture.license_pools(
+            collection=collection, count=10
+        )
+
+        active_set = IdentifierSet(identifier_tasks_fixture.redis_client)
+        active_set.add(*identifier_tasks_fixture.identifiers(license_pools[:5]))
+
+        with (
+            patch.object(identifiers, "circulation_apply") as mock_apply,
+            pytest.raises(ChordError, match="Kaboom!"),
+        ):
+            identifiers.create_mark_unavailable_chord(
+                collection.id, identifiers_test_task.s(active_set, raise_exception=True)
+            ).delay().wait()
+
+        # Because one of the tasks raised an exception, we never made it into the mark_identifiers_unavailable
+        # task at all
+        assert mock_apply.delay.call_count == 0

--- a/tests/manager/service/redis/models/test_set.py
+++ b/tests/manager/service/redis/models/test_set.py
@@ -1,0 +1,172 @@
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from kombu.utils.json import dumps, loads
+
+from palace.manager.core.exceptions import PalaceValueError
+from palace.manager.data_layer.identifier import IdentifierData
+from palace.manager.service.redis.models.set import IdentifierSet
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.redis import RedisFixture
+
+
+class TestIdentifierSet:
+    def test_set(
+        self, redis_fixture: RedisFixture, db: DatabaseTransactionFixture
+    ) -> None:
+        client = redis_fixture.client
+        identifier_set = IdentifierSet(client)
+
+        # Before adding any identifiers, the set should be empty, and
+        # not exist in Redis
+        assert identifier_set.len() == 0
+        assert identifier_set.get() == set()
+        assert identifier_set.exists() is False
+
+        identifier1 = IdentifierData.from_identifier(db.identifier())
+        identifier2 = db.identifier()
+
+        assert identifier1 not in identifier_set
+        assert identifier2 not in identifier_set
+
+        # Add an Identifier and an IdentifierData object
+        assert identifier_set.add(identifier1, identifier2) == 2
+
+        assert identifier1 in identifier_set
+        assert identifier2 in identifier_set
+
+        # Check that the identifiers were added
+        assert identifier_set.len() == 2
+        assert identifier_set.get() == {
+            identifier1,
+            IdentifierData.from_identifier(identifier2),
+        }
+
+        # We set an expiration time on the set
+        assert client.ttl(identifier_set._key) > 0
+
+        # We can remove identifiers from the set (including identifiers that are not in the set)
+        assert identifier_set.remove(identifier2, db.identifier()) == 1
+        assert identifier_set.len() == 1
+        assert identifier_set.get() == {identifier1}
+
+        # We can add the same identifier again, but it won't be added again
+        assert identifier_set.add(identifier1) == 0
+        assert identifier_set.len() == 1
+        assert identifier_set.get() == {identifier1}
+
+        # We can delete the set
+        assert identifier_set.exists() is True
+        assert identifier_set.delete() is True
+        assert identifier_set.exists() is False
+        assert identifier_set.len() == 0
+        assert identifier_set.get() == set()
+        assert client.exists(identifier_set._key) == 0
+        assert identifier_set.delete() is False
+
+        # Calling remove on an empty set should return 0
+        assert identifier_set.remove(identifier1) == 0
+
+    def test_pop(self, redis_fixture: RedisFixture) -> None:
+        client = redis_fixture.client
+        identifier_set = IdentifierSet(client)
+
+        identifiers = {
+            IdentifierData(type="test", identifier=str(i)) for i in range(10)
+        }
+
+        # Add identifiers to the set
+        assert identifier_set.add(*identifiers) == 10
+
+        # Pop 5 identifiers from the set
+        popped_identifiers = identifier_set.pop(5)
+        assert len(popped_identifiers) == 5
+        assert identifier_set.len() == 5
+        assert identifier_set.get() == set(identifiers) - set(popped_identifiers)
+
+        popped_identifiers_2 = identifier_set.pop(10)
+        assert len(popped_identifiers_2) == 5
+        assert identifier_set.len() == 0
+
+        # Check that the popped equal the original identifiers
+        assert identifiers == popped_identifiers | popped_identifiers_2
+
+        # We can pop from an empty set
+        assert identifier_set.pop(5) == set()
+        assert identifier_set.len() == 0
+
+    def test__json__(self, redis_fixture: RedisFixture) -> None:
+        client = redis_fixture.client
+        test_identifier = IdentifierData(type="test", identifier="test_identifier")
+
+        identifier_set = IdentifierSet(client, expire_time=timedelta(days=4))
+        identifier_set.add(test_identifier)
+
+        dumped = dumps(identifier_set)
+        recreated_identifier_set = IdentifierSet(redis_fixture.client, **loads(dumped))
+
+        assert recreated_identifier_set._key == identifier_set._key
+        assert recreated_identifier_set.expire_time == identifier_set.expire_time
+        assert recreated_identifier_set.get() == {test_identifier}
+
+    def test_iteration(self, redis_fixture: RedisFixture) -> None:
+        client = redis_fixture.client
+        identifier_set = IdentifierSet(client)
+
+        identifiers = {
+            IdentifierData(type="test", identifier=str(i)) for i in range(200)
+        }
+
+        # Add identifiers to the set
+        assert identifier_set.add(*identifiers) == 200
+
+        iterated_identifiers = set()
+
+        # Check that we can iterate over the set
+        for identifier in identifier_set:
+            assert identifier in identifiers
+            iterated_identifiers.add(identifier)
+
+        # Make sure we iterated over all the identifiers
+        assert iterated_identifiers == identifiers
+
+    def test_repr(self, redis_fixture: RedisFixture) -> None:
+        client = redis_fixture.client
+        identifier_set = IdentifierSet(client)
+
+        # Check that the repr is correct
+        assert repr(identifier_set) == f"IdentifierSet(set())"
+
+    def test_diff(self, redis_fixture: RedisFixture) -> None:
+        client = redis_fixture.client
+        identifier_set1 = IdentifierSet(client)
+        identifier_set2 = IdentifierSet(client)
+
+        identifiers1 = {
+            IdentifierData(type="test", identifier=str(i)) for i in range(10)
+        }
+        identifiers2 = {
+            IdentifierData(type="test", identifier=str(i)) for i in range(5, 15)
+        }
+
+        # Add identifiers to the sets
+        assert identifier_set1.add(*identifiers1) == 10
+        assert identifier_set2.add(*identifiers2) == 10
+
+        # Check the difference between the two sets
+        diff = identifier_set1 - identifier_set2
+        assert len(diff) == 5
+        assert diff == identifiers1 - identifiers2
+
+        # We get an error if we try to diff sets with different clients
+        identifier_set3 = IdentifierSet(MagicMock())
+        with pytest.raises(
+            PalaceValueError,
+            match="Cannot subtract IdentifierSets from different Redis clients.",
+        ):
+            identifier_set1 - identifier_set3
+
+        # We can also diff a set with a normal set
+        assert identifier_set1 - identifiers2 == identifiers1 - identifiers2
+        assert identifiers2 - identifier_set1 == identifiers2 - identifiers1


### PR DESCRIPTION
## Description

Adds a series of tasks meant to provide the foundation for provider specific celery tasks that mark any identifiers not found in the providers feed as unavailable. The intention is to compose these tasks using celery workflows.

It also adds a new redis data structure to store sets of items, so we are able to store sets of identifiers that persist over mutliple celery task invocations.

Note: these tasks are not used anywhere yet. I'm planning to use them in a follow up to convert the OPDS importer tasks.

## Motivation and Context

See PP-2469. This is building up some of the tools needed to convert the OPDS importer tasks to Celery.

## How Has This Been Tested?

- New unit tests added to CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
