### PR TITLE
Make sure classifier lookup isn't dependent on import order (PP-2682)

### DIFF
--- a/src/palace/manager/core/classifier/age.py
+++ b/src/palace/manager/core/classifier/age.py
@@ -317,10 +317,3 @@ class FreeformAudienceClassifier(AgeOrGradeClassifier):
 
         # Default to assuming it's an unmarked age.
         return AgeClassifier.target_age(identifier, name, False)
-
-
-Classifier.classifiers[Classifier.AGE_RANGE] = AgeClassifier
-Classifier.classifiers[Classifier.GRADE_LEVEL] = GradeLevelClassifier
-Classifier.classifiers[Classifier.INTEREST_LEVEL] = InterestLevelClassifier
-Classifier.classifiers[Classifier.FREEFORM_AUDIENCE] = FreeformAudienceClassifier
-Classifier.classifiers[Classifier.AXIS_360_AUDIENCE] = AgeOrGradeClassifier

--- a/src/palace/manager/core/classifier/bic.py
+++ b/src/palace/manager/core/classifier/bic.py
@@ -139,6 +139,3 @@ class BICClassifier(Classifier):
                 if identifier.startswith(v.lower()):
                     return l
         return None
-
-
-Classifier.classifiers[Classifier.BIC] = BICClassifier

--- a/src/palace/manager/core/classifier/bisac.py
+++ b/src/palace/manager/core/classifier/bisac.py
@@ -756,6 +756,3 @@ class BISACClassifier(Classifier):
         else:
             parts = [name]
         return parts
-
-
-Classifier.classifiers[Classifier.BISAC] = BISACClassifier

--- a/src/palace/manager/core/classifier/ddc.py
+++ b/src/palace/manager/core/classifier/ddc.py
@@ -198,6 +198,3 @@ class DeweyDecimalClassifier(Classifier):
             ):
                 return genre
         return None
-
-
-Classifier.classifiers[Classifier.DDC] = DeweyDecimalClassifier

--- a/src/palace/manager/core/classifier/gutenberg.py
+++ b/src/palace/manager/core/classifier/gutenberg.py
@@ -261,6 +261,3 @@ class GutenbergBookshelfClassifier(Classifier):
             if identifier == v or (isinstance(v, list) and identifier in v):
                 return l
         return None
-
-
-Classifier.classifiers[Classifier.GUTENBERG_BOOKSHELF] = GutenbergBookshelfClassifier

--- a/src/palace/manager/core/classifier/keyword.py
+++ b/src/palace/manager/core/classifier/keyword.py
@@ -2,7 +2,6 @@ import re
 from collections import Counter
 
 from palace.manager.core import classifier
-from palace.manager.core.classifier import Classifier
 from palace.manager.core.classifier.age import AgeOrGradeClassifier
 
 
@@ -1273,8 +1272,3 @@ class FASTClassifier(KeywordBasedClassifier):
 
 class TAGClassifier(KeywordBasedClassifier):
     pass
-
-
-Classifier.classifiers[Classifier.FAST] = FASTClassifier
-Classifier.classifiers[Classifier.LCSH] = LCSHClassifier
-Classifier.classifiers[Classifier.TAG] = TAGClassifier

--- a/src/palace/manager/core/classifier/lcc.py
+++ b/src/palace/manager/core/classifier/lcc.py
@@ -158,6 +158,3 @@ class LCCClassifier(classifier.Classifier):
         # Everything else is _supposedly_ for adults, but we don't
         # trust that assumption.
         return None
-
-
-classifier.Classifier.classifiers[classifier.Classifier.LCC] = LCCClassifier

--- a/src/palace/manager/core/classifier/overdrive.py
+++ b/src/palace/manager/core/classifier/overdrive.py
@@ -233,6 +233,3 @@ class OverdriveClassifier(classifier.Classifier):
         if identifier == "Gay/Lesbian" and fiction:
             return classifier.LGBTQ_Fiction
         return None
-
-
-classifier.Classifier.classifiers[classifier.Classifier.OVERDRIVE] = OverdriveClassifier

--- a/src/palace/manager/core/classifier/simplified.py
+++ b/src/palace/manager/core/classifier/simplified.py
@@ -65,9 +65,3 @@ class SimplifiedFictionClassifier(Classifier):
             return False
         else:
             return None
-
-
-Classifier.classifiers[Classifier.SIMPLIFIED_GENRE] = SimplifiedGenreClassifier
-Classifier.classifiers[Classifier.SIMPLIFIED_FICTION_STATUS] = (
-    SimplifiedFictionClassifier
-)

--- a/src/palace/manager/sqlalchemy/model/classification.py
+++ b/src/palace/manager/sqlalchemy/model/classification.py
@@ -20,7 +20,12 @@ from sqlalchemy.orm import Mapped, relationship
 from sqlalchemy.orm.session import Session
 
 from palace.manager.core import classifier
-from palace.manager.core.classifier import Classifier, Erotica, GenreData
+from palace.manager.core.classifier import (
+    Classifier,
+    Erotica,
+    GenreData,
+    lookup_classifier,
+)
 from palace.manager.sqlalchemy.constants import DataSourceConstants
 from palace.manager.sqlalchemy.hassessioncache import HasSessionCache
 from palace.manager.sqlalchemy.model.base import Base
@@ -272,7 +277,7 @@ class Subject(Base):
 
     def assign_to_genre(self) -> None:
         """Assign this subject to a genre."""
-        classifier = Classifier.classifiers.get(self.type, None)
+        classifier = lookup_classifier(self.type)
         if not classifier:
             return
         self.checked = True

--- a/tests/manager/core/classifiers/test_classifier.py
+++ b/tests/manager/core/classifiers/test_classifier.py
@@ -11,6 +11,7 @@ from palace.manager.core.classifier import (
     Lowercased,
     Science,
     Science_Fiction,
+    lookup_classifier,
 )
 from palace.manager.core.classifier.age import (
     AgeClassifier,
@@ -24,6 +25,7 @@ from palace.manager.core.classifier.keyword import (
     LCSHClassifier as LCSH,
 )
 from palace.manager.core.classifier.lcc import LCCClassifier as LCC
+from palace.manager.core.classifier.overdrive import OverdriveClassifier
 from palace.manager.core.classifier.simplified import SimplifiedGenreClassifier
 from palace.manager.core.classifier.work import WorkClassifier
 from palace.manager.sqlalchemy.model.classification import Genre, Subject
@@ -163,15 +165,16 @@ class TestClassifier:
 
 
 class TestClassifierLookup:
-    def test_lookup(self):
-        assert DDC == Classifier.lookup(Classifier.DDC)
-        assert LCC == Classifier.lookup(Classifier.LCC)
-        assert LCSH == Classifier.lookup(Classifier.LCSH)
-        assert FAST == Classifier.lookup(Classifier.FAST)
-        assert GradeLevelClassifier == Classifier.lookup(Classifier.GRADE_LEVEL)
-        assert AgeClassifier == Classifier.lookup(Classifier.AGE_RANGE)
-        assert InterestLevelClassifier == Classifier.lookup(Classifier.INTEREST_LEVEL)
-        assert None == Classifier.lookup("no-such-key")
+    def test_lookup_classifier(self) -> None:
+        assert lookup_classifier(Classifier.DDC) == DDC
+        assert lookup_classifier(Classifier.LCC) == LCC
+        assert lookup_classifier(Classifier.LCSH) == LCSH
+        assert lookup_classifier(Classifier.FAST) == FAST
+        assert lookup_classifier(Classifier.GRADE_LEVEL) == GradeLevelClassifier
+        assert lookup_classifier(Classifier.AGE_RANGE) == AgeClassifier
+        assert lookup_classifier(Classifier.INTEREST_LEVEL) == InterestLevelClassifier
+        assert lookup_classifier(Classifier.OVERDRIVE) == OverdriveClassifier
+        assert lookup_classifier("no-such-key") is None
 
 
 class TestNestedSubgenres:

--- a/tests/manager/core/classifiers/test_overdrive.py
+++ b/tests/manager/core/classifiers/test_overdrive.py
@@ -1,10 +1,10 @@
-from palace.manager.core.classifier import Classifier
+from palace.manager.core.classifier import Classifier, lookup_classifier
 from palace.manager.core.classifier.overdrive import OverdriveClassifier as Overdrive
 
 
 class TestOverdriveClassifier:
     def test_lookup(self):
-        assert Overdrive == Classifier.lookup(Classifier.OVERDRIVE)
+        assert Overdrive == lookup_classifier(Classifier.OVERDRIVE)
 
     def test_scrub_identifier(self):
         scrub = Overdrive.scrub_identifier

--- a/tests/manager/core/test_opds_import.py
+++ b/tests/manager/core/test_opds_import.py
@@ -24,6 +24,7 @@ from palace.manager.api.saml.metadata.model import (
     SAMLNameIDFormat,
     SAMLSubject,
 )
+from palace.manager.core.classifier import Classifier
 from palace.manager.core.coverage import CoverageFailure
 from palace.manager.core.opds_import import (
     OPDSAPI,
@@ -887,10 +888,6 @@ class TestOPDSImporter:
         assert "7" == seven.subject.identifier
         assert 100 == seven.weight
         assert Subject.AGE_RANGE == seven.subject.type
-        from palace.manager.core.classifier import Classifier
-
-        classifier = Classifier.classifiers[seven.subject.type]
-        classifier.classify(seven.subject)
 
         def sort_key(x: LicensePool) -> str:
             assert x.presentation_edition.title is not None


### PR DESCRIPTION
## Description

This PR creates a new function `lookup_classifier` that makes sure all the classifiers are imported and registered when it is called. Previously which classifiers were registered depended on import order, which meant that changing imports could cause different subjects to be classified.

## Motivation and Context

Looking into PP-2682 (and more directly SUP-366) I found that at some point, our import order changed, and the `OverdriveClassifier` was not getting added to the list of available classifiers. 

This means that we were ignoring the most relevant Overdrive metadata, which was causing bad classifications for Overdrive books.

## How Has This Been Tested?

- Running unit tests in CI
- Tested locally with some of the titles mentioned in SUP-366 and verified that:
  - Before this change we were getting bad classifications
  - After this change we are getting much better classifications

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
