### PR TITLE
Allow empty add call for redis sets (PP-2923)

### DIFF
--- a/src/palace/manager/service/redis/models/set.py
+++ b/src/palace/manager/service/redis/models/set.py
@@ -74,6 +74,12 @@ class RedisSet(Generic[T], LoggerMixin):
         Add models to the set. This method will also set an expiration time for the set,
         resetting the expiration time if the set already exists.
         """
+        if not models:
+            # Extend the expiration time, even if no models are added. In the case
+            # where the set doesn't exist, this is a no-op.
+            self._redis_client.expire(self._key, self.expire_time)
+            return 0
+
         with self._redis_client.pipeline() as pipe:
             pipe.sadd(self._key, *self._strs_from_models(*models))
             pipe.expire(self._key, self.expire_time)


### PR DESCRIPTION
## Description

Handle the case where the `RedisSet.add` method is called with no arguments (or an empty list of args). Previously this would raise an exception from Redis as shown below.

## Motivation and Context

We are seeing a number of these errors in our logs from the new OPDS for Distributors tasks:
```
Traceback (most recent call last):
  File "/var/www/circulation/env/lib/python3.10/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/var/www/circulation/env/lib/python3.10/site-packages/celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
  File "/var/www/circulation/src/palace/manager/celery/tasks/opds_for_distributors.py", line 71, in import_collection
    return opds_import_task(
  File "/var/www/circulation/src/palace/manager/celery/opds.py", line 53, in opds_import_task
    import_result = importer.import_feed(
  File "/var/www/circulation/src/palace/manager/integration/license/opds/importer.py", line 272, in import_feed
    identifier_set.add(*feed_bibliographic.keys())
  File "/var/www/circulation/src/palace/manager/service/redis/models/set.py", line 222, in add
    return super().add(*[self._convert(model) for model in models])
  File "/var/www/circulation/src/palace/manager/service/redis/models/set.py", line 80, in add
    sadd_result, _ = pipe.execute()
  File "/var/www/circulation/env/lib/python3.10/site-packages/redis/client.py", line 1530, in execute
    return conn.retry.call_with_retry(
  File "/var/www/circulation/env/lib/python3.10/site-packages/redis/retry.py", line 62, in call_with_retry
    return do()
  File "/var/www/circulation/env/lib/python3.10/site-packages/redis/client.py", line 1531, in <lambda>
    lambda: execute(conn, stack, raise_on_error),
  File "/var/www/circulation/env/lib/python3.10/site-packages/redis/client.py", line 1395, in _execute_transaction
    raise errors[0][1]
  File "/var/www/circulation/env/lib/python3.10/site-packages/redis/client.py", line 1385, in _execute_transaction
    self.parse_response(connection, "_")
  File "/var/www/circulation/env/lib/python3.10/site-packages/redis/client.py", line 1462, in parse_response
    result = Redis.parse_response(self, connection, command_name, **options)
  File "/var/www/circulation/env/lib/python3.10/site-packages/redis/client.py", line 584, in parse_response
    response = connection.read_response()
  File "/var/www/circulation/env/lib/python3.10/site-packages/redis/connection.py", line 616, in read_response
    raise response
redis.exceptions.ResponseError: Command # 1 (SADD ri-rhodeisland::IdentifierSet::ImportCollection::Collection::17::53366711-f5fe-4bd1-92a5-a0e5da4c11c5) of pipeline caused error: wrong number of arguments for 'sadd' command
```

## How Has This Been Tested?

- New test case

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
