### PR TITLE
Increase import lock timeout to 1 hour (PP-2842)

### DIFF
--- a/src/palace/manager/celery/importer.py
+++ b/src/palace/manager/celery/importer.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from celery.canvas import Signature
 
 from palace.manager.service.redis.models.lock import RedisLock
@@ -46,4 +48,4 @@ def import_lock(client: Redis, collection_id: int) -> RedisLock:
     This makes sure only one task is importing data for the collection
     at a time.
     """
-    return RedisLock(client, import_key(collection_id))
+    return RedisLock(client, import_key(collection_id), lock_timeout=timedelta(hours=1))


### PR DESCRIPTION
## Description

Increase the timeout for the import_lock to 1 hour.

## Motivation and Context

Currently this lock is using the default of 5 minutes. This is too short for large imports, I've seen the lock expire while boundless imports are still taking place.

I'm planning to pull in a task next sprint to speed up the boundless imports, but I think 5 minutes is too short for this lock timeout anyway, so I think its a good idea to bump it up.

## How Has This Been Tested?

- Will test on GA and CA CM once this is merged.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
