### PR TITLE
[PP-2523] Hide currently selected book titles

### DIFF
--- a/src/palace/manager/api/controller/work.py
+++ b/src/palace/manager/api/controller/work.py
@@ -194,6 +194,7 @@ class WorkController(CirculationManagerController):
             pagination=None,
             facets=facets,
             search_engine=search_engine,
+            work_ids_to_exclude=[work.id],
         ).as_response(
             max_age=lane.max_cache_age(), mime_types=flask.request.accept_mimetypes
         )

--- a/src/palace/manager/feed/acquisition.py
+++ b/src/palace/manager/feed/acquisition.py
@@ -686,6 +686,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         *,
         search_engine: ExternalSearchIndex = Provide["search.index"],
         search_debug: bool = False,
+        work_ids_to_exclude: list[int] | None = None,
     ) -> OPDSAcquisitionFeed:
         """Internal method called by groups() when a grouped feed
         must be regenerated.
@@ -706,6 +707,11 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         # Make a typical grouped feed.
         all_works = []
         for work, sublane in works_and_lanes:
+
+            # skip works in the exclusion list
+            if work_ids_to_exclude and work.id in work_ids_to_exclude:
+                continue
+
             if sublane == worklist:
                 # We are looking at the groups feed for (e.g.)
                 # "Science Fiction", and we're seeing a book

--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -736,12 +736,16 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         self.circulation = circulation
         self.library: Library = library
         self.patron = patron
-        self.lanes_by_work: dict[Work, list[Any]] = defaultdict(list)
+        self._lanes_by_work: dict[Work, list[Any]] = defaultdict(list)
         self.facet_view = facet_view
         self._adobe_id_cache: dict[str, Any] = {}
         self._top_level_title = top_level_title
         self.identifies_patrons = library_identifies_patrons
         self.facets = facets or None
+
+    @property
+    def lanes_by_work(self) -> dict[Work, list[Any]]:
+        return self._lanes_by_work
 
     @cached_property
     def is_novelist_configured(self) -> bool:

--- a/tests/manager/api/controller/test_work.py
+++ b/tests/manager/api/controller/test_work.py
@@ -788,6 +788,7 @@ class TestWorkController:
             )
         assert kwargs.pop("url") == expect_url
         assert kwargs.pop("pagination") == None
+        assert kwargs.pop("work_ids_to_exclude") == [work.id]
         # That's it!
         assert {} == kwargs
 


### PR DESCRIPTION
## Description
This PR filters the related_books endpoint results such that the work identified in the /related_books URI does not appear in the results ( since that would be redundant). 

I've added a test that ensures the values passed via the  "work_ids_to_exclude" parameter of the `OPDSAcquisitionFeed.groups` method are being filtered out of the generated OPDS acquisition feed.

I also updated the test of the `WorkController.related` method to ensure that the work id is being passed to the `OPDSAcquisitionFeed.groups` method.

## Motivation and Context
When a user is looking at the book details for Book A in the mobile apps, we do not want Book A to appear in the related book results.
https://ebce-lyrasis.atlassian.net/browse/PP-2523
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I tested it locally with manual testing, updated the unit tests, and added a new test.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
