### PR TITLE
Mark all dependency injected arguments as keyword only

### DIFF
--- a/src/palace/manager/api/circulation_manager.py
+++ b/src/palace/manager/api/circulation_manager.py
@@ -149,6 +149,7 @@ class CirculationManager(LoggerMixin):
     def __init__(
         self,
         _db,
+        *,
         services: Services = Provide[Services],
     ):
         self._db = _db

--- a/src/palace/manager/feed/acquisition.py
+++ b/src/palace/manager/feed/acquisition.py
@@ -460,6 +460,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         annotator: CirculationManagerAnnotator,
         facets: FacetsWithEntryPoint | None,
         pagination: Pagination | None,
+        *,
         search_engine: ExternalSearchIndex = Provide["search.index"],
     ) -> OPDSAcquisitionFeed:
         works = worklist.works(
@@ -682,6 +683,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         annotator: LibraryAnnotator,
         pagination: Pagination | None = None,
         facets: FacetsWithEntryPoint | None = None,
+        *,
         search_engine: ExternalSearchIndex = Provide["search.index"],
         search_debug: bool = False,
     ) -> OPDSAcquisitionFeed:

--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -201,6 +201,7 @@ class CirculationManagerAnnotator(Annotator):
         active_holds_by_work: dict[Work, Hold] | None = None,
         active_fulfillments_by_work: dict[Work, UrlFulfillment] | None = None,
         hidden_content_types: list[str] | None = None,
+        *,
         analytics: Analytics = Provide[Services.analytics.analytics],
     ) -> None:
         if lane:

--- a/src/palace/manager/sqlalchemy/model/collection.py
+++ b/src/palace/manager/sqlalchemy/model/collection.py
@@ -644,7 +644,7 @@ class Collection(Base, HasSessionCache, RedisKeyMixin):
 
     @inject
     def delete(
-        self, search_index: ExternalSearchIndex = Provide["search.index"]
+        self, *, search_index: ExternalSearchIndex = Provide["search.index"]
     ) -> None:
         """Delete a collection.
 

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -1735,6 +1735,7 @@ class WorkList:
         include_sublanes=True,
         pagination=None,
         facets=None,
+        *,
         search_engine: ExternalSearchIndex = Provide["search.index"],
         debug=False,
     ):
@@ -1804,6 +1805,7 @@ class WorkList:
         _db,
         facets=None,
         pagination=None,
+        *,
         search_engine: ExternalSearchIndex = Provide["search.index"],
         debug=False,
         **kwargs,
@@ -1987,6 +1989,7 @@ class WorkList:
         queryable_lanes,
         pagination,
         facets,
+        *,
         search_engine: ExternalSearchIndex = Provide["search.index"],
         debug=False,
     ):
@@ -3137,6 +3140,7 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
         include_sublanes=True,
         pagination=None,
         facets=None,
+        *,
         search_engine: ExternalSearchIndex = Provide["search.index"],
         debug=False,
     ):

--- a/src/palace/manager/sqlalchemy/model/work.py
+++ b/src/palace/manager/sqlalchemy/model/work.py
@@ -1874,7 +1874,7 @@ class Work(Base, LoggerMixin):
 
     @inject
     def delete(
-        self, search_index: ExternalSearchIndex = Provide["search.index"]
+        self, *, search_index: ExternalSearchIndex = Provide["search.index"]
     ) -> None:
         """Delete the work from both the DB and search index."""
         _db = Session.object_session(self)

--- a/tests/manager/api/test_controller_cm.py
+++ b/tests/manager/api/test_controller_cm.py
@@ -40,7 +40,7 @@ class TestCirculationManager:
             CirculationManager, "setup_one_time_controllers", mock_setup_controllers
         )
 
-        manager = CirculationManager(mock_db, services_fixture.services)
+        manager = CirculationManager(mock_db, services=services_fixture.services)
 
         assert mock_load_settings.called
         assert mock_setup_controllers.called

--- a/tests/manager/feed/test_opds_acquisition_feed.py
+++ b/tests/manager/feed/test_opds_acquisition_feed.py
@@ -185,7 +185,7 @@ class TestOPDSAcquisitionFeed:
             CirculationManagerAnnotator(None),
             None,
             None,
-            MagicMock(),
+            search_engine=MagicMock(),
         ).as_response(max_age=10, private=private)
 
         # The result is an OPDSFeedResponse. The 'private' argument,
@@ -1075,7 +1075,7 @@ class TestEntrypointLinkInsertion:
                 data.annotator(),
                 facets,
                 pagination,
-                MagicMock(),
+                search_engine=MagicMock(),
             )
 
             return data.mock.called_with

--- a/tests/mocks/circulation.py
+++ b/tests/mocks/circulation.py
@@ -228,7 +228,7 @@ class MockCirculationManager(CirculationManager):
     d_circulation: MockCirculationAPI
 
     def __init__(self, db: Session, services: Services):
-        super().__init__(db, services)
+        super().__init__(db, services=services)
 
     def setup_circulation_api(
         self,


### PR DESCRIPTION
## Description

Update all the arguments that we use dependency injection for, to make it clear that they should only be specified as keyword arguments.

## Motivation and Context

This is very similar to https://github.com/ThePalaceProject/circulation/pull/2472, but it updates all the arguments that we use dependency injection for so we don't run into the same bug we did in PP-2527.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
