### PR TITLE
Revert "Bypass update when reaping boundless collections (#2601)"

### DIFF
--- a/src/palace/manager/celery/tasks/boundless.py
+++ b/src/palace/manager/celery/tasks/boundless.py
@@ -484,13 +484,12 @@ def reap_collection(
 
             _check_api_credentials(task, collection, api.api_requests)
 
-            api.reap_identifiers_if_no_longer_available(identifiers=identifiers)
-
+            api.update_licensepools_for_identifiers(identifiers=identifiers)
         except (IntegrationException, OperationalError) as e:
             _check_if_deadlock(e)
             wait_time = exponential_backoff(task.request.retries)
             task.log.exception(
-                f"An error was encountered while attempting to reap {len(identifiers)} "
+                f"An error was encountered while attempting to update license pools for {len(identifiers)} "
                 f'in collection("{collection_name}") task(id={task.request.id} due to {e}. '
                 f"Retrying in {wait_time} seconds."
             )

--- a/src/palace/manager/integration/license/boundless/api.py
+++ b/src/palace/manager/integration/license/boundless/api.py
@@ -597,23 +597,6 @@ class BoundlessApi(
         for removed_identifier in remainder:
             self._reap(removed_identifier)
 
-    def reap_identifiers_if_no_longer_available(
-        self, identifiers: list[Identifier]
-    ) -> None:
-        """Reap identifiers if no longer available."""
-        remainder = set(identifiers)
-        for bibliographic, availability in self._fetch_remote_availability(identifiers):
-            assert availability
-            identifier = availability.load_primary_identifier(self._db)
-            if identifier in remainder:
-                remainder.remove(identifier)
-
-        # We asked Boundless about n books. It sent us n-k responses. Those
-        # k books are the identifiers in `remainder`. These books have
-        # been removed from the collection without us being notified.
-        for removed_identifier in remainder:
-            self._reap(removed_identifier)
-
     def update_book(
         self,
         bibliographic: BibliographicData,

--- a/tests/manager/celery/tasks/test_boundless.py
+++ b/tests/manager/celery/tasks/test_boundless.py
@@ -400,15 +400,13 @@ def test_reap_collection_with_requeue(
 
         reap_collection.delay(collection_id=collection.id, batch_size=2).wait()
 
-        reap_identifiers_if_no_longer_available = (
-            mock_api.reap_identifiers_if_no_longer_available
-        )
-        assert reap_identifiers_if_no_longer_available.call_count == 2
+        update_license_pools = mock_api.update_licensepools_for_identifiers
+        assert update_license_pools.call_count == 2
 
-        assert reap_identifiers_if_no_longer_available.call_args_list[0].kwargs == {
+        assert update_license_pools.call_args_list[0].kwargs == {
             "identifiers": identifiers[0:2]
         }
-        assert reap_identifiers_if_no_longer_available.call_args_list[1].kwargs == {
+        assert update_license_pools.call_args_list[1].kwargs == {
             "identifiers": identifiers[2:]
         }
         assert f"Re-queuing reap_collection task at offset=2" in caplog.text
@@ -547,7 +545,7 @@ def test_retry_reap_collection(
     )
 
     mock_api = MagicMock()
-    mock_api.reap_identifiers_if_no_longer_available.side_effect = [
+    mock_api.update_licensepools_for_identifiers.side_effect = [
         error,  # first time throw error
         None,  # second call is successful
     ]
@@ -561,10 +559,8 @@ def test_retry_reap_collection(
         else:
             reap_collection.delay(collection_id=collection.id, batch_size=1).wait()
 
-        reap_identifiers_if_no_longer_available = (
-            mock_api.reap_identifiers_if_no_longer_available
-        )
-        assert reap_identifiers_if_no_longer_available.call_count == update_count
+        update_license_pools = mock_api.update_licensepools_for_identifiers
+        assert update_license_pools.call_count == update_count
 
 
 def test_process_item_creates_presentation_ready_work(

--- a/tests/manager/integration/license/boundless/test_api.py
+++ b/tests/manager/integration/license/boundless/test_api.py
@@ -763,48 +763,6 @@ class TestBoundlessApi:
         # The second was reaped.
         mock_reap.assert_called_once_with(no_longer_in_collection)
 
-    def test_reap_identifiers_if_no_longer_available(self, boundless: BoundlessFixture):
-        def _fetch_remote_availability(identifiers):
-            for i, identifier in enumerate(identifiers):
-                # The first identifer in the list is still
-                # available.
-                identifier_data = IdentifierData.from_identifier(identifier)
-                bibliographic = BibliographicData(
-                    data_source_name=DataSource.BOUNDLESS,
-                    primary_identifier_data=identifier_data,
-                )
-                availability = CirculationData(
-                    data_source_name=DataSource.BOUNDLESS,
-                    primary_identifier_data=identifier_data,
-                    licenses_owned=7,
-                    licenses_available=6,
-                )
-
-                bibliographic.circulation = availability
-                yield bibliographic, availability
-
-                # The rest are no longer known to Boundless.
-                break
-
-        api = boundless.api
-        api._fetch_remote_availability = MagicMock(
-            side_effect=_fetch_remote_availability
-        )
-        mock_reap = create_autospec(api._reap)
-        api._reap = mock_reap
-        still_in_collection = boundless.db.identifier(
-            identifier_type=Identifier.AXIS_360_ID
-        )
-        no_longer_in_collection = boundless.db.identifier(
-            identifier_type=Identifier.AXIS_360_ID
-        )
-        api.reap_identifiers_if_no_longer_available(
-            [still_in_collection, no_longer_in_collection]
-        )
-
-        # The second was reaped.
-        mock_reap.assert_called_once_with(no_longer_in_collection)
-
     def test_fetch_remote_availability(self, boundless: BoundlessFixture):
         # Test the _fetch_remote_availability method, as
         # used by update_licensepools_for_identifiers.


### PR DESCRIPTION
This reverts commit 9646a9a46ca5ccb54411198320c4c32a7c432ca2.

## Description
From my testing on Georgia, It appears that https://github.com/ThePalaceProject/circulation/pull/2623 is a more effective fix both for the problem of queue build up as well as that of deadlocks in CMs with multiple overlapping Boundless collections.
Since this change opened the possibility of missing updates, reverting it here makes sense.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I deployed v32.0.2 + #2623   (which does not included the commit I'm reverting here in this PR) to georgia and observed it for a couple of hours and all looks good.  While I did observe a deadlock, it was in a different place in the code than the place we were seeing before.  Additionally the default queue, which previously would touch zero but generally not stay there,  is now staying at zero.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
