### PR TITLE
Run OPDS2+ODL Importer less frequently (PP-2842)

### DIFF
--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -99,8 +99,8 @@ def beat_schedule() -> dict[str, Any]:
         "opds2_odl_import_all": {
             "task": opds_odl.import_all.name,
             "schedule": crontab(
-                minute="45",
-            ),  # Run every hour at 45 minutes past the hour
+                minute="45", hour="*/3"
+            ),  # Run every 3 hours at 45 minutes past the hour
         },
         "rotate_jwe_key": {
             "task": rotate_jwe_key.rotate_jwe_key.name,


### PR DESCRIPTION
## Description

Run the OPDS2+ODL importer every 3 hours instead of every hour.

## Motivation and Context

The OPDS2+ODL importer runs too slowly to be able to run it every hour. 

My plan is to bring in a task next sprint to look at this and see if I can get it running faster, but for now, I'd like to slow down the frequency with which we are running it.

## How Has This Been Tested?

- Once this is merged, I'm planning to test it out on GA and CA CM

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
