### PR TITLE
[PP-2812] Fix missing contributor from Boundless and Bibliotheca impo…

### DIFF
--- a/src/palace/manager/data_layer/bibliographic.py
+++ b/src/palace/manager/data_layer/bibliographic.py
@@ -755,15 +755,14 @@ class BibliographicData(BaseMutableData):
                 old_contributors.append(contribution.contributor.id)
 
         for contributor_data in self.contributors:
-
-            dn = contributor_data.display_name
-            if not dn or not dn.strip():
+            try:
+                contributor_sort_name = contributor_data.find_sort_name(_db)
+            except ValueError as e:
                 self.log.warning(
-                    f"contributor display name is blank for {contributor_data}: skipping..."
+                    f"ValueError for {contributor_data}: message='{e}': skipping..."
                 )
                 continue
 
-            contributor_sort_name = contributor_data.find_sort_name(_db)
             if contributor_sort_name or contributor_data.lc or contributor_data.viaf:
                 contributor = edition.add_contributor(
                     name=contributor_sort_name,


### PR DESCRIPTION
…rts.

## Description
Changes made in https://github.com/ThePalaceProject/circulation/pull/2638 had the unintended side-effect of ignoring contributor data with sort_name but no display name.  This update fixes that bug by adding a catch block for a ValueError when resolving the sort name and skipping if no sort name can be resolved instead of wrongly assuming that a contributor data with no display name is necessarily useless.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-2812
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested locally.  Unit tests updated.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
