### PR TITLE
[PP-2610] Ensure that published dates from OPDS2 imports contain no time info.

### DIFF
--- a/src/palace/manager/core/opds2_import.py
+++ b/src/palace/manager/core/opds2_import.py
@@ -647,6 +647,7 @@ class OPDS2Importer(BaseOPDSImporter[OPDS2ImporterSettings]):
         imprint = str(first_imprint.name) if first_imprint else None
 
         published = publication.metadata.published
+
         subjects = self._extract_subjects(publication.metadata.subjects)
         contributors = (
             self._extract_contributors(

--- a/src/palace/manager/data_layer/bibliographic.py
+++ b/src/palace/manager/data_layer/bibliographic.py
@@ -94,7 +94,9 @@ class BibliographicData(BaseMutableData):
 
     @field_validator("published", mode="before")
     @classmethod
-    def _published_validator(cls, value: datetime.date | None) -> datetime.date | None:
+    def _published_validator(
+        cls, value: datetime.date | datetime.datetime | None
+    ) -> datetime.date | None:
         # guarantee the published date is a date rather than datetime (which may have time data which will
         # cause a pydantic validation error)
         if value:

--- a/src/palace/manager/data_layer/bibliographic.py
+++ b/src/palace/manager/data_layer/bibliographic.py
@@ -92,6 +92,16 @@ class BibliographicData(BaseMutableData):
     def _filter_links(cls, links: list[LinkData]) -> list[LinkData]:
         return [link for link in links if link.rel in Hyperlink.BIBLIOGRAPHIC_ALLOWED]
 
+    @field_validator("published", mode="before")
+    @classmethod
+    def _published_validator(cls, value: datetime.date | None) -> datetime.date | None:
+        # guarantee the published date is a date rather than datetime (which may have time data which will
+        # cause a pydantic validation error)
+        if value:
+            return datetime.date(year=value.year, month=value.month, day=value.day)
+        else:
+            return None
+
     @model_validator(mode="after")
     def _primary_identifier_in_identifiers(self) -> Self:
         if (

--- a/tests/manager/data_layer/test_bibliographic.py
+++ b/tests/manager/data_layer/test_bibliographic.py
@@ -297,6 +297,33 @@ class TestBibliographicData:
         assert Measurement.POPULARITY == m.quantity_measured
         assert 100 == m.value
 
+    def test_published(self, db: DatabaseTransactionFixture):
+        published = datetime.datetime.now()
+
+        bibliographic = BibliographicData(
+            published=published,
+            data_source_last_updated=datetime.datetime.now(),
+            data_source_name="test",
+        )
+
+        assert isinstance(bibliographic.published, datetime.date)
+
+        bibliographic = BibliographicData(
+            published=None,
+            data_source_last_updated=datetime.datetime.now(),
+            data_source_name="test",
+        )
+
+        assert bibliographic.published is None
+
+        bibliographic = BibliographicData(
+            published=published.date(),
+            data_source_last_updated=datetime.datetime.now(),
+            data_source_name="test",
+        )
+
+        assert bibliographic.published == published.date()
+
     def test_coverage_record(self, db: DatabaseTransactionFixture):
         edition, pool = db.edition(with_license_pool=True)
         data_source = edition.data_source


### PR DESCRIPTION
when being imported into palace.

## Description
This PR addresses the import error we were seeing on some titles that had time data in in the "published" field in the OPDS import.  Pydantic wasn't liking it:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for BibliographicData
published
  Datetimes provided to dates should have zero time - e.g. be exact dates [type=date_from_datetime_inexact, input_value=datetime.datetime(1970, 1... 43, tzinfo=TzInfo(UTC)), input_type=datetime]
    For further information visit https://errors.pydantic.dev/2.11/v/date_from_datetime_inexact
```


<!--- Describe your changes -->

## Motivation and Context
See above.  Or for more details - see the following link:
https://ebce-lyrasis.atlassian.net/browse/PP-2610
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I added a unit test the reproduce the failure.  I fixed it using a validator and confirmed that the fix prevents the error.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
