### PR TITLE
Increase autoscale limit on default queue worker to 8 from 4

### DIFF
--- a/docker/runit-scripts/worker-default/run
+++ b/docker/runit-scripts/worker-default/run
@@ -10,4 +10,4 @@ mkdir -p /var/log/celery
 chown 1000:adm /var/log/celery
 
 # Start the celery worker
-exec env/bin/celery -A "palace.manager.celery.app" worker --uid 1000 --gid 1000 --autoscale 4,1 --hostname default@%h -Q high,default --logfile /var/log/celery/default.log
+exec env/bin/celery -A "palace.manager.celery.app" worker --uid 1000 --gid 1000 --autoscale 8,1 --hostname default@%h -Q high,default --logfile /var/log/celery/default.log


### PR DESCRIPTION
## Description
Increases the autoscale limit on the default queue to 8 from 4, which should enable the celery workers to stay on top of the queue.

## Motivation and Context
Some CMs with large numbers of parallel tasks - such as Georgia  due to an inordinate number of collections (where there are 40 odd Boundless Collections) - are unable to keep their default queues from growing due to insufficient parallelization.  

## How Has This Been Tested?
I tested this change on Georgia and verified that it will keep the queue size under control without over taxing the CPU.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
