### PR TITLE
Create session fixture for services container (PP-2569)

### DIFF
--- a/tests/fixtures/celery.py
+++ b/tests/fixtures/celery.py
@@ -119,7 +119,7 @@ def celery_fixture(
     """Fixture to provide a Celery app and worker for testing."""
 
     # Make sure our services container has the correct celery app setup
-    container = services_fixture.celery_fixture.celery_container
+    container = services_fixture.services.celery()
     container.config.from_dict(celery_pydantic_config.model_dump())
     container.app.override(celery_session_app)
 

--- a/tests/manager/api/admin/controller/test_reset_password.py
+++ b/tests/manager/api/admin/controller/test_reset_password.py
@@ -11,7 +11,7 @@ from palace.manager.api.admin.problem_details import (
 )
 from palace.manager.util.problem_detail import ProblemDetail
 from tests.fixtures.api_admin import AdminControllerFixture
-from tests.fixtures.services import ServicesEmailFixture
+from tests.fixtures.services import ServicesFixture
 
 
 class TestResetPasswordController:
@@ -68,7 +68,7 @@ class TestResetPasswordController:
     def test_forgot_password_post(
         self,
         admin_ctrl_fixture: AdminControllerFixture,
-        services_email_fixture: ServicesEmailFixture,
+        services_fixture: ServicesFixture,
     ):
         reset_password_ctrl = admin_ctrl_fixture.manager.admin_reset_password_controller
 
@@ -116,17 +116,17 @@ class TestResetPasswordController:
             assert "Email successfully sent" in response.get_data(as_text=True)
 
             # Check the email is sent
-            assert services_email_fixture.mock_emailer.send.call_count == 1
+            assert services_fixture.mock_services.emailer.send.call_count == 1
 
             # Check that the email is sent to the right admin
-            assert services_email_fixture.mock_emailer.send.call_args.kwargs[
+            assert services_fixture.mock_services.emailer.send.call_args.kwargs[
                 "receivers"
             ] == [admin_email]
 
     def test_reset_password_get(
         self,
         admin_ctrl_fixture: AdminControllerFixture,
-        services_email_fixture: ServicesEmailFixture,
+        services_fixture: ServicesFixture,
     ):
         reset_password_ctrl = admin_ctrl_fixture.manager.admin_reset_password_controller
         token = "token"
@@ -211,7 +211,7 @@ class TestResetPasswordController:
 
             assert forgot_password_response.status_code == 200
 
-            mail_text = services_email_fixture.mock_emailer.send.call_args.kwargs[
+            mail_text = services_fixture.mock_services.emailer.send.call_args.kwargs[
                 "text"
             ]
 
@@ -244,7 +244,7 @@ class TestResetPasswordController:
     def test_reset_password_post(
         self,
         admin_ctrl_fixture: AdminControllerFixture,
-        services_email_fixture: ServicesEmailFixture,
+        services_fixture: ServicesFixture,
     ):
         reset_password_ctrl = admin_ctrl_fixture.manager.admin_reset_password_controller
 
@@ -260,7 +260,7 @@ class TestResetPasswordController:
             response = reset_password_ctrl.forgot_password()
             assert response.status_code == 200
 
-            mail_text = services_email_fixture.mock_emailer.send.call_args.kwargs[
+            mail_text = services_fixture.mock_services.emailer.send.call_args.kwargs[
                 "text"
             ]
 

--- a/tests/manager/api/overdrive/test_api.py
+++ b/tests/manager/api/overdrive/test_api.py
@@ -972,9 +972,7 @@ class TestOverdriveAPI:
             match="format of this book is not supported",
         ):
             api.checkout(patron, pin, pool, None)
-        mock_collect = (
-            services_fixture_wired.analytics_fixture.analytics_mock.collect_event
-        )
+        mock_collect = services_fixture_wired.mock_services.analytics.collect_event
         mock_collect.assert_called_once_with(
             db.default_library(),
             pool,

--- a/tests/manager/api/test_controller_cm.py
+++ b/tests/manager/api/test_controller_cm.py
@@ -46,8 +46,8 @@ class TestCirculationManager:
         assert mock_setup_controllers.called
 
         assert manager.services is services_fixture.services
-        assert manager.analytics is services_fixture.analytics_fixture.analytics_mock
-        assert manager.external_search is services_fixture.search_fixture.index_mock
+        assert manager.analytics is services_fixture.mock_services.analytics
+        assert manager.external_search is services_fixture.mock_services.search_index
 
     def test_load_settings(
         self,

--- a/tests/manager/celery/tasks/test_generate_inventory_and_hold_reports.py
+++ b/tests/manager/celery/tasks/test_generate_inventory_and_hold_reports.py
@@ -390,23 +390,23 @@ def test_generate_inventory_and_hold_reports_task(
     # there must be at least one opds collection associated with the library for this to work
     create_test_opds_collection("c1", "d1", db, library)
     generate_inventory_and_hold_reports.delay(library.id, "test@email").wait()
-    services_fixture.email_fixture.mock_emailer.send.assert_called_once()
+    services_fixture.mock_services.emailer.send.assert_called_once()
 
     mock_s3_service.store_stream.assert_called_once()
     mock_s3_service.generate_url.assert_called_once()
 
     assert (
         "Inventory and Holds Reports"
-        in services_fixture.email_fixture.mock_emailer.send.call_args.kwargs["subject"]
+        in services_fixture.mock_services.emailer.send.call_args.kwargs["subject"]
     )
-    assert services_fixture.email_fixture.mock_emailer.send.call_args.kwargs[
+    assert services_fixture.mock_services.emailer.send.call_args.kwargs[
         "receivers"
     ] == ["test@email"]
     assert (
         "Download Report here -> http://test"
-        in services_fixture.email_fixture.mock_emailer.send.call_args.kwargs["text"]
+        in services_fixture.mock_services.emailer.send.call_args.kwargs["text"]
     )
     assert (
         "This report will be available for download for 30 days."
-        in services_fixture.email_fixture.mock_emailer.send.call_args.kwargs["text"]
+        in services_fixture.mock_services.emailer.send.call_args.kwargs["text"]
     )

--- a/tests/manager/celery/tasks/test_opds_odl.py
+++ b/tests/manager/celery/tasks/test_opds_odl.py
@@ -225,7 +225,6 @@ def test__recalculate_holds_for_licensepool(
     collection = db.collection(protocol=OPDS2WithODLApi)
     pool, [license1, license2] = opds_task_fixture.pool_with_licenses(collection)
 
-    analytics = opds_task_fixture.services.analytics_fixture.analytics_mock
     # Recalculate the hold queue
     _recalculate_holds_for_licensepool(pool, timedelta(days=5))
 
@@ -285,9 +284,9 @@ def test_remove_expired_holds_for_collection_task(
     # Remove the expired holds
     remove_expired_holds_for_collection_task.delay(collection1.id).wait()
 
-    assert len(
-        opds_task_fixture.services.analytics_fixture.analytics_mock.method_calls
-    ) == len(expired_holds1)
+    assert len(opds_task_fixture.services.mock_services.analytics.method_calls) == len(
+        expired_holds1
+    )
 
     current_holds = {h.id for h in db.session.scalars(select(Hold))}
     assert expired_holds1.isdisjoint(current_holds)

--- a/tests/manager/celery/tasks/test_reaper.py
+++ b/tests/manager/celery/tasks/test_reaper.py
@@ -112,7 +112,7 @@ class TestWorkReaper:
     ) -> None:
         # Set up our search mock to track calls to remove_work
         removed = set()
-        mock_remove_work = services_fixture.search_fixture.index_mock.remove_work
+        mock_remove_work = services_fixture.mock_services.search_index.remove_work
         mock_remove_work.side_effect = lambda x: removed.add(x.id)
 
         # First, create three works.
@@ -435,9 +435,7 @@ def test_hold_reaper(
     assert len(db.session.query(Hold).where(Hold.patron == current_patron).all()) == 2
 
     # verify expected circ event count for hold reaper run
-    call_args_list = (
-        services_fixture.analytics_fixture.analytics_mock.collect.call_args_list
-    )
+    call_args_list = services_fixture.mock_services.analytics.collect.call_args_list
     assert len(call_args_list) == 2
     event_types = [call_args.kwargs["event"].type for call_args in call_args_list]
     assert event_types == [

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -158,7 +158,7 @@ def test_search_reindex_failures(
     # Make sure our backoff function doesn't delay the test.
     mock_backoff.return_value = 0
 
-    add_documents_mock = services_fixture.search_fixture.index_mock.add_documents
+    add_documents_mock = services_fixture.mock_services.search_index.add_documents
 
     # If we fail to add documents, we should retry up to 4 times, then fail.
     add_documents_mock.return_value = [1, 2, 3]
@@ -208,7 +208,7 @@ def test_search_reindex_failures_multiple_batch(
             offset : offset + batch_size
         ]
     )
-    add_documents_mock = services_fixture.search_fixture.index_mock.add_documents
+    add_documents_mock = services_fixture.mock_services.search_index.add_documents
     add_documents_mock.side_effect = [
         # First batch
         OpenSearchException(),
@@ -268,7 +268,7 @@ def test_update_read_pointer_failures(
     mock_backoff.return_value = 0
 
     read_pointer_set_mock = (
-        services_fixture.search_fixture.service_mock.read_pointer_set
+        services_fixture.mock_services.search_service.read_pointer_set
     )
     read_pointer_set_mock.side_effect = OpenSearchException()
     with pytest.raises(MaxRetriesExceededError):
@@ -456,7 +456,7 @@ def test_index_works_failures(
 
     # If we fail to add documents, we should retry up to 4 times, then fail.
     work = db.work(with_open_access_download=True)
-    add_document_mocks = services_fixture.search_fixture.index_mock.add_documents
+    add_document_mocks = services_fixture.mock_services.search_index.add_documents
     add_document_mocks.side_effect = OpenSearchException()
     with pytest.raises(MaxRetriesExceededError):
         index_works.delay([work.id]).wait()

--- a/tests/manager/scripts/test_customlist.py
+++ b/tests/manager/scripts/test_customlist.py
@@ -112,7 +112,7 @@ class TestCustomListUpdateEntriesScript:
     def test_search_facets(
         self, db: DatabaseTransactionFixture, services_fixture_wired: ServicesFixture
     ):
-        mock_index = services_fixture_wired.search_fixture.index_mock
+        mock_index = services_fixture_wired.mock_services.search_index
 
         last_updated = datetime.datetime.now() - datetime.timedelta(hours=1)
         custom_list, _ = db.customlist()

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -19,7 +19,7 @@ class TestRebuildSearchIndexScript:
         RebuildSearchIndexScript(db.session).do_run()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
         # But we don't delete the index before rebuilding.
-        services_fixture.search_fixture.index_mock.clear_search_documents.assert_not_called()
+        services_fixture.mock_services.search_index.clear_search_documents.assert_not_called()
 
     @patch("palace.manager.scripts.search.search_reindex")
     def test_do_run_blocking(
@@ -38,7 +38,7 @@ class TestRebuildSearchIndexScript:
     ):
         # If we are called with the --delete argument, we clear the index before rebuilding.
         RebuildSearchIndexScript(db.session, cmd_args=["--delete"]).do_run()
-        services_fixture.search_fixture.index_mock.clear_search_documents.assert_called_once_with()
+        services_fixture.mock_services.search_index.clear_search_documents.assert_called_once_with()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
 
     @patch("palace.manager.scripts.search.get_migrate_search_chain")

--- a/tests/manager/sqlalchemy/model/test_collection.py
+++ b/tests/manager/sqlalchemy/model/test_collection.py
@@ -670,7 +670,7 @@ class TestCollection:
         collection2.delete()
 
         # The search index was injected and told to remove the second work.
-        services_fixture_wired.search_fixture.index_mock.remove_work.assert_called_once_with(
+        services_fixture_wired.mock_services.search_index.remove_work.assert_called_once_with(
             work2
         )
 

--- a/tests/manager/sqlalchemy/model/test_patron.py
+++ b/tests/manager/sqlalchemy/model/test_patron.py
@@ -292,7 +292,7 @@ class TestHold:
         hold, _ = pool.on_hold_to(patron)
         hold.collect_event_and_delete()
         assert db.session.query(Hold).count() == 0
-        services_fixture_wired.analytics_fixture.analytics_mock.collect_event.assert_called_once()
+        services_fixture_wired.mock_services.analytics.collect_event.assert_called_once()
 
 
 class TestLoans:


### PR DESCRIPTION
## Description

- Create a session fixture that contains the autospec mocks for our services container, so we don't have to run `create_autospec` on every test run.
- Refactor our services fixture, so it uses the new session fixture. 
- Remove a number of fixtures that were created for the sub-containers that weren't very useful, and replace them with calls to the main services fixture.

## Motivation and Context

`create_autospec` is surprisingly expensive to run, and with our current services container, we have to run several times for almost every test run. This ends up making out tests take longer.

I think the new structure where we don't have a bunch of different services fixtures is a better design and it shaves a minute or so off our tests runs.

## How Has This Been Tested?

- Tested locally
- Tested in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
