### PR TITLE
More calculate work optimizations

### DIFF
--- a/src/palace/manager/data_layer/bibliographic.py
+++ b/src/palace/manager/data_layer/bibliographic.py
@@ -598,9 +598,9 @@ class BibliographicData(BaseMutableData):
 
         if old_links != new_links:
             links_to_delete = old_links - new_links
-            for link in links_to_delete:
-                db.delete(link)
-                identifier.links.remove(link)
+            for link_to_delete in links_to_delete:
+                db.delete(link_to_delete)
+                identifier.links.remove(link_to_delete)
 
         # Apply all measurements to the primary identifier
         for measurement in self.measurements:

--- a/src/palace/manager/sqlalchemy/model/identifier.py
+++ b/src/palace/manager/sqlalchemy/model/identifier.py
@@ -899,7 +899,9 @@ class Identifier(Base, IdentifierConstants, LoggerMixin):
             rep, is_new = get_one_or_create(
                 _db, Representation, url=resource.url, media_type=media_type
             )
-            resource.representation = rep
+
+            if resource.representation != rep:
+                resource.representation = rep
         elif (
             media_type
             and resource.representation

--- a/src/palace/manager/sqlalchemy/model/measurement.py
+++ b/src/palace/manager/sqlalchemy/model/measurement.py
@@ -844,7 +844,8 @@ class Measurement(Base):
             return None
         elif self.data_source.name == DataSourceConstants.METADATA_WRANGLER:
             # Data from the metadata wrangler comes in pre-normalized.
-            self._normalized_value = self.value
+            if self._normalized_value != self.value:
+                self._normalized_value = self.value
         elif (
             self.quantity_measured == self.RATING
             and self.data_source.name in self.RATING_SCALES
@@ -854,7 +855,9 @@ class Measurement(Base):
             scale_min, scale_max = self.RATING_SCALES[self.data_source.name]
             width = float(scale_max - scale_min)
             value = self.value - scale_min
-            self._normalized_value = value / width
+            new_normalized_value = value / width
+            if self._normalized_value != new_normalized_value:
+                self._normalized_value = new_normalized_value
         elif self.quantity_measured in self.PERCENTILE_SCALES:
             # Other measured quantities need to be normalized using
             # a percentile scale determined emperically.
@@ -865,6 +868,8 @@ class Measurement(Base):
                 return None
             percentiles = by_data_source[self.data_source.name]
             position = bisect.bisect_left(percentiles, self.value)
-            self._normalized_value = position * 0.01
+            new_normalized_value = position * 0.01
+            if self._normalized_value != new_normalized_value:
+                self._normalized_value = new_normalized_value
 
         return self._normalized_value

--- a/src/palace/manager/sqlalchemy/model/resource.py
+++ b/src/palace/manager/sqlalchemy/model/resource.py
@@ -196,7 +196,9 @@ class Resource(Base):
         representation, is_new = get_one_or_create(
             _db, Representation, url=self.url, media_type=media_type
         )
-        self.representation = representation
+
+        if self.representation != representation:
+            self.representation = representation
         representation.set_fetched_content(content, content_path)
 
     def set_estimated_quality(self, estimated_quality):

--- a/src/palace/manager/sqlalchemy/model/work.py
+++ b/src/palace/manager/sqlalchemy/model/work.py
@@ -1314,13 +1314,18 @@ class Work(Base, LoggerMixin):
         for classification in classifications:
             classifier.add(classification)
 
-        (genre_weights, self.fiction, self.audience, target_age) = classifier.classify(
+        (genre_weights, new_fiction, new_audience, target_age) = classifier.classify(
             default_fiction=default_fiction, default_audience=default_audience
         )
 
         new_target_age = tuple_to_numericrange(target_age)
         if self.target_age != new_target_age:
             self.target_age = new_target_age
+
+        if new_fiction != old_fiction:
+            self.fiction = new_fiction
+        if new_audience != old_audience:
+            self.audience = new_audience
 
         workgenres, workgenres_changed = self.assign_genres_from_weights(genre_weights)
 

--- a/tests/manager/data_layer/test_bibliographic.py
+++ b/tests/manager/data_layer/test_bibliographic.py
@@ -291,6 +291,93 @@ class TestBibliographicData:
         assert "http://largeimage.com/" == edition.cover_full_url
         assert None == edition.cover_thumbnail_url
 
+    def test_links_are_replaced(self, db: DatabaseTransactionFixture):
+        edition = db.edition()
+        l1 = LinkData(
+            rel=Hyperlink.IMAGE,
+            href="http://example.com/",
+            media_type=Representation.JPEG_MEDIA_TYPE,
+        )
+
+        link_to_be_deleted, ignore = edition.primary_identifier.add_link(
+            rel=Hyperlink.IMAGE,
+            href="http://example.com/to_be_deleted",
+            data_source=edition.data_source,
+            media_type=Representation.JPEG_MEDIA_TYPE,
+        )
+
+        assert len(edition.primary_identifier.links) == 1
+
+        bibliographic = BibliographicData(
+            links=[l1],
+            data_source_name=edition.data_source.name,
+        )
+        replace = ReplacementPolicy(links=True)
+        bibliographic.apply(db.session, edition, None, replace=replace)
+
+        # we expect a change because the image link has changed.
+        assert len(edition.primary_identifier.links) == 1
+        assert edition.primary_identifier.links != [link_to_be_deleted]
+
+    def test_that_links_are_not_replaced_when_no_change(
+        self, db: DatabaseTransactionFixture
+    ):
+        edition = db.edition()
+        l1 = LinkData(
+            rel=Hyperlink.IMAGE,
+            href="http://example.com/existing_link",
+            media_type=Representation.JPEG_MEDIA_TYPE,
+        )
+
+        existing_link, ignore = edition.primary_identifier.add_link(
+            rel=Hyperlink.IMAGE,
+            href="http://example.com/existing_link",
+            data_source=edition.data_source,
+            media_type=Representation.JPEG_MEDIA_TYPE,
+        )
+
+        assert len(edition.primary_identifier.links) == 1
+
+        bibliographic = BibliographicData(
+            links=[l1],
+            data_source_name=edition.data_source.name,
+        )
+        replace = ReplacementPolicy(links=True)
+        bibliographic.apply(db.session, edition, None, replace=replace)
+
+        # we expect a change because the image link has changed.
+        assert len(edition.primary_identifier.links) == 1
+        assert existing_link.id == edition.primary_identifier.links[0].id
+
+    def test_that_links_are_not_replaced_with_replacement_policy_is_false(
+        self, db: DatabaseTransactionFixture
+    ):
+        edition = db.edition()
+        l1 = LinkData(
+            rel=Hyperlink.IMAGE,
+            href="http://example.com/new_link",
+            media_type=Representation.JPEG_MEDIA_TYPE,
+        )
+
+        existing_link, ignore = edition.primary_identifier.add_link(
+            rel=Hyperlink.IMAGE,
+            href="http://example.com/existing_link",
+            data_source=edition.data_source,
+            media_type=Representation.JPEG_MEDIA_TYPE,
+        )
+
+        assert len(edition.primary_identifier.links) == 1
+
+        bibliographic = BibliographicData(
+            links=[l1],
+            data_source_name=edition.data_source.name,
+        )
+        replace = ReplacementPolicy(links=False)
+        bibliographic.apply(db.session, edition, None, replace=replace)
+
+        # we expect a change because the image link has changed.
+        assert len(edition.primary_identifier.links) == 2
+
     def test_measurements(self, db: DatabaseTransactionFixture):
         edition = db.edition()
         measurement = MeasurementData(

--- a/tests/manager/data_layer/test_bibliographic.py
+++ b/tests/manager/data_layer/test_bibliographic.py
@@ -789,6 +789,37 @@ class TestBibliographicData:
         assert "123" == contributor.lc
         assert "Robert_Jordan" == contributor.wikipedia_name
 
+    def test_update_contributions_in_relace_mode_with_no_changes(
+        self, db: DatabaseTransactionFixture
+    ):
+        edition = db.edition()
+        original_contributions = list(edition.contributions)
+        original_contributors = edition.contributors
+        assert len(edition.contributions) == 1
+        contribution = edition.contributions[0]
+        contributor = contribution.contributor
+
+        # update the contributions with the identical contribution.
+        contributor_data = ContributorData(
+            display_name=contributor.display_name,
+            sort_name=contributor.sort_name,
+            wikipedia_name=contributor.wikipedia_name,
+            viaf=contributor.viaf,
+            lc=contributor.lc,
+            roles=[contribution.role],
+        )
+
+        bibliographic = BibliographicData(
+            data_source_name=DataSource.OVERDRIVE, contributors=[contributor_data]
+        )
+
+        # we expect that no change occurred despite the replace flag.
+        assert not bibliographic.update_contributions(db.session, edition, replace=True)
+
+        # validate that the contributions did not change since no change occurred.
+        assert edition.contributions == original_contributions
+        assert edition.contributors == original_contributors
+
     def test_update_contributions_with_blank_display_name(
         self, db: DatabaseTransactionFixture
     ):


### PR DESCRIPTION
## Description
We are still seeing deadlocks and long waits on row level locks for data being updated during work.calculate_work_presentation tasks.  This update attempts to reduce lock contention by preventing unnecessary database writes when updating contributors (a source of two different classes of deadlocks), updating hyperlinks (a source of one class of deadlock) and updating measurements (not a source of dead locks but appears to be implicated in high database load due to long lock waits).  

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2788
https://ebce-lyrasis.atlassian.net/browse/PP-2763
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Unit tests updated.  
New tests added:  
*  one test to confirm that updating the contributors in replace mode with no data changes results in no deletion and reinsertion.
* one to confirm both updating the identifier links in replace mode with no data changes results in no deletions or insertions.
* one to confirm that updating the identifier links in replace mode with data changes results in insertions of new data and deletions of stale data.  Unchanged data is not touched. 

When I initially updated 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
