### PR TITLE
Remove superseded license pool concept. (PP-2590)

### DIFF
--- a/src/palace/manager/feed/admin.py
+++ b/src/palace/manager/feed/admin.py
@@ -30,7 +30,6 @@ class AdminFeed(OPDSAcquisitionFeed):
             .filter(
                 and_(
                     LicensePool.suppressed == false(),
-                    LicensePool.superceded == false(),
                     Work.suppressed_for.contains(library),
                 )
             )

--- a/src/palace/manager/scripts/informational.py
+++ b/src/palace/manager/scripts/informational.py
@@ -388,14 +388,11 @@ class Explain(IdentifierInputScript):
             self.write("  %s" % genre)
         self.write(" License pools:")
         for pool in work.license_pools:
-            active = "SUPERCEDED"
-            if not pool.superceded:
-                active = "ACTIVE"
             if pool.collection:
                 collection = pool.collection.name
             else:
                 collection = "!collection"
-            self.write(f"  {active}: {pool.identifier!r} {collection}")
+            self.write(f"  ACTIVE: {pool.identifier!r} {collection}")
 
     def explain_coverage_record(self, cr):
         self._explain_coverage_record(

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -2313,12 +2313,7 @@ class DatabaseBackedWorkList(WorkList):
         """Return a query that contains the joins set up as necessary to
         create OPDS feeds.
         """
-        qu = (
-            _db.query(Work)
-            .join(Work.license_pools)
-            .join(Work.presentation_edition)
-            .filter(LicensePool.superceded == False)
-        )
+        qu = _db.query(Work).join(Work.license_pools).join(Work.presentation_edition)
 
         # Apply optimizations.
         qu = cls._modify_loading(qu)

--- a/tests/manager/feed/test_admin.py
+++ b/tests/manager/feed/test_admin.py
@@ -190,17 +190,11 @@ class TestOPDS:
         work1.suppressed_for.append(library)
         work2.suppressed_for.append(library)
 
-        # This work won't be included in the feed, since its
-        # license pool is superceded.
-        work3 = db.work(with_open_access_download=True)
-        work3.license_pools[0].superceded = True
-        work3.suppressed_for.append(library)
-
         # This work won't be included in the feed, since it is
         # also suppressed at the collection (license pool) level.
-        work4 = db.work(with_open_access_download=True)
-        work4.license_pools[0].suppressed = True
-        work4.suppressed_for.append(library)
+        work3 = db.work(with_open_access_download=True)
+        work3.license_pools[0].suppressed = True
+        work3.suppressed_for.append(library)
 
         pagination = Pagination(size=1)
         pagination_page_1 = pagination

--- a/tests/manager/sqlalchemy/model/test_lane.py
+++ b/tests/manager/sqlalchemy/model/test_lane.py
@@ -3002,7 +3002,6 @@ class TestDatabaseBackedWorkList:
             db.session.query(Work)
             .join(Work.license_pools)
             .join(Work.presentation_edition)
-            .filter(LicensePool.superceded == False)
         )
         assert str(expect) == str(base_query)
         assert "_modify_loading" == m
@@ -3482,20 +3481,6 @@ class TestDatabaseBackedWorkList:
             l.remove_entry(work)
             assert [] == _run(both_lists_qu, both_lists_clauses)
             l.add_entry(work)
-
-    def test_works_from_database_with_superceded_pool(
-        self, db: DatabaseTransactionFixture
-    ):
-        work = db.work(with_license_pool=True)
-        work.license_pools[0].superceded = True
-        ignore, pool = db.edition(with_license_pool=True)
-        work.license_pools.append(pool)
-        db.session.commit()
-
-        lane = db.lane()
-        [w] = lane.works_from_database(db.session).all()
-        # Only one pool is loaded, and it's the non-superceded one.
-        assert [pool] == w.license_pools
 
 
 class TestHierarchyWorkList:


### PR DESCRIPTION
## Description

Removes the concept of a superseded ("superceded" [sic] in code) license pool.

NB: The `LicensePool.superceded` column will be removed in a future update, but all references to it have been removed.

## Motivation and Context

Before this change, Open Access license pools could be superseded by another license pool. This caused problems if the _superseding_ license pool was not associated with and active in all libraries that were associated with the _superseded_ pool.

## How Has This Been Tested?

- Removed or reworked tests that used superseded.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/15682544711).

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
