### PR TITLE
Sort known delivery mechanisms (PP-2744)

### DIFF
--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -308,7 +308,7 @@ class CirculationManagerAnnotator(Annotator):
         # that is hidden from the OPDS feed.
         delivery_mechanisms = [
             dm
-            for dm in licensepool.available_delivery_mechanisms
+            for dm in licensepool.sorted_available_delivery_mechanisms
             if dm.delivery_mechanism.content_type not in self.hidden_content_types
         ]
 


### PR DESCRIPTION
## Description

Provide a baseline reasonable sorting of Delivery Mechanisms to get returned in our feeds.

## Motivation and Context

Right now the CM returns our delivery mechanisms in the feed in the order that they are returned from the database, which is generally insertion order. This is kind of random, and isn't ideal. It mostly doesn't matter too much, since mostly things only have one or two delivery mechanisms, but we are getting more cases where items have multiple delivery mechanisms, so its nice to provide a reasonable order that can be adjusted over time as we add new DRM methods.

## How Has This Been Tested?

- New unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
