### PR TITLE
Bypass update when reaping boundless collections

### DIFF
--- a/src/palace/manager/api/boundless/api.py
+++ b/src/palace/manager/api/boundless/api.py
@@ -536,6 +536,22 @@ class BoundlessApi(
         for removed_identifier in remainder:
             self._reap(removed_identifier)
 
+    def reap_identifiers_if_no_longer_available(
+        self, identifiers: list[Identifier]
+    ) -> None:
+        """Reap identifiers if no longer available."""
+        remainder = set(identifiers)
+        for bibliographic, availability in self._fetch_remote_availability(identifiers):
+            identifier = bibliographic.circulation.load_primary_identifier(self._db)
+            if identifier in remainder:
+                remainder.remove(identifier)
+
+        # We asked Boundless about n books. It sent us n-k responses. Those
+        # k books are the identifiers in `remainder`. These books have
+        # been removed from the collection without us being notified.
+        for removed_identifier in remainder:
+            self._reap(removed_identifier)
+
     def update_book(
         self,
         bibliographic: BibliographicData,

--- a/src/palace/manager/api/boundless/api.py
+++ b/src/palace/manager/api/boundless/api.py
@@ -542,7 +542,8 @@ class BoundlessApi(
         """Reap identifiers if no longer available."""
         remainder = set(identifiers)
         for bibliographic, availability in self._fetch_remote_availability(identifiers):
-            identifier = bibliographic.circulation.load_primary_identifier(self._db)
+            assert availability
+            identifier = availability.load_primary_identifier(self._db)
             if identifier in remainder:
                 remainder.remove(identifier)
 

--- a/src/palace/manager/celery/tasks/boundless.py
+++ b/src/palace/manager/celery/tasks/boundless.py
@@ -484,12 +484,13 @@ def reap_collection(
 
             _check_api_credentials(task, collection, api.api_requests)
 
-            api.update_licensepools_for_identifiers(identifiers=identifiers)
+            api.reap_identifiers_if_no_longer_available(identifiers=identifiers)
+
         except (IntegrationException, OperationalError) as e:
             _check_if_deadlock(e)
             wait_time = exponential_backoff(task.request.retries)
             task.log.exception(
-                f"An error was encountered while attempting to update license pools for {len(identifiers)} "
+                f"An error was encountered while attempting to reap {len(identifiers)} "
                 f'in collection("{collection_name}") task(id={task.request.id} due to {e}. '
                 f"Retrying in {wait_time} seconds."
             )

--- a/tests/manager/api/boundless/test_api.py
+++ b/tests/manager/api/boundless/test_api.py
@@ -712,6 +712,48 @@ class TestBoundlessApi:
         # The second was reaped.
         mock_reap.assert_called_once_with(no_longer_in_collection)
 
+    def test_reap_identifiers_if_no_longer_available(self, boundless: BoundlessFixture):
+        def _fetch_remote_availability(identifiers):
+            for i, identifier in enumerate(identifiers):
+                # The first identifer in the list is still
+                # available.
+                identifier_data = IdentifierData.from_identifier(identifier)
+                bibliographic = BibliographicData(
+                    data_source_name=DataSource.AXIS_360,
+                    primary_identifier_data=identifier_data,
+                )
+                availability = CirculationData(
+                    data_source_name=DataSource.AXIS_360,
+                    primary_identifier_data=identifier_data,
+                    licenses_owned=7,
+                    licenses_available=6,
+                )
+
+                bibliographic.circulation = availability
+                yield bibliographic, availability
+
+                # The rest are no longer known to Boundless.
+                break
+
+        api = boundless.api
+        api._fetch_remote_availability = MagicMock(
+            side_effect=_fetch_remote_availability
+        )
+        mock_reap = create_autospec(api._reap)
+        api._reap = mock_reap
+        still_in_collection = boundless.db.identifier(
+            identifier_type=Identifier.AXIS_360_ID
+        )
+        no_longer_in_collection = boundless.db.identifier(
+            identifier_type=Identifier.AXIS_360_ID
+        )
+        api.reap_identifiers_if_no_longer_available(
+            [still_in_collection, no_longer_in_collection]
+        )
+
+        # The second was reaped.
+        mock_reap.assert_called_once_with(no_longer_in_collection)
+
     def test_fetch_remote_availability(self, boundless: BoundlessFixture):
         # Test the _fetch_remote_availability method, as
         # used by update_licensepools_for_identifiers.

--- a/tests/manager/api/boundless/test_api.py
+++ b/tests/manager/api/boundless/test_api.py
@@ -719,11 +719,11 @@ class TestBoundlessApi:
                 # available.
                 identifier_data = IdentifierData.from_identifier(identifier)
                 bibliographic = BibliographicData(
-                    data_source_name=DataSource.AXIS_360,
+                    data_source_name=DataSource.BOUNDLESS,
                     primary_identifier_data=identifier_data,
                 )
                 availability = CirculationData(
-                    data_source_name=DataSource.AXIS_360,
+                    data_source_name=DataSource.BOUNDLESS,
                     primary_identifier_data=identifier_data,
                     licenses_owned=7,
                     licenses_available=6,

--- a/tests/manager/celery/tasks/test_boundless.py
+++ b/tests/manager/celery/tasks/test_boundless.py
@@ -400,13 +400,15 @@ def test_reap_collection_with_requeue(
 
         reap_collection.delay(collection_id=collection.id, batch_size=2).wait()
 
-        update_license_pools = mock_api.update_licensepools_for_identifiers
-        assert update_license_pools.call_count == 2
+        reap_identifiers_if_no_longer_available = (
+            mock_api.reap_identifiers_if_no_longer_available
+        )
+        assert reap_identifiers_if_no_longer_available.call_count == 2
 
-        assert update_license_pools.call_args_list[0].kwargs == {
+        assert reap_identifiers_if_no_longer_available.call_args_list[0].kwargs == {
             "identifiers": identifiers[0:2]
         }
-        assert update_license_pools.call_args_list[1].kwargs == {
+        assert reap_identifiers_if_no_longer_available.call_args_list[1].kwargs == {
             "identifiers": identifiers[2:]
         }
         assert f"Re-queuing reap_collection task at offset=2" in caplog.text
@@ -545,7 +547,7 @@ def test_retry_reap_collection(
     )
 
     mock_api = MagicMock()
-    mock_api.update_licensepools_for_identifiers.side_effect = [
+    mock_api.reap_identifiers_if_no_longer_available.side_effect = [
         error,  # first time throw error
         None,  # second call is successful
     ]
@@ -559,8 +561,10 @@ def test_retry_reap_collection(
         else:
             reap_collection.delay(collection_id=collection.id, batch_size=1).wait()
 
-        update_license_pools = mock_api.update_licensepools_for_identifiers
-        assert update_license_pools.call_count == update_count
+        reap_identifiers_if_no_longer_available = (
+            mock_api.reap_identifiers_if_no_longer_available
+        )
+        assert reap_identifiers_if_no_longer_available.call_count == update_count
 
 
 def test_process_item_creates_presentation_ready_work(


### PR DESCRIPTION
## Description
Boundless collections are being reaped on a weekly basis.   Before this PR, the reaping process was actually reaping and update.  So for each collection, we are looping through all identifiers in the database associated with that collection and performing the following logic on each identifier:

     * Get the bibliographic and availability info 
     * if it exists,  update it
     * else remove it

Since very few items are removed  was causing redundant updates to metadata and availability.  So for each identifier were are performing 1 availability update and spawning a presentation calculation update task.  Since the boundless api supports updating bibliographic and availability data since x date (which we are currently running every 15 minutes) the weekly collection wide scan is unnecessary.

For most CMs the redundancy isn't a problem. However for those with multiple overlapping Boundless collections we're seeing two interrelated issues:  1) frequent dead locks which tie up celery threads and can cause 2) default queue build up when there are a sufficient number of Boundless collections (currently it is happening on georgia).

<!--- Describe your changes -->
This update simply adds a new api method that performs the reaping on a set of identifiers without triggering updates when reaping is unnecessary (which is almost always the case).

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests updated.
New tests added.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
