### PR TITLE
M pp 2705 remove coverage from calculate presentation

### DIFF
--- a/src/palace/manager/sqlalchemy/model/coverage.py
+++ b/src/palace/manager/sqlalchemy/model/coverage.py
@@ -320,7 +320,6 @@ class CoverageRecord(Base, BaseCoverageRecord):
 
     __tablename__ = "coveragerecords"
 
-    CHOOSE_COVER_OPERATION = "choose-cover"
     REAP_OPERATION = "reap"
     IMPORT_OPERATION = "import"
     RESOLVE_IDENTIFIER_OPERATION = "resolve-identifier"

--- a/src/palace/manager/sqlalchemy/model/coverage.py
+++ b/src/palace/manager/sqlalchemy/model/coverage.py
@@ -320,7 +320,6 @@ class CoverageRecord(Base, BaseCoverageRecord):
 
     __tablename__ = "coveragerecords"
 
-    SET_EDITION_METADATA_OPERATION = "set-edition-metadata"
     CHOOSE_COVER_OPERATION = "choose-cover"
     REAP_OPERATION = "reap"
     IMPORT_OPERATION = "import"

--- a/src/palace/manager/sqlalchemy/model/edition.py
+++ b/src/palace/manager/sqlalchemy/model/edition.py
@@ -32,7 +32,6 @@ from palace.manager.sqlalchemy.constants import (
 )
 from palace.manager.sqlalchemy.model.base import Base
 from palace.manager.sqlalchemy.model.contributor import Contribution, Contributor
-from palace.manager.sqlalchemy.model.coverage import CoverageRecord
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import DeliveryMechanism, LicensePool
@@ -367,37 +366,6 @@ class Edition(Base, EditionConstants):
         return _db.query(Edition).filter(
             Edition.primary_identifier_id.in_(identifier_id_subquery)
         )
-
-    @classmethod
-    def missing_coverage_from(
-        cls, _db, edition_data_sources, coverage_data_source, operation=None
-    ):
-        """Find Editions from `edition_data_source` whose primary
-        identifiers have no CoverageRecord from
-        `coverage_data_source`.
-        e.g.::
-        gutenberg = DataSource.lookup(_db, DataSource.GUTENBERG)
-        oclc_classify = DataSource.lookup(_db, DataSource.OCLC)
-        missing_coverage_from(_db, gutenberg, oclc_classify)
-
-        will find Editions that came from Project Gutenberg and
-        have never been used as input to the OCLC Classify web
-        service.
-        """
-        if isinstance(edition_data_sources, DataSource):
-            edition_data_sources = [edition_data_sources]
-        edition_data_source_ids = [x.id for x in edition_data_sources]
-        join_clause = (
-            (Edition.primary_identifier_id == CoverageRecord.identifier_id)
-            & (CoverageRecord.data_source_id == coverage_data_source.id)
-            & (CoverageRecord.operation == operation)
-        )
-
-        q = _db.query(Edition).outerjoin(CoverageRecord, join_clause)
-        if edition_data_source_ids:
-            q = q.filter(Edition.data_source_id.in_(edition_data_source_ids))
-        q2 = q.filter(CoverageRecord.id == None)
-        return q2
 
     @classmethod
     def sort_by_priority(cls, editions, license_source=None):

--- a/src/palace/manager/sqlalchemy/model/edition.py
+++ b/src/palace/manager/sqlalchemy/model/edition.py
@@ -694,11 +694,6 @@ class Edition(Base, EditionConstants):
             self.author, self.sort_author = self.calculate_author()
             self.sort_title = TitleProcessor.sort_title_for(self.title)
             self.calculate_permanent_work_id()
-            CoverageRecord.add_for(
-                self,
-                data_source=self.data_source,
-                operation=CoverageRecord.SET_EDITION_METADATA_OPERATION,
-            )
 
         if policy.choose_cover:
             self.choose_cover(policy=policy)
@@ -846,14 +841,6 @@ class Edition(Base, EditionConstants):
                 # it needs to be removed.
                 if self.cover_thumbnail_url:
                     self.cover_thumbnail_url = None
-
-        # Whether or not we succeeded in setting the cover,
-        # record the fact that we tried.
-        CoverageRecord.add_for(
-            self,
-            data_source=self.data_source,
-            operation=CoverageRecord.CHOOSE_COVER_OPERATION,
-        )
 
 
 Index(

--- a/tests/manager/sqlalchemy/model/test_edition.py
+++ b/tests/manager/sqlalchemy/model/test_edition.py
@@ -6,7 +6,6 @@ from palace.manager.data_layer.policy.presentation import (
 )
 from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.contributor import Contributor
-from palace.manager.sqlalchemy.model.coverage import CoverageRecord
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.sqlalchemy.model.identifier import Identifier
@@ -582,36 +581,6 @@ class TestEdition:
         e.calculate_presentation()
         assert None == e.cover_full_url
         assert "http://mirror/thumb" == e.cover_thumbnail_url
-
-    def test_calculate_presentation_registers_coverage_records(
-        self, db: DatabaseTransactionFixture
-    ):
-        edition = db.edition()
-        identifier = edition.primary_identifier
-
-        # This Identifier has no CoverageRecords.
-        assert [] == identifier.coverage_records
-
-        # But once we calculate the Edition's presentation...
-        edition.calculate_presentation()
-
-        # Two CoverageRecords have been associated with this Identifier.
-        records = identifier.coverage_records
-
-        # One for setting the Edition metadata and one for choosing
-        # the Edition's cover.
-        expect = {
-            CoverageRecord.CHOOSE_COVER_OPERATION,
-        }
-        assert expect == {x.operation for x in records}
-
-        # We know the records are associated with this specific
-        # Edition, not just the Identifier, because each
-        # CoverageRecord's DataSource is set to this Edition's
-        # DataSource.
-        assert [edition.data_source, edition.data_source] == [
-            x.data_source for x in records
-        ]
 
     def test_no_permanent_work_id_for_edition_without_title_or_medium(
         self, db: DatabaseTransactionFixture

--- a/tests/manager/sqlalchemy/model/test_edition.py
+++ b/tests/manager/sqlalchemy/model/test_edition.py
@@ -601,7 +601,6 @@ class TestEdition:
         # One for setting the Edition metadata and one for choosing
         # the Edition's cover.
         expect = {
-            CoverageRecord.SET_EDITION_METADATA_OPERATION,
             CoverageRecord.CHOOSE_COVER_OPERATION,
         }
         assert expect == {x.operation for x in records}


### PR DESCRIPTION
## Description
This PR removes the updates to the CoverageRecord table when an edition's cover or metadata is recalculated.
<!--- Describe your changes -->

## Motivation and Context
Since we are using celery now to recalculate presentation information, we no longer need to support Edition related coverage records.  
https://ebce-lyrasis.atlassian.net/browse/PP-2705
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
