### PR TITLE
Add some basic validation for boundless DRM parameters

### DIFF
--- a/src/palace/manager/api/boundless/api.py
+++ b/src/palace/manager/api/boundless/api.py
@@ -255,6 +255,8 @@ class BoundlessApi(
         )
         return DirectFulfillment(str(fnd_manifest), fnd_manifest.MEDIA_TYPE)
 
+    # See RFC7515 for base64 encoding specification. Its normal base64 with no trailing
+    # = padding, and using URL-safe characters (i.e., '-' instead of '+', and '_' instead of '/').
     _baker_taylor_base64_regex = re.compile(r"^[0-9a-zA-Z_-]+$")
     # RSA 2048 bit modulus is 256 bytes, which is ceil(256 * 4 / 3) = 342 characters when
     # base64 encoded without padding.
@@ -266,6 +268,8 @@ class BoundlessApi(
             ),
         ]
     ).validate_python
+    # The exponent is typically 65537, which is 4 characters when base64 encoded without padding,
+    # but this isn't guaranteed, so we just validate the proper base64 encoding.
     _baker_taylor_kdrm_exponent_validator: Callable[[str], None] = TypeAdapter(
         Annotated[
             str,

--- a/src/palace/manager/api/boundless/api.py
+++ b/src/palace/manager/api/boundless/api.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import datetime
 import html
-from collections.abc import Generator, Sequence
+import re
+from collections.abc import Callable, Generator, Sequence
 from datetime import timedelta
-from typing import cast
+from typing import Annotated, cast
 
 from flask_babel import lazy_gettext as _
+from pydantic import StringConstraints, TypeAdapter, ValidationError
 from sqlalchemy.orm import Session
 from typing_extensions import Unpack
 
@@ -253,6 +255,54 @@ class BoundlessApi(
         )
         return DirectFulfillment(str(fnd_manifest), fnd_manifest.MEDIA_TYPE)
 
+    _baker_taylor_base64_regex = re.compile(r"^[0-9a-zA-Z_-]+$")
+    _baker_taylor_kdrm_modulus_validator = TypeAdapter(
+        Annotated[
+            str,
+            StringConstraints(
+                min_length=342, max_length=342, pattern=_baker_taylor_base64_regex
+            ),
+        ]
+    ).validate_python
+    _baker_taylor_kdrm_exponent_validator = TypeAdapter(
+        Annotated[
+            str,
+            StringConstraints(
+                min_length=4, max_length=4, pattern=_baker_taylor_base64_regex
+            ),
+        ]
+    ).validate_python
+
+    @classmethod
+    def _validate_baker_taylor_kdrm_param(
+        cls, validation_func: Callable[[str], None], param_name: str, param: str
+    ) -> None:
+        """Validate the Baker & Taylor KDRM modulus parameter."""
+        try:
+            validation_func(param)
+        except ValidationError as e:
+            error = e.errors()[0]
+            error_msg = error["msg"]
+            error_type = error["type"]
+
+            # In the case of a pattern mismatch, we can provide a more specific error message.
+            if error_type == "string_pattern_mismatch":
+                error_msg = "String should be a url safe base64 encoded string with no padding, see RFC 7515"
+
+            raise InvalidInputException(
+                "Invalid parameters, unable to fulfill loan",
+                f"Error validating {param_name} '{param}': {error_msg}",
+            )
+
+    @classmethod
+    def _validate_baker_taylor_kdrm_params(cls, modulus: str, exponent: str) -> None:
+        cls._validate_baker_taylor_kdrm_param(
+            cls._baker_taylor_kdrm_modulus_validator, "modulus", modulus
+        )
+        cls._validate_baker_taylor_kdrm_param(
+            cls._baker_taylor_kdrm_exponent_validator, "exponent", exponent
+        )
+
     def _fulfill_baker_taylor_kdrm(
         self,
         title: Title,
@@ -276,6 +326,13 @@ class BoundlessApi(
                 "Missing required URL parameters for fulfillment",
                 debug_message,
             )
+
+        # It appears that Baker & Taylor does basically no validation on the parameters we send
+        # so we do a little validation here, so we can give more friendly error messages.
+        self._validate_baker_taylor_kdrm_params(
+            modulus=params["modulus"],
+            exponent=params["exponent"],
+        )
 
         license_response = self.api_requests.license(
             book_vault_uuid=fulfillment_info.book_vault_uuid,

--- a/src/palace/manager/api/boundless/api.py
+++ b/src/palace/manager/api/boundless/api.py
@@ -256,7 +256,7 @@ class BoundlessApi(
         return DirectFulfillment(str(fnd_manifest), fnd_manifest.MEDIA_TYPE)
 
     _baker_taylor_base64_regex = re.compile(r"^[0-9a-zA-Z_-]+$")
-    _baker_taylor_kdrm_modulus_validator = TypeAdapter(
+    _baker_taylor_kdrm_modulus_validator: Callable[[str], None] = TypeAdapter(
         Annotated[
             str,
             StringConstraints(
@@ -264,7 +264,7 @@ class BoundlessApi(
             ),
         ]
     ).validate_python
-    _baker_taylor_kdrm_exponent_validator = TypeAdapter(
+    _baker_taylor_kdrm_exponent_validator: Callable[[str], None] = TypeAdapter(
         Annotated[
             str,
             StringConstraints(

--- a/src/palace/manager/api/boundless/api.py
+++ b/src/palace/manager/api/boundless/api.py
@@ -256,6 +256,8 @@ class BoundlessApi(
         return DirectFulfillment(str(fnd_manifest), fnd_manifest.MEDIA_TYPE)
 
     _baker_taylor_base64_regex = re.compile(r"^[0-9a-zA-Z_-]+$")
+    # RSA 2048 bit modulus is 256 bytes, which is ceil(256 * 4 / 3) = 342 characters when
+    # base64 encoded without padding.
     _baker_taylor_kdrm_modulus_validator: Callable[[str], None] = TypeAdapter(
         Annotated[
             str,
@@ -267,9 +269,7 @@ class BoundlessApi(
     _baker_taylor_kdrm_exponent_validator: Callable[[str], None] = TypeAdapter(
         Annotated[
             str,
-            StringConstraints(
-                min_length=4, max_length=4, pattern=_baker_taylor_base64_regex
-            ),
+            StringConstraints(pattern=_baker_taylor_base64_regex),
         ]
     ).validate_python
 

--- a/tests/manager/api/boundless/test_api.py
+++ b/tests/manager/api/boundless/test_api.py
@@ -524,8 +524,8 @@ class TestBoundlessApi:
         fulfillment = fulfill(
             client_ip="2.2.2.2",
             device_id="device-id",
-            modulus="modulus",
-            exponent="exponent",
+            modulus="a" * 342,
+            exponent="abcd",
         )
 
         assert isinstance(fulfillment, DirectFulfillment)
@@ -600,6 +600,66 @@ class TestBoundlessApi:
         }
         assert metadata_args["params"] is not None
         assert metadata_args["params"] == {"fndcontentid": "04960"}
+
+    def test___validate_baker_taylor_kdrm_params(self) -> None:
+        correct_modulus = (
+            "vOa694N296HWud_b3CCIvIBOuGqwE_mAPcf2MXqGmC1VIolhDIkMsdX38bUBRT-Ui6Q_KacF4MPrD-"
+            "vywhEmS1qVYDRV-Ee4wYENCFtgk92j9dPW9TIg1SC3g4oLw7dkvkIrWCzX_r42haAss5NnkKC8FJ7d"
+            "14h-f3b-aNPjfowYupZtmmHdq9FEm-g6IjQBYBd569PeC_kXcGBreDspClUQZZMYGW3fYbvg-1vOG0"
+            "Pyu0zExgJ9T6omF9gSbW0fojm2SFHhgOcyK271SwOiHUM2KTc7tZEndzoBiaR8t66N84Th7bZxYLWW"
+            "hvGS3_YeTYo6OdQj_QBc_vFau5exVw"
+        )
+
+        correct_exponent = "ABCD"
+
+        # Test that the validation method works correctly with valid parameters.
+        BoundlessApi._validate_baker_taylor_kdrm_params(
+            correct_modulus, correct_exponent
+        )
+
+        # Test error cases - modulus
+        with pytest.raises(InvalidInputException) as excinfo:
+            BoundlessApi._validate_baker_taylor_kdrm_params("", correct_exponent)
+        assert "modulus" in str(excinfo.value.problem_detail)
+        assert "String should have at least 342 characters" in str(
+            excinfo.value.problem_detail
+        )
+
+        with pytest.raises(InvalidInputException) as excinfo:
+            BoundlessApi._validate_baker_taylor_kdrm_params("a" * 343, correct_exponent)
+        assert "modulus" in str(excinfo.value.problem_detail)
+        assert "String should have at most 342 characters" in str(
+            excinfo.value.problem_detail
+        )
+
+        with pytest.raises(InvalidInputException) as excinfo:
+            BoundlessApi._validate_baker_taylor_kdrm_params("%" * 342, correct_exponent)
+        assert "modulus" in str(excinfo.value.problem_detail)
+        assert "String should be a url safe base64 encoded string" in str(
+            excinfo.value.problem_detail
+        )
+
+        # Test error cases - exponent
+        with pytest.raises(InvalidInputException) as excinfo:
+            BoundlessApi._validate_baker_taylor_kdrm_params(correct_modulus, "a")
+        assert "exponent" in str(excinfo.value.problem_detail)
+        assert "String should have at least 4 characters" in str(
+            excinfo.value.problem_detail
+        )
+
+        with pytest.raises(InvalidInputException) as excinfo:
+            BoundlessApi._validate_baker_taylor_kdrm_params(correct_modulus, "abcde")
+        assert "exponent" in str(excinfo.value.problem_detail)
+        assert "String should have at most 4 characters" in str(
+            excinfo.value.problem_detail
+        )
+
+        with pytest.raises(InvalidInputException) as excinfo:
+            BoundlessApi._validate_baker_taylor_kdrm_params(correct_modulus, "ab*c")
+        assert "exponent" in str(excinfo.value.problem_detail)
+        assert "String should be a url safe base64 encoded string" in str(
+            excinfo.value.problem_detail
+        )
 
     def test_patron_activity(self, boundless: BoundlessFixture):
         """Test the method that locates all current activity

--- a/tests/manager/api/boundless/test_api.py
+++ b/tests/manager/api/boundless/test_api.py
@@ -641,20 +641,6 @@ class TestBoundlessApi:
 
         # Test error cases - exponent
         with pytest.raises(InvalidInputException) as excinfo:
-            BoundlessApi._validate_baker_taylor_kdrm_params(correct_modulus, "a")
-        assert "exponent" in str(excinfo.value.problem_detail)
-        assert "String should have at least 4 characters" in str(
-            excinfo.value.problem_detail
-        )
-
-        with pytest.raises(InvalidInputException) as excinfo:
-            BoundlessApi._validate_baker_taylor_kdrm_params(correct_modulus, "abcde")
-        assert "exponent" in str(excinfo.value.problem_detail)
-        assert "String should have at most 4 characters" in str(
-            excinfo.value.problem_detail
-        )
-
-        with pytest.raises(InvalidInputException) as excinfo:
             BoundlessApi._validate_baker_taylor_kdrm_params(correct_modulus, "ab*c")
         assert "exponent" in str(excinfo.value.problem_detail)
         assert "String should be a url safe base64 encoded string" in str(


### PR DESCRIPTION
## Description

Add some validation for the parameters passed into boundless DRM

## Motivation and Context

See slack here:
https://lyrasis.slack.com/archives/CCY3PH8JD/p1752831605606329

After doing some debugging on parameters today, I thought it might be helpful to do a bit of validation of the parameters before we pass them on to boundless. Should make it easier to troubleshoot issues in the future.

## How Has This Been Tested?

- New unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
