### PR TITLE
Add helper functions to data_layer (PP-2722)

### DIFF
--- a/src/palace/manager/data_layer/identifier.py
+++ b/src/palace/manager/data_layer/identifier.py
@@ -27,6 +27,24 @@ class IdentifierData(BaseFrozenData):
 
         return cls(type=identifier.type, identifier=identifier.identifier)
 
+    @classmethod
+    def parse_urn(
+        cls,
+        urn: str,
+    ) -> Self:
+        """
+        Parse identifier string.
+
+        Raises PalaceValueError if the URN cannot be parsed.
+        """
+
+        type_, identifier = Identifier.type_and_identifier_for_urn(urn)
+
+        return cls(
+            type=type_,
+            identifier=identifier,
+        )
+
     def redis_key(self) -> str:
         """
         String representation of the IdentifierData object suitable for use

--- a/src/palace/manager/sqlalchemy/model/identifier.py
+++ b/src/palace/manager/sqlalchemy/model/identifier.py
@@ -31,7 +31,7 @@ from sqlalchemy.sql import Select, select
 from sqlalchemy.sql.elements import ClauseElement
 from sqlalchemy.sql.expression import and_, or_
 
-from palace.manager.core.exceptions import BasePalaceException
+from palace.manager.core.exceptions import BasePalaceException, PalaceValueError
 from palace.manager.data_layer.policy.presentation import (
     PresentationCalculationPolicy,
 )
@@ -486,7 +486,7 @@ class Identifier(Base, IdentifierConstants, LoggerMixin):
                 identifier_type, identifier = result
                 return identifier_type, identifier
 
-        raise ValueError(
+        raise PalaceValueError(
             "Could not turn %s into a recognized identifier." % identifier_string
         )
 

--- a/tests/manager/data_layer/test_identifier.py
+++ b/tests/manager/data_layer/test_identifier.py
@@ -24,3 +24,15 @@ class TestIdentifierData:
         # Calling from_identifier() on an IdentifierData object is a no-op
         # and returns the same object.
         assert IdentifierData.from_identifier(data) is data
+
+    def test_parse_urn(self, db: DatabaseTransactionFixture) -> None:
+        urn = "urn:isbn:9781449358068"
+        data = IdentifierData.parse_urn(urn)
+        assert data.type == Identifier.ISBN
+        assert data.identifier == "9781449358068"
+
+        # Test with a different type
+        urn = db.fresh_url()
+        data = IdentifierData.parse_urn(urn)
+        assert data.type == "URI"
+        assert data.identifier == urn


### PR DESCRIPTION
## Description

Add some helper functions for PP-2722 to the data_layer code.

- Add ability to call `bibliographic_apply` task without passing an edition
- Add `load_edition` method to `BibliographicData` to load a existing edition without autocreating it
- Add `parse_urn` method to `IdentifierData` to load an `IdentifierData` from a URN without creating the related `Identifier`
- Make `Identifier` raise `PalaceValueError` instead of a `ValueError`

## Motivation and Context

A smattering of changes I made to the datalayer to support the work on PP-2722. Since all these changes stand on their own, I think it makes sense to PR them separately, to make the final PP-2722 PR easier to review.

## How Has This Been Tested?

- New unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
