### PR TITLE
Revert "Increase autoscale limit on default queue worker to 8 from 4 …

### DIFF
--- a/docker/runit-scripts/worker-default/run
+++ b/docker/runit-scripts/worker-default/run
@@ -10,4 +10,4 @@ mkdir -p /var/log/celery
 chown 1000:adm /var/log/celery
 
 # Start the celery worker
-exec env/bin/celery -A "palace.manager.celery.app" worker --uid 1000 --gid 1000 --autoscale 8,1 --hostname default@%h -Q high,default --logfile /var/log/celery/default.log
+exec env/bin/celery -A "palace.manager.celery.app" worker --uid 1000 --gid 1000 --autoscale 4,1 --hostname default@%h -Q high,default --logfile /var/log/celery/default.log


### PR DESCRIPTION
…(#2592)"

This reverts commit 2e257432bd65df0052d64393094d9d25a8fbc837.

## Description
Now that #2623 is in place, it appears that this commit wasn't really helping after all.   I tested ga-georgia with 4 default workers and all was well so I think we can safely revert this.
<!--- Describe your changes -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
