### PR TITLE
Update booleans in configuration forms to use bool values

### DIFF
--- a/src/palace/manager/api/boundless/settings.py
+++ b/src/palace/manager/api/boundless/settings.py
@@ -51,8 +51,8 @@ class BoundlessSettings(BaseCirculationApiSettings, FormatPrioritiesSettings):
             ),
             type=ConfigurationFormItemType.SELECT,
             options={
-                "True": _("True"),
-                "False": _("False"),
+                True: _("True"),
+                False: _("False"),
             },
         ),
     )

--- a/src/palace/manager/api/millenium_patron.py
+++ b/src/palace/manager/api/millenium_patron.py
@@ -46,8 +46,8 @@ class MilleniumPatronSettings(BasicAuthProviderSettings):
             label="Certificate Verification",
             type=ConfigurationFormItemType.SELECT,
             options={
-                "true": "Verify Certificate Normally (Required for production)",
-                "false": "Ignore Certificate Problems (For temporary testing only)",
+                True: "Verify Certificate Normally (Required for production)",
+                False: "Ignore Certificate Problems (For temporary testing only)",
             },
         ),
     )
@@ -109,8 +109,8 @@ class MilleniumPatronSettings(BasicAuthProviderSettings):
             "setting. Otherwise, do not use POST, as it is NOT compatible with other Millenium integrations.",
             type=ConfigurationFormItemType.SELECT,
             options={
-                "true": "True",
-                "false": "False",
+                True: "True",
+                False: "False",
             },
         ),
     )

--- a/src/palace/manager/api/saml/configuration/model.py
+++ b/src/palace/manager/api/saml/configuration/model.py
@@ -152,8 +152,8 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
             ),
             type=ConfigurationFormItemType.SELECT,
             options={
-                "true": "Use SAML NameID",
-                "false": "Do NOT use SAML NameID",
+                True: "Use SAML NameID",
+                False: "Do NOT use SAML NameID",
             },
         ),
     )

--- a/src/palace/manager/api/sip/__init__.py
+++ b/src/palace/manager/api/sip/__init__.py
@@ -90,8 +90,8 @@ class SIP2Settings(BasicAuthProviderSettings):
             label="Connect over SSL?",
             type=ConfigurationFormItemType.SELECT,
             options={
-                "true": "Connect to the SIP2 server over SSL",
-                "false": "Connect to the SIP2 server over an ordinary socket connection",
+                True: "Connect to the SIP2 server over SSL",
+                False: "Connect to the SIP2 server over an ordinary socket connection",
             },
             required=True,
         ),
@@ -102,8 +102,8 @@ class SIP2Settings(BasicAuthProviderSettings):
             label="Perform SSL certificate verification.",
             type=ConfigurationFormItemType.SELECT,
             options={
-                "true": "Perform SSL certificate verification.",
-                "false": "Do not perform SSL certificate verification.",
+                True: "Perform SSL certificate verification.",
+                False: "Do not perform SSL certificate verification.",
             },
             description=(
                 "Strict certificate verification may be optionally turned off for "
@@ -169,8 +169,8 @@ class SIP2Settings(BasicAuthProviderSettings):
             ),
             type=ConfigurationFormItemType.SELECT,
             options={
-                "true": "Block based on patron status field",
-                "false": "No blocks based on patron status field",
+                True: "Block based on patron status field",
+                False: "No blocks based on patron status field",
             },
         ),
     )

--- a/src/palace/manager/api/sirsidynix_authentication_provider.py
+++ b/src/palace/manager/api/sirsidynix_authentication_provider.py
@@ -65,8 +65,8 @@ class SirsiDynixHorizonAuthSettings(BasicAuthProviderSettings):
             ),
             type=ConfigurationFormItemType.SELECT,
             options={
-                "true": "Patron blocks enforced",
-                "false": "Patron blocks NOT enforced.",
+                True: "Patron blocks enforced",
+                False: "Patron blocks NOT enforced.",
             },
         ),
     )

--- a/src/palace/manager/core/opds_import.py
+++ b/src/palace/manager/core/opds_import.py
@@ -126,8 +126,8 @@ class OPDSImporterSettings(
             label=_("Include in inventory report?"),
             type=ConfigurationFormItemType.SELECT,
             options={
-                "true": "(Default) Yes",
-                "false": "No",
+                True: "(Default) Yes",
+                False: "No",
             },
         ),
     )

--- a/src/palace/manager/integration/configuration/library.py
+++ b/src/palace/manager/integration/configuration/library.py
@@ -132,8 +132,8 @@ class LibrarySettings(BaseSettings):
             label="Allow books to be put on hold",
             type=ConfigurationFormItemType.SELECT,
             options={
-                "true": "Allow holds",
-                "false": "Disable holds",
+                True: "Allow holds",
+                False: "Disable holds",
             },
             category="Loans, Holds, & Fines",
             level=Level.SYS_ADMIN_ONLY,

--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -189,7 +189,7 @@ class ConfigurationFormItemType(Enum):
     IMAGE = "image"
 
 
-ConfigurationFormOptionsType = Mapping[Enum | str | None, str | LazyString]
+ConfigurationFormOptionsType = Mapping[Enum | str | bool | None, str | LazyString]
 
 
 @dataclass(frozen=True)

--- a/src/palace/manager/marc/settings.py
+++ b/src/palace/manager/marc/settings.py
@@ -52,7 +52,7 @@ class MarcExporterLibrarySettings(BaseSettings):
         form=ConfigurationFormItem(
             label="Include summaries in MARC records (520 field)",
             type=ConfigurationFormItemType.SELECT,
-            options={"false": "Do not include summaries", "true": "Include summaries"},
+            options={False: "Do not include summaries", True: "Include summaries"},
         ),
     )
 
@@ -62,8 +62,8 @@ class MarcExporterLibrarySettings(BaseSettings):
             label="Include Palace Collection Manager genres in MARC records (650 fields)",
             type=ConfigurationFormItemType.SELECT,
             options={
-                "false": "Do not include Palace Collection Manager genres",
-                "true": "Include Palace Collection Manager genres",
+                False: "Do not include Palace Collection Manager genres",
+                True: "Include Palace Collection Manager genres",
             },
         ),
     )


### PR DESCRIPTION
## Description

Update type hint, and update configuration form booleans to use boolean values in options.

## Motivation and Context

In one of our config forms we were using "True" instead of "true" in `options` which was causing the form not to work. Instead of mixing string and boolean, just update them all use to use boolean values for options to make it clear what we should be using.

## How Has This Been Tested?

- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
