### PR TITLE
Add support contact label text configuration. (PP-2768)

### DIFF
--- a/src/palace/manager/api/admin/controller/view.py
+++ b/src/palace/manager/api/admin/controller/view.py
@@ -75,6 +75,7 @@ class ViewController(AdminController):
                 sitewide_tos_text=Configuration.DEFAULT_TOS_TEXT,
                 show_circ_events_download=AdminClientConfig.admin_feature_flags().show_circ_events_download,
                 support_contact_url=AdminClientConfig.admin_client_settings().support_contact_url,
+                support_contact_text=AdminClientConfig.admin_client_settings().support_contact_text,
                 setting_up=setting_up,
                 email=email,
                 roles=roles,

--- a/src/palace/manager/api/admin/password_admin_authentication_provider.py
+++ b/src/palace/manager/api/admin/password_admin_authentication_provider.py
@@ -37,7 +37,7 @@ class PasswordAdminAuthenticationProvider(AdminAuthenticationProvider, LoggerMix
             password_sign_in_url=password_sign_in_url,
             forgot_password_url=forgot_password_url,
             support_contact_url=AdminClientConfig.admin_client_settings().support_contact_url,
-            support_contact_text=AdminClientConfig.admin_client_settings().support_contact_url,
+            support_contact_text=AdminClientConfig.admin_client_settings().support_contact_text,
             label_style=label_style,
             input_style=input_style,
             button_style=button_style,

--- a/src/palace/manager/api/admin/password_admin_authentication_provider.py
+++ b/src/palace/manager/api/admin/password_admin_authentication_provider.py
@@ -37,6 +37,7 @@ class PasswordAdminAuthenticationProvider(AdminAuthenticationProvider, LoggerMix
             password_sign_in_url=password_sign_in_url,
             forgot_password_url=forgot_password_url,
             support_contact_url=AdminClientConfig.admin_client_settings().support_contact_url,
+            support_contact_text=AdminClientConfig.admin_client_settings().support_contact_url,
             label_style=label_style,
             input_style=input_style,
             button_style=button_style,

--- a/src/palace/manager/api/templates/admin/app-home-page.html.jinja2
+++ b/src/palace/manager/api/templates/admin/app-home-page.html.jinja2
@@ -15,6 +15,10 @@
         showCircEventsDownload: {{ "true" if show_circ_events_download else "false" }},
 {%- if support_contact_url %}
         support_contact_url: "{{ support_contact_url }}",
+        supportContactUrl: "{{ support_contact_url }}",
+{%- endif %}
+{%- if support_contact_text %}
+        supportContactText: "{{ support_contact_text }}",
 {%- endif %}
         settingUp: {{ "true" if setting_up else "false" }},
         email: "{{ email }}",

--- a/src/palace/manager/api/templates/admin/auth/sign-in-form.html.jinja2
+++ b/src/palace/manager/api/templates/admin/auth/sign-in-form.html.jinja2
@@ -15,5 +15,5 @@
 
 {%- if support_contact_url %}
 <br/>
-<a href="{{ support_contact_url }}">Need help? Contact support.</a>
+<a href="{{ support_contact_url }}">Need help? {{ support_contact_text }}</a>
 {%- endif %}


### PR DESCRIPTION
## Description

- Provides customizable text labels for the sign in page support contact link.
  - Default text is provided if a support contact URL (`support_contact_text`) setting is configured via the `PALACE_ADMINUI_SUPPORT_CONTACT_URL` environment variable:
    - "mailto:" URLs default to: "Need help? Email `<email-address-from-url>`."
    - other URLs: "Need help?  Contact support."
  - The default can be overridden with the `support_contact_text` (`PALACE_ADMINUI_SUPPORT_CONTACT_TEXT` environment variable) configuration setting: "Need help? `<support_contact_text>`"

## Motivation and Context

Improve site UX and increase configurability.

[Jira PP-2768]

## How Has This Been Tested?

- Manual testing in local development environment.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/16657396612) pass.

## Checklist:

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
