### PR TITLE
Retry calculate_work_presentation when work is not found

### DIFF
--- a/src/palace/manager/celery/utils.py
+++ b/src/palace/manager/celery/utils.py
@@ -29,16 +29,21 @@ def load_from_id(db: Session, model: type[T], id: int) -> T:
     This function will raise a ModelNotFoundError if the instance is not found.
     """
 
-    instance = get_one(db, model, id=id)
-    return validate_not_none(instance, f"{model.__name__} with id '{id}' not found.")
+    try:
+        instance = get_one(db, model, id=id)
+        return validate_not_none(
+            instance, f"{model.__name__} with id '{id}' not found."
+        )
+    except PalaceTypeError as e:
+        raise ModelNotFoundError(e.message)
 
 
 def validate_not_none(value: T | None, message: str) -> T:
     """
     Validate that a value is not None.
 
-    Raises a ModelNotFoundError if the value is None.
+    Raises a PalaceTypeError if the value is None.
     """
     if value is None:
-        raise ModelNotFoundError(message)
+        raise PalaceTypeError(message)
     return value

--- a/src/palace/manager/celery/utils.py
+++ b/src/palace/manager/celery/utils.py
@@ -6,10 +6,16 @@ from typing import TypeVar
 
 from sqlalchemy.orm import Session
 
-from palace.manager.core.exceptions import PalaceValueError
+from palace.manager.core.exceptions import PalaceTypeError
 from palace.manager.sqlalchemy.util import get_one
 
 T = TypeVar("T")
+
+
+class ModelNotFoundError(PalaceTypeError):
+    """
+    Raised when a model instance is not found in the database.
+    """
 
 
 def load_from_id(db: Session, model: type[T], id: int) -> T:
@@ -20,7 +26,7 @@ def load_from_id(db: Session, model: type[T], id: int) -> T:
     these tasks are asynchronous, we need to load the instance from the database
     and its possible the instance has been deleted or modified in the meantime.
 
-    This function will raise a PalaceValueError if the instance is not found.
+    This function will raise a ModelNotFoundError if the instance is not found.
     """
 
     instance = get_one(db, model, id=id)
@@ -31,8 +37,8 @@ def validate_not_none(value: T | None, message: str) -> T:
     """
     Validate that a value is not None.
 
-    Raises a PalaceValueError if the value is None.
+    Raises a ModelNotFoundError if the value is None.
     """
     if value is None:
-        raise PalaceValueError(message)
+        raise ModelNotFoundError(message)
     return value

--- a/src/palace/manager/celery/utils.py
+++ b/src/palace/manager/celery/utils.py
@@ -6,13 +6,13 @@ from typing import TypeVar
 
 from sqlalchemy.orm import Session
 
-from palace.manager.core.exceptions import PalaceTypeError
+from palace.manager.core.exceptions import PalaceTypeError, PalaceValueError
 from palace.manager.sqlalchemy.util import get_one
 
 T = TypeVar("T")
 
 
-class ModelNotFoundError(PalaceTypeError):
+class ModelNotFoundError(PalaceValueError):
     """
     Raised when a model instance is not found in the database.
     """

--- a/src/palace/manager/core/exceptions.py
+++ b/src/palace/manager/core/exceptions.py
@@ -13,6 +13,9 @@ class BasePalaceException(Exception):
 class PalaceValueError(BasePalaceException, ValueError): ...
 
 
+class PalaceTypeError(BasePalaceException, TypeError): ...
+
+
 class IntegrationException(BasePalaceException):
     """An exception that happens when the site's connection to a
     third-party service is broken.

--- a/tests/manager/celery/tasks/test_apply.py
+++ b/tests/manager/celery/tasks/test_apply.py
@@ -1,7 +1,7 @@
 import pytest
 
 from palace.manager.celery.tasks import apply
-from palace.manager.core.exceptions import PalaceValueError
+from palace.manager.core.exceptions import PalaceTypeError
 from palace.manager.data_layer.bibliographic import BibliographicData
 from palace.manager.data_layer.circulation import CirculationData
 from palace.manager.data_layer.identifier import IdentifierData
@@ -92,7 +92,7 @@ class TestBibliographicApply:
             primary_identifier_data=None,
         )
 
-        with pytest.raises(PalaceValueError, match="No primary identifier provided"):
+        with pytest.raises(PalaceTypeError, match="No primary identifier provided"):
             apply.bibliographic_apply.delay(data, edition.id, None).wait()
 
     def test_already_locked(

--- a/tests/manager/celery/tasks/test_work.py
+++ b/tests/manager/celery/tasks/test_work.py
@@ -1,9 +1,9 @@
 from unittest.mock import call, patch
 
 import pytest
-from sqlalchemy.exc import SQLAlchemyError
 
 from palace.manager.celery.tasks import apply, work as work_tasks
+from palace.manager.celery.utils import ModelNotFoundError
 from palace.manager.data_layer.policy.presentation import PresentationCalculationPolicy
 from palace.manager.service.logging.configuration import LogLevel
 from palace.manager.sqlalchemy.model.classification import Subject
@@ -70,7 +70,7 @@ def test_calculate_work_presentation_retry(
         patch.object(Work, "calculate_presentation") as calc_presentation,
         celery_fixture.patch_retry_backoff(),
     ):
-        calc_presentation.side_effect = [SQLAlchemyError(), None]
+        calc_presentation.side_effect = [ModelNotFoundError(), None]
         work_tasks.calculate_work_presentation.delay(
             work_id=work.id, policy=policy
         ).wait()

--- a/tests/manager/celery/test_utils.py
+++ b/tests/manager/celery/test_utils.py
@@ -1,6 +1,10 @@
 import pytest
 
-from palace.manager.celery.utils import load_from_id
+from palace.manager.celery.utils import (
+    ModelNotFoundError,
+    load_from_id,
+    validate_not_none,
+)
 from palace.manager.core.exceptions import PalaceTypeError
 from palace.manager.sqlalchemy.model.collection import Collection
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -19,6 +23,15 @@ class TestLoadFromId:
         db.session.delete(collection)
 
         with pytest.raises(
-            PalaceTypeError, match=f"Collection with id '{collection_id}' not found."
+            ModelNotFoundError, match=f"Collection with id '{collection_id}' not found."
         ):
             load_from_id(db.session, Collection, collection_id)
+
+
+class TestValidateNotNone:
+    def test_validate_not_none(self) -> None:
+        assert validate_not_none(1, "Should not be None") == 1
+        assert validate_not_none("test", "Should not be None") == "test"
+
+        with pytest.raises(PalaceTypeError, match="Should not be None"):
+            validate_not_none(None, "Should not be None")

--- a/tests/manager/celery/test_utils.py
+++ b/tests/manager/celery/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from palace.manager.celery.utils import load_from_id
-from palace.manager.core.exceptions import PalaceValueError
+from palace.manager.core.exceptions import PalaceTypeError
 from palace.manager.sqlalchemy.model.collection import Collection
 from tests.fixtures.database import DatabaseTransactionFixture
 
@@ -19,6 +19,6 @@ class TestLoadFromId:
         db.session.delete(collection)
 
         with pytest.raises(
-            PalaceValueError, match=f"Collection with id '{collection_id}' not found."
+            PalaceTypeError, match=f"Collection with id '{collection_id}' not found."
         ):
             load_from_id(db.session, Collection, collection_id)


### PR DESCRIPTION
## Description

- Retry `work.calculate_work_presentation` when `ModelNotFoundError` is raised.
- Make `load_from_id` raise more specific `ModelNotFoundError` instead of `PalaceValueError`
- Create a new `PalaceTypeError` exception, and make `validate_not_none` raise `PalaceTypeError`. It doesn't seem like this should have been raising a `ValueError` before. 
  - This function was only used in one place, and I made sure it wasn't handling the exception explicitly, so it should be fine to change the exception type.

## Motivation and Context

In my testing on GA and CA CM, we are getting a lot of this sort of exception: 
```
Task work.calculate_work_presentation[bede800f-84e6-4b65-87ba-a5b734027cd3] raised unexpected: PalaceValueError("Work with id '4598931' not found.")
```

Looking in the database after this is raised, in every case I've seen, the work does exist. What is happening is that this task is being run before the transaction that creates the work has been committed. Retrying in this case should solve the issue.

## How Has This Been Tested?

- I'm planning to roll this out to CA and GA once its merged to see if that sorts out the unhandled exceptions.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
