### PR TITLE
Update the retry parameters for apply tasks

### DIFF
--- a/src/palace/manager/celery/tasks/apply.py
+++ b/src/palace/manager/celery/tasks/apply.py
@@ -41,6 +41,7 @@ _validate_primary_identifier = partial(
     autoretry_for=(LockNotAcquired,),
     max_retries=5,
     retry_backoff=60,
+    retry_backoff_max=15 * 60,
 )
 def circulation_apply(
     task: Task,
@@ -71,6 +72,7 @@ def circulation_apply(
     autoretry_for=(LockNotAcquired,),
     max_retries=5,
     retry_backoff=60,
+    retry_backoff_max=15 * 60,
 )
 def bibliographic_apply(
     task: Task,

--- a/src/palace/manager/celery/tasks/apply.py
+++ b/src/palace/manager/celery/tasks/apply.py
@@ -25,7 +25,7 @@ def _lock(client: Redis, identifier: IdentifierData) -> RedisLock:
     return RedisLock(
         client,
         ["Apply", identifier],
-        lock_timeout=timedelta(minutes=20),
+        lock_timeout=timedelta(minutes=5),
     )
 
 
@@ -39,8 +39,8 @@ _validate_primary_identifier = partial(
     queue=QueueNames.apply,
     bind=True,
     autoretry_for=(LockNotAcquired,),
-    max_retries=4,
-    retry_backoff=30,
+    max_retries=5,
+    retry_backoff=60,
 )
 def circulation_apply(
     task: Task,
@@ -69,8 +69,8 @@ def circulation_apply(
     queue=QueueNames.apply,
     bind=True,
     autoretry_for=(LockNotAcquired,),
-    max_retries=4,
-    retry_backoff=30,
+    max_retries=5,
+    retry_backoff=60,
 )
 def bibliographic_apply(
     task: Task,

--- a/tests/manager/celery/tasks/test_apply.py
+++ b/tests/manager/celery/tasks/test_apply.py
@@ -120,4 +120,4 @@ class TestBibliographicApply:
             apply.bibliographic_apply.delay(data, edition.id, None).wait()
 
         # Make sure the task was retried
-        assert retry_mock.retry_count == 4
+        assert retry_mock.retry_count == 5


### PR DESCRIPTION
## Description

Update the lock and retry parameters for the `apply` tasks.

## Motivation and Context

Last night after the roll out of v33.0.1, we had a few celery exceptions like this:
```
Task apply.bibliographic_apply[7c5187ff-10de-40a3-b9ee-36e9da86e07f] raised unexpected: LockNotAcquired
```

There weren't too many of them, and I'd expect we did a huge amount of importing, based on the timestamps being reset, but I think based on the data in our logs, we can tune the retry parameters to make this less likely to happen. 

I set the `lock_timeout` to 5 minutes, since looking at the logs most of these apply in less then a second, and the ones that take a long time take 10 seconds. 5 minutes should be plenty of time for the timeout.

I also increased the number of retries, and the backoff, as well as setting the maximum backoff. This should all give the tasks more time to complete, and allow them to be better spaced out if there are competing tasks.

## How Has This Been Tested?

- This is mostly configuration, so it shouldn't cause an issue. 
- Once this rolls out we'll keep monitoring exceptions to see if it helps

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
