### PR TITLE
Don't raise `RequestNetworkException` when retries fail (PP-2845)

### DIFF
--- a/src/palace/manager/util/http.py
+++ b/src/palace/manager/util/http.py
@@ -250,6 +250,9 @@ class HTTP(LoggerMixin):
             total=max_retry_count,
             status_forcelist=cls.RETRY_STATUS_CODES,
             backoff_factor=backoff_factor,
+            # We set raise_on_status to False, so if our automatic retries are exhausted,
+            # we can handle the final response ourselves in _process_response.
+            raise_on_status=False,
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
 

--- a/tests/manager/core/test_http.py
+++ b/tests/manager/core/test_http.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import pytest
 import requests
 
-from palace.manager.util.http import HTTP, RequestNetworkException
+from palace.manager.util.http import HTTP, BadResponseException
 from tests.manager.util.test_mock_web_server import MockAPIServer, MockAPIServerResponse
 
 
@@ -34,7 +34,7 @@ class TestHTTP:
             response.status_code = 502
             test_http_fixture.server.enqueue_response("GET", "/test", response)
 
-        with pytest.raises(RequestNetworkException):
+        with pytest.raises(BadResponseException):
             test_http_fixture.request_with_timeout(
                 "GET", test_http_fixture.server.url("/test")
             )
@@ -50,7 +50,7 @@ class TestHTTP:
         response.status_code = 502
 
         test_http_fixture.server.enqueue_response("GET", "/test", response)
-        with pytest.raises(RequestNetworkException):
+        with pytest.raises(BadResponseException):
             test_http_fixture.request_with_timeout(
                 "GET", test_http_fixture.server.url("/test"), max_retry_count=0
             )


### PR DESCRIPTION
## Description

When `HTTP.request_with_timeout` retries a request, and the request runs out of retries and still fails we return the response as usual instead of raising a `RequestNetworkException`.

This seems like a less surprising outcome to me, and better aligns the response in the case where we have no retries, and when we do have retries. Previously with retries we would raise `RequestNetworkException` and in the case of no retries we would return the request or process it and raise a `BadResponseException`.

## Motivation and Context

In https://github.com/ThePalaceProject/circulation/pull/2709 I added `BadResponseException` to `autoretry_for`, in order to retry when we get a 429 status. 

In testing, this didn't work because we were getting a `RequestNetworkException`, because of the requests level retries.

This is a bit of a change in behaviour for `HTTP.request_with_timeout`, but looking through our codebase, I don't see anywhere we are specifically handling `RequestNetworkException` for this case, so I don't think this will have an impact anywhere.

## How Has This Been Tested?

- Updated unit tests

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
