### PR TITLE
Speed up celery tests by using session worker fixture (PP-2569)

### DIFF
--- a/src/palace/manager/celery/app.py
+++ b/src/palace/manager/celery/app.py
@@ -9,32 +9,13 @@ Note: This file is not used in the app directly and shouldn't be imported anywhe
 Its only used to provide a global app instance for the Celery cli to use.
 """
 
-import importlib
 import logging
 from logging.handlers import WatchedFileHandler
-from pathlib import Path
 from typing import Any
 
 from celery.signals import setup_logging
 
 from palace.manager.service.container import container_instance
-
-
-def import_celery_tasks() -> None:
-    """
-    Import all the Celery tasks from the tasks module.
-
-    This automatically imports all the tasks from the tasks module so that they are registered
-    with the worker when it starts up.
-
-    This makes the assumption that all of our Celery tasks will be in the `tasks` module.
-    """
-    tasks_path = Path(__file__).parent / "tasks"
-    for task_file in tasks_path.glob("*.py"):
-        if task_file.stem == "__init__":
-            continue
-        module = f"palace.manager.celery.tasks.{task_file.stem}"
-        importlib.import_module(module)
 
 
 @setup_logging.connect
@@ -57,5 +38,6 @@ def celery_logger_setup(loglevel: int, logfile: str | None, **kwargs: Any) -> No
 
 services = container_instance()
 services.init_resources()
-import_celery_tasks()
+import palace.manager.celery.tasks  # noqa: autoflake
+
 app = services.celery.app()

--- a/src/palace/manager/celery/tasks/__init__.py
+++ b/src/palace/manager/celery/tasks/__init__.py
@@ -1,0 +1,22 @@
+import importlib
+from pathlib import Path
+
+
+def import_celery_tasks() -> None:
+    """
+    Import all the Celery tasks from the tasks module.
+
+    This automatically imports all the tasks from the tasks module so that they are registered
+    with the worker when it starts up.
+
+    This makes the assumption that all of our Celery tasks will be in the `tasks` module.
+    """
+    tasks_path = Path(__file__).parent
+    for task_file in tasks_path.glob("*.py"):
+        if task_file.stem == "__init__":
+            continue
+        module = f"{__name__}.{task_file.stem}"
+        importlib.import_module(module)
+
+
+import_celery_tasks()


### PR DESCRIPTION
## Description

Use a Celery worker the persists for the whole session, rather then starting and stopping a celery worker for each test.

## Motivation and Context

We used to be able to run the tests in 5 - 6 minutes, but we're up to around 10 minutes now. Looking at whats slowing things down, its mostly the Celery tests. The process of starting and stopping a Celery worker for each of our Celery tests ends up slowing down out tests significantly. 

Celery provides a `celery_session_worker` fixture that only starts the worker once, in a thread, and then uses that same worker for all the tests. There is a bit more risk doing things this way, that state will leak between tests. In practice though, I think this is reasonably minimal, since Celery workers are supposed to be fairly stateless to start with. They just process the jobs sent to them.

This change seems like it takes a couple minutes off the time is takes to do a test run in CI.

## How Has This Been Tested?

- Running tests locally
- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
