### PR TITLE
Don't log warning when creating analytics event outside flask

### DIFF
--- a/src/palace/manager/service/analytics/eventdata.py
+++ b/src/palace/manager/service/analytics/eventdata.py
@@ -114,8 +114,16 @@ class AnalyticsEventData(BaseModel, LoggerMixin):
                 user_agent = flask.request.user_agent.string
                 if user_agent == "":
                     user_agent = None
+            except RuntimeError:
+                # Flask raises a RuntimeError if there is no request context.
+                # This can happen if the event is created outside of a flask request
+                # context, for example when the event is created in a background task.
+                pass
             except Exception as e:
-                cls.logger().warning(f"Unable to resolve the user_agent: {repr(e)}")
+                # If we get any other exception, we log it but do not raise it.
+                cls.logger().warning(
+                    f"Unable to resolve the user_agent: {repr(e)}", exc_info=e
+                )
 
         if not time:
             time = utc_now()

--- a/tests/manager/service/analytics/test_eventdata.py
+++ b/tests/manager/service/analytics/test_eventdata.py
@@ -1,4 +1,10 @@
+from unittest.mock import PropertyMock, patch
+
+import pytest
+
+from palace.manager.service.analytics import eventdata
 from palace.manager.service.analytics.eventdata import AnalyticsEventData
+from palace.manager.service.logging.configuration import LogLevel
 from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.flask import FlaskAppFixture
@@ -9,7 +15,10 @@ class TestAnalyticsEventData:
         self,
         db: DatabaseTransactionFixture,
         flask_app_fixture: FlaskAppFixture,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
+        caplog.set_level(LogLevel.warning)
+
         edition = db.edition()
         pool = db.licensepool(edition=edition)
         library = db.default_library()
@@ -39,6 +48,20 @@ class TestAnalyticsEventData:
             )
         assert event.user_agent is None
 
-        # call outside of request context
+        # call outside of request context, we don't log a warning, as this is an expected case
+        # we just set user_agent to None
         event = AnalyticsEventData.create(library, pool, CirculationEvent.CM_CHECKOUT)
         assert event.user_agent is None
+        assert len(caplog.records) == 0
+
+        # Exception getting user agent. This isn't expected, but isn't fatal, so we log a warning
+        with patch.object(eventdata, "flask") as mock_flask:
+            type(mock_flask.request).user_agent = PropertyMock(
+                side_effect=Exception("Test exception")
+            )
+            event = AnalyticsEventData.create(
+                library, pool, CirculationEvent.CM_CHECKOUT
+            )
+        assert event.user_agent is None
+        assert len(caplog.records) == 1
+        assert "Unable to resolve the user_agent" in caplog.text


### PR DESCRIPTION
## Description

Don't log a warning when creating analytics events outside of a flask context.

## Motivation and Context

While working on https://github.com/ThePalaceProject/circulation/pull/2639 I had to dig though a lot of our celery logs, and we are getting a large number of warnings in the logs `Unable to resolve the user_agent`. This is expected in a celery task, so I don't think it warrants a log message.

I updated the `RuntimeError` we would expect from flask to do nothing, and updated the logging we do for any other exception to include a stack trace with the message since it would be unexpected.

## How Has This Been Tested?

- New unit tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
