### PR TITLE
Move DeliveryMechanismTuple (PP-2722)

### DIFF
--- a/src/palace/manager/integration/license/boundless/api.py
+++ b/src/palace/manager/integration/license/boundless/api.py
@@ -39,7 +39,6 @@ from palace.manager.integration.license.boundless.constants import (
     DELIVERY_MECHANISM_TO_INTERNAL_FORMAT,
     INTERNAL_FORMAT_TO_DELIVERY_MECHANISM,
     BoundlessFormat,
-    DeliveryMechanismTuple,
 )
 from palace.manager.integration.license.boundless.fulfillment import (
     BoundlessAcsFulfillment,
@@ -64,6 +63,7 @@ from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import (
     DeliveryMechanism,
+    DeliveryMechanismTuple,
     LicensePool,
     LicensePoolDeliveryMechanism,
 )

--- a/src/palace/manager/integration/license/boundless/constants.py
+++ b/src/palace/manager/integration/license/boundless/constants.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import sys
-from typing import NamedTuple
 
 from bidict import frozenbidict
 from frozendict import frozendict
 
-from palace.manager.sqlalchemy.model.licensing import DeliveryMechanism
+from palace.manager.sqlalchemy.model.licensing import (
+    DeliveryMechanism,
+    DeliveryMechanismTuple,
+)
 from palace.manager.sqlalchemy.model.resource import Representation
 
 # TODO: Remove this when we drop support for Python 3.10
@@ -43,11 +45,6 @@ LICENSE_SERVER_BASE_URLS = frozendict(
         ServerNickname.qa: "https://qa-frontdoor.axisnow.com/",
     }
 )
-
-
-class DeliveryMechanismTuple(NamedTuple):
-    content_type: str | None
-    drm_scheme: str | None
 
 
 DELIVERY_MECHANISM_TO_INTERNAL_FORMAT: frozenbidict[DeliveryMechanismTuple, str] = (

--- a/tests/manager/sqlalchemy/model/test_licensing.py
+++ b/tests/manager/sqlalchemy/model/test_licensing.py
@@ -19,6 +19,7 @@ from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import (
     DeliveryMechanism,
+    DeliveryMechanismTuple,
     Hold,
     LicensePool,
     LicensePoolDeliveryMechanism,
@@ -284,6 +285,14 @@ class TestDeliveryMechanism:
         assert DeliveryMechanism.sort(
             [unknown_drm_2, adobe_drm, unknown_drm_1, no_drm]
         ) == [no_drm, adobe_drm, unknown_drm_2, unknown_drm_1]
+
+    def test_as_tuple(self) -> None:
+        content_type = Representation.EPUB_MEDIA_TYPE
+        drm_scheme = DeliveryMechanism.NO_DRM
+        dm = DeliveryMechanism(content_type=content_type, drm_scheme=drm_scheme)
+
+        assert dm.as_tuple == (content_type, drm_scheme)
+        assert dm.as_tuple == DeliveryMechanismTuple(content_type, drm_scheme)
 
 
 class TestRightsStatus:


### PR DESCRIPTION
## Description

Move around `DeliveryMechanismTuple` from the boundless integration. Use it in our `DeliveryMechanism` class and provide a helper to go from `DeliveryMechanism` -> `DeliveryMechanismTuple`

## Motivation and Context

Landing some smaller parts of my PR for PP-2722, to try to make the main PR a bit easier to review.

## How Has This Been Tested?

- New unit test

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
