### PR TITLE
Update MockHttpClientFixture to allow queuing responses out of order (PP-2724)

### DIFF
--- a/tests/manager/api/circulation/test_fulfillment.py
+++ b/tests/manager/api/circulation/test_fulfillment.py
@@ -57,7 +57,7 @@ class TestFetchFulfillment:
             204,
             content="This is some content.",
             media_type="application/xyz",
-            other_headers={"X-Test": "test"},
+            headers={"X-Test": "test"},
         )
         fulfillment = FetchFulfillment("http://some.location", "foo/bar")
         response = fulfillment.response()

--- a/tests/manager/integration/license/opds/odl/test_api.py
+++ b/tests/manager/integration/license/opds/odl/test_api.py
@@ -263,7 +263,7 @@ class TestOPDS2WithODLApi:
     ) -> None:
         # The response can't be parsed as JSON.
         opds2_with_odl_api_fixture.mock_http.queue_response(
-            status, other_headers=headers, content=content
+            status, headers=headers, content=content
         )
         with pytest.raises(exception):
             opds2_with_odl_api_fixture.api._request_loan_status("GET", "http://loan")
@@ -727,12 +727,12 @@ class TestOPDS2WithODLApi:
         # But the distributor says there are no available copies.
         opds2_with_odl_api_fixture.mock_http.queue_response(
             400,
-            response_type,
+            media_type=response_type,
             content=opds2_with_odl_api_fixture.files.sample_text("unavailable.json"),
         )
         opds2_with_odl_api_fixture.mock_http.queue_response(
             400,
-            response_type,
+            media_type=response_type,
             content=opds2_with_odl_api_fixture.files.sample_text("unavailable.json"),
         )
 
@@ -788,13 +788,13 @@ class TestOPDS2WithODLApi:
         # But the distributor says there are no available copies for license_unavailable_1
         opds2_with_odl_api_fixture.mock_http.queue_response(
             400,
-            "application/api-problem+json",
+            media_type="application/api-problem+json",
             content=opds2_with_odl_api_fixture.files.sample_text("unavailable.json"),
         )
         # And for license_unavailable_2
         opds2_with_odl_api_fixture.mock_http.queue_response(
             400,
-            "application/api-problem+json",
+            media_type="application/api-problem+json",
             content=opds2_with_odl_api_fixture.files.sample_text("unavailable.json"),
         )
         # But license_lent is still available, and we successfully check it out
@@ -838,7 +838,7 @@ class TestOPDS2WithODLApi:
         # But the distributor says there are no available copies.
         opds2_with_odl_api_fixture.mock_http.queue_response(
             400,
-            "application/api-problem+json",
+            media_type="application/api-problem+json",
             content=opds2_with_odl_api_fixture.files.sample_text("unavailable.json"),
         )
 
@@ -868,7 +868,7 @@ class TestOPDS2WithODLApi:
         # Test the case where we get bad JSON back from the distributor.
         opds2_with_odl_api_fixture.mock_http.queue_response(
             400,
-            "application/api-problem+json",
+            media_type="application/api-problem+json",
             content="hot garbage",
         )
 
@@ -877,7 +877,7 @@ class TestOPDS2WithODLApi:
 
         # Test the case where we just get an unknown bad response.
         opds2_with_odl_api_fixture.mock_http.queue_response(
-            500, "text/plain", content="halt and catch fire 🔥"
+            500, media_type="text/plain", content="halt and catch fire 🔥"
         )
         with pytest.raises(BadResponseException):
             opds2_with_odl_api_fixture.api_checkout()

--- a/tests/manager/integration/metadata/test_novelist.py
+++ b/tests/manager/integration/metadata/test_novelist.py
@@ -173,7 +173,7 @@ class TestNoveListAPI:
         self, novelist_fixture: NoveListFixture, http_client: MockHttpClientFixture
     ):
         # Test the lookup_recommendations() method.
-        http_client.queue_response(200, "text/html", content="yay")
+        http_client.queue_response(200, media_type="text/html", content="yay")
 
         novelist = novelist_fixture.novelist
 


### PR DESCRIPTION
## Description

Update `MockHttpClientFixture` to:
- Add `index` parameter, so we can queue out of order
- While I was there, I updated the parameter for headers from `other_headers` to `headers` and updated the type hint.
- Change requests to use a `deque` instead of a `list`, since we are inserting and removing from both sides of the list.

## Motivation and Context

In PP-2724, I need to be able to queue up responses out of order, to fit the existing test structure. Adding this in a separate PR to make it a little easier to review.

## How Has This Been Tested?

- Running unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
