### PR TITLE
[PP-2555] Catch and log expected NYT celery exceptions.

### DIFF
--- a/src/palace/manager/celery/tasks/nyt.py
+++ b/src/palace/manager/celery/tasks/nyt.py
@@ -12,10 +12,11 @@ def update_nyt_best_sellers_lists(task: Task, include_history: bool = False) -> 
     with task.session() as session:
         try:
             api = NYTBestSellerAPI.from_config(session)
-            names = api.list_of_lists()
         except CannotLoadConfiguration as e:
             task.log.warning(f"Skipping update: {e.message}")
             return
+
+    names = api.list_of_lists()
 
     for l in sorted(names["results"], key=lambda x: x["list_name_encoded"]):
         # run each list update in its own transaction to minimize transaction time and size

--- a/src/palace/manager/celery/tasks/nyt.py
+++ b/src/palace/manager/celery/tasks/nyt.py
@@ -16,7 +16,7 @@ def update_nyt_best_sellers_lists(task: Task, include_history: bool = False) -> 
             task.log.warning(f"Skipping update: {e.message}")
             return
 
-    names = api.list_of_lists()
+        names = api.list_of_lists()
 
     for l in sorted(names["results"], key=lambda x: x["list_name_encoded"]):
         # run each list update in its own transaction to minimize transaction time and size

--- a/tests/manager/celery/tasks/test_nyt.py
+++ b/tests/manager/celery/tasks/test_nyt.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import create_autospec, patch
 
 import pytest
@@ -56,3 +57,14 @@ def test_update_nyt_best_sellers_lists(
             assert mock_api.update.call_count == 2
 
         assert best_seller_list.to_customlist.call_count == 2
+
+
+def test_cannot_load_configuration(
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+    caplog: pytest.LogCaptureFixture,
+):
+
+    caplog.set_level(logging.WARN)
+    update_nyt_best_sellers_lists.delay().wait()
+    assert "Skipping update: No Integration found for the NYT." in caplog.text


### PR DESCRIPTION
## Description
This PR ensures that exceptions in the NYT bestsellers update celery task  arising due to the absence of a NYT bestseller service are caught and logged  within the task.

## Motivation and Context
We don't want to see uncaught celery exceptions when a PM doesn't have an NYT integration configured.  A warning should be sufficient.

https://ebce-lyrasis.atlassian.net/browse/PP-2555
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
New unit test added.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
