### PR TITLE
Use default lane priority level if there are no license pools associated with a work.

### DIFF
--- a/src/palace/manager/sqlalchemy/model/work.py
+++ b/src/palace/manager/sqlalchemy/model/work.py
@@ -1719,9 +1719,14 @@ class Work(Base, LoggerMixin):
                 )
                 result["licensepools"].append(lc)
             # use the maximum lane priority level associated with the work.
-            result["lane_priority_level"] = max(
-                [lc["lane_priority_level"] for lc in result["licensepools"]]
-            )
+            if result["licensepools"]:
+                result["lane_priority_level"] = max(
+                    [lc["lane_priority_level"] for lc in result["licensepools"]]
+                )
+            else:
+                result["lane_priority_level"] = (
+                    IntegrationConfigurationConstants.DEFAULT_LANE_PRIORITY_LEVEL
+                )
 
         # Extra special genre massaging
         result["genres"] = []


### PR DESCRIPTION
## Description

The search reindex task was failing because in some cases works have no associated license pools.  As a result attempting to calculate the max value of an empty sequence was causing an error:
```
{"host": "cb652e4b0fdf", "name": "palace.manager.sqlalchemy.model.work.Work", "level": "ERROR", "filename": "work.py", "message": "Could not create search document for <Work #182319 \"The Brothers Karamazov\" (by Fyodor Dostoyevsky) Classics lang=eng (1 lp)>", "timestamp": "2025-05-19T15:45:01.618591+00:00", "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/src/palace/manager/sqlalchemy/model/work.py\", line 1575, in to_search_documents\n    search_doc = cls.search_doc_as_dict(cast(Self, item))\n  File \"/var/www/circulation/src/palace/manager/sqlalchemy/model/work.py\", line 1722, in search_doc_as_dict\n    result[\"lane_priority_level\"] = max(\nValueError: max() arg is an empty sequence", "process": 293, "celery": {"request_id": "74c83756-7020-4db5-bc9b-e0cc47e8e32f", "task_name": "search.index_works"}}
```

This update fixes this bug by ensuring that default value is used when no licensepools exist for a work.
## Motivation and Context
It fixes a bug in the lane priority level feature: https://github.com/ThePalaceProject/circulation/pull/2475
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
