### PR TITLE
Refactor MockHttpClient to be pytest fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ pytest_plugins = [
     "tests.fixtures.database",
     "tests.fixtures.files",
     "tests.fixtures.flask",
+    "tests.fixtures.http",
     "tests.fixtures.library",
     "tests.fixtures.marc",
     "tests.fixtures.odl",

--- a/tests/fixtures/http.py
+++ b/tests/fixtures/http.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from requests import Response
+from typing_extensions import Self, Unpack
+
+from palace.manager.util.http import HTTP, GetRequestKwargs, RequestKwargs
+from tests.mocks.mock import MockRequestsResponse
+
+
+class MockHttpClientFixture:
+    def __init__(self) -> None:
+        self.responses: list[Response] = []
+        self.requests: list[str] = []
+        self.requests_args: list[RequestKwargs] = []
+        self.requests_methods: list[str] = []
+        self._unpatch: Callable[[], None] | None = None
+
+    def reset_mock(self) -> None:
+        self.responses = []
+        self.requests = []
+        self.requests_args = []
+        self.requests_methods = []
+
+    def stop_patch(self) -> None:
+        if self._unpatch is None:
+            raise RuntimeError("MockHTTPClientFixture is not currently patched.")
+        self._unpatch()
+
+    def queue_response(
+        self,
+        response_code: int,
+        media_type: str | None = None,
+        other_headers: dict[str, str] | None = None,
+        content: str | bytes | dict[str, Any] = "",
+    ):
+        """Queue a response of the type produced by HTTP.get_with_timeout."""
+        headers = dict(other_headers or {})
+        if media_type:
+            headers["Content-Type"] = media_type
+
+        self.responses.append(MockRequestsResponse(response_code, headers, content))
+
+    def _request(self, *args: Any, **kwargs: Any) -> Response:
+        return self.responses.pop(0)
+
+    def do_request(
+        self, http_method: str, url: str, **kwargs: Unpack[RequestKwargs]
+    ) -> Response:
+        self.requests.append(url)
+        self.requests_methods.append(http_method)
+        self.requests_args.append(kwargs)
+        return HTTP._request_with_timeout(http_method, url, self._request, **kwargs)
+
+    def do_get(self, url: str, **kwargs: Unpack[GetRequestKwargs]) -> Response:
+        return self.do_request("GET", url, **kwargs)
+
+    @classmethod
+    @contextmanager
+    def fixture(cls) -> Generator[Self]:
+        fixture = cls()
+        patcher = patch.object(HTTP, "request_with_timeout", fixture.do_request)
+        fixture._unpatch = patcher.stop
+        patcher.start()
+        try:
+            yield fixture
+        finally:
+            fixture.stop_patch()
+
+
+@pytest.fixture
+def http_client() -> Generator[MockHttpClientFixture]:
+    """Fixture to provide a mock HTTP client for testing."""
+    with MockHttpClientFixture.fixture() as mock_client:
+        yield mock_client

--- a/tests/fixtures/odl.py
+++ b/tests/fixtures/odl.py
@@ -31,10 +31,11 @@ from palace.manager.sqlalchemy.model.work import Work
 from palace.manager.util.datetime_helpers import utc_now
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.files import FilesFixture, OPDS2WithODLFilesFixture
+from tests.fixtures.http import MockHttpClientFixture
 from tests.fixtures.work import (
     WorkIdPolicyQueuePresentationRecalculationFixture,
 )
-from tests.mocks.mock import MockHTTPClient, MockRequestsResponse
+from tests.mocks.mock import MockRequestsResponse
 from tests.mocks.odl import MockOPDS2WithODLApi
 
 
@@ -42,6 +43,7 @@ class OPDS2WithODLApiFixture:
     def __init__(
         self,
         db: DatabaseTransactionFixture,
+        http_client: MockHttpClientFixture,
         files: FilesFixture,
     ):
         self.db = db
@@ -51,8 +53,8 @@ class OPDS2WithODLApiFixture:
         self.collection = self.create_collection(self.library)
         self.work = self.create_work(self.collection)
         self.license = self.setup_license()
-        self.mock_http = MockHTTPClient()
-        self.api = MockOPDS2WithODLApi(self.db.session, self.collection, self.mock_http)
+        self.mock_http = http_client
+        self.api = MockOPDS2WithODLApi(self.db.session, self.collection)
         self.patron = db.patron()
         self.pool = self.license.license_pool
         self.license_document = partial(
@@ -211,9 +213,10 @@ class OPDS2WithODLApiFixture:
 @pytest.fixture(scope="function")
 def opds2_with_odl_api_fixture(
     db: DatabaseTransactionFixture,
+    http_client: MockHttpClientFixture,
     opds2_with_odl_files_fixture: OPDS2WithODLFilesFixture,
 ) -> OPDS2WithODLApiFixture:
-    return OPDS2WithODLApiFixture(db, opds2_with_odl_files_fixture)
+    return OPDS2WithODLApiFixture(db, http_client, opds2_with_odl_files_fixture)
 
 
 class LicenseHelper:

--- a/tests/manager/api/overdrive/test_api.py
+++ b/tests/manager/api/overdrive/test_api.py
@@ -78,6 +78,7 @@ class TestOverdriveAPI:
         overdrive_api_fixture: OverdriveAPIFixture,
         mock_web_server: MockAPIServer,
     ):
+        overdrive_api_fixture.mock_http.stop_patch()
         collection = overdrive_api_fixture.collection
 
         # Enqueue a response for the request that the server will make for a token.

--- a/tests/manager/api/overdrive/test_monitor.py
+++ b/tests/manager/api/overdrive/test_monitor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from functools import partial
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -342,11 +341,8 @@ class TestNewTitlesOverdriveCollectionMonitor:
         self, overdrive_api_fixture: OverdriveAPIFixture, db: DatabaseTransactionFixture
     ):
         db = overdrive_api_fixture.db
-        mock_api_partial = partial(
-            MockOverdriveAPI, mock_http=overdrive_api_fixture.mock_http
-        )
         monitor = NewTitlesOverdriveCollectionMonitor(
-            db.session, overdrive_api_fixture.collection, api_class=mock_api_partial
+            db.session, overdrive_api_fixture.collection, api_class=MockOverdriveAPI
         )
 
         # for this test, we will not count consecutive out of scope dates: if one
@@ -393,11 +389,8 @@ class TestNewTitlesOverdriveCollectionMonitor:
     ):
         caplog.set_level(logging.INFO)
 
-        mock_api_partial = partial(
-            MockOverdriveAPI, mock_http=overdrive_api_fixture.mock_http
-        )
         monitor = NewTitlesOverdriveCollectionMonitor(
-            db.session, overdrive_api_fixture.collection, api_class=mock_api_partial
+            db.session, overdrive_api_fixture.collection, api_class=MockOverdriveAPI
         )
 
         # for this test, we will count consecutive out of scope date
@@ -439,11 +432,8 @@ class TestNewTitlesOverdriveCollectionMonitor:
     def test_should_stop_again(
         self, overdrive_api_fixture: OverdriveAPIFixture, db: DatabaseTransactionFixture
     ):
-        mock_api_partial = partial(
-            MockOverdriveAPI, mock_http=overdrive_api_fixture.mock_http
-        )
         monitor = RecentOverdriveCollectionMonitor(
-            db.session, overdrive_api_fixture.collection, api_class=mock_api_partial
+            db.session, overdrive_api_fixture.collection, api_class=MockOverdriveAPI
         )
         assert monitor.consecutive_unchanged_books == 0
         # This book hasn't been changed, but we're under the limit, so we should
@@ -475,23 +465,17 @@ class TestReaper:
         self, overdrive_api_fixture: OverdriveAPIFixture, db: DatabaseTransactionFixture
     ):
         # Validate the standard CollectionMonitor interface.
-        mock_api_partial = partial(
-            MockOverdriveAPI, mock_http=overdrive_api_fixture.mock_http
-        )
         monitor = OverdriveCollectionReaper(
-            db.session, overdrive_api_fixture.collection, api_class=mock_api_partial  # type: ignore[arg-type]
+            db.session, overdrive_api_fixture.collection, api_class=MockOverdriveAPI
         )
 
 
 class TestOverdriveFormatSweep:
     def test_process_item(self, overdrive_api_fixture: OverdriveAPIFixture):
         db = overdrive_api_fixture.db
-        mock_api_partial = partial(
-            MockOverdriveAPI, mock_http=overdrive_api_fixture.mock_http
-        )
         # Validate the standard CollectionMonitor interface.
         monitor = OverdriveFormatSweep(
-            db.session, overdrive_api_fixture.collection, api_class=mock_api_partial  # type: ignore[arg-type]
+            db.session, overdrive_api_fixture.collection, api_class=MockOverdriveAPI
         )
         overdrive_api_fixture.queue_collection_token()
         # We're not testing that the work actually gets done (that's
@@ -514,9 +498,8 @@ class TestOverdriveFormatSweep:
             def update_formats(self, licensepool):
                 self.update_format_calls += 1
 
-        mock_api_partial = partial(MockApi, mock_http=overdrive_api_fixture.mock_http)
         monitor = OverdriveFormatSweep(
-            db.session, overdrive_api_fixture.collection, api_class=mock_api_partial  # type: ignore[arg-type]
+            db.session, overdrive_api_fixture.collection, api_class=MockApi
         )
         overdrive_api_fixture.queue_collection_token()
         overdrive_api_fixture.mock_http.queue_response(404)

--- a/tests/manager/api/test_circulation.py
+++ b/tests/manager/api/test_circulation.py
@@ -129,7 +129,7 @@ class TestFetchFulfillment:
         fulfillment = FetchFulfillment(
             "http://some.location", allowed_response_codes=["2xx"]
         )
-        with (pytest.raises(BadResponseException) as excinfo,):
+        with pytest.raises(BadResponseException) as excinfo:
             fulfillment.response()
 
         assert (

--- a/tests/mocks/mock.py
+++ b/tests/mocks/mock.py
@@ -1,12 +1,8 @@
 import json
 import logging
-from collections.abc import Generator
-from contextlib import contextmanager
 from typing import Any
-from unittest.mock import patch
 
 from requests import Request, Response
-from typing_extensions import Unpack
 
 from palace.manager.core.coverage import (
     BibliographicCoverageProvider,
@@ -16,7 +12,6 @@ from palace.manager.core.coverage import (
 from palace.manager.core.opds_import import OPDSAPI
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.resource import HttpResponseTuple
-from palace.manager.util.http import HTTP, GetRequestKwargs, RequestKwargs
 
 
 def _normalize_level(level):
@@ -188,53 +183,6 @@ class TaskIgnoringCoverageProvider(InstrumentedCoverageProvider):
         return []
 
 
-class MockHTTPClient:
-    def __init__(self) -> None:
-        self.responses: list[Response] = []
-        self.requests: list[str] = []
-        self.requests_args: list[RequestKwargs] = []
-        self.requests_methods: list[str] = []
-
-    def reset_mock(self) -> None:
-        self.responses = []
-        self.requests = []
-        self.requests_args = []
-        self.requests_methods = []
-
-    def queue_response(
-        self,
-        response_code: int,
-        media_type: str | None = None,
-        other_headers: dict[str, str] | None = None,
-        content: str | bytes | dict[str, Any] = "",
-    ):
-        """Queue a response of the type produced by HTTP.get_with_timeout."""
-        headers = dict(other_headers or {})
-        if media_type:
-            headers["Content-Type"] = media_type
-
-        self.responses.append(MockRequestsResponse(response_code, headers, content))
-
-    def _request(self, *args: Any, **kwargs: Any) -> Response:
-        return self.responses.pop(0)
-
-    def do_request(
-        self, http_method: str, url: str, **kwargs: Unpack[RequestKwargs]
-    ) -> Response:
-        self.requests.append(url)
-        self.requests_methods.append(http_method)
-        self.requests_args.append(kwargs)
-        return HTTP._request_with_timeout(http_method, url, self._request, **kwargs)
-
-    def do_get(self, url: str, **kwargs: Unpack[GetRequestKwargs]) -> Response:
-        return self.do_request("GET", url, **kwargs)
-
-    @contextmanager
-    def patch(self) -> Generator[None, None, None]:
-        with patch.object(HTTP, "request_with_timeout", self.do_request):
-            yield
-
-
 class MockRepresentationHTTPClient:
     def __init__(self) -> None:
         self.responses: list[HttpResponseTuple] = []
@@ -271,17 +219,6 @@ class MockRepresentationHTTPClient:
     ) -> HttpResponseTuple:
         self.requests.append((url, data))
         return self.responses.pop(0)
-
-
-class MockRequestsRequest:
-    """A mock object that simulates an HTTP request from the
-    `requests` library.
-    """
-
-    def __init__(self, url, method="GET", headers=None):
-        self.url = url
-        self.method = method
-        self.headers = headers or dict()
 
 
 class MockRequestsResponse(Response):

--- a/tests/mocks/odl.py
+++ b/tests/mocks/odl.py
@@ -1,8 +1,5 @@
-from collections.abc import Mapping
 from datetime import timedelta
-from typing import Any
 
-from requests import Response
 from sqlalchemy.orm import Session
 
 from palace.manager.api.odl.api import OPDS2WithODLApi
@@ -10,7 +7,6 @@ from palace.manager.api.odl.auth import TokenTuple
 from palace.manager.api.odl.settings import OPDS2AuthType
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.util.datetime_helpers import utc_now
-from tests.mocks.mock import MockHTTPClient
 
 
 class MockOPDS2WithODLApi(OPDS2WithODLApi):
@@ -18,11 +14,8 @@ class MockOPDS2WithODLApi(OPDS2WithODLApi):
         self,
         _db: Session,
         collection: Collection,
-        mock_http_client: MockHTTPClient,
     ) -> None:
         super().__init__(_db, collection)
-
-        self.mock_http_client = mock_http_client
         self.mock_auth_type = self.settings.auth_type
         self.refresh_token_calls = 0
         self.refresh_token_timedelta = timedelta(minutes=30)
@@ -42,30 +35,3 @@ class MockOPDS2WithODLApi(OPDS2WithODLApi):
         short_name: str | None, patron_id: str, license_id: str
     ) -> str:
         return f"https://cm/{short_name}/odl/notify/{patron_id}/{license_id}"
-
-    def _basic_auth_request(
-        self,
-        method: str,
-        url: str,
-        headers: Mapping[str, str] | None = None,
-        **kwargs: Any,
-    ) -> Response:
-        return self.mock_http_client.do_request(method, url, headers=headers, **kwargs)
-
-    def _oauth_request(
-        self,
-        method: str,
-        url: str,
-        headers: Mapping[str, str] | None = None,
-        **kwargs: Any,
-    ) -> Response:
-        return self.mock_http_client.do_request(method, url, headers=headers, **kwargs)
-
-    def _no_auth_request(
-        self,
-        method: str,
-        url: str,
-        headers: Mapping[str, str] | None = None,
-        **kwargs: Any,
-    ) -> Response:
-        return self.mock_http_client.do_request(method, url, headers=headers, **kwargs)

--- a/tests/mocks/overdrive.py
+++ b/tests/mocks/overdrive.py
@@ -1,26 +1,18 @@
 from datetime import timedelta
-from typing import Any
 
-from requests import Response
 from sqlalchemy.orm import Session
-from typing_extensions import Unpack, override
 
 from palace.manager.api.overdrive.api import OverdriveAPI, OverdriveToken
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.util.datetime_helpers import utc_now
-from palace.manager.util.http import RequestKwargs
-from tests.mocks.mock import MockHTTPClient
 
 
 class MockOverdriveAPI(OverdriveAPI):
-    def __init__(
-        self, _db: Session, collection: Collection, mock_http: MockHTTPClient
-    ) -> None:
+    def __init__(self, _db: Session, collection: Collection) -> None:
         # Almost all tests will try to request the access token, so
         # set the response that will be returned if an attempt is
         # made.
         super().__init__(_db, collection)
-        self.mock_http = mock_http
 
         # Initialize some variables that are normally set when they are first accessed,
         # since most tests will access them.
@@ -28,24 +20,3 @@ class MockOverdriveAPI(OverdriveAPI):
         self._cached_client_oauth_token = OverdriveToken(
             "fake client oauth token", utc_now() + timedelta(hours=1)
         )
-
-    @override
-    def _do_get(self, url: str, headers: dict[str, str], **kwargs: Any) -> Response:
-        url = self.endpoint(url)
-        return self.mock_http.do_request("GET", url, headers=headers, **kwargs)
-
-    @override
-    def _do_post(
-        self, url: str, payload: dict[str, str], headers: dict[str, str], **kwargs: Any
-    ) -> Response:
-        url = self.endpoint(url)
-        return self.mock_http.do_request(
-            "POST", url, data=payload, headers=headers, **kwargs
-        )
-
-    @override
-    def _do_patron_request(
-        self, http_method: str, url: str, **kwargs: Unpack[RequestKwargs]
-    ) -> Response:
-        url = self.endpoint(url)
-        return self.mock_http.do_request(http_method, url, **kwargs)


### PR DESCRIPTION
## Description

Refactor MockHttpClient to be pytest fixture. Previously it was a standalone class, but it makes more sense for it to be a fixture that other test functions can call in.

## Motivation and Context

This change was part of the work I'm doing in PP-2133. Breaking it out to its own PR, since PP-2133 is getting rather large.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
