### PR TITLE
Add some more context to import errors (PP-2802)

### DIFF
--- a/src/palace/manager/integration/license/opds/odl/importer.py
+++ b/src/palace/manager/integration/license/opds/odl/importer.py
@@ -186,7 +186,9 @@ class OPDS2WithODLImporter(Generic[PublicationType, SettingsType], LoggerMixin):
                 raw_identifier = publication_dict.get("metadata", {}).get("identifier")
                 raw_title = publication_dict.get("metadata", {}).get("title")
                 self.log.error(
-                    f"Error validating publication (identifier: {raw_identifier}, title: {raw_title}): {e}"
+                    f"Error validating publication "
+                    f"(identifier: {raw_identifier}, title: {raw_title}, feed: {self._feed_base_url}): "
+                    f"{e}"
                 )
                 continue
 
@@ -194,7 +196,8 @@ class OPDS2WithODLImporter(Generic[PublicationType, SettingsType], LoggerMixin):
                 identifier = self._extractor.extract_identifier(publication)
             except PalaceValueError:
                 self.log.exception(
-                    "The publications identifier could not be parsed. Skipping publication."
+                    f"The publications identifier '{publication.metadata.identifier}' could not be parsed. "
+                    f"Skipping publication. Feed: {self._feed_base_url}. Metadata: {publication.metadata!r}"
                 )
                 continue
 
@@ -222,12 +225,14 @@ class OPDS2WithODLImporter(Generic[PublicationType, SettingsType], LoggerMixin):
             resp = e.response
             self.log.warning(
                 f"License Info Document is not available. "
-                f"Status link {document_link} failed with {resp.status_code} code."
+                f"Feed: {self._feed_base_url}. "
+                f"Status link '{document_link}' failed with '{resp.status_code}' code. "
+                f"Response: {resp.text if resp.text else 'No response body'}"
             )
             return None
         except ValidationError as e:
             self.log.error(
-                f"License Info Document at {document_link} is not valid. {e}"
+                f"License Info Document '{document_link}' is not valid. Feed: {self._feed_base_url}. {e}"
             )
             return None
 

--- a/tests/manager/celery/tasks/test_opds2.py
+++ b/tests/manager/celery/tasks/test_opds2.py
@@ -857,8 +857,8 @@ class TestImportCollection:
         assert len(imported) == 0
 
         assert (
-            "Error validating publication (identifier: urn:ISBN:9780792766919, title: Past Imperfect)"
-            in caplog.text
+            "Error validating publication (identifier: urn:ISBN:9780792766919, "
+            "title: Past Imperfect, feed: http://opds2.example.org/feed)" in caplog.text
         )
 
 

--- a/tests/manager/integration/license/opds/odl/test_importer.py
+++ b/tests/manager/integration/license/opds/odl/test_importer.py
@@ -320,7 +320,8 @@ class TestOPDS2WithODLImporter:
 
         # 4. Make sure that the failure is covered
         assert (
-            "Error validating publication (identifier: urn:isbn:9781234567897, title: None): 2 validation errors"
+            "Error validating publication (identifier: urn:isbn:9781234567897, "
+            "title: None, feed: http://example.com/feed): 2 validation errors"
             in caplog.text
         )
 
@@ -1216,6 +1217,6 @@ class TestOPDS2WithODLImporter:
 
         # We also logged a warning about the invalid publication
         assert (
-            "Error validating publication (identifier: None, title: None)"
+            "Error validating publication (identifier: None, title: None, feed: http://example.com/feed)"
             in caplog.text
         )


### PR DESCRIPTION
## Description

Add more context when errors occur in the OPDS2+ODL importer.

## Motivation and Context

Right now errors in our OPDS2+ODL importer don't give information about what feed the errors came from, which is useful when troubleshooting these errors.

## How Has This Been Tested?

- Updated tests
- Tested locally

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
