### PR TITLE
Add type hints for LicensePool.for_foreign_id (PP-2805)

### DIFF
--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -1551,7 +1551,7 @@ class OverdriveAPI(
             self._db,
             DataSource.OVERDRIVE,
             Identifier.OVERDRIVE_ID,
-            book_id,
+            cast(str, book_id),
             collection=self.collection,
         )
         if is_new or not license_pool.work:

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -454,7 +454,11 @@ class LicensePool(Base):
             )
 
         # Get the Identifier.
-        identifier, ignore = Identifier.for_foreign_id(_db, foreign_id_type, foreign_id)
+        identifier, ignore = Identifier.for_foreign_id(
+            _db, foreign_id_type, foreign_id, autocreate=autocreate
+        )
+        if identifier is None:
+            return None, False
 
         kw: dict[str, Any] = dict(
             data_source=data_source, identifier=identifier, collection=collection

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -6,7 +6,7 @@ import datetime
 import logging
 from collections.abc import Sequence
 from enum import IntEnum, auto
-from typing import TYPE_CHECKING, Literal, NamedTuple, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
 
 from frozendict import frozendict
 from sqlalchemy import (
@@ -386,37 +386,38 @@ class LicensePool(Base):
     @overload
     def for_foreign_id(
         self,
-        _db,
-        data_source,
-        foreign_id_type,
-        foreign_id,
-        rights_status=None,
-        collection=None,
+        _db: Session,
+        data_source: DataSource | str,
+        foreign_id_type: str,
+        foreign_id: str,
+        rights_status: str | None = ...,
+        collection: Collection | None = ...,
+        autocreate: Literal[True] = ...,
     ) -> tuple[LicensePool, bool]: ...
 
     @classmethod
     @overload
     def for_foreign_id(
         self,
-        _db,
-        data_source,
-        foreign_id_type,
-        foreign_id,
-        rights_status,
-        collection,
-        autocreate: Literal[False],
+        _db: Session,
+        data_source: DataSource | str,
+        foreign_id_type: str,
+        foreign_id: str,
+        rights_status: str | None = ...,
+        collection: Collection | None = ...,
+        autocreate: bool = ...,
     ) -> tuple[LicensePool | None, bool]: ...
 
     @classmethod
     def for_foreign_id(
         self,
-        _db,
-        data_source,
-        foreign_id_type,
-        foreign_id,
-        rights_status=None,
-        collection=None,
-        autocreate=True,
+        _db: Session,
+        data_source: DataSource | str,
+        foreign_id_type: str,
+        foreign_id: str,
+        rights_status: str | None = None,
+        collection: Collection | None = None,
+        autocreate: bool = True,
     ) -> tuple[LicensePool | None, bool]:
         """Find or create a LicensePool for the given foreign ID."""
         from palace.manager.sqlalchemy.model.collection import CollectionMissing
@@ -428,18 +429,19 @@ class LicensePool(Base):
 
         # Get the DataSource.
         if isinstance(data_source, str):
-            data_source = DataSource.lookup(_db, data_source)
-
-        active_foreign_id_type = Identifier.get_active_type(foreign_id_type)
-        active_primary_identifier_type = Identifier.get_active_type(
-            data_source.primary_identifier_type
-        )
+            data_source_or_none = DataSource.lookup(
+                _db, data_source, autocreate=autocreate
+            )
+            if data_source_or_none is None:
+                return None, False
+            data_source = data_source_or_none
 
         # The type of the foreign ID must be the primary identifier
         # type for the data source.
         if (
-            data_source.primary_identifier_type
-            and active_foreign_id_type != active_primary_identifier_type
+            data_source.primary_identifier_type is not None
+            and Identifier.get_active_type(foreign_id_type)
+            != Identifier.get_active_type(data_source.primary_identifier_type)
         ):
             raise ValueError(
                 "License pools for data source '%s' are keyed to "
@@ -454,7 +456,9 @@ class LicensePool(Base):
         # Get the Identifier.
         identifier, ignore = Identifier.for_foreign_id(_db, foreign_id_type, foreign_id)
 
-        kw = dict(data_source=data_source, identifier=identifier, collection=collection)
+        kw: dict[str, Any] = dict(
+            data_source=data_source, identifier=identifier, collection=collection
+        )
         if rights_status:
             kw["rights_status"] = rights_status
 

--- a/tests/manager/sqlalchemy/model/test_circulationevent.py
+++ b/tests/manager/sqlalchemy/model/test_circulationevent.py
@@ -48,10 +48,12 @@ class TestCirculationEvent:
         # Identify the source of the event.
         source_name = data["source"]
         source = DataSource.lookup(db.session, source_name)
+        assert source is not None
 
         # Identify which LicensePool the event is talking about.
         foreign_id = data["id"]
         identifier_type = source.primary_identifier_type
+        assert identifier_type is not None
         collection = data["collection"]
 
         license_pool, was_new = LicensePool.for_foreign_id(


### PR DESCRIPTION
## Description

Add some missing type hints for PP-2805.

## Motivation and Context

I needed these hints to fix some type issues in the PR I'm working on for PP-2805. I figured I'd break this out to its own PR to make that easier to review.

## How Has This Been Tested?

- Running mypy
- New test

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
