### PR TITLE
Include download link in Boundless DRM fulfillment (PP-2702)

### DIFF
--- a/src/palace/manager/api/boundless/models/response.py
+++ b/src/palace/manager/api/boundless/models/response.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+from palace.manager.opds.types.link import BaseLink
+
+
+class KdrmFulfillmentResponse(BaseModel):
+    """
+    Response returned from the CM when doing a Baker & Taylor KDRM fulfillment.
+
+    This response encapsulates the license document in the `license_document` field,
+    which we get directly from the Boundless API.
+
+    It also includes a links field, formatted like an OPDS link list, which contains
+    the links to the actual content files that can be downloaded.
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        validate_by_name=True,
+    )
+
+    license_document: dict[str, Any]
+    links: list[BaseLink]

--- a/src/palace/manager/api/boundless/requests.py
+++ b/src/palace/manager/api/boundless/requests.py
@@ -269,7 +269,7 @@ class BoundlessRequests(LoggerMixin):
         isbn: str,
         modulus: str,
         exponent: str,
-    ) -> bytes:
+    ) -> dict[str, Any]:
         """
         Make a request to the license server to fetch a license document.
 
@@ -312,4 +312,13 @@ class BoundlessRequests(LoggerMixin):
 
             raise
 
-        return response.content
+        return response.json()  # type: ignore[no-any-return]
+
+    def encrypted_content_url(
+        self,
+        isbn: str,
+    ) -> str:
+        """
+        Get the URL to download the encrypted content for a given ISBN.
+        """
+        return self._license_server_url + f"content/download/{isbn}"

--- a/tests/manager/api/boundless/test_api.py
+++ b/tests/manager/api/boundless/test_api.py
@@ -529,7 +529,16 @@ class TestBoundlessApi:
 
         assert isinstance(fulfillment, DirectFulfillment)
         assert fulfillment.content_type == DeliveryMechanism.BAKER_TAYLOR_KDRM_DRM
-        assert fulfillment.content == license_data
+        assert json.loads(fulfillment.content) == {
+            "licenseDocument": json.loads(license_data),
+            "links": [
+                {
+                    "href": "https://frontdoor.axisnow.com/content/download/9780547351551",
+                    "rel": "publication",
+                    "type": "application/epub+zip",
+                }
+            ],
+        }
 
     def test_fulfill_findaway(self, boundless: BoundlessFixture):
         # Test our ability to fulfill a Boundless audio title.

--- a/tests/manager/api/boundless/test_requests.py
+++ b/tests/manager/api/boundless/test_requests.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Generator
 from functools import partial
 from unittest.mock import MagicMock
@@ -438,7 +439,7 @@ class TestBoundlessRequests:
         boundless_requests.client.queue_response(200, content=data)
         response = license_request()
 
-        assert response == data
+        assert response == json.loads(data)
         assert boundless_requests.client.requests_methods[0] == "GET"
         assert (
             "license/book_vault_uuid/device_id/client_id/isbn/modulus/exponent"


### PR DESCRIPTION
## Description

Include a link to the encrypted epub along with the boundless license document when doing a boundless DRM fulfillment.

The new document looks like this:
```json
{
  "licenseDocument": {},
  "links": [
    {
      "rel": "publication",
      "type": "application/epub+zip",
      "href": "http://blahblah"
    }
  ]
}
```

## Motivation and Context

Currently the apps don't have a way to get from the fulfillment document to the encrypted epub, since the license document does not provide a link. So we encapsulate the document, to provide the apps with all the information they need to complete the fulfillment.

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
