### PR TITLE
Update our calls to Hold.collect_event_and_delete (PP-2527)

### DIFF
--- a/src/palace/manager/api/circulation.py
+++ b/src/palace/manager/api/circulation.py
@@ -1074,7 +1074,7 @@ class CirculationAPI(LoggerMixin):
             if existing_hold:
                 # The book was on hold, and now we have a loan. Call
                 # collect cm event and delete the record of the hold.
-                existing_hold.collect_event_and_delete(self.analytics)
+                existing_hold.collect_event_and_delete(analytics=self.analytics)
 
             __transaction.commit()
 

--- a/src/palace/manager/sqlalchemy/model/patron.py
+++ b/src/palace/manager/sqlalchemy/model/patron.py
@@ -698,7 +698,7 @@ class Hold(Base, LoanAndHoldMixin):
 
     @inject
     def collect_event_and_delete(
-        self, analytics: Analytics | None = Provide["analytics.analytics"]
+        self, *, analytics: Analytics | None = Provide["analytics.analytics"]
     ) -> None:
         """
         When a hold is converted to a loan, we log the event and delete


### PR DESCRIPTION
## Description

Update `Hold.collect_event_and_delete` `analytics` parameter to be an optional keyword only parameter and update all calls to it to reflect this.

## Motivation and Context

When you use dependency injector `Provide`, the parameter is always supplied as a keyword argument. So supplying it as a positional argument will result in:
> TypeError: Hold.collect_event_and_delete() got multiple values for argument 'analytics'

We were seeing this error happening in production due to the call in `palace/manager/api/circulation.py`

## How Has This Been Tested?

- Updated tests
- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
