### PR TITLE
Refactor the apply task fixture (PP-2805)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ exclude_also = [
     '^\s*\.\.\.\s*$',
     '^\s*pass\s*$',
     '^\s*raise NotImplementedError\s*$',
+    'class .*\bProtocol\):',
 ]
 include_namespace_packages = true
 

--- a/src/palace/manager/celery/tasks/apply.py
+++ b/src/palace/manager/celery/tasks/apply.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from datetime import timedelta
 from functools import partial
+from typing import Any, Protocol
 
 from celery import shared_task
 
@@ -106,3 +109,41 @@ def bibliographic_apply(
         bibliographic.apply(
             session, edition, collection, replace, create_coverage_record=False
         )
+
+
+class ApplyBibliographicCallable(Protocol):
+    """
+    A callable that applies bibliographic data to the system.
+
+    For example, this could be the signature of a Celery task that processes
+    bibliographic data and updates the database accordingly:
+    apply.bibliographic_apply.delay
+    """
+
+    def __call__(
+        self,
+        bibliographic: BibliographicData,
+        /,
+        *,
+        collection_id: int,
+        replace: ReplacementPolicy | None = None,
+    ) -> Any: ...
+
+
+class ApplyCirculationCallable(Protocol):
+    """
+    A callable that applies circulation data to the system.
+
+    For example, this could be the signature of a Celery task that processes
+    circulation data and updates the database accordingly:
+    apply.circulation_apply.delay
+    """
+
+    def __call__(
+        self,
+        circulation: CirculationData,
+        /,
+        *,
+        collection_id: int,
+        replace: ReplacementPolicy | None = None,
+    ) -> Any: ...

--- a/src/palace/manager/integration/license/opds/importer.py
+++ b/src/palace/manager/integration/license/opds/importer.py
@@ -3,14 +3,17 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Any, Generic, Literal, Protocol, TypeVar
+from typing import Generic, Literal, TypeVar
 from urllib.parse import urljoin
 
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
+from palace.manager.celery.tasks.apply import (
+    ApplyBibliographicCallable,
+    ApplyCirculationCallable,
+)
 from palace.manager.data_layer.bibliographic import BibliographicData
-from palace.manager.data_layer.circulation import CirculationData
 from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.integration.license.opds.data import FailedPublication
 from palace.manager.integration.license.opds.extractor import (
@@ -23,35 +26,6 @@ from palace.manager.service.redis.models.set import IdentifierSet
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.util.http import BadResponseException
 from palace.manager.util.log import LoggerMixin
-
-
-class ApplyBibliographicCallable(Protocol):
-    """
-    A callable that applies bibliographic data to the system.
-
-    For example, this could be the signature of a Celery task that processes
-    bibliographic data and updates the database accordingly:
-    apply.bibliographic_apply.delay
-    """
-
-    def __call__(
-        self, bibliographic: BibliographicData, /, *, collection_id: int
-    ) -> Any: ...
-
-
-class ApplyCirculationCallable(Protocol):
-    """
-    A callable that applies circulation data to the system.
-
-    For example, this could be the signature of a Celery task that processes
-    circulation data and updates the database accordingly:
-    apply.circulation_apply.delay
-    """
-
-    def __call__(
-        self, circulation: CirculationData, /, *, collection_id: int
-    ) -> Any: ...
-
 
 FeedType = TypeVar("FeedType")
 PublicationType = TypeVar("PublicationType")

--- a/tests/manager/celery/tasks/test_apply.py
+++ b/tests/manager/celery/tasks/test_apply.py
@@ -120,4 +120,6 @@ class TestBibliographicApply:
             apply.bibliographic_apply.delay(data, edition.id, None).wait()
 
         # Make sure the task was retried
-        assert retry_mock.retry_count == 5
+        assert (
+            retry_mock.retry_count == 5 + 1
+        )  # 5 retries + the final call before failing


### PR DESCRIPTION
## Description

Refactor the Celery apply task fixture to more accurately mock the apply task. Previously the fixture could not handle all the arguments that the apply task could take, which was causing problems in PP-2805 when converting the Boundless importers to the the apply task.

Note: This PR also excludes `Protocol` classes from coverage, since they can't be called, it seems silly to mark those lines as uncovered.

## Motivation and Context

Breaking up some of the unrelated changes in the PR for PP-2805.

## How Has This Been Tested?

- Running unit tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
