### PR TITLE
Fix issue with docker/ci/test_webapp.sh intermittantly failing

### DIFF
--- a/docker/ci/check_service_status.sh
+++ b/docker/ci/check_service_status.sh
@@ -16,6 +16,14 @@ function check_service_status()
   # The location of the runit service should be passed.
   service="$2"
 
+  # Wait up to 15 seconds for the service file to exist
+  timeout --foreground 15s docker compose exec "$container" bash -c "until test -e $service; do sleep 1; done"
+  file_status=$?
+  if [[ "$file_status" != 0 ]]; then
+    echo "  FAIL: $service file does not exist after waiting"
+    exit 1
+  fi
+
   # Check the status of the service.
   service_status=$(docker compose exec "$container" /bin/bash -c "sv check $service")
 


### PR DESCRIPTION
## Description

Recently in CI I've been seeing a lot of failures due to `docker/ci/test_webapp.sh`. It looks like this is because the tests are running before the container has fully started. Add a test to make sure the file exists before running the test. This will timeout after 15s, so if something is stopping the container from starting fully it shouldn't freeze.

## Motivation and Context

Try to reduce test failures.

Here is an example of a failure I hope this will prevent: https://github.com/ThePalaceProject/circulation/actions/runs/15880645569/job/44779939474

## How Has This Been Tested?

- Running locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
