### PR TITLE
Add created_at and updated_at timestamps to Editions table (PP-2722)

### DIFF
--- a/alembic/versions/20250721_1290ca457ee4_add_created_and_updated_timestamps_to_.py
+++ b/alembic/versions/20250721_1290ca457ee4_add_created_and_updated_timestamps_to_.py
@@ -1,0 +1,30 @@
+"""Add created and updated timestamps to editions
+
+Revision ID: 1290ca457ee4
+Revises: 5e33dc35b5b9
+Create Date: 2025-07-21 18:29:35.463120+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1290ca457ee4"
+down_revision = "5e33dc35b5b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "editions", sa.Column("created_at", sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column(
+        "editions", sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("editions", "updated_at")
+    op.drop_column("editions", "created_at")

--- a/src/palace/manager/sqlalchemy/model/edition.py
+++ b/src/palace/manager/sqlalchemy/model/edition.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import (
     Column,
     Date,
+    DateTime,
     Enum,
     Float,
     ForeignKey,
@@ -37,6 +38,7 @@ from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import DeliveryMechanism, LicensePool
 from palace.manager.sqlalchemy.util import get_one_or_create
 from palace.manager.util import MetadataSimilarity, TitleProcessor
+from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.languages import LanguageCodes
 from palace.manager.util.permanent_work_id import WorkIDCalculator
 
@@ -166,6 +168,10 @@ class Edition(Base, EditionConstants):
     extra: Mapped[dict[str, str]] = Column(
         MutableDict.as_mutable(JSON), default={}, nullable=False
     )
+
+    # Timestamps to let us know when this item was created in our database, and when it was last updated.
+    created_at = Column(DateTime(timezone=True), default=utc_now)
+    updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
 
     def __repr__(self):
         id_repr = repr(self.primary_identifier)

--- a/tests/manager/sqlalchemy/model/test_edition.py
+++ b/tests/manager/sqlalchemy/model/test_edition.py
@@ -104,7 +104,7 @@ class TestEdition:
         id_ = db.fresh_str()
         type_ = db.fresh_str()
 
-        creation_time = utc_now() - timedelta(days=-365)
+        creation_time = utc_now() - timedelta(days=365)
         with freeze_time(creation_time):
             record, _ = Edition.for_foreign_id(db.session, data_source, type_, id_)
 

--- a/tests/manager/sqlalchemy/model/test_edition.py
+++ b/tests/manager/sqlalchemy/model/test_edition.py
@@ -1,5 +1,8 @@
 import random
 import string
+from datetime import timedelta
+
+from freezegun import freeze_time
 
 from palace.manager.data_layer.policy.presentation import (
     PresentationCalculationPolicy,
@@ -95,6 +98,44 @@ class TestEdition:
         assert data_source == record.data_source
         assert identifier == record.primary_identifier
         assert False == was_new
+
+    def test_created_and_updated_timestamps(self, db: DatabaseTransactionFixture):
+        data_source = DataSource.lookup(db.session, DataSource.GUTENBERG)
+        id_ = db.fresh_str()
+        type_ = db.fresh_str()
+
+        creation_time = utc_now() - timedelta(days=-365)
+        with freeze_time(creation_time):
+            record, _ = Edition.for_foreign_id(db.session, data_source, type_, id_)
+
+        # The edition automatically gets timestamps set on it
+        assert record.created_at == creation_time
+        assert record.updated_at == creation_time
+
+        # Retrieving the same edition again does not change the timestamps.
+        record, was_new = Edition.for_foreign_id(
+            db.session, DataSource.GUTENBERG, type_, id_
+        )
+        assert record.created_at == creation_time
+        assert record.updated_at == creation_time
+
+        # If I update the edition, the updated_at timestamp changes automatically
+        update_time = utc_now()
+        with freeze_time(update_time):
+            record.title = "New Title"
+            db.session.flush()
+        assert record.created_at == creation_time
+        assert record.updated_at == update_time
+
+        # If I manually set the updated_at timestamp, it does not change automatically
+        manual_update_time = utc_now() + timedelta(days=1)
+        with freeze_time(manual_update_time):
+            record.title = "Another New Title"
+            record.updated_at = manual_update_time
+            record.series = "New Series"
+            db.session.flush()
+        assert record.created_at == creation_time
+        assert record.updated_at == manual_update_time
 
     def test_sort_by_priority(self, db: DatabaseTransactionFixture):
         # Make editions created by the license source, the metadata


### PR DESCRIPTION
## Description

Add two new timestamps `created_at` and `updated_at` to the editions table. 

If not supplied, these timestamps use `default` and `onupdate` to set themselves to the current time.

## Motivation and Context

Helpful for keeping track of when the edition was last updated and used in PP-2722.

## How Has This Been Tested?

- New unit test

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
