### PR TITLE
Fix size update for large custom lists. (PP-2711)

### DIFF
--- a/src/palace/manager/core/query/customlist.py
+++ b/src/palace/manager/core/query/customlist.py
@@ -4,6 +4,8 @@ import datetime
 import json
 from typing import TYPE_CHECKING
 
+from sqlalchemy import func, select
+
 from palace.manager.api.admin.problem_details import (
     CUSTOMLIST_ENTRY_NOT_VALID_FOR_LIBRARY,
     CUSTOMLIST_SOURCE_COLLECTION_MISSING,
@@ -159,6 +161,8 @@ class CustomListQueries(LoggerMixin):
         # update this lists last updated time
         custom_list.auto_update_last_update = datetime.datetime.now()
         # update the list size
-        custom_list.size = len(custom_list.entries)
+        custom_list.size = _db.execute(
+            select(func.count()).where(CustomListEntry.list_id == custom_list.id)
+        ).scalar_one()
 
         return total_works_updated

--- a/src/palace/manager/core/query/customlist.py
+++ b/src/palace/manager/core/query/customlist.py
@@ -4,8 +4,6 @@ import datetime
 import json
 from typing import TYPE_CHECKING
 
-from sqlalchemy import func, select
-
 from palace.manager.api.admin.problem_details import (
     CUSTOMLIST_ENTRY_NOT_VALID_FOR_LIBRARY,
     CUSTOMLIST_SOURCE_COLLECTION_MISSING,
@@ -160,9 +158,7 @@ class CustomListQueries(LoggerMixin):
 
         # update this lists last updated time
         custom_list.auto_update_last_update = datetime.datetime.now()
-        # update the list size
-        custom_list.size = _db.execute(
-            select(func.count()).where(CustomListEntry.list_id == custom_list.id)
-        ).scalar_one()
+        # Update the cached list size.
+        custom_list.size = custom_list.get_entry_count(_db)
 
         return total_works_updated


### PR DESCRIPTION
## Description

Use a database row count, rather than a Python `len` to calculate the current size of a custom list.

## Motivation and Context

Updates to auto update custom lists were loading the list's entries into memory and counting them. When lists were large enough, the list update script would fail. We didn't need most of those records for anything else, so it's a lot less expensive (and dangerous) to just count them at the database and return the count.

[Jira PP-2711]

## How Has This Been Tested?

- Existing custom list tests pass (specifically `tests/manager/scripts/test_customlist.py::TestCustomListUpdateEntriesScript`'s `test_process_custom_list` and `test_repopulate_state`).
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/16429590778).

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
