### PR TITLE
Add a setting so we can manually set the timeout on boundless requests (PP-2755)

### DIFF
--- a/src/palace/manager/api/boundless/settings.py
+++ b/src/palace/manager/api/boundless/settings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from flask_babel import lazy_gettext as _
+from pydantic import NonNegativeInt
 
 from palace.manager.api.boundless.constants import ServerNickname
 from palace.manager.api.circulation.settings import (
@@ -65,6 +66,18 @@ class BoundlessSettings(BaseCirculationApiSettings):
                 True: _("Yes, prioritize Boundless DRM"),
                 False: _("No, do not prioritize Boundless DRM"),
             },
+        ),
+    )
+    timeout: NonNegativeInt = FormField(
+        default=15,
+        form=ConfigurationFormItem(
+            label=_("Timeout (seconds)"),
+            description=_(
+                "The number of seconds to wait for a response from Boundless. Set to 0 for no timeout. "
+                "Care should be taken when increasing this value as it can lead to long waits and "
+                "server side performance issues."
+            ),
+            type=ConfigurationFormItemType.NUMBER,
         ),
     )
 


### PR DESCRIPTION
## Description

Add a configuration option to override the default timeout for B&T requests.

## Motivation and Context

While testing Boundless DRM on Minotaur we are seeing timeouts. This seems like its worse in their dev environment, although looking at the logs we are seeing some timeouts in production as well. Hopefully we won't have to leave this config setting in forever, but for now I think its helpful to be able to tune the timeout for B&T via config.

## How Has This Been Tested?

- New unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
