### PR TITLE
More lenient OPDS2 language parsing

### DIFF
--- a/src/palace/manager/opds/types/language.py
+++ b/src/palace/manager/opds/types/language.py
@@ -30,6 +30,7 @@ class LanguageTag(str):
 
     _original: str
     _subtags: tuple[str, ...]
+    _name: str
 
     def __new__(
         cls,

--- a/src/palace/manager/opds/types/language.py
+++ b/src/palace/manager/opds/types/language.py
@@ -51,10 +51,10 @@ class LanguageTag(str):
         subtags = tuple([t.lower() for t in value.replace("_", "-").split("-")])
         primary_language = subtags[0]
 
-        # This parser is very lenient, it will accept both 2-letter and 3-letter
-        # codes and even full language names. This is not how a strict reading of
-        # RFC 5646 would work, but we see codes like this in our feed, so we do
-        # our best to handle them.
+        # This parser is intentionally lenient. It accepts both 2-letter and 3-letter
+        # language codes as well as full language names. While RFC 5646 specifies stricter
+        # parsing rules, we've implemented this approach to handle the non-standard codes
+        # frequently encountered in our feeds.
         # See: https://datatracker.ietf.org/doc/rfc5646/
         if len(primary_language) == 2:
             code = pycountry.languages.get(alpha_2=primary_language)
@@ -68,8 +68,7 @@ class LanguageTag(str):
                 # See: https://en.wikipedia.org/wiki/ISO_639-2#B_and_T_codes
                 code = pycountry.languages.get(bibliographic=primary_language)
         else:
-            # Fall back to looking up the language by name. This is not a technically valid language
-            # code, but we see it in some feeds, so we handle it anyway.
+            # Fall back to looking up the language by name.
             # TODO: We may want to add a strict mode, that raises an error in this case.
             code = pycountry.languages.get(name=value)
             if code is not None:

--- a/src/palace/manager/opds/types/language.py
+++ b/src/palace/manager/opds/types/language.py
@@ -26,7 +26,7 @@ class LanguageTag(str):
       I did some research, but at the time of writing, I wasn't able to find one.
     """
 
-    __slots__ = ("_original", "_subtags")
+    __slots__ = ("_original", "_subtags", "_name")
 
     _original: str
     _subtags: tuple[str, ...]
@@ -50,11 +50,29 @@ class LanguageTag(str):
         subtags = tuple([t.lower() for t in value.replace("_", "-").split("-")])
         primary_language = subtags[0]
 
-        code = None
+        # This parser is very lenient, it will accept both 2-letter and 3-letter
+        # codes and even full language names. This is not how a strict reading of
+        # RFC 5646 would work, but we see codes like this in our feed, so we do
+        # our best to handle them.
+        # See: https://datatracker.ietf.org/doc/rfc5646/
         if len(primary_language) == 2:
             code = pycountry.languages.get(alpha_2=primary_language)
         elif len(primary_language) == 3:
             code = pycountry.languages.get(alpha_3=primary_language)
+            if code is None:
+                # Some languages have two three-letter codes. A bibliographic
+                # code and a terminological code. We try the terminological code
+                # first, which is stored in alpha_3, and if that fails, we
+                # fall back to try the bibliographic code.
+                # See: https://en.wikipedia.org/wiki/ISO_639-2#B_and_T_codes
+                code = pycountry.languages.get(bibliographic=primary_language)
+        else:
+            # Fall back to looking up the language by name. This is not a technically valid language
+            # code, but we see it in some feeds, so we handle it anyway.
+            # TODO: We may want to add a strict mode, that raises an error in this case.
+            code = pycountry.languages.get(name=value)
+            if code is not None:
+                subtags = (code.alpha_3,)
 
         if code is None:
             raise ValueError(f"Invalid language code '{primary_language}'")
@@ -62,6 +80,7 @@ class LanguageTag(str):
         language_code = super().__new__(cls, code.alpha_3)
         language_code._original = value
         language_code._subtags = subtags
+        language_code._name = code.name
         return language_code
 
     @classmethod
@@ -107,6 +126,13 @@ class LanguageTag(str):
         Return the 3-letter ISO 639-2 language code.
         """
         return str(self)
+
+    @property
+    def name(self) -> str:
+        """
+        Return the name of the language.
+        """
+        return self._name
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {self._original}>"

--- a/tests/manager/opds/types/test_language.py
+++ b/tests/manager/opds/types/test_language.py
@@ -17,6 +17,9 @@ class TestLanguageTag:
             ("en_uk", "eng"),
             ("fra", "fra"),
             ("fR", "fra"),
+            ("fre", "fra"),
+            ("ger", "deu"),
+            ("GERMAN", "deu"),
         ],
     )
     def test_validation(self, language_code: str, expected: str) -> None:
@@ -80,6 +83,14 @@ class TestLanguageTag:
         assert language_code.code == str(language_code) == "eng"
         assert language_code.subtags == ("en", "latn", "gb", "x", "private")
         assert language_code.original == "en-Latn-GB-x-private"
+        assert language_code.name == "English"
+
+        language_code = LanguageTag("chinese")
+        assert language_code.primary_language == "zho"
+        assert language_code.code == str(language_code) == "zho"
+        assert language_code.subtags == ("zho",)
+        assert language_code.original == "chinese"
+        assert language_code.name == "Chinese"
 
 
 class TestLanguageMap:

--- a/tests/manager/opds/types/test_language.py
+++ b/tests/manager/opds/types/test_language.py
@@ -84,12 +84,36 @@ class TestLanguageTag:
         assert language_code.name == "English"
 
     @pytest.mark.parametrize(
-        "language_code, expected, warning",
+        "language_code, expected, expected_name, warning",
         [
-            ("fre", "fra", "use the terminological code 'fra' instead"),
-            ("ger", "deu", "use the terminological code 'deu' instead"),
-            ("GERMAN", "deu", "use the 3-letter code 'deu' instead"),
-            ("chinese", "zho", "use the 3-letter code 'zho' instead"),
+            pytest.param(
+                "fre",
+                "fra",
+                "French",
+                "use the terminological code 'fra' instead",
+                id="fre",
+            ),
+            pytest.param(
+                "ger",
+                "deu",
+                "German",
+                "use the terminological code 'deu' instead",
+                id="ger",
+            ),
+            pytest.param(
+                "GERMAN",
+                "deu",
+                "German",
+                "use the 3-letter code 'deu' instead",
+                id="GERMAN",
+            ),
+            pytest.param(
+                "chinese",
+                "zho",
+                "Chinese",
+                "use the 3-letter code 'zho' instead",
+                id="chinese",
+            ),
         ],
     )
     def test_lenient_parsing(
@@ -97,13 +121,17 @@ class TestLanguageTag:
         language_code: str,
         expected: str,
         warning: str,
+        expected_name: str,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """
         Test our lenient parsing of language codes.
         """
         caplog.set_level(LogLevel.warning)
-        assert LanguageTag(language_code) == expected
+        tag = LanguageTag(language_code)
+        assert tag == expected
+        assert tag.code == expected
+        assert tag.name == expected_name
         assert TypeAdapter(LanguageTag).validate_python(language_code) == expected
         assert (
             TypeAdapter(LanguageTag).validate_json(json.dumps(language_code))


### PR DESCRIPTION
## Description

Be more lenient about how we parse the OPDS2 language information.

## Motivation and Context

I was checking in on PP-2722 this morning, to make sure it looks good as it rolls out everywhere. It generally is looking good, but I'm seeing a lot of failures to parse the language information in some collections. 

This would have existed before the update to Celery, but since I'm noticing it, I thought it would make sense to make our language parsing a bit more lax. The two major categories of errors I'm seeing are: specifying the full language name like "english" or using the 3-letter bibliographic code, instead of the terminological code ("ger" instead of "deu"). 

This PR updates our language parsing to handle both those cases.

## How Has This Been Tested?

- New unit tests.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
