### PR TITLE
[PP-2713] Fulfillment of open access books in OPDS for Distributors

### DIFF
--- a/src/palace/manager/integration/license/opds/opds_for_distributors.py
+++ b/src/palace/manager/integration/license/opds/opds_for_distributors.py
@@ -298,10 +298,10 @@ class OPDSForDistributorsAPI(
 
         :return: a DirectFulfillment object.
         """
-        if (
-            delivery_mechanism.delivery_mechanism.drm_scheme
-            != DeliveryMechanism.BEARER_TOKEN
-        ):
+        if delivery_mechanism.delivery_mechanism.drm_scheme not in [
+            DeliveryMechanism.NO_DRM,
+            DeliveryMechanism.BEARER_TOKEN,
+        ]:
             raise DeliveryMechanismError(
                 "Cannot fulfill a loan through OPDS For Distributors using a delivery mechanism with DRM scheme %s"
                 % delivery_mechanism.delivery_mechanism.drm_scheme
@@ -317,8 +317,8 @@ class OPDSForDistributorsAPI(
             media_type = link.resource.representation.media_type
             if (
                 link.rel == Hyperlink.GENERIC_OPDS_ACQUISITION
-                and media_type == delivery_mechanism.delivery_mechanism.content_type
-            ):
+                or link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD
+            ) and media_type == delivery_mechanism.delivery_mechanism.content_type:
                 url = link.resource.representation.url
                 break
 

--- a/src/palace/manager/integration/license/opds/opds_for_distributors.py
+++ b/src/palace/manager/integration/license/opds/opds_for_distributors.py
@@ -17,7 +17,10 @@ from palace.manager.api.circulation.exceptions import (
     DeliveryMechanismError,
     LibraryAuthorizationFailedException,
 )
-from palace.manager.api.circulation.fulfillment import DirectFulfillment
+from palace.manager.api.circulation.fulfillment import (
+    DirectFulfillment,
+    RedirectFulfillment,
+)
 from palace.manager.api.selftest import HasCollectionSelfTests
 from palace.manager.core.monitor import TimestampData
 from palace.manager.data_layer.format import FormatData
@@ -293,7 +296,7 @@ class OPDSForDistributorsAPI(
         licensepool: LicensePool,
         delivery_mechanism: LicensePoolDeliveryMechanism,
         **kwargs: Unpack[BaseCirculationAPI.FulfillKwargs],
-    ) -> DirectFulfillment:
+    ) -> DirectFulfillment | RedirectFulfillment:
         """Retrieve a bearer token that can be used to download the book.
 
         :return: a DirectFulfillment object.
@@ -311,10 +314,14 @@ class OPDSForDistributorsAPI(
 
         # Find the acquisition link with the right media type.
         url = None
+        open_access = False
+        media_type = None
+
         for link in links:
             if link.resource.representation is None:
                 continue
             media_type = link.resource.representation.media_type
+            open_access = link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD
             if (
                 link.rel == Hyperlink.GENERIC_OPDS_ACQUISITION
                 or link.rel == Hyperlink.OPEN_ACCESS_DOWNLOAD
@@ -325,6 +332,9 @@ class OPDSForDistributorsAPI(
         if url is None:
             # We couldn't find an acquisition link for this book.
             raise CannotFulfill()
+
+        if open_access:
+            return RedirectFulfillment(content_link=url, content_type=media_type)
 
         # Obtain a Credential with the information from our
         # bearer token.


### PR DESCRIPTION
## Description

This PR modifies the OPDS for Distributors API fulfillment routine to allow for open access content to be fulfilled.

## Motivation and Context
Currently open access content with no DRM cannot be fulfilled for OPDS for Distributors content.
https://ebce-lyrasis.atlassian.net/browse/PP-2713

## How Has This Been Tested?
A unit test was added and I confirmed that it works locally.

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
