### PR TITLE
Only apply updates if they have a newer timestamp (PP-2805)

### DIFF
--- a/src/palace/manager/sqlalchemy/model/edition.py
+++ b/src/palace/manager/sqlalchemy/model/edition.py
@@ -171,7 +171,7 @@ class Edition(Base, EditionConstants):
 
     # Timestamps to let us know when this item was created in our database, and when it was last updated.
     created_at = Column(DateTime(timezone=True), default=utc_now)
-    updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
+    updated_at = Column(DateTime(timezone=True), default=None)
 
     def __repr__(self):
         id_repr = repr(self.primary_identifier)

--- a/tests/manager/sqlalchemy/model/test_edition.py
+++ b/tests/manager/sqlalchemy/model/test_edition.py
@@ -166,34 +166,24 @@ class TestEdition:
         with freeze_time(creation_time):
             record, _ = Edition.for_foreign_id(db.session, data_source, type_, id_)
 
-        # The edition automatically gets timestamps set on it
+        # The edition automatically gets its created_at timestamp set
         assert record.created_at == creation_time
-        assert record.updated_at == creation_time
+
+        # Its updated_at timestamp starts out as None
+        assert record.updated_at is None
 
         # Retrieving the same edition again does not change the timestamps.
         record, was_new = Edition.for_foreign_id(
             db.session, DataSource.GUTENBERG, type_, id_
         )
         assert record.created_at == creation_time
-        assert record.updated_at == creation_time
+        assert record.updated_at is None
 
-        # If I update the edition, the updated_at timestamp changes automatically
-        update_time = utc_now()
-        with freeze_time(update_time):
-            record.title = "New Title"
-            db.session.flush()
+        # If I update the edition, the updated_at timestamp does not update automatically
+        record.title = "New Title"
+        db.session.flush()
         assert record.created_at == creation_time
-        assert record.updated_at == update_time
-
-        # If I manually set the updated_at timestamp, it does not change automatically
-        manual_update_time = utc_now() + timedelta(days=1)
-        with freeze_time(manual_update_time):
-            record.title = "Another New Title"
-            record.updated_at = manual_update_time
-            record.series = "New Series"
-            db.session.flush()
-        assert record.created_at == creation_time
-        assert record.updated_at == manual_update_time
+        assert record.updated_at is None
 
     def test_sort_by_priority(self, db: DatabaseTransactionFixture):
         # Make editions created by the license source, the metadata


### PR DESCRIPTION
## Description

This PR updates the `BibliographicData.apply` and `CirculationData.apply` so that they:
- Respect `ReplacementPolicy.even_if_not_apparently_updated`
- Check before doing an apply if their timestamp is out of date

## Motivation and Context

As part of PP-2805, I wanted to make sure that we are not applying old `BibliographicData` and `CirculationData` for two reasons: 
- Since we are processing from a queue, the data in the queue may be stale
- To reduce the amount of unnecessary work we are doing

## How Has This Been Tested?

- New unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
