### PR TITLE
Update circulation api to cache settings

### DIFF
--- a/src/palace/manager/api/bibliotheca.py
+++ b/src/palace/manager/api/bibliotheca.py
@@ -189,11 +189,10 @@ class BibliothecaAPI(
         super().__init__(_db, collection)
 
         self._db = _db
-        settings = self.settings
         self.version = self.DEFAULT_VERSION
-        self.account_id = settings.username
-        self.account_key = settings.password
-        self.library_id = settings.external_account_id
+        self.account_id = self.settings.username
+        self.account_key = self.settings.password
+        self.library_id = self.settings.external_account_id
         self.base_url = self.DEFAULT_BASE_URL
 
         if not self.account_id or not self.account_key or not self.library_id:

--- a/src/palace/manager/api/circulation/base.py
+++ b/src/palace/manager/api/circulation/base.py
@@ -4,6 +4,7 @@ import dataclasses
 import datetime
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
+from functools import cached_property
 from typing import TypedDict, TypeVar
 
 from flask_babel import lazy_gettext as _
@@ -128,7 +129,7 @@ class BaseCirculationAPI(
             )
         return config
 
-    @property
+    @cached_property
     def settings(self) -> SettingsType:
         return self.settings_load(self.integration_configuration())
 

--- a/src/palace/manager/api/odl/api.py
+++ b/src/palace/manager/api/odl/api.py
@@ -108,8 +108,7 @@ class OPDS2WithODLApi(
                 % (collection.protocol, self.__class__.__name__)
             )
         self.collection_id = collection.id
-        settings = self.settings
-        self.data_source_name = settings.data_source
+        self.data_source_name = self.settings.data_source
         # Create the data source if it doesn't exist yet.
         DataSource.lookup(_db, self.data_source_name, autocreate=True)
 
@@ -117,8 +116,8 @@ class OPDS2WithODLApi(
         self._credential_factory = LCPCredentialFactory()
         self._hasher_instance: Hasher | None = None
 
-        self.loan_limit = settings.loan_limit
-        self.hold_limit = settings.hold_limit
+        self.loan_limit = self.settings.loan_limit
+        self.hold_limit = self.settings.hold_limit
         self._request = get_opds_requests(
             self.settings.auth_type,
             self.settings.username,
@@ -131,10 +130,9 @@ class OPDS2WithODLApi(
 
         :return: Hasher instance
         """
-        settings = self.settings
         if self._hasher_instance is None:
             self._hasher_instance = self._hasher_factory.create(
-                settings.encryption_algorithm
+                self.settings.encryption_algorithm
             )
 
         return self._hasher_instance

--- a/src/palace/manager/api/opds_for_distributors.py
+++ b/src/palace/manager/api/opds_for_distributors.py
@@ -114,11 +114,10 @@ class OPDSForDistributorsAPI(
     def __init__(self, _db: Session, collection: Collection):
         super().__init__(_db, collection)
 
-        settings = self.settings
-        self.data_source_name = settings.data_source
-        self.username = settings.username
-        self.password = settings.password
-        self.feed_url = settings.external_account_id
+        self.data_source_name = self.settings.data_source
+        self.username = self.settings.username
+        self.password = self.settings.password
+        self.feed_url = self.settings.external_account_id
         self.auth_url: str | None = None
 
     def _run_self_tests(self, _db: Session) -> Generator[SelfTestResult]:


### PR DESCRIPTION
## Description

- Use `@cached_property` for settings on `BaseCirculationAPI`
- Update places where we were reusing settings to try to get around this to just use self.settings

## Motivation and Context

Its a lot of work to load our settings, we have to load them from the database, then run the pydantic validation on them, so it makes sense to cache them instead of doing it every time we access the property.

## How Has This Been Tested?

- Tested locally
- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
