### PR TITLE
Allow axis to set format prioritities (PP-2133)

### DIFF
--- a/src/palace/manager/api/axis/settings.py
+++ b/src/palace/manager/api/axis/settings.py
@@ -11,6 +11,7 @@ from palace.manager.api.circulation import (
     BaseCirculationApiSettings,
     BaseCirculationLoanSettings,
 )
+from palace.manager.integration.configuration.formats import FormatPrioritiesSettings
 from palace.manager.integration.settings import (
     ConfigurationFormItem,
     ConfigurationFormItemType,
@@ -18,7 +19,7 @@ from palace.manager.integration.settings import (
 )
 
 
-class Axis360Settings(BaseCirculationApiSettings):
+class Axis360Settings(BaseCirculationApiSettings, FormatPrioritiesSettings):
     username: str = FormField(
         form=ConfigurationFormItem(label=_("Username"), required=True)
     )


### PR DESCRIPTION
## Description

Allow the Axis integration to set format priorities settings, so that we are able to prioritize / de-prioritize the new AxisNow DRM implementation. 

Once this is rolled out and working, we will want to make sure AxisNow is always prioritized, but for now adding these settings is helpful for testing.

## Motivation and Context

Testing PP-2133

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
