### PR TITLE
Add setting to prioritize Boundless DRM (PP-2744)

### DIFF
--- a/src/palace/manager/api/boundless/api.py
+++ b/src/palace/manager/api/boundless/api.py
@@ -102,6 +102,7 @@ class BoundlessApi(
         self.api_requests = (
             BoundlessRequests(self.settings) if requests is None else requests
         )
+        self._prioritize_boundless_drm = self.settings.prioritize_boundless_drm
 
     @staticmethod
     def _delivery_mechanism_to_internal_format(
@@ -715,3 +716,25 @@ class BoundlessApi(
             identifier_strings.append(value)
 
         return identifier_strings
+
+    def sort_delivery_mechanisms(
+        self, lpdms: list[LicensePoolDeliveryMechanism]
+    ) -> list[LicensePoolDeliveryMechanism]:
+        """
+        Do any custom sorting of delivery mechanisms configured for this API.
+        """
+        if self._prioritize_boundless_drm:
+            # If we prioritize Boundless DRM, we want to put the Boundless DRM
+            # delivery mechanism first in the list.
+            lpdms.sort(
+                key=lambda x: (
+                    1
+                    if (
+                        x.delivery_mechanism.drm_scheme
+                        != DeliveryMechanism.BAKER_TAYLOR_KDRM_DRM
+                    )
+                    else 0
+                )
+            )
+
+        return lpdms

--- a/src/palace/manager/api/boundless/api.py
+++ b/src/palace/manager/api/boundless/api.py
@@ -726,7 +726,8 @@ class BoundlessApi(
         if self._prioritize_boundless_drm:
             # If we prioritize Boundless DRM, we want to put the Boundless DRM
             # delivery mechanism first in the list.
-            lpdms.sort(
+            lpdms = sorted(
+                lpdms,
                 key=lambda x: (
                     1
                     if (
@@ -734,7 +735,7 @@ class BoundlessApi(
                         != DeliveryMechanism.BAKER_TAYLOR_KDRM_DRM
                     )
                     else 0
-                )
+                ),
             )
 
         return lpdms

--- a/src/palace/manager/api/boundless/settings.py
+++ b/src/palace/manager/api/boundless/settings.py
@@ -55,6 +55,18 @@ class BoundlessSettings(BaseCirculationApiSettings):
             },
         ),
     )
+    prioritize_boundless_drm: bool = FormField(
+        default=False,
+        form=ConfigurationFormItem(
+            label=_("Prioritize Boundless DRM"),
+            description=_("Always use Boundless DRM if it is available."),
+            type=ConfigurationFormItemType.SELECT,
+            options={
+                True: _("Yes, prioritize Boundless DRM"),
+                False: _("No, do not prioritize Boundless DRM"),
+            },
+        ),
+    )
 
 
 class BoundlessLibrarySettings(BaseCirculationLoanSettings):

--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -120,15 +120,15 @@ class OPDS2WithODLApi(
         self.loan_limit = self.settings.loan_limit
         self.hold_limit = self.settings.hold_limit
         self._request = get_opds_requests(
-            settings.auth_type,
-            settings.username,
-            settings.password,
-            settings.external_account_id,
+            self.settings.auth_type,
+            self.settings.username,
+            self.settings.password,
+            self.settings.external_account_id,
         )
         self._format_priorities = FormatPriorities(
-            settings.prioritized_drm_schemes,
-            settings.prioritized_content_types,
-            settings.deprioritize_lcp_non_epubs,
+            self.settings.prioritized_drm_schemes,
+            self.settings.prioritized_content_types,
+            self.settings.deprioritize_lcp_non_epubs,
         )
 
     def _get_hasher(self) -> Hasher:

--- a/src/palace/manager/api/opds_for_distributors.py
+++ b/src/palace/manager/api/opds_for_distributors.py
@@ -121,9 +121,9 @@ class OPDSForDistributorsAPI(
         self.feed_url = self.settings.external_account_id
         self.auth_url: str | None = None
         self._format_priorities = FormatPriorities(
-            settings.prioritized_drm_schemes,
-            settings.prioritized_content_types,
-            settings.deprioritize_lcp_non_epubs,
+            self.settings.prioritized_drm_schemes,
+            self.settings.prioritized_content_types,
+            self.settings.deprioritize_lcp_non_epubs,
         )
 
     def _run_self_tests(self, _db: Session) -> Generator[SelfTestResult]:

--- a/tests/manager/api/boundless/test_api.py
+++ b/tests/manager/api/boundless/test_api.py
@@ -999,7 +999,7 @@ class TestBoundlessApi:
     ) -> None:
         def get_mechanisms(
             items: list[LicensePoolDeliveryMechanism],
-        ) -> list[tuple[str, str]]:
+        ) -> list[tuple[str | None, str | None]]:
             return [
                 (dm.delivery_mechanism.content_type, dm.delivery_mechanism.drm_scheme)
                 for dm in items


### PR DESCRIPTION
## Description

Building on the work in: https://github.com/ThePalaceProject/circulation/pull/2606 this PR adds a setting to prioritize boundless DRM.

## Motivation and Context

Once our apps support Boundless DRM we would like to be able to prioritize it in our OPDS output.

## How Has This Been Tested?

- New unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
