### PR TITLE
Add autocreate parameter when looking up edition and licensepool (PP-2805)

### DIFF
--- a/src/palace/manager/data_layer/base/mutable.py
+++ b/src/palace/manager/data_layer/base/mutable.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal, overload
+
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
@@ -27,19 +29,43 @@ class BaseMutableData(BaseModel, LoggerMixin):
     data_source_name: str
     primary_identifier_data: IdentifierData | None = None
 
-    def load_data_source(self, _db: Session) -> DataSource:
+    @overload
+    def load_data_source(
+        self, _db: Session, autocreate: Literal[True] = ...
+    ) -> DataSource: ...
+
+    @overload
+    def load_data_source(self, _db: Session, autocreate: bool) -> DataSource | None: ...
+
+    def load_data_source(
+        self, _db: Session, autocreate: bool = True
+    ) -> DataSource | None:
         """Find the DataSource associated with this circulation information."""
         if self._data_source is None:
-            obj = DataSource.lookup(_db, self.data_source_name, autocreate=True)
+            obj = DataSource.lookup(_db, self.data_source_name, autocreate=autocreate)
             self._data_source = obj
             return obj
         return self._data_source
 
-    def load_primary_identifier(self, _db: Session) -> Identifier:
+    @overload
+    def load_primary_identifier(
+        self, _db: Session, autocreate: Literal[True] = ...
+    ) -> Identifier: ...
+
+    @overload
+    def load_primary_identifier(
+        self, _db: Session, autocreate: bool
+    ) -> Identifier | None: ...
+
+    def load_primary_identifier(
+        self, _db: Session, autocreate: bool = True
+    ) -> Identifier | None:
         """Find the Identifier associated with this data."""
         if self._primary_identifier is None:
             if self.primary_identifier_data:
-                obj, ignore = self.primary_identifier_data.load(_db)
+                obj, ignore = self.primary_identifier_data.load(
+                    _db, autocreate=autocreate
+                )
                 self._primary_identifier = obj
                 return obj
             else:

--- a/src/palace/manager/data_layer/circulation.py
+++ b/src/palace/manager/data_layer/circulation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+from typing import Literal, overload
 
 from pydantic import Field, model_validator
 from sqlalchemy.orm import Session
@@ -116,9 +117,22 @@ class CirculationData(BaseMutableData):
 
         return self
 
+    @overload
     def license_pool(
-        self, _db: Session, collection: Collection | None
-    ) -> tuple[LicensePool, bool]:
+        self,
+        _db: Session,
+        collection: Collection | None,
+        autocreate: Literal[True] = ...,
+    ) -> tuple[LicensePool, bool]: ...
+
+    @overload
+    def license_pool(
+        self, _db: Session, collection: Collection | None, autocreate: bool
+    ) -> tuple[LicensePool | None, bool]: ...
+
+    def license_pool(
+        self, _db: Session, collection: Collection | None, autocreate: bool = True
+    ) -> tuple[LicensePool | None, bool]:
         """Find or create a LicensePool object for this CirculationData.
 
         :param collection: The LicensePool object will be associated with
@@ -126,18 +140,24 @@ class CirculationData(BaseMutableData):
         """
         if not collection:
             raise ValueError("Cannot find license pool: no collection provided.")
-        identifier = self.load_primary_identifier(_db)
+        identifier = self.load_primary_identifier(_db, autocreate=autocreate)
+        if identifier is None:
+            return None, False
 
-        data_source_obj = self.load_data_source(_db)
+        data_source_obj = self.load_data_source(_db, autocreate=autocreate)
+        if data_source_obj is None:
+            return None, False
+
         license_pool, is_new = LicensePool.for_foreign_id(
             _db,
             data_source=data_source_obj,
             foreign_id_type=identifier.type,
             foreign_id=identifier.identifier,
             collection=collection,
+            autocreate=autocreate,
         )
 
-        if is_new:
+        if license_pool is not None and is_new:
             license_pool.open_access = self.has_open_access_link
             license_pool.availability_time = self.last_checked
             license_pool.last_checked = self.last_checked
@@ -267,7 +287,7 @@ class CirculationData(BaseMutableData):
         # Finally, if we have data for a specific Collection's license
         # for this book, find its LicensePool and update it.
         changed_availability = False
-        if pool and self._availability_needs_update(pool):
+        if pool and self.has_changed(_db, pool=pool, collection=collection):
             # Update availability information. This may result in
             # the issuance of additional circulation events.
             if self.licenses is not None:
@@ -312,14 +332,27 @@ class CirculationData(BaseMutableData):
 
         return pool, made_changes
 
-    def _availability_needs_update(self, pool: LicensePool) -> bool:
-        """Does this CirculationData represent information more recent than
+    def has_changed(
+        self,
+        session: Session,
+        *,
+        collection: Collection | None = None,
+        pool: LicensePool | None = None,
+    ) -> bool:
+        """
+        Does this CirculationData represent information more recent than
         what we have for the given LicensePool?
         """
         if not self.last_checked:
-            # Assume that our data represents the state of affairs
-            # right now.
+            # Assume that our data represents the state of affairs right now.
             return True
+
+        if pool is None:
+            pool, _ = self.license_pool(session, collection, autocreate=False)
+        if pool is None:
+            # We don't have an existing license pool, so we need to create one.
+            return True
+
         if not pool.last_checked:
             # It looks like the LicensePool has never been checked.
             return True

--- a/src/palace/manager/data_layer/identifier.py
+++ b/src/palace/manager/data_layer/identifier.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import Field
 from sqlalchemy.orm import Session
-from typing_extensions import Self
+from typing_extensions import Self, overload
 
 from palace.manager.data_layer.base.frozen import BaseFrozenData
 from palace.manager.service.redis.key import RedisKeyGenerator
@@ -14,8 +16,22 @@ class IdentifierData(BaseFrozenData):
     identifier: str
     weight: float = Field(1.0, repr=False)
 
-    def load(self, _db: Session) -> tuple[Identifier, bool]:
-        return Identifier.for_foreign_id(_db, self.type, self.identifier)
+    @overload
+    def load(
+        self, _db: Session, autocreate: Literal[True] = ...
+    ) -> tuple[Identifier, bool]: ...
+
+    @overload
+    def load(
+        self, _db: Session, autocreate: bool
+    ) -> tuple[Identifier | None, bool]: ...
+
+    def load(
+        self, _db: Session, autocreate: bool = True
+    ) -> tuple[Identifier | None, bool]:
+        return Identifier.for_foreign_id(
+            _db, self.type, self.identifier, autocreate=autocreate
+        )
 
     @classmethod
     def from_identifier(cls, identifier: Identifier | IdentifierData) -> Self:

--- a/tests/manager/celery/tasks/test_apply.py
+++ b/tests/manager/celery/tasks/test_apply.py
@@ -74,7 +74,7 @@ class TestBibliographicApply:
         # Calling apply, creates a new edition, and sets the title as you would expect
         apply.bibliographic_apply.delay(data).wait()
 
-        edition = data.load_edition(db.session)
+        edition, _ = data.edition(db.session, autocreate=False)
         assert edition is not None
         assert edition.title == title
         assert edition.primary_identifier.type == identifier.type

--- a/tests/manager/data_layer/test_bibliographic.py
+++ b/tests/manager/data_layer/test_bibliographic.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 from copy import deepcopy
+from functools import partial
 from unittest.mock import patch
 
 import pytest
@@ -966,7 +967,7 @@ class TestBibliographicData:
         equivalent_identifiers = [x.output for x in identifier.equivalencies]
         assert [book.primary_identifier] == equivalent_identifiers
 
-    def test_load_edition(self, db: DatabaseTransactionFixture) -> None:
+    def test_edition_autocreate_false(self, db: DatabaseTransactionFixture) -> None:
         identifier = IdentifierData(
             type=db.fresh_str(),
             identifier=db.fresh_str(),
@@ -975,30 +976,32 @@ class TestBibliographicData:
             data_source_name=db.fresh_str(),
         )
 
-        # Need to have a primary identifier to load an edition.
+        get_edition = partial(data.edition, db.session, autocreate=False)
+
+        # Need to have a primary identifier to get an edition.
         with pytest.raises(
             PalaceValueError, match="BibliographicData has no primary identifier"
         ):
-            data.load_edition(db.session)
+            get_edition()
 
         data.primary_identifier_data = identifier
 
         # No datasource, no edition.
-        assert data.load_edition(db.session) is None
+        assert get_edition() == (None, False)
 
         # Datasource exists, but no identifier.
         DataSource.lookup(db.session, data.data_source_name, autocreate=True)
-        assert data.load_edition(db.session) is None
+        assert get_edition() == (None, False)
 
         # Identifier exists, but no edition.
         identifier.load(db.session)
-        assert data.load_edition(db.session) is None
+        assert get_edition() == (None, False)
 
         # Edition exists!
         edition, _ = Edition.for_foreign_id(
             db.session, data.data_source_name, identifier.type, identifier.identifier
         )
-        assert data.load_edition(db.session) is edition
+        assert get_edition() == (edition, False)
 
     def test_roundtrip(self) -> None:
         bibliographic = BibliographicData(


### PR DESCRIPTION
## Description

Add an `autocreate` parameter to the `CirculationData.licensepool` and `BibliographicData.edition` calls, to control if we create new objects in these cases.

## Motivation and Context

I needed this functionality in PP-2805, so I broke this out to a separate PR, since its logically different from the rest of that PR. In order to accomplish this I needed to pass `autocreate` though to a couple other calls, and to add a `autocreate` parameter to `Edition`.

I removed the `BibliographicData.load_edition` call and replaced it with `Bibliographic.edition(autocreate=False)` since this is more consistent with the rest of our codebase.

## How Has This Been Tested?

- New unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
