### PR TITLE
Set MARC `245` first indicator to "1" when main entry present. (PP-2807)

### DIFF
--- a/src/palace/manager/integration/catalog/marc/annotator.py
+++ b/src/palace/manager/integration/catalog/marc/annotator.py
@@ -69,7 +69,28 @@ class Annotator(LoggerMixin):
         cls.add_summary(record, work)
         cls.add_genres(record, work)
 
+        # Normalize record should always be called after all additions to the
+        # record have been completed.
+        cls._normalize_record(record)
         return record
+
+    @classmethod
+    def _normalize_record(cls, record: Record) -> None:
+        """Make any necessary adjustments to the record.
+
+        This method is the place to add record updates that depend on
+        information from the MARC record itself.
+        """
+
+        # Set the `245` first indicator to "1", if a Main Entry (`1xx`) is present.
+        _245_fields = record.get_fields("245")
+        if len(_245_fields) > 0 and any(
+            field
+            for field in record.fields
+            if field.tag.startswith("1") and len(field.tag) == 3
+        ):
+            for field_245 in _245_fields:
+                field_245.indicator1 = "1"
 
     @classmethod
     def library_marc_record(

--- a/src/palace/manager/integration/catalog/marc/annotator.py
+++ b/src/palace/manager/integration/catalog/marc/annotator.py
@@ -83,15 +83,17 @@ class Annotator(LoggerMixin):
         """
 
         # Set the `245` first indicator to "1", if a Main Entry (`1xx`) is present.
+        # Otherwise, set it to "0".
         # See: https://www.loc.gov/marc/bibliographic/bd245.html
         _245_fields = record.get_fields("245")
-        if len(_245_fields) > 0 and any(
+        is_1xx_present = any(
             field
             for field in record.fields
             if field.tag.startswith("1") and len(field.tag) == 3
-        ):
-            for field_245 in _245_fields:
-                field_245.indicator1 = "1"
+        )
+        _245_first_indicator = "1" if is_1xx_present else "0"
+        for field_245 in _245_fields:
+            field_245.indicator1 = _245_first_indicator
 
     @classmethod
     def library_marc_record(
@@ -311,6 +313,8 @@ class Annotator(LoggerMixin):
             subfields += [Subfield("b", str(edition.subtitle))]
         if edition.author:
             subfields += [Subfield("c", str(edition.author))]
+        # NB: The `245` first indicator is set to "0" here, but is normalized
+        # to its correct value in `cls._normalize_record`.
         record.add_field(
             Field(
                 tag="245",

--- a/src/palace/manager/integration/catalog/marc/annotator.py
+++ b/src/palace/manager/integration/catalog/marc/annotator.py
@@ -83,6 +83,7 @@ class Annotator(LoggerMixin):
         """
 
         # Set the `245` first indicator to "1", if a Main Entry (`1xx`) is present.
+        # See: https://www.loc.gov/marc/bibliographic/bd245.html
         _245_fields = record.get_fields("245")
         if len(_245_fields) > 0 and any(
             field

--- a/tests/manager/integration/catalog/marc/test_annotator.py
+++ b/tests/manager/integration/catalog/marc/test_annotator.py
@@ -647,3 +647,58 @@ class TestAnnotator:
 
         assert field1.get_subfields("u")[0] == expected_client_url_1
         assert field2.get_subfields("u")[0] == expected_client_url_2
+
+    # @pytest.mark.parametrize(
+    #     "author",
+    #     (
+    #         pytest.param("An author.")
+    #     )
+    # )
+    def test_normalize_record(
+        self,
+        db: DatabaseTransactionFixture,
+        annotator_fixture: AnnotatorFixture,
+    ):
+        # 1. Verify that a `245` in a record with at least one `1xx`
+        #    Main Entry field has a First Indicator of "1".
+        record = annotator_fixture.record()
+
+        # We need exactly one author and a sorted_author property on the
+        # edition to get a `100` field. And we need to get a `100` field
+        # here because it is the only "Main Entry" field that we currently
+        # support in the MARC export.
+        sorted_author = "Lastname, Firstname"
+        author = "Firstname Lastname"
+        edition = db.edition(authors=[author])
+        edition.sort_author = sorted_author
+        # Note the non-filing characters in the title.
+        edition.title = "Good Book"
+        non_filing_characters = 0
+
+        annotator_fixture.annotator.add_title(record, edition)
+        annotator_fixture.annotator.add_contributors(record, edition)
+        assert len(record.get_fields("245")) == 1
+        assert len(record.get_fields("100")) == 1
+        # Before we normalize the record, the `245`first indicator does
+        # not account for the `100` field...
+        annotator_fixture.assert_field(
+            record,
+            "245",
+            {
+                "a": edition.title,
+                "c": edition.author,
+            },
+            Indicators("0", str(non_filing_characters)),
+        )
+
+        # ... but, after normalization, it does.
+        annotator_fixture.annotator._normalize_record(record)
+        annotator_fixture.assert_field(
+            record,
+            "245",
+            {
+                "a": edition.title,
+                "c": edition.author,
+            },
+            Indicators("1", str(non_filing_characters)),
+        )

--- a/tests/manager/integration/catalog/marc/test_annotator.py
+++ b/tests/manager/integration/catalog/marc/test_annotator.py
@@ -673,6 +673,7 @@ class TestAnnotator:
         annotator_fixture.annotator.add_contributors(record, edition)
         assert len(record.get_fields("245")) == 1
         assert len(record.get_fields("100")) == 1
+
         # Before we normalize the record, the `245`first indicator does
         # not account for the `100` field...
         annotator_fixture.assert_field(
@@ -684,7 +685,6 @@ class TestAnnotator:
             },
             Indicators("0", str(non_filing_characters)),
         )
-
         # ... but, after normalization, it does.
         annotator_fixture.annotator._normalize_record(record)
         annotator_fixture.assert_field(

--- a/tests/manager/integration/catalog/marc/test_annotator.py
+++ b/tests/manager/integration/catalog/marc/test_annotator.py
@@ -648,12 +648,6 @@ class TestAnnotator:
         assert field1.get_subfields("u")[0] == expected_client_url_1
         assert field2.get_subfields("u")[0] == expected_client_url_2
 
-    # @pytest.mark.parametrize(
-    #     "author",
-    #     (
-    #         pytest.param("An author.")
-    #     )
-    # )
     def test_normalize_record(
         self,
         db: DatabaseTransactionFixture,

--- a/tests/manager/integration/catalog/marc/test_annotator.py
+++ b/tests/manager/integration/catalog/marc/test_annotator.py
@@ -696,3 +696,17 @@ class TestAnnotator:
             },
             Indicators("1", str(non_filing_characters)),
         )
+
+        # If we remove the `100` field and re-normalize, then
+        # the `245` first indicator should be "0".
+        record.remove_fields("100")
+        annotator_fixture.annotator._normalize_record(record)
+        annotator_fixture.assert_field(
+            record,
+            "245",
+            {
+                "a": edition.title,
+                "c": edition.author,
+            },
+            Indicators("0", str(non_filing_characters)),
+        )


### PR DESCRIPTION
## Description

Updates the MARC exporter to set [MARC 245 field](https://www.loc.gov/marc/bibliographic/bd245.html) first indicator to "1" when a main entry ("1xx") field is present and to "0" otherwise.

## Motivation and Context

Feedback from OCLC and stakeholders of The Palace Project.

[Jira PP-2807]

## How Has This Been Tested?

- Added new test cases.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/16950592379) pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [X] All new and existing tests passed.