### PR TITLE
Update the apply queue worker settings (PP-2842)

### DIFF
--- a/docker/runit-scripts/worker-apply/run
+++ b/docker/runit-scripts/worker-apply/run
@@ -9,5 +9,13 @@ source env/bin/activate
 mkdir -p /var/log/celery
 chown 1000:adm /var/log/celery
 
+# Tune the configuration for this worker, since it handles high volume
+# short running tasks, its configuration needs to be different from the
+# other workers.
+# These can be overridden by setting the environment variables
+# PALACE_CELERY_WORKER_APPLY_* before starting the container.
+export PALACE_CELERY_WORKER_MAX_TASKS_PER_CHILD="${PALACE_CELERY_WORKER_APPLY_MAX_TASKS_PER_CHILD:-500}"
+export PALACE_CELERY_WORKER_PREFETCH_MULTIPLIER="${PALACE_CELERY_WORKER_APPLY_PREFETCH_MULTIPLIER:-32}"
+
 # Start the celery worker
-exec env/bin/celery -A "palace.manager.celery.app" worker --uid 1000 --gid 1000 --concurrency 4 --hostname apply@%h -Q apply --logfile /var/log/celery/apply.log
+exec env/bin/celery -A "palace.manager.celery.app" worker --uid 1000 --gid 1000 --concurrency 6 --hostname apply@%h -Q apply --logfile /var/log/celery/apply.log


### PR DESCRIPTION
## Description

Bump up the apply queue worker settings with some settings suggested in the [celery documentation](https://docs.celeryq.dev/en/latest/userguide/optimizing.html#worker-settings) for queues with many short running tasks:
- PALACE_CELERY_WORKER_MAX_TASKS_PER_CHILD
- PALACE_CELERY_WORKER_PREFETCH_MULTIPLIER

I load these from the environment as well, so that they can be overridden if we need to test values in production. 

I also am bumping up the apply queue workers to 6 to see if that helps.

## Motivation and Context

I'm looking at why I can't acquire a lock in PP-2842 and I think its because the default queue is so busy with both short and long running tasks. I'm going to customize the settings for the `apply` queue, and move the `calculate_work_presentation` task there, so see if that helps resolve the issue we are seeing.

## How Has This Been Tested?

- Local docker container

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
