### PR TITLE
Add ability to look up an equivalent integration by type or string (PP-2722)

### DIFF
--- a/src/palace/manager/service/integration_registry/base.py
+++ b/src/palace/manager/service/integration_registry/base.py
@@ -143,17 +143,20 @@ class IntegrationRegistry(Generic[T]):
         """Return the canonical protocol name for a given protocol."""
         return self.get_protocol(self[protocol], default=False)
 
-    def equivalent(self, protocol1: str | None, protocol2: str | None) -> bool:
+    def equivalent(
+        self, protocol1: str | type[T] | None, protocol2: str | type[T] | None
+    ) -> bool:
         """Return whether two protocols are equivalent."""
-        if (
-            protocol1 is None
-            or protocol1 not in self
-            or protocol2 is None
-            or protocol2 not in self
-        ):
+        if isinstance(protocol1, str):
+            protocol1 = self.get(protocol1)
+
+        if isinstance(protocol2, str):
+            protocol2 = self.get(protocol2)
+
+        if protocol1 is None or protocol2 is None:
             return False
 
-        return self[protocol1] is self[protocol2]
+        return protocol1 is protocol2
 
     def configurations_query(self, protocol_or_integration: str | type[T]) -> Select:
         """

--- a/tests/manager/service/integration_registry/test_base.py
+++ b/tests/manager/service/integration_registry/test_base.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -154,15 +155,21 @@ def test_registry_canonicalize(registry: IntegrationRegistry):
     [
         ("test", "test", True),
         ("object", "test", True),
+        (object, "test", True),
         ("list", "list", True),
+        ("list", list, True),
         ("object", "list", False),
+        (object, list, False),
         ("object", "not_registered", False),
         ("not_registered", "not_registered", False),
         ("not_registered1", "not_registered2", False),
     ],
 )
 def test_registry_equivalent(
-    protocol1: str, protocol2: str, expected: bool, registry: IntegrationRegistry
+    protocol1: str | type[Any],
+    protocol2: str | type[Any],
+    expected: bool,
+    registry: IntegrationRegistry,
 ):
     """Test that equivalent() works."""
     registry.register(object, canonical="test")


### PR DESCRIPTION
## Description

Update the helper method `IntegrationRegistry.equivalent` to take either string or type args.

## Motivation and Context

Makes it a bit easier to check if an integration is equivalent to a protocol. Used in PP-2722.

## How Has This Been Tested?

- New unit test

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
