### PR TITLE
Add type hints to bibliotheca integration (PP-2720)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ module = [
     "palace.manager.api.admin.form_data",
     "palace.manager.api.admin.model.dashboard_statistics",
     "palace.manager.api.adobe_vendor_id",
+    "palace.manager.api.bibliotheca",
     "palace.manager.api.boundless.*",
     "palace.manager.api.circulation.*",
     "palace.manager.api.controller.circulation_manager",

--- a/src/palace/manager/api/boundless/api.py
+++ b/src/palace/manager/api/boundless/api.py
@@ -143,9 +143,6 @@ class BoundlessApi(
             "Asking for circulation events for the last five minutes", _count_events
         )
 
-        if self.collection is None:
-            raise ValueError("Collection is None")
-
         for library_result in self.default_patrons(self.collection):
             if isinstance(library_result, SelfTestResult):
                 yield library_result

--- a/src/palace/manager/api/circulation/base.py
+++ b/src/palace/manager/api/circulation/base.py
@@ -15,6 +15,7 @@ from palace.manager.api.circulation.data import HoldInfo, LoanInfo
 from palace.manager.api.circulation.exceptions import DeliveryMechanismError
 from palace.manager.api.circulation.fulfillment import Fulfillment
 from palace.manager.api.circulation.settings import BaseCirculationApiSettings
+from palace.manager.core.exceptions import PalaceValueError
 from palace.manager.integration.base import HasLibraryIntegrationConfiguration
 from palace.manager.integration.settings import BaseSettings
 from palace.manager.sqlalchemy.model.collection import Collection
@@ -98,8 +99,13 @@ class BaseCirculationAPI(
             )
 
     @property
-    def collection(self) -> Collection | None:
-        return Collection.by_id(self._db, id=self.collection_id)
+    def collection(self) -> Collection:
+        collection = Collection.by_id(self._db, id=self.collection_id)
+        if collection is None:
+            raise PalaceValueError(
+                f"Collection with id {self.collection_id} not found for {self.__class__.__name__}"
+            )
+        return collection
 
     def default_notification_email_address(
         self, patron: Patron, pin: str | None

--- a/src/palace/manager/api/enki.py
+++ b/src/palace/manager/api/enki.py
@@ -194,9 +194,6 @@ class EnkiAPI(
             count_title_changes,
         )
 
-        if self.collection is None:
-            raise ValueError("Collection is None")
-
         for result in self.default_patrons(self.collection):
             if isinstance(result, SelfTestResult):
                 yield result

--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -47,7 +47,6 @@ from palace.manager.api.odl.settings import (
 )
 from palace.manager.api.opds.exception import OpdsResponseException
 from palace.manager.api.opds.requests import OAuthOpdsRequest, get_opds_requests
-from palace.manager.core.exceptions import PalaceValueError
 from palace.manager.core.lcp.credential import LCPCredentialFactory
 from palace.manager.opds.lcp.license import LicenseDocument
 from palace.manager.opds.lcp.status import LoanStatus
@@ -328,8 +327,6 @@ class OPDS2WithODLApi(
         ) and licensepool.licenses_available < 1:
             raise NoAvailableCopies()
 
-        if self.collection is None:
-            raise PalaceValueError(f"Collection not found: {self.collection_id}")
         default_loan_period = self.collection.default_loan_period(patron.library)
         requested_expiry = utc_now() + datetime.timedelta(days=default_loan_period)
         patron_id = patron.identifier_to_remote_service(licensepool.data_source)

--- a/src/palace/manager/api/opds_for_distributors.py
+++ b/src/palace/manager/api/opds_for_distributors.py
@@ -130,7 +130,7 @@ class OPDSForDistributorsAPI(
     ) -> Response:
         """Wrapper around HTTP.request_with_timeout to be overridden for tests."""
         if url is None:
-            name = self.collection.name if self.collection else "unknown"
+            name = self.collection.name
             raise LibraryAuthorizationFailedException(
                 f"No URL provided to request_with_timeout for collection: {name}/{self.collection_id}."
             )

--- a/src/palace/manager/scripts/input.py
+++ b/src/palace/manager/scripts/input.py
@@ -382,7 +382,7 @@ class CollectionInputScript(Script):
 
 class CollectionArgumentsScript(CollectionInputScript):
     @classmethod
-    def arg_parser(cls):
+    def arg_parser(cls) -> argparse.ArgumentParser:
         parser = argparse.ArgumentParser()
         parser.add_argument(
             "collection_names",

--- a/tests/manager/api/overdrive/test_api.py
+++ b/tests/manager/api/overdrive/test_api.py
@@ -65,11 +65,11 @@ class TestOverdriveAPI:
         api = OverdriveAPI(db.session, overdrive_api_fixture.collection)
         db.session.delete(overdrive_api_fixture.collection)
         patron = db.patron()
-        with pytest.raises(BasePalaceException) as excinfo:
+        with pytest.raises(
+            BasePalaceException,
+            match=r"Collection with id \d* not found for OverdriveAPI",
+        ):
             api.sync_patron_activity(patron, "pin")
-        assert "No collection available for Overdrive patron activity." in str(
-            excinfo.value
-        )
 
     def test_errors_not_retried(
         self,


### PR DESCRIPTION
## Description

Add type hints to the Bibliotheca integration.

Note: As well as adding type hints, this does some light refactoring to make it easier to type hint. I'll add some comments with reasoning for these changes.

## Motivation and Context

- Trying to slowly make sure all our code is type hinted
- Blocks doing some code organization

## How Has This Been Tested?

- Running in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
