### PR TITLE
Share `monkeypatch_env` test fixture.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ pytest_plugins = [
     "tests.fixtures.s3",
     "tests.fixtures.search",
     "tests.fixtures.services",
+    "tests.fixtures.test_utils",
     "tests.fixtures.time",
     "tests.fixtures.tls_server",
     "tests.fixtures.vendor_id",

--- a/tests/fixtures/test_utils.py
+++ b/tests/fixtures/test_utils.py
@@ -1,0 +1,20 @@
+import os
+
+import pytest
+from pytest import MonkeyPatch
+
+
+class MonkeyPatchEnvFixture:
+    def __init__(self, monkeypatch: MonkeyPatch):
+        self.monkeypatch = monkeypatch
+
+    def __call__(self, key: str, value: str | None) -> None:
+        if value:
+            self.monkeypatch.setenv(key, value)
+        elif key in os.environ:
+            self.monkeypatch.delenv(key)
+
+
+@pytest.fixture
+def monkeypatch_env(monkeypatch: MonkeyPatch) -> MonkeyPatchEnvFixture:
+    return MonkeyPatchEnvFixture(monkeypatch)

--- a/tests/manager/api/admin/test_config.py
+++ b/tests/manager/api/admin/test_config.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,22 +9,7 @@ from palace.manager.api.admin.config import (
     Configuration as AdminConfig,
     OperationalMode,
 )
-
-
-class MonkeyPatchEnvFixture:
-    def __init__(self, monkeypatch: MonkeyPatch):
-        self.monkeypatch = monkeypatch
-
-    def __call__(self, key: str, value: str | None) -> None:
-        if value:
-            self.monkeypatch.setenv(key, value)
-        elif key in os.environ:
-            self.monkeypatch.delenv(key)
-
-
-@pytest.fixture
-def monkeypatch_env(monkeypatch: MonkeyPatch) -> MonkeyPatchEnvFixture:
-    return MonkeyPatchEnvFixture(monkeypatch)
+from tests.fixtures.test_utils import MonkeyPatchEnvFixture
 
 
 class TestAdminUI:


### PR DESCRIPTION
## Description

Pulls the `monkeypatch_env` fixture and associated class out of a test file and into shared test configuration.

## Motivation and Context

It's useful to have this fixture available to other tests.

## How Has This Been Tested?

CI tests pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
