### PR TITLE
CORS headers for patron auth token responses. (PP-2651)

### DIFF
--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -373,6 +373,7 @@ def delete_patron_devices():
 
 @library_dir_route("/patrons/me/token", methods=["POST"])
 @has_library
+@allows_patron_web
 @requires_auth
 @returns_problem_detail
 def patron_auth_token():


### PR DESCRIPTION
## Description

Support CORS headers for `/patron/me/token` endpoint.

## Motivation and Context

Now that we have a web browser-based client using this endpoint, it needs CORS support. The mobile app clients did not need this, since that interaction did not include a web browser.

## How Has This Been Tested?

- Will validate in staging and development environments once this change is deployed.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/15712111656).

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
