### PR TITLE
MARC export updates for OCLC (PP-2618)

### DIFF
--- a/src/palace/manager/integration/catalog/marc/annotator.py
+++ b/src/palace/manager/integration/catalog/marc/annotator.py
@@ -64,7 +64,6 @@ class Annotator(LoggerMixin):
             cls.add_publisher(record, edition)
             cls.add_physical_description(record, edition)
             cls.add_series(record, edition)
-        cls.add_audience(record, work)
         cls.add_ebooks_subject(record)
         cls.add_distributor(record, license_pool)
         cls.add_summary(record, work)
@@ -183,9 +182,9 @@ class Annotator(LoggerMixin):
             + _006_09_09_type_of_computer_file
             + " " * 8
         )
-        # If the lenght is not correct, then this is a programming error.
+        # If the length is not correct, then this is a programming error.
         assert len(_006_field) == 18
-        record.add_field(Field(tag="006", data="m     o  d        "))
+        record.add_field(Field(tag="006", data=_006_field))
 
         # Field 007: more details about electronic resource
         # Since this depends on the pool, it might be better not to cache it.
@@ -450,40 +449,6 @@ class Annotator(LoggerMixin):
                     ],
                 )
             )
-
-        # Form of work
-        form = None
-        if edition.medium == Edition.BOOK_MEDIUM:
-            form = "eBook"
-        elif edition.medium == Edition.AUDIO_MEDIUM:
-            # This field doesn't seem to be used for audio.
-            pass
-        if form:
-            record.add_field(
-                Field(
-                    tag="380",
-                    indicators=Indicators(" ", " "),
-                    subfields=[
-                        Subfield("a", "eBook"),
-                        Subfield("2", "tlcgt"),
-                    ],
-                )
-            )
-
-    @classmethod
-    def add_audience(cls, record: Record, work: Work) -> None:
-        work_audience = work.audience or Classifier.AUDIENCE_ADULT
-        audience = cls.AUDIENCE_TERMS.get(work_audience, "General")
-        record.add_field(
-            Field(
-                tag="385",
-                indicators=Indicators(" ", " "),
-                subfields=[
-                    Subfield("a", audience),
-                    Subfield("2", cls.AUDIENCE_SOURCE),
-                ],
-            )
-        )
 
     @classmethod
     def add_series(cls, record: Record, edition: Edition) -> None:

--- a/src/palace/manager/integration/catalog/marc/annotator.py
+++ b/src/palace/manager/integration/catalog/marc/annotator.py
@@ -22,6 +22,7 @@ class Annotator(LoggerMixin):
     a MARC record."""
 
     # From https://www.loc.gov/standards/valuelist/marctarget.html
+    AUDIENCE_SOURCE = "marctarget"
     AUDIENCE_TERMS: Mapping[str, str] = {
         Classifier.AUDIENCE_CHILDREN: "Juvenile",
         Classifier.AUDIENCE_YOUNG_ADULT: "Adolescent",
@@ -64,10 +65,8 @@ class Annotator(LoggerMixin):
             cls.add_physical_description(record, edition)
             cls.add_series(record, edition)
         cls.add_audience(record, work)
-        cls.add_system_details(record)
         cls.add_ebooks_subject(record)
         cls.add_distributor(record, license_pool)
-        cls.add_formats(record, license_pool)
         cls.add_summary(record, work)
         cls.add_genres(record, work)
 
@@ -168,8 +167,25 @@ class Annotator(LoggerMixin):
 
         record.add_field(Field(tag="005", data=utc_now().strftime("%Y%m%d%H%M%S.0")))
 
-        # Field 006: m = computer file, d = the file is a document
-        record.add_field(Field(tag="006", data="m        d        "))
+        # Field 006: m = computer file, o = online, d = the file is a document
+        # See https://www.loc.gov/marc/bibliographic/bd006.html
+        # Refer to the corresponding positions (18-34) in field 008 for descriptions
+        # of field 006 character positions 01-17.
+        # See https://www.loc.gov/marc/bibliographic/bd008c.html
+        _006_00_00_form_of_material = "m"
+        _006_06_06_form_of_item = "o"
+        _006_09_09_type_of_computer_file = "d"
+        _006_field = (
+            _006_00_00_form_of_material
+            + " " * 5
+            + _006_06_06_form_of_item
+            + " " * 2
+            + _006_09_09_type_of_computer_file
+            + " " * 8
+        )
+        # If the lenght is not correct, then this is a programming error.
+        assert len(_006_field) == 18
+        record.add_field(Field(tag="006", data="m     o  d        "))
 
         # Field 007: more details about electronic resource
         # Since this depends on the pool, it might be better not to cache it.
@@ -184,7 +200,9 @@ class Annotator(LoggerMixin):
         )
 
         # Field 008 (fixed-length data elements):
+        # 00-05 Date entered on file
         data = utc_now().strftime("%y%m%d")
+        # 06 Type of date / Publication status, 07-10 Date 1
         publication_date = (edition.issued or edition.published) if edition else None
         if publication_date:
             date_type = "s"  # single known date
@@ -194,16 +212,30 @@ class Annotator(LoggerMixin):
             date_type = "n"  # dates unknown
             date_value = "    "
         data += date_type + date_value
+        # 11-14 Date 2
         data += "    "
+        # 15-17 Place of publication
         # TODO: Start tracking place of publication when available. Since we don't have
         # this yet, assume everything was published in the US.
         data += "xxu"
-        data += "                 "
+        # 18-22 (multiple fields)
+        data += "     "
+        # 23 Form of item
+        data += "o"  # "o" = Online
+        # 24-28 (multiple fields)
+        data += "     "
+        # 29-34 Conference publication, Festschrift, Index, (undefined), Literary Form, Biography
+        # These should all (except the undefined position) be '|' for "No attempt to code".
+        data += "||| ||"
+        # 35-37 Language
         language = "eng"
         if edition and edition.language:
             language = LanguageCodes.string_to_alpha_3(edition.language)
         data += language
-        data += "  "
+        # 38 Modified record
+        data += " "
+        # 39 Cataloging source
+        data += "d"
         record.add_field(Field(tag="008", data=data))
 
     @classmethod
@@ -448,7 +480,7 @@ class Annotator(LoggerMixin):
                 indicators=Indicators(" ", " "),
                 subfields=[
                     Subfield("a", audience),
-                    Subfield("2", "tlctarget"),
+                    Subfield("2", cls.AUDIENCE_SOURCE),
                 ],
             )
         )
@@ -466,32 +498,6 @@ class Annotator(LoggerMixin):
                     subfields=subfields,
                 )
             )
-
-    @classmethod
-    def add_system_details(cls, record: Record) -> None:
-        record.add_field(
-            Field(
-                tag="538",
-                indicators=Indicators(" ", " "),
-                subfields=[Subfield("a", "Mode of access: World Wide Web.")],
-            )
-        )
-
-    @classmethod
-    def add_formats(cls, record: Record, pool: LicensePool) -> None:
-        for lpdm in pool.available_delivery_mechanisms:
-            dm = lpdm.delivery_mechanism
-            format = cls.FORMAT_TERMS.get((dm.content_type, dm.drm_scheme))
-            if format:
-                record.add_field(
-                    Field(
-                        tag="538",
-                        indicators=Indicators(" ", " "),
-                        subfields=[
-                            Subfield("a", format),
-                        ],
-                    )
-                )
 
     @classmethod
     def add_summary(cls, record: Record, work: Work) -> None:

--- a/tests/manager/integration/catalog/marc/test_annotator.py
+++ b/tests/manager/integration/catalog/marc/test_annotator.py
@@ -120,7 +120,6 @@ class TestAnnotator:
             264,
             300,
             336,
-            385,
             490,
             655,
             520,
@@ -128,7 +127,6 @@ class TestAnnotator:
             337,
             338,
             347,
-            380,
         }
 
     def test__copy_record(self, annotator_fixture: AnnotatorFixture):
@@ -454,14 +452,6 @@ class TestAnnotator:
                 "2": "rda",
             },
         )
-        annotator_fixture.assert_field(
-            record,
-            "380",
-            {
-                "a": "eBook",
-                "2": "tlcgt",
-            },
-        )
 
         record = annotator_fixture.record()
         annotator_fixture.annotator.add_physical_description(record, audio)
@@ -509,24 +499,6 @@ class TestAnnotator:
             },
         )
         assert [] == record.get_fields("380")
-
-    def test_add_audience(
-        self,
-        db: DatabaseTransactionFixture,
-        annotator_fixture: AnnotatorFixture,
-    ):
-        for audience, term in list(annotator_fixture.annotator.AUDIENCE_TERMS.items()):
-            work = db.work(audience=audience)
-            record = annotator_fixture.record()
-            annotator_fixture.annotator.add_audience(record, work)
-            annotator_fixture.assert_field(
-                record,
-                "385",
-                {
-                    "a": term,
-                    "2": "marctarget",
-                },
-            )
 
     def test_add_series(
         self,

--- a/tests/manager/integration/catalog/marc/test_annotator.py
+++ b/tests/manager/integration/catalog/marc/test_annotator.py
@@ -122,7 +122,6 @@ class TestAnnotator:
             336,
             385,
             490,
-            538,
             655,
             520,
             650,
@@ -234,10 +233,10 @@ class TestAnnotator:
         )
         annotator_fixture.assert_control_field(record, "001", identifier.urn)
         assert now.strftime("%Y%m%d") in record.get_fields("005")[0].value()
-        annotator_fixture.assert_control_field(record, "006", "m        d        ")
+        annotator_fixture.assert_control_field(record, "006", "m     o  d        ")
         annotator_fixture.assert_control_field(record, "007", "cr cn ---anuuu")
         annotator_fixture.assert_control_field(
-            record, "008", now.strftime("%y%m%d") + "s0956    xxu                 eng  "
+            record, "008", now.strftime("%y%m%d") + "s0956    xxu     o     ||| ||eng d"
         )
 
         # This French edition has two formats and was published in 2018.
@@ -259,10 +258,10 @@ class TestAnnotator:
         )
         annotator_fixture.assert_control_field(record, "001", identifier2.urn)
         assert now.strftime("%Y%m%d") in record.get_fields("005")[0].value()
-        annotator_fixture.assert_control_field(record, "006", "m        d        ")
+        annotator_fixture.assert_control_field(record, "006", "m     o  d        ")
         annotator_fixture.assert_control_field(record, "007", "cr cn ---mnuuu")
         annotator_fixture.assert_control_field(
-            record, "008", now.strftime("%y%m%d") + "s2018    xxu                 fre  "
+            record, "008", now.strftime("%y%m%d") + "s2018    xxu     o     ||| ||fre d"
         )
 
     def test_add_marc_organization_code(self, annotator_fixture: AnnotatorFixture):
@@ -525,7 +524,7 @@ class TestAnnotator:
                 "385",
                 {
                     "a": term,
-                    "2": "tlctarget",
+                    "2": "marctarget",
                 },
             )
 
@@ -570,41 +569,6 @@ class TestAnnotator:
         record = annotator_fixture.record()
         annotator_fixture.annotator.add_series(record, edition)
         assert [] == record.get_fields("490")
-
-    def test_add_system_details(self, annotator_fixture: AnnotatorFixture):
-        record = annotator_fixture.record()
-        annotator_fixture.annotator.add_system_details(record)
-        annotator_fixture.assert_field(
-            record, "538", {"a": "Mode of access: World Wide Web."}
-        )
-
-    def test_add_formats(
-        self,
-        db: DatabaseTransactionFixture,
-        annotator_fixture: AnnotatorFixture,
-    ):
-        edition, pool = db.edition(with_license_pool=True)
-        epub_no_drm, ignore = DeliveryMechanism.lookup(
-            db.session, Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM
-        )
-        pool.delivery_mechanisms[0].delivery_mechanism = epub_no_drm
-        LicensePoolDeliveryMechanism.set(
-            pool.data_source,
-            pool.identifier,
-            Representation.PDF_MEDIA_TYPE,
-            DeliveryMechanism.ADOBE_DRM,
-            RightsStatus.IN_COPYRIGHT,
-        )
-
-        record = annotator_fixture.record()
-        annotator_fixture.annotator.add_formats(record, pool)
-        fields = record.get_fields("538")
-        assert 2 == len(fields)
-        [pdf, epub] = sorted(fields, key=lambda x: x.get_subfields("a")[0])
-        assert "Adobe PDF eBook" == pdf.get_subfields("a")[0]
-        assert Indicators(" ", " ") == pdf.indicators
-        assert "EPUB eBook" == epub.get_subfields("a")[0]
-        assert Indicators(" ", " ") == epub.indicators
 
     def test_add_summary(
         self,


### PR DESCRIPTION
## Description

Makes some of the updates requested by OCLC to MARC records produced by MARC exporter functionality:
- 006 field (http://www.loc.gov/marc/bibliographic/bd006.html) This field is not required but if provided, it must be coded correctly for the electronic component. Byte 6 (Form) should be “o” for online resource. 
- 008 field (https://www.loc.gov/marc/bibliographic/bd008.html) 
  - Byte 23 (Form) must be coded “o” for online resource. When this is not coded, or coded incorrectly, the system defaults to blank which is for print materials. This will cause the record to incorrectly match to a print item instead of an electronic item.
  - Change the following from a space to a pipe symbol (|) for “no attempt to code”
    - §  Byte 29 (Conference publication) 
    - §  Byte 30 (Festschrift) 
    - §  Byte 31 (Inex)
    - §  Byte 33 (Literary form)
  - Byte 39 must be coded “d”.
- The [385 field](https://www.loc.gov/marc/bibliographic/bd385.html) has invalid data in the $2 and will need to be corrected
  - Dropped field per customer guidance.
- The 385 field also has invalid data in the $2 and will need to be corrected.
  - Dropped field per customer guidance.
- 538 fields should be deleted. According to the [Provider-neutral Guidelines](https://www.loc.gov/aba/pcc/scs/documents/PCC-PN-guidelines.html), for RDA, Mode of Access is not used, it is covered by Carrier type (338 field).
  - Dropped field.


## Motivation and Context

Support for OCLC vendor record contribution and additional customer feedback (see Jira PP-2618).

## How Has This Been Tested?

- Updated tests to reflect changes.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/16572446278) pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
