### PR TITLE
Remove old THREEM datasource constant (PP-1911)

### DIFF
--- a/src/palace/manager/scripts/availability.py
+++ b/src/palace/manager/scripts/availability.py
@@ -29,7 +29,7 @@ class AvailabilityRefreshScript(IdentifierInputScript):
     def refresh_availability(self, identifiers):
         provider = None
         identifier = identifiers[0]
-        if identifier.type == Identifier.THREEM_ID:
+        if identifier.type == Identifier.BIBLIOTHECA_ID:
             sweeper = BibliothecaCirculationSweep(self._db)
             sweeper.process_batch(identifiers)
         elif identifier.type == Identifier.OVERDRIVE_ID:

--- a/src/palace/manager/sqlalchemy/constants.py
+++ b/src/palace/manager/sqlalchemy/constants.py
@@ -166,7 +166,6 @@ class IdentifierConstants:
     DEPRECATED_NAMES = {
         "3M ID": BIBLIOTHECA_ID,
     }
-    THREEM_ID = BIBLIOTHECA_ID
 
     LICENSE_PROVIDING_IDENTIFIER_TYPES = [
         BIBLIOTHECA_ID,

--- a/src/palace/manager/sqlalchemy/constants.py
+++ b/src/palace/manager/sqlalchemy/constants.py
@@ -42,7 +42,6 @@ class DataSourceConstants:
     PROQUEST = "ProQuest"
 
     DEPRECATED_NAMES = {"3M": BIBLIOTHECA}
-    THREEM = BIBLIOTHECA
 
     # Some sources of open-access ebooks are better than others. This
     # list shows which sources we prefer, in ascending order of

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -644,7 +644,7 @@ class TestLoanController:
     ):
         threem_edition, pool = loan_fixture.db.edition(
             with_open_access_download=False,
-            data_source_name=DataSource.THREEM,
+            data_source_name=DataSource.BIBLIOTHECA,
             identifier_type=Identifier.THREEM_ID,
             with_license_pool=True,
         )
@@ -707,7 +707,7 @@ class TestLoanController:
         """
         threem_edition, pool = loan_fixture.db.edition(
             with_open_access_download=False,
-            data_source_name=DataSource.THREEM,
+            data_source_name=DataSource.BIBLIOTHECA,
             identifier_type=Identifier.THREEM_ID,
             with_license_pool=True,
         )
@@ -746,7 +746,7 @@ class TestLoanController:
     ):
         threem_edition, pool = loan_fixture.db.edition(
             with_open_access_download=False,
-            data_source_name=DataSource.THREEM,
+            data_source_name=DataSource.BIBLIOTHECA,
             identifier_type=Identifier.THREEM_ID,
             with_license_pool=True,
         )
@@ -1319,7 +1319,7 @@ class TestLoanController:
     ):
         threem_edition, pool = loan_fixture.db.edition(
             with_open_access_download=False,
-            data_source_name=DataSource.THREEM,
+            data_source_name=DataSource.BIBLIOTHECA,
             identifier_type=Identifier.THREEM_ID,
             with_license_pool=True,
         )
@@ -1373,7 +1373,7 @@ class TestLoanController:
     def test_3m_cant_revoke_hold_if_reserved(self, loan_fixture: LoanFixture):
         threem_edition, pool = loan_fixture.db.edition(
             with_open_access_download=False,
-            data_source_name=DataSource.THREEM,
+            data_source_name=DataSource.BIBLIOTHECA,
             identifier_type=Identifier.THREEM_ID,
             with_license_pool=True,
         )

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -645,7 +645,7 @@ class TestLoanController:
         threem_edition, pool = loan_fixture.db.edition(
             with_open_access_download=False,
             data_source_name=DataSource.BIBLIOTHECA,
-            identifier_type=Identifier.THREEM_ID,
+            identifier_type=Identifier.BIBLIOTHECA_ID,
             with_license_pool=True,
         )
         threem_book = loan_fixture.db.work(
@@ -708,7 +708,7 @@ class TestLoanController:
         threem_edition, pool = loan_fixture.db.edition(
             with_open_access_download=False,
             data_source_name=DataSource.BIBLIOTHECA,
-            identifier_type=Identifier.THREEM_ID,
+            identifier_type=Identifier.BIBLIOTHECA_ID,
             with_license_pool=True,
         )
         threem_book = loan_fixture.db.work(
@@ -747,7 +747,7 @@ class TestLoanController:
         threem_edition, pool = loan_fixture.db.edition(
             with_open_access_download=False,
             data_source_name=DataSource.BIBLIOTHECA,
-            identifier_type=Identifier.THREEM_ID,
+            identifier_type=Identifier.BIBLIOTHECA_ID,
             with_license_pool=True,
         )
         threem_book = loan_fixture.db.work(
@@ -1320,7 +1320,7 @@ class TestLoanController:
         threem_edition, pool = loan_fixture.db.edition(
             with_open_access_download=False,
             data_source_name=DataSource.BIBLIOTHECA,
-            identifier_type=Identifier.THREEM_ID,
+            identifier_type=Identifier.BIBLIOTHECA_ID,
             with_license_pool=True,
         )
         threem_book = loan_fixture.db.work(
@@ -1374,7 +1374,7 @@ class TestLoanController:
         threem_edition, pool = loan_fixture.db.edition(
             with_open_access_download=False,
             data_source_name=DataSource.BIBLIOTHECA,
-            identifier_type=Identifier.THREEM_ID,
+            identifier_type=Identifier.BIBLIOTHECA_ID,
             with_license_pool=True,
         )
         threem_book = loan_fixture.db.work(

--- a/tests/manager/api/test_bibliotheca.py
+++ b/tests/manager/api/test_bibliotheca.py
@@ -338,7 +338,7 @@ class TestBibliothecaAPI:
 
         # Create a LicensePool that needs updating.
         edition, pool = db.edition(
-            identifier_type=Identifier.THREEM_ID,
+            identifier_type=Identifier.BIBLIOTHECA_ID,
             data_source_name=DataSource.BIBLIOTHECA,
             with_license_pool=True,
             collection=bibliotheca_fixture.collection,
@@ -1812,7 +1812,7 @@ class TestItemListParser:
 
         primary = cooked.primary_identifier_data
         assert "ddf4gr9" == primary.identifier
-        assert Identifier.THREEM_ID == primary.type
+        assert Identifier.BIBLIOTHECA_ID == primary.type
 
         identifiers = sorted(cooked.identifiers, key=lambda x: x.identifier)
         assert ["9781250015280", "9781250031112", "ddf4gr9"] == [

--- a/tests/manager/api/test_bibliotheca.py
+++ b/tests/manager/api/test_bibliotheca.py
@@ -339,7 +339,7 @@ class TestBibliothecaAPI:
         # Create a LicensePool that needs updating.
         edition, pool = db.edition(
             identifier_type=Identifier.THREEM_ID,
-            data_source_name=DataSource.THREEM,
+            data_source_name=DataSource.BIBLIOTHECA,
             with_license_pool=True,
             collection=bibliotheca_fixture.collection,
         )

--- a/tests/manager/sqlalchemy/model/test_datasource.py
+++ b/tests/manager/sqlalchemy/model/test_datasource.py
@@ -72,7 +72,7 @@ class TestDataSource:
     def test_license_source_for_string(self, db: DatabaseTransactionFixture):
         session = db.session
         source = DataSource.license_source_for(session, Identifier.THREEM_ID)
-        assert DataSource.THREEM == source.name
+        assert DataSource.BIBLIOTHECA == source.name
 
     def test_license_source_fails_if_identifier_type_does_not_provide_licenses(
         self, db

--- a/tests/manager/sqlalchemy/model/test_datasource.py
+++ b/tests/manager/sqlalchemy/model/test_datasource.py
@@ -71,7 +71,7 @@ class TestDataSource:
 
     def test_license_source_for_string(self, db: DatabaseTransactionFixture):
         session = db.session
-        source = DataSource.license_source_for(session, Identifier.THREEM_ID)
+        source = DataSource.license_source_for(session, Identifier.BIBLIOTHECA_ID)
         assert DataSource.BIBLIOTHECA == source.name
 
     def test_license_source_fails_if_identifier_type_does_not_provide_licenses(

--- a/tests/manager/sqlalchemy/model/test_edition.py
+++ b/tests/manager/sqlalchemy/model/test_edition.py
@@ -477,7 +477,7 @@ class TestEdition:
         # there are no descriptions from that data source, a
         # head-to-head evaluation is performed, and OCLC Linked Data
         # wins.
-        threem = DataSource.lookup(db.session, DataSource.THREEM, autocreate=True)
+        threem = DataSource.lookup(db.session, DataSource.BIBLIOTHECA, autocreate=True)
         champ3, resources3 = Identifier.evaluate_summary_quality(
             db.session, ids, [threem]
         )

--- a/tests/manager/sqlalchemy/model/test_work.py
+++ b/tests/manager/sqlalchemy/model/test_work.py
@@ -894,7 +894,7 @@ class TestWork:
             if c.role == Contributor.Role.AUTHOR
         ]
 
-        data_source = DataSource.lookup(db.session, DataSource.THREEM)
+        data_source = DataSource.lookup(db.session, DataSource.BIBLIOTHECA)
 
         # This identifier is strongly equivalent to the edition's.
         identifier1 = db.identifier(identifier_type=Identifier.ISBN)

--- a/tests/mocks/circulation.py
+++ b/tests/mocks/circulation.py
@@ -181,7 +181,7 @@ class MockCirculationAPI(CirculationAPI):
             can_revoke_hold_when_reserved = True
             if source == DataSource.AXIS_360:
                 set_delivery_mechanism_at = BaseCirculationAPI.BORROW_STEP
-            if source == DataSource.THREEM:
+            if source == DataSource.BIBLIOTHECA:
                 can_revoke_hold_when_reserved = False
             remote = MockBaseCirculationAPI(
                 self._db,


### PR DESCRIPTION
## Description

`DataSource.THREEM` is an old deprecated constant, that is equivalent to `DataSource.BIBLIOTHECA`. Switch to using `DataSource.BIBLIOTHECA` everywhere and remove `DataSource.THREEM`.

## Motivation and Context

I did this as part of the work for PP-1911, but it isn't exactly related to that, so I broke it out to its own PR.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
