### PR TITLE
Refactor our ServicesFixture to make sure a wired services container is always available

### DIFF
--- a/tests/fixtures/api_controller.py
+++ b/tests/fixtures/api_controller.py
@@ -109,11 +109,6 @@ class ControllerFixture:
         # TestScopedSession to hang.
         app.manager = self.circulation_manager_setup()
 
-    @contextmanager
-    def wired_container(self):
-        with self.services_fixture.wired():
-            yield
-
     def circulation_manager_setup_with_session(
         self, session: Session, overrides: ControllerFixtureSetupOverrides | None = None
     ) -> CirculationManager:

--- a/tests/manager/api/admin/controller/test_custom_lists.py
+++ b/tests/manager/api/admin/controller/test_custom_lists.py
@@ -32,7 +32,6 @@ from palace.manager.sqlalchemy.util import create, get_one
 from palace.manager.util.problem_detail import ProblemDetail
 from tests.fixtures.api_admin import AdminLibrarianFixture
 from tests.fixtures.database import DatabaseTransactionFixture
-from tests.fixtures.services import ServicesFixture
 from tests.mocks.flask import add_request_context
 from tests.mocks.search import ExternalSearchIndexFake, SearchServiceFake
 
@@ -462,10 +461,7 @@ class TestCustomListsController:
         list.add_entry(work1)
         list.add_entry(work2)
 
-        with (
-            admin_librarian_fixture.request_context_with_library_and_admin("/"),
-            admin_librarian_fixture.ctrl.wired_container(),
-        ):
+        with admin_librarian_fixture.request_context_with_library_and_admin("/"):
             assert isinstance(list.id, int)
             response = admin_librarian_fixture.manager.admin_custom_lists_controller.custom_list(
                 list.id
@@ -493,7 +489,6 @@ class TestCustomListsController:
     def test_custom_list_get_with_pagination(
         self,
         admin_librarian_fixture: AdminLibrarianFixture,
-        services_fixture: ServicesFixture,
     ):
         data_source = DataSource.lookup(
             admin_librarian_fixture.ctrl.db.session, DataSource.LIBRARY_STAFF
@@ -512,10 +507,7 @@ class TestCustomListsController:
             work = admin_librarian_fixture.ctrl.db.work(with_license_pool=True)
             list.add_entry(work)
 
-        with (
-            admin_librarian_fixture.request_context_with_library_and_admin("/"),
-            services_fixture.wired(),
-        ):
+        with (admin_librarian_fixture.request_context_with_library_and_admin("/"),):
             assert isinstance(list.id, int)
             response = admin_librarian_fixture.manager.admin_custom_lists_controller.custom_list(
                 list.id

--- a/tests/manager/api/admin/controller/test_feed.py
+++ b/tests/manager/api/admin/controller/test_feed.py
@@ -16,10 +16,7 @@ class TestFeedController:
         suppressed_work.suppressed_for.append(library)
         unsuppressed_work = admin_librarian_fixture.ctrl.db.work()
 
-        with (
-            admin_librarian_fixture.request_context_with_library_and_admin("/"),
-            admin_librarian_fixture.ctrl.wired_container(),
-        ):
+        with admin_librarian_fixture.request_context_with_library_and_admin("/"):
             response = (
                 admin_librarian_fixture.manager.admin_feed_controller.suppressed()
             )

--- a/tests/manager/api/admin/controller/test_reset_password.py
+++ b/tests/manager/api/admin/controller/test_reset_password.py
@@ -116,12 +116,12 @@ class TestResetPasswordController:
             assert "Email successfully sent" in response.get_data(as_text=True)
 
             # Check the email is sent
-            assert services_fixture.mock_services.emailer.send.call_count == 1
+            assert services_fixture.emailer.send.call_count == 1
 
             # Check that the email is sent to the right admin
-            assert services_fixture.mock_services.emailer.send.call_args.kwargs[
-                "receivers"
-            ] == [admin_email]
+            assert services_fixture.emailer.send.call_args.kwargs["receivers"] == [
+                admin_email
+            ]
 
     def test_reset_password_get(
         self,
@@ -211,9 +211,7 @@ class TestResetPasswordController:
 
             assert forgot_password_response.status_code == 200
 
-            mail_text = services_fixture.mock_services.emailer.send.call_args.kwargs[
-                "text"
-            ]
+            mail_text = services_fixture.emailer.send.call_args.kwargs["text"]
 
             (
                 token,
@@ -260,9 +258,7 @@ class TestResetPasswordController:
             response = reset_password_ctrl.forgot_password()
             assert response.status_code == 200
 
-            mail_text = services_fixture.mock_services.emailer.send.call_args.kwargs[
-                "text"
-            ]
+            mail_text = services_fixture.emailer.send.call_args.kwargs["text"]
 
             (
                 token,

--- a/tests/manager/api/admin/controller/test_work_editor.py
+++ b/tests/manager/api/admin/controller/test_work_editor.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-from collections.abc import Generator
 from typing import Any
 
 import feedparser
@@ -81,10 +80,8 @@ class WorkFixture(AdminControllerFixture):
 def work_fixture(
     controller_fixture: ControllerFixture,
     work_policy_recalc_fixture: WorkIdPolicyQueuePresentationRecalculationFixture,
-) -> Generator[WorkFixture, None, None]:
-    fixture = WorkFixture(controller_fixture, work_policy_recalc_fixture)
-    with fixture.ctrl.wired_container():
-        yield fixture
+) -> WorkFixture:
+    return WorkFixture(controller_fixture, work_policy_recalc_fixture)
 
 
 class TestWorkController:

--- a/tests/manager/api/controller/test_crawlfeed.py
+++ b/tests/manager/api/controller/test_crawlfeed.py
@@ -319,10 +319,7 @@ class TestCrawlableFeed:
         # Finally, remove the mock feed class and verify that a real OPDS
         # feed is generated from the result of MockLane.works()
         del in_kwargs["feed_class"]
-        with (
-            circulation_fixture.request_context_with_library("/"),
-            circulation_fixture.wired_container(),
-        ):
+        with circulation_fixture.request_context_with_library("/"):
             response = circulation_fixture.manager.opds_feeds._crawlable_feed(
                 **in_kwargs
             )

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -1,5 +1,4 @@
 import datetime
-from collections.abc import Generator
 from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock, create_autospec, patch
@@ -115,10 +114,8 @@ class LoanFixture(CirculationControllerFixture):
 @pytest.fixture(scope="function")
 def loan_fixture(
     db: DatabaseTransactionFixture, services_fixture: ServicesFixture
-) -> Generator[LoanFixture, None, None]:
-    fixture = LoanFixture(db, services_fixture)
-    with fixture.wired_container():
-        yield fixture
+) -> LoanFixture:
+    return LoanFixture(db, services_fixture)
 
 
 class OPDSSerializationTestHelper:

--- a/tests/manager/api/controller/test_opds_feed.py
+++ b/tests/manager/api/controller/test_opds_feed.py
@@ -94,11 +94,8 @@ class TestOPDSFeedController:
         settings.about = "d"
 
         # Make a real OPDS feed and poke at it.
-        with (
-            circulation_fixture.request_context_with_library(
-                "/?entrypoint=Book&size=10"
-            ),
-            circulation_fixture.wired_container(),
+        with circulation_fixture.request_context_with_library(
+            "/?entrypoint=Book&size=10"
         ):
             response = circulation_fixture.manager.opds_feeds.feed(
                 circulation_fixture.english_adult_fiction.id

--- a/tests/manager/api/controller/test_urn_lookup.py
+++ b/tests/manager/api/controller/test_urn_lookup.py
@@ -12,10 +12,7 @@ class TestURNLookupController:
         work = controller_fixture.db.work(with_open_access_download=True)
         [pool] = work.license_pools
         urn = pool.identifier.urn
-        with (
-            controller_fixture.request_context_with_library("/?urn=%s" % urn),
-            controller_fixture.wired_container(),
-        ):
+        with controller_fixture.request_context_with_library("/?urn=%s" % urn):
             route_name = "work"
 
             # Look up a work.

--- a/tests/manager/api/controller/test_work.py
+++ b/tests/manager/api/controller/test_work.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import urllib.parse
-from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock, create_autospec
 
@@ -59,10 +58,8 @@ class WorkFixture(CirculationControllerFixture):
 @pytest.fixture(scope="function")
 def work_fixture(
     db: DatabaseTransactionFixture, services_fixture: ServicesFixture
-) -> Generator[WorkFixture, None, None]:
-    fixture = WorkFixture(db, services_fixture)
-    with fixture.wired_container():
-        yield fixture
+) -> WorkFixture:
+    return WorkFixture(db, services_fixture)
 
 
 class TestWorkController:

--- a/tests/manager/api/test_app.py
+++ b/tests/manager/api/test_app.py
@@ -12,7 +12,7 @@ from tests.fixtures.services import ServicesFixture
 
 
 def test_initialize_application_http(
-    db: DatabaseTransactionFixture, services_fixture_wired: ServicesFixture
+    db: DatabaseTransactionFixture, services_fixture: ServicesFixture
 ):
     # Use the db transaction fixture so that we don't use the production settings by mistake
     with (

--- a/tests/manager/api/test_controller_cm.py
+++ b/tests/manager/api/test_controller_cm.py
@@ -46,8 +46,8 @@ class TestCirculationManager:
         assert mock_setup_controllers.called
 
         assert manager.services is services_fixture.services
-        assert manager.analytics is services_fixture.mock_services.analytics
-        assert manager.external_search is services_fixture.mock_services.search_index
+        assert manager.analytics is services_fixture.analytics
+        assert manager.external_search is services_fixture.search_index
 
     def test_load_settings(
         self,

--- a/tests/manager/celery/tasks/test_generate_inventory_and_hold_reports.py
+++ b/tests/manager/celery/tasks/test_generate_inventory_and_hold_reports.py
@@ -488,23 +488,21 @@ def test_generate_inventory_and_hold_reports_task(
     # there must be at least one opds collection associated with the library for this to work
     create_test_opds_collection("c1", "d1", db, library)
     generate_inventory_and_hold_reports.delay(library.id, "test@email").wait()
-    services_fixture.mock_services.emailer.send.assert_called_once()
+    services_fixture.emailer.send.assert_called_once()
 
     mock_s3_service.store_stream.assert_called_once()
     mock_s3_service.generate_url.assert_called_once()
 
     assert (
         "Inventory and Holds Reports"
-        in services_fixture.mock_services.emailer.send.call_args.kwargs["subject"]
+        in services_fixture.emailer.send.call_args.kwargs["subject"]
     )
-    assert services_fixture.mock_services.emailer.send.call_args.kwargs[
-        "receivers"
-    ] == ["test@email"]
+    assert services_fixture.emailer.send.call_args.kwargs["receivers"] == ["test@email"]
     assert (
         "Download Report here -> http://test"
-        in services_fixture.mock_services.emailer.send.call_args.kwargs["text"]
+        in services_fixture.emailer.send.call_args.kwargs["text"]
     )
     assert (
         "This report will be available for download for 30 days."
-        in services_fixture.mock_services.emailer.send.call_args.kwargs["text"]
+        in services_fixture.emailer.send.call_args.kwargs["text"]
     )

--- a/tests/manager/celery/tasks/test_opds_odl.py
+++ b/tests/manager/celery/tasks/test_opds_odl.py
@@ -284,9 +284,7 @@ def test_remove_expired_holds_for_collection_task(
     # Remove the expired holds
     remove_expired_holds_for_collection_task.delay(collection1.id).wait()
 
-    assert len(opds_task_fixture.services.mock_services.analytics.method_calls) == len(
-        expired_holds1
-    )
+    assert len(opds_task_fixture.services.analytics.method_calls) == len(expired_holds1)
 
     current_holds = {h.id for h in db.session.scalars(select(Hold))}
     assert expired_holds1.isdisjoint(current_holds)

--- a/tests/manager/celery/tasks/test_reaper.py
+++ b/tests/manager/celery/tasks/test_reaper.py
@@ -111,7 +111,7 @@ class TestWorkReaper:
     ) -> None:
         # Set up our search mock to track calls to remove_work
         removed = set()
-        mock_remove_work = services_fixture.mock_services.search_index.remove_work
+        mock_remove_work = services_fixture.search_index.remove_work
         mock_remove_work.side_effect = lambda x: removed.add(x.id)
 
         # First, create three works.
@@ -426,7 +426,7 @@ def test_hold_reaper(
     assert len(db.session.query(Hold).where(Hold.patron == current_patron).all()) == 2
 
     # verify expected circ event count for hold reaper run
-    call_args_list = services_fixture.mock_services.analytics.collect.call_args_list
+    call_args_list = services_fixture.analytics.collect.call_args_list
     assert len(call_args_list) == 2
     event_types = [call_args.kwargs["event"].type for call_args in call_args_list]
     assert event_types == [

--- a/tests/manager/feed/test_annotators.py
+++ b/tests/manager/feed/test_annotators.py
@@ -294,7 +294,7 @@ class TestAnnotators:
         assert set(expected) == set(ratings)
 
     def test_subtitle(
-        self, db: DatabaseTransactionFixture, services_fixture_wired: ServicesFixture
+        self, db: DatabaseTransactionFixture, services_fixture: ServicesFixture
     ):
         work = db.work(with_license_pool=True, with_open_access_download=True)
         work.presentation_edition.subtitle = "Return of the Jedi"
@@ -325,7 +325,7 @@ class TestAnnotators:
         assert computed.subtitle == None
 
     def test_series(
-        self, db: DatabaseTransactionFixture, services_fixture_wired: ServicesFixture
+        self, db: DatabaseTransactionFixture, services_fixture: ServicesFixture
     ):
         work = db.work(with_license_pool=True, with_open_access_download=True)
         work.presentation_edition.series = "Harry Otter and the Lifetime of Despair"
@@ -532,7 +532,7 @@ class CirculationManagerAnnotatorFixture:
 def circulation_fixture(
     db: DatabaseTransactionFixture,
     patch_url_for: PatchedUrlFor,
-    services_fixture_wired: ServicesFixture,
+    services_fixture: ServicesFixture,
 ) -> CirculationManagerAnnotatorFixture:
     return CirculationManagerAnnotatorFixture(db)
 

--- a/tests/manager/feed/test_opds_acquisition_feed.py
+++ b/tests/manager/feed/test_opds_acquisition_feed.py
@@ -47,7 +47,6 @@ from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.flask_util import OPDSEntryResponse, OPDSFeedResponse
 from palace.manager.util.opds_writer import OPDSFeed, OPDSMessage
 from tests.fixtures.database import DatabaseTransactionFixture
-from tests.fixtures.services import ServicesFixture
 from tests.manager.feed.conftest import PatchedUrlFor
 
 
@@ -880,16 +879,13 @@ class TestOPDSAcquisitionFeed:
         self,
         db: DatabaseTransactionFixture,
         patch_url_for: PatchedUrlFor,
-        services_fixture: ServicesFixture,
     ):
         patron = db.patron()
         work = db.work(with_license_pool=True)
         hold, _ = work.active_license_pool().on_hold_to(patron)
-
-        with services_fixture.wired():
-            feed = OPDSAcquisitionFeed.active_loans_for(
-                None, patron, LibraryAnnotator(None, None, db.default_library())
-            )
+        feed = OPDSAcquisitionFeed.active_loans_for(
+            None, patron, LibraryAnnotator(None, None, db.default_library())
+        )
         assert feed.annotator.active_holds_by_work == {work: hold}
 
     def test_single_entry_loans_feed_errors(self, db: DatabaseTransactionFixture):

--- a/tests/manager/integration/license/boundless/test_api.py
+++ b/tests/manager/integration/license/boundless/test_api.py
@@ -964,7 +964,7 @@ class TestBoundlessApi:
         )
 
     def test_sort_delivery_mechanisms(
-        self, db: DatabaseTransactionFixture, services_fixture_wired: ServicesFixture
+        self, db: DatabaseTransactionFixture, services_fixture: ServicesFixture
     ) -> None:
         def get_mechanisms(
             items: list[LicensePoolDeliveryMechanism],

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -874,7 +874,7 @@ class TestOverdriveAPI:
         self,
         overdrive_api_fixture: OverdriveAPIFixture,
         db: DatabaseTransactionFixture,
-        services_fixture_wired: ServicesFixture,
+        services_fixture: ServicesFixture,
         response_file: str,
     ):
         # Verify the process of checking out a book.
@@ -979,7 +979,7 @@ class TestOverdriveAPI:
             match="format of this book is not supported",
         ):
             api.checkout(patron, pin, pool, None)
-        mock_collect = services_fixture_wired.mock_services.analytics.collect_event
+        mock_collect = services_fixture.analytics.collect_event
         mock_collect.assert_called_once_with(
             db.default_library(),
             pool,

--- a/tests/manager/scripts/test_customlist.py
+++ b/tests/manager/scripts/test_customlist.py
@@ -110,9 +110,9 @@ class TestCustomListUpdateEntriesScript:
         assert custom_list1.auto_update_last_update == frozen_time()
 
     def test_search_facets(
-        self, db: DatabaseTransactionFixture, services_fixture_wired: ServicesFixture
+        self, db: DatabaseTransactionFixture, services_fixture: ServicesFixture
     ):
-        mock_index = services_fixture_wired.mock_services.search_index
+        mock_index = services_fixture.search_index
 
         last_updated = datetime.datetime.now() - datetime.timedelta(hours=1)
         custom_list, _ = db.customlist()

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -19,7 +19,7 @@ class TestRebuildSearchIndexScript:
         RebuildSearchIndexScript(db.session).do_run()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
         # But we don't delete the index before rebuilding.
-        services_fixture.mock_services.search_index.clear_search_documents.assert_not_called()
+        services_fixture.search_index.clear_search_documents.assert_not_called()
 
     @patch("palace.manager.scripts.search.search_reindex")
     def test_do_run_blocking(
@@ -38,7 +38,7 @@ class TestRebuildSearchIndexScript:
     ):
         # If we are called with the --delete argument, we clear the index before rebuilding.
         RebuildSearchIndexScript(db.session, cmd_args=["--delete"]).do_run()
-        services_fixture.mock_services.search_index.clear_search_documents.assert_called_once_with()
+        services_fixture.search_index.clear_search_documents.assert_called_once_with()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
 
     @patch("palace.manager.scripts.search.get_migrate_search_chain")

--- a/tests/manager/sqlalchemy/model/test_collection.py
+++ b/tests/manager/sqlalchemy/model/test_collection.py
@@ -136,7 +136,7 @@ class TestCollection:
     def test_select_by_protocol(
         self,
         example_collection_fixture: ExampleCollectionFixture,
-        services_fixture_wired: ServicesFixture,
+        services_fixture: ServicesFixture,
     ):
         """Verify the ability to find all collections that implement
         a certain protocol.
@@ -598,7 +598,7 @@ class TestCollection:
     def test_delete(
         self,
         db: DatabaseTransactionFixture,
-        services_fixture_wired: ServicesFixture,
+        services_fixture: ServicesFixture,
         is_inactive: bool,
         active_collection_count: int,
     ):
@@ -724,9 +724,7 @@ class TestCollection:
         collection2.delete()
 
         # The search index was injected and told to remove the second work.
-        services_fixture_wired.mock_services.search_index.remove_work.assert_called_once_with(
-            work2
-        )
+        services_fixture.search_index.remove_work.assert_called_once_with(work2)
 
         # We've now deleted every LicensePool created for this test.
         assert 0 == db.session.query(LicensePool).count()
@@ -781,7 +779,7 @@ class TestCollection:
     def test_circulation_api_with_registry_from_container(
         self,
         example_collection_fixture: ExampleCollectionFixture,
-        services_fixture_wired: ServicesFixture,
+        services_fixture: ServicesFixture,
     ) -> None:
         collection = example_collection_fixture.collection
         api = collection.circulation_api()

--- a/tests/manager/sqlalchemy/model/test_patron.py
+++ b/tests/manager/sqlalchemy/model/test_patron.py
@@ -270,7 +270,7 @@ class TestHold:
         assert_calculated_value_used()
 
     def test_collect_event_and_delete(
-        self, db: DatabaseTransactionFixture, services_fixture_wired: ServicesFixture
+        self, db: DatabaseTransactionFixture, services_fixture: ServicesFixture
     ) -> None:
         patron = db.patron()
         work = db.work(with_license_pool=True)
@@ -292,7 +292,7 @@ class TestHold:
         hold, _ = pool.on_hold_to(patron)
         hold.collect_event_and_delete()
         assert db.session.query(Hold).count() == 0
-        services_fixture_wired.mock_services.analytics.collect_event.assert_called_once()
+        services_fixture.analytics.collect_event.assert_called_once()
 
 
 class TestLoans:

--- a/tests/manager/sqlalchemy/model/test_work.py
+++ b/tests/manager/sqlalchemy/model/test_work.py
@@ -45,7 +45,6 @@ from tests.fixtures.search import (
     ExternalSearchFixtureFake,
     WorkQueueIndexingFixture,
 )
-from tests.fixtures.services import ServicesFixture
 from tests.fixtures.work import (
     WorkIdPolicyQueuePresentationRecalculationFixture,
 )
@@ -1784,18 +1783,15 @@ class TestWork:
         assert db.session.query(Work).filter(Work.id == work.id).all() == []
         assert warning_is_present
 
-    def test_queue_indexing(
-        self, redis_fixture: RedisFixture, services_fixture: ServicesFixture
-    ):
+    def test_queue_indexing(self, redis_fixture: RedisFixture):
         # Test the method that adds a work to a redis set to wait for indexing
         waiting = WaitingForIndexing(redis_fixture.client)
 
-        with services_fixture.wired():
-            Work.queue_indexing(555)
-            assert waiting.pop(1) == [555]
+        Work.queue_indexing(555)
+        assert waiting.pop(1) == [555]
 
-            Work.queue_indexing(None)
-            assert waiting.pop(1) == []
+        Work.queue_indexing(None)
+        assert waiting.pop(1) == []
 
     def test_queue_presentation_recalculation(self):
         with patch(

--- a/tests/migration/test_instance_init_script.py
+++ b/tests/migration/test_instance_init_script.py
@@ -78,7 +78,7 @@ def _run_script(config_path: Path, db_url: str) -> None:
             return SessionManager.engine(db_url)
 
         mock_services = MagicMock()
-        with (mock_services_container(mock_services),):
+        with mock_services_container(mock_services):
             script = InstanceInitializationScript(
                 config_file=config_path, engine_factory=engine_factory
             )


### PR DESCRIPTION
## Description

This PR refactors our `ServicesContainer` fixture to make sure that tests always have a wired services container available.

## Motivation and Context

Previously, if a test required a wired `services_container`, it had to either wire it manually or use the `wired_services_container` fixture. This approach was chosen because wiring the container is a relatively expensive operation.

However, as we increasingly rely on the `services_container` and use it for more dependency injection, managing it manually has become cumbersome. We’re finding ourselves needing to request a wired container in more and more places, which adds overhead and friction.

Specifically in https://github.com/ThePalaceProject/circulation/pull/2643, because we call up `Collection.data_source` in many places, that PR required adding a lot of code to the tests, just to wire a services container in various places.

This PR introduces an alternative approach:

* A session-level `services_container` is created and wired once.
* A function-level fixture then ensures the container is reset between tests to avoid state leakage.

There is some risk of test data leaking if the container isn’t fully reset, but the dependency injection framework provides helper methods to assist with cleanup. If we encounter issues, we can enhance the session fixture to handle additional reset logic.

Overall, I believe the convenience of always having a pre-wired container outweighs the potential risk of state leakage between tests.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
