### PR TITLE
Update logrotate configuration for celery (PP-2814)

### DIFF
--- a/docker/services/logrotate/logrotate.d/celery.conf
+++ b/docker/services/logrotate/logrotate.d/celery.conf
@@ -2,9 +2,8 @@
     missingok
     daily
     create 0660 simplified adm
-    rotate 13
+    rotate 7
     compress
-    delaycompress
     notifempty
     dateext
 }


### PR DESCRIPTION
## Description

Update the logrotate configuration baked into our docker files to be more aggressive about rotating our celery logs:
- Keep less logs on disk (they are in cloudwatch anyway, so this should be fine)
- Make sure we compress them every day

## Motivation and Context

There have been a couple instances recently where Celery logs have filled a disk.

## How Has This Been Tested?

Difficult to test this one before it gets baked into docker image.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
