### PR TITLE
Add IntegrationRegistry.configurations_query (PP-2470)

### DIFF
--- a/src/palace/manager/api/controller/marc.py
+++ b/src/palace/manager/api/controller/marc.py
@@ -62,7 +62,7 @@ class MARCRecordController:
         return get_request_library()
 
     def has_integration(self, session: Session, library: Library) -> bool:
-        base_query = self.registry.select_integrations(MarcExporter)
+        base_query = self.registry.configurations_query(MarcExporter)
 
         integration_query = (
             select(IntegrationLibraryConfiguration)

--- a/src/palace/manager/celery/tasks/boundless.py
+++ b/src/palace/manager/celery/tasks/boundless.py
@@ -381,13 +381,13 @@ def get_collections_by_protocol(
     protocol_class: type[BaseCirculationAPI[SettingsType, LibrarySettingsType]],
 ) -> list[Collection]:
     registry = task.services.integration_registry.license_providers()
-    protocols = registry.get_protocols(protocol_class, default=False)
-    collections = [
-        collection
-        for collection in Collection.by_protocol(session, protocols)
-        if collection.id is not None
-    ]
-    return collections
+    return (
+        session.execute(
+            Collection.select_by_protocol(protocol_class, registry=registry)
+        )
+        .scalars()
+        .all()
+    )
 
 
 @shared_task(queue=QueueNames.default, bind=True)

--- a/src/palace/manager/marc/exporter.py
+++ b/src/palace/manager/marc/exporter.py
@@ -124,7 +124,7 @@ class MarcExporter(
             name="library_integration_library_configuration",
         )
 
-        library_integration_configuration_query = registry.select_integrations(cls)
+        library_integration_configuration_query = registry.configurations_query(cls)
 
         collection_query = (
             select(Collection, library_integration_library_configuration)

--- a/src/palace/manager/service/integration_registry/base.py
+++ b/src/palace/manager/service/integration_registry/base.py
@@ -5,8 +5,12 @@ from collections.abc import Iterable, Iterator
 from itertools import chain
 from typing import Generic, Literal, TypeVar, cast, overload
 
+from sqlalchemy import select
+from sqlalchemy.sql import Select
+
 from palace.manager.core.exceptions import BasePalaceException
 from palace.manager.integration.goals import Goals
+from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
 
 T = TypeVar("T", covariant=True)
 V = TypeVar("V")
@@ -58,7 +62,7 @@ class IntegrationRegistry(Generic[T]):
                     f"Integration {protocol} already registered"
                 )
             self._lookup[protocol] = integration
-            self._reverse_lookup[integration].append(protocol)
+        self._reverse_lookup[integration] = list(names.keys())
 
         return integration
 
@@ -150,6 +154,30 @@ class IntegrationRegistry(Generic[T]):
             return False
 
         return self[protocol1] is self[protocol2]
+
+    def select_integrations(self, protocol_or_integration: str | type[T]) -> Select:
+        if isinstance(protocol_or_integration, str):
+            integration = self[protocol_or_integration]
+        else:
+            integration = protocol_or_integration
+        protocols = self.get_protocols(integration, default=False)
+        integration_query = select(IntegrationConfiguration).where(
+            IntegrationConfiguration.goal == self.goal,
+        )
+        # This should never happen, because get_protocols raises an exception
+        # if the integration is not found, but we check so that we fail fast
+        # if for some reason this doesn't hold true.
+        assert len(protocols) > 0
+
+        if len(protocols) == 1:
+            integration_query = integration_query.where(
+                IntegrationConfiguration.protocol == protocols[0]
+            )
+        else:
+            integration_query = integration_query.where(
+                IntegrationConfiguration.protocol.in_(protocols)
+            )
+        return integration_query
 
     def __iter__(self) -> Iterator[tuple[str, type[T]]]:
         for integration, names in self._reverse_lookup.items():

--- a/src/palace/manager/sqlalchemy/model/collection.py
+++ b/src/palace/manager/sqlalchemy/model/collection.py
@@ -49,7 +49,7 @@ from palace.manager.sqlalchemy.model.work import Work
 from palace.manager.sqlalchemy.util import create
 
 if TYPE_CHECKING:
-    from palace.manager.api.circulation import CirculationApiType
+    from palace.manager.api.circulation.base import CirculationApiType
     from palace.manager.search.external_search import ExternalSearchIndex
     from palace.manager.sqlalchemy.model.credential import Credential
     from palace.manager.sqlalchemy.model.customlist import CustomList

--- a/src/palace/manager/sqlalchemy/model/collection.py
+++ b/src/palace/manager/sqlalchemy/model/collection.py
@@ -306,7 +306,7 @@ class Collection(Base, HasSessionCache, RedisKeyMixin):
         :param protocol: Protocol to use. Either the protocol name as a string, or
           the protocol class itself (e.g. OverdriveAPI).
         """
-        integration_query = registry.select_integrations(protocol)
+        integration_query = registry.configurations_query(protocol)
         return (
             select(Collection)
             .join(integration_query.subquery())

--- a/tests/manager/service/integration_registry/test_base.py
+++ b/tests/manager/service/integration_registry/test_base.py
@@ -253,16 +253,18 @@ def test_registry_select_integrations(registry: IntegrationRegistry):
     assert protocol_clause.operator == eq
     assert protocol_clause.right.value == "object"
 
-    # If the protocol has aliases, it will include those in the query
+    # If the protocol has aliases, it will include those in the query. You can pass either
+    # the type or the name of the protocol (or its aliases) to select_integrations.
     registry.register(object, aliases=["test", "test2"])
-    selected = registry.select_integrations(object)
-    assert len(selected.froms) == 1
-    assert selected.froms[0] == IntegrationConfiguration.__table__
-    assert len(selected.whereclause.clauses) == 2
-    goal_clause, protocol_clause = selected.whereclause.clauses
-    assert goal_clause.left.name == "goal"
-    assert goal_clause.operator == eq
-    assert goal_clause.right.value == Goals.PATRON_AUTH_GOAL
-    assert protocol_clause.left.name == "protocol"
-    assert protocol_clause.operator == in_op
-    assert protocol_clause.right.value == ["object", "test", "test2"]
+    for protocol in [object, "test"]:
+        selected = registry.select_integrations(protocol)
+        assert len(selected.froms) == 1
+        assert selected.froms[0] == IntegrationConfiguration.__table__
+        assert len(selected.whereclause.clauses) == 2
+        goal_clause, protocol_clause = selected.whereclause.clauses
+        assert goal_clause.left.name == "goal"
+        assert goal_clause.operator == eq
+        assert goal_clause.right.value == Goals.PATRON_AUTH_GOAL
+        assert protocol_clause.left.name == "protocol"
+        assert protocol_clause.operator == in_op
+        assert protocol_clause.right.value == ["object", "test", "test2"]

--- a/tests/manager/service/integration_registry/test_base.py
+++ b/tests/manager/service/integration_registry/test_base.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy.sql.operators import eq, in_op
 
 from palace.manager.integration.goals import Goals
 from palace.manager.service.integration_registry.base import (
@@ -8,6 +9,7 @@ from palace.manager.service.integration_registry.base import (
     LookupException,
     RegistrationException,
 )
+from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
 
 
 @pytest.fixture
@@ -232,3 +234,35 @@ def test_registry_add_errors():
 
     with pytest.raises(TypeError):
         registry + object
+
+
+def test_registry_select_integrations(registry: IntegrationRegistry):
+    registry = IntegrationRegistry(Goals.PATRON_AUTH_GOAL)
+    registry.register(object)
+
+    # Produces a select query, that looks for the integration by goal and protocol
+    selected = registry.select_integrations(object)
+    assert len(selected.froms) == 1
+    assert selected.froms[0] == IntegrationConfiguration.__table__
+    assert len(selected.whereclause.clauses) == 2
+    goal_clause, protocol_clause = selected.whereclause.clauses
+    assert goal_clause.left.name == "goal"
+    assert goal_clause.operator == eq
+    assert goal_clause.right.value == Goals.PATRON_AUTH_GOAL
+    assert protocol_clause.left.name == "protocol"
+    assert protocol_clause.operator == eq
+    assert protocol_clause.right.value == "object"
+
+    # If the protocol has aliases, it will include those in the query
+    registry.register(object, aliases=["test", "test2"])
+    selected = registry.select_integrations(object)
+    assert len(selected.froms) == 1
+    assert selected.froms[0] == IntegrationConfiguration.__table__
+    assert len(selected.whereclause.clauses) == 2
+    goal_clause, protocol_clause = selected.whereclause.clauses
+    assert goal_clause.left.name == "goal"
+    assert goal_clause.operator == eq
+    assert goal_clause.right.value == Goals.PATRON_AUTH_GOAL
+    assert protocol_clause.left.name == "protocol"
+    assert protocol_clause.operator == in_op
+    assert protocol_clause.right.value == ["object", "test", "test2"]

--- a/tests/manager/service/integration_registry/test_base.py
+++ b/tests/manager/service/integration_registry/test_base.py
@@ -236,7 +236,7 @@ def test_registry_add_errors():
         registry + object
 
 
-def test_registry_select_integrations() -> None:
+def test_registry_configurations_query() -> None:
     class MockIntegration: ...
 
     registry: IntegrationRegistry[MockIntegration] = IntegrationRegistry(
@@ -245,7 +245,7 @@ def test_registry_select_integrations() -> None:
     registry.register(MockIntegration)
 
     # Produces a select query, that looks for the integration by goal and protocol
-    selected = registry.select_integrations(MockIntegration)
+    selected = registry.configurations_query(MockIntegration)
     assert len(selected.froms) == 1
     assert selected.froms[0] == IntegrationConfiguration.__table__
     assert len(selected.whereclause.clauses) == 2
@@ -261,7 +261,7 @@ def test_registry_select_integrations() -> None:
     # the type or the name of the protocol (or its aliases) to select_integrations.
     registry.register(MockIntegration, aliases=["test", "test2"])
     for protocol in (MockIntegration, "test"):
-        selected = registry.select_integrations(protocol)
+        selected = registry.configurations_query(protocol)
         assert len(selected.froms) == 1
         assert selected.froms[0] == IntegrationConfiguration.__table__
         assert len(selected.whereclause.clauses) == 2


### PR DESCRIPTION
## Description

Add two new functions:
- `IntegrationRegistry.configurations_query`
  - This gives a sqlalchemy select statement to find all the `IntegrationConfiguration` for a particular protocol in the registry.
- `Collection.select_by_protocol`
  - Leverages `IntegrationRegistry.configurations_query` to provide a select statement targeted at collections with a particular protocol.

And refactored some older code to use these new functions. Note: Not all code has been updated, only code that was already doing the same thing. Eventually it would be good to move all code using `Collection.by_protocol` to `Collection.select_by_protocol`, but for now I just added a comment saying that `select_by_protocol` should be used for new code.

## Motivation and Context

In PP-2470 I need to query collections by protocol. We already do this in the opds_odl celery task, and the boundless celery task, so I decided to pull this out to a function, so its not being duplicated.

## How Has This Been Tested?

- New unit tests
- Running existing tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
