### PR TITLE
Disable the Celery autoscaler (PP-2803)

### DIFF
--- a/docker/runit-scripts/worker-apply/run
+++ b/docker/runit-scripts/worker-apply/run
@@ -10,4 +10,4 @@ mkdir -p /var/log/celery
 chown 1000:adm /var/log/celery
 
 # Start the celery worker
-exec env/bin/celery -A "palace.manager.celery.app" worker --uid 1000 --gid 1000 --autoscale 4,1 --hostname apply@%h -Q apply --logfile /var/log/celery/apply.log
+exec env/bin/celery -A "palace.manager.celery.app" worker --uid 1000 --gid 1000 --concurrency 4 --hostname apply@%h -Q apply --logfile /var/log/celery/apply.log

--- a/docker/runit-scripts/worker-default/run
+++ b/docker/runit-scripts/worker-default/run
@@ -10,4 +10,4 @@ mkdir -p /var/log/celery
 chown 1000:adm /var/log/celery
 
 # Start the celery worker
-exec env/bin/celery -A "palace.manager.celery.app" worker --uid 1000 --gid 1000 --autoscale 4,1 --hostname default@%h -Q high,default --logfile /var/log/celery/default.log
+exec env/bin/celery -A "palace.manager.celery.app" worker --uid 1000 --gid 1000 --concurrency 4 --hostname default@%h -Q high,default --logfile /var/log/celery/default.log


### PR DESCRIPTION
## Description

Set a fixed number of Celery workers, and disable the autoscaler.

## Motivation and Context

We're seeing this error happening, especially when we have a lot of tasks coming in:
```
{"host": "fdb0cf4d90dc", "name": "celery.worker.request", "level": "ERROR", "filename": "request.py", "message": "Task handler raised error: WorkerLostError('Worker exited prematurely: signal 15 (SIGTERM) Job: 833413.')", "timestamp": "2025-08-11T16:18:27.074656+00:00", "traceback": "Traceback (most recent call last):\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/billiard/pool.py\", line 1265, in mark_as_worker_lost\n    raise WorkerLostError(\nbilliard.einfo.ExceptionWithTraceback: \n\"\"\"\nTraceback (most recent call last):\n  File \"/var/www/circulation/env/lib/python3.10/site-packages/billiard/pool.py\", line 1265, in mark_as_worker_lost\n    raise WorkerLostError(\nbilliard.exceptions.WorkerLostError: Worker exited prematurely: signal 15 (SIGTERM) Job: 833413.\n\"\"\"", "process": 82}
```

My best guess as to whats happening is that we are triggering the race condition noted in this Celery issue: https://github.com/celery/celery/issues/7266.

I don't think we're getting much out of the autoscaler anyway, so I'm going to disable it and use a fixed concurrency number and see if that solves the `WorkerLostError`. If it doesn't I'll roll this back and look into other fixes.

## How Has This Been Tested?

- Unit tests in CI
- This one is hard to test, but its happening on minotaur, so once I get this rolled out there, we should know within a day or so if this is the fix or if I need to keep looking.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
