### PR TITLE
Add a pre-commit hook to prevent adding __init__.py to src/palace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,5 +70,13 @@ repos:
           - .pymarkdown.config.json
           - scan
 
+  -   repo: local
+      hooks:
+      -   id: check-namespace-package
+          name: Check that palace is a namespace package
+          language: fail
+          entry: Please remove src/palace/__init__.py
+          files: ^src/palace/__init__.py$
+
 # Exclude test files, since they may be intentionally malformed
 exclude: ^tests/files/


### PR DESCRIPTION
## Description

Add a pre-commit hook that fails if `src/palace/__init__.py` exists.

## Motivation and Context

When refactoring pycharm likes to add a `src/palace/__init__.py` file. This is undesirable, because we want to keep `palace` as a namespace package.

As I move things around, I keep missing this and accidentally adding this file, so this pre-commit hook is mostly for me 😅. 

It uses: https://pre-commit.com/index.html#fail
See: https://adamj.eu/tech/2024/01/24/pre-commit-fail-hook/

## How Has This Been Tested?

- Did some testing locally and the hook seems to be doing what I want

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
