### PR TITLE
Remove circulation events API. (PP-2633)

### DIFF
--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -318,15 +318,6 @@ def bulk_circulation_events():
     return response
 
 
-@library_route("/admin/circulation_events")
-@has_library
-@returns_json_or_response_or_problem_detail
-@requires_admin
-def circulation_events():
-    """Returns a JSON representation of the most recent circulation events."""
-    return app.manager.admin_dashboard_controller.circulation_events()
-
-
 @app.route("/admin/stats")
 @returns_json_or_response_or_problem_detail
 @requires_admin

--- a/tests/manager/api/admin/test_routes.py
+++ b/tests/manager/api/admin/test_routes.py
@@ -476,12 +476,6 @@ class TestAdminDashboard:
             url, fixture.controller.bulk_circulation_events, file_response=True
         )
 
-    def test_circulation_events(self, fixture: AdminRouteFixture):
-        url = "/admin/circulation_events"
-        fixture.assert_authenticated_request_calls(
-            url, fixture.controller.circulation_events
-        )
-
 
 class TestAdminLibrarySettings:
     CONTROLLER_NAME = "admin_library_settings_controller"


### PR DESCRIPTION
## Description

Removes the `/admin/circulation_events` API endpoint.

## Motivation and Context

The running list of circulation events was removed in [Palace Manager v30.6.0](https://github.com/ThePalaceProject/circulation/releases/tag/v30.6.0) with the inclusion of [Admin UI v1.30.0](https://github.com/ThePalaceProject/circulation-admin/releases/tag/v1.30.0) and is no longer needed.

[Jira PP-2633]

## How Has This Been Tested?

- Tests pass locally.
- CI tests pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.
