### PR TITLE
Potential optimization for `Library.active_collections`. (PP-2492)

### DIFF
--- a/src/palace/manager/sqlalchemy/listeners.py
+++ b/src/palace/manager/sqlalchemy/listeners.py
@@ -11,15 +11,15 @@ from sqlalchemy.orm import Mapper, Session
 from palace.manager.core.config import Configuration
 from palace.manager.core.query.coverage import EquivalencyCoverageQueries
 from palace.manager.sqlalchemy.before_flush_decorator import Listener, ListenerState
-from palace.manager.sqlalchemy.model import (
-    IntegrationConfiguration,
-    IntegrationLibraryConfiguration,
-)
 from palace.manager.sqlalchemy.model.base import Base
 from palace.manager.sqlalchemy.model.identifier import (
     Equivalency,
     Identifier,
     RecursiveEquivalencyCache,
+)
+from palace.manager.sqlalchemy.model.integration import (
+    IntegrationConfiguration,
+    IntegrationLibraryConfiguration,
 )
 from palace.manager.sqlalchemy.model.lane import Lane, LaneGenre
 from palace.manager.sqlalchemy.model.library import Library

--- a/src/palace/manager/sqlalchemy/model/__init__.py
+++ b/src/palace/manager/sqlalchemy/model/__init__.py
@@ -6,12 +6,6 @@ This is necessary to make sure that all of our models are properly reflected in
 the database when we run migrations or create a new database.
 """
 
-from typing import Any
-
-from sqlalchemy import event
-from sqlalchemy.engine import Connection
-from sqlalchemy.orm import Mapper
-
 import palace.manager.sqlalchemy.model.admin
 import palace.manager.sqlalchemy.model.announcements
 import palace.manager.sqlalchemy.model.base
@@ -39,29 +33,3 @@ import palace.manager.sqlalchemy.model.resource
 import palace.manager.sqlalchemy.model.saml
 import palace.manager.sqlalchemy.model.time_tracking
 import palace.manager.sqlalchemy.model.work
-from palace.manager.sqlalchemy.model.base import Base
-from palace.manager.sqlalchemy.model.collection import Collection
-from palace.manager.sqlalchemy.model.integration import (
-    IntegrationConfiguration,
-    IntegrationLibraryConfiguration,
-)
-from palace.manager.sqlalchemy.model.library import Library
-
-# The following supports an optimization in `Library.active_collections`.
-
-
-@event.listens_for(IntegrationConfiguration, "after_insert")
-@event.listens_for(IntegrationConfiguration, "after_delete")
-@event.listens_for(IntegrationConfiguration, "after_update")
-@event.listens_for(IntegrationLibraryConfiguration, "after_insert")
-@event.listens_for(IntegrationLibraryConfiguration, "after_delete")
-@event.listens_for(IntegrationLibraryConfiguration, "after_update")
-def handle_collection_change(_: Mapper, _connection: Connection, target: Base) -> None:
-    Library.clear_active_collections_cache(target)
-
-
-@event.listens_for(IntegrationConfiguration.library_configurations, "append")
-@event.listens_for(IntegrationConfiguration.library_configurations, "remove")
-@event.listens_for(IntegrationConfiguration.library_configurations, "set")
-def handle_collection_library_relationship_change(target: Base, *_args: Any) -> None:
-    Library.clear_active_collections_cache(target)

--- a/src/palace/manager/sqlalchemy/model/__init__.py
+++ b/src/palace/manager/sqlalchemy/model/__init__.py
@@ -6,6 +6,12 @@ This is necessary to make sure that all of our models are properly reflected in
 the database when we run migrations or create a new database.
 """
 
+from typing import Any
+
+from sqlalchemy import event
+from sqlalchemy.engine import Connection
+from sqlalchemy.orm import Mapper
+
 import palace.manager.sqlalchemy.model.admin
 import palace.manager.sqlalchemy.model.announcements
 import palace.manager.sqlalchemy.model.base
@@ -33,3 +39,29 @@ import palace.manager.sqlalchemy.model.resource
 import palace.manager.sqlalchemy.model.saml
 import palace.manager.sqlalchemy.model.time_tracking
 import palace.manager.sqlalchemy.model.work
+from palace.manager.sqlalchemy.model.base import Base
+from palace.manager.sqlalchemy.model.collection import Collection
+from palace.manager.sqlalchemy.model.integration import (
+    IntegrationConfiguration,
+    IntegrationLibraryConfiguration,
+)
+from palace.manager.sqlalchemy.model.library import Library
+
+# The following supports an optimization in `Library.active_collections`.
+
+
+@event.listens_for(IntegrationConfiguration, "after_insert")
+@event.listens_for(IntegrationConfiguration, "after_delete")
+@event.listens_for(IntegrationConfiguration, "after_update")
+@event.listens_for(IntegrationLibraryConfiguration, "after_insert")
+@event.listens_for(IntegrationLibraryConfiguration, "after_delete")
+@event.listens_for(IntegrationLibraryConfiguration, "after_update")
+def handle_collection_change(_: Mapper, _connection: Connection, target: Base) -> None:
+    Library.clear_active_collections_cache(target)
+
+
+@event.listens_for(IntegrationConfiguration.library_configurations, "append")
+@event.listens_for(IntegrationConfiguration.library_configurations, "remove")
+@event.listens_for(IntegrationConfiguration.library_configurations, "set")
+def handle_collection_library_relationship_change(target: Base, *_args: Any) -> None:
+    Library.clear_active_collections_cache(target)

--- a/src/palace/manager/sqlalchemy/model/library.py
+++ b/src/palace/manager/sqlalchemy/model/library.py
@@ -216,7 +216,7 @@ class Library(Base, HasSessionCache):
         return cache[self.id]
 
     @staticmethod
-    def clear_active_collections_cache(target: Base) -> None:
+    def _clear_active_collections_cache(target: Base) -> None:
         """Helper to clear the cache for `active_collections`.
 
         It is called by SQLAlchemy event listeners.


### PR DESCRIPTION
## Description

Caches the result of `Library.active_collections` and adds event listeners to conservatively clear the cache.

## Motivation and Context

Needed to improve the performance of `LibraryAnnotator.active_licensepool_for`, which, according profiling, accounted for about a fifth of the response time. This turned out to be mostly tied to the performance of `Library.active_collections` and its underlying query.

[Jira PP-2492]

## How Has This Been Tested?

- All existing tests pass.
- Performance profiling to demonstrate that neither `LibraryAnnotator.active_licensepool_for` nor `Library.active_collections` accounts for 
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/15000149186).

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
