### PR TITLE
Fix cross-library SAML credential collision (PP-2890)

### DIFF
--- a/src/palace/manager/integration/patron_auth/saml/provider.py
+++ b/src/palace/manager/integration/patron_auth/saml/provider.py
@@ -1,5 +1,6 @@
 from flask import url_for
 from flask_babel import lazy_gettext as _
+from sqlalchemy.orm import Session
 from werkzeug.datastructures import Authorization
 
 from palace.manager.api.authentication.base import PatronData
@@ -267,7 +268,7 @@ class SAMLWebSSOAuthenticationProvider(
     def _run_self_tests(self, _db):
         pass
 
-    def authenticated_patron(self, db, token):
+    def authenticated_patron(self, db: Session, token: dict | str):
         """Go from a token to an authenticated Patron.
 
         :param db: Database session
@@ -284,7 +285,9 @@ class SAMLWebSSOAuthenticationProvider(
             ProblemDetail if an error occurs.
         :rtype: Union[Patron, ProblemDetail]
         """
-        credential = self._credential_manager.lookup_saml_token_by_value(db, token)
+        credential = self._credential_manager.lookup_saml_token_by_value(
+            db, token, self.library_id
+        )
         if credential:
             return credential.patron
 

--- a/src/palace/manager/sqlalchemy/model/credential.py
+++ b/src/palace/manager/sqlalchemy/model/credential.py
@@ -97,7 +97,7 @@ class Credential(Base):
 
     @classmethod
     def _filter_invalid_credential(
-        cls, credential: Credential, allow_persistent_token: bool
+        cls, credential: Credential | None, allow_persistent_token: bool
     ) -> Credential | None:
         """Filter out invalid credentials based on their expiration time and persistence.
 
@@ -158,15 +158,33 @@ class Credential(Base):
 
     @classmethod
     def lookup_by_token(
-        cls, _db, data_source, token_type, token, allow_persistent_token=False
-    ):
+        cls,
+        _db: Session,
+        data_source: DataSource | None,
+        token_type: str | None,
+        token: str,
+        allow_persistent_token: bool = False,
+        *,
+        constraint: Any = None,
+    ) -> Credential | None:
         """Look up a unique token.
         Lookup will fail on expired tokens. Unless persistent tokens
         are specifically allowed, lookup will fail on persistent tokens.
-        """
 
+        :param _db: A database session.
+        :param token_type: The type of the token / credential.
+        :param token: The value of the token / credential.
+        :param data_source: A DataSource associated with the token.
+        :param allow_persistent_token: Boolean indicating whether persistent tokens are allowed.
+        :param constraint: A `sqlalchemy.Query.filter` clause.
+        """
         credential = get_one(
-            _db, Credential, data_source=data_source, type=token_type, credential=token
+            _db,
+            Credential,
+            data_source=data_source,
+            type=token_type,
+            credential=token,
+            constraint=constraint,
         )
 
         return cls._filter_invalid_credential(credential, allow_persistent_token)


### PR DESCRIPTION
## Description

Constrains patron lookup by token token in a SAML auth provider to patrons in the library associated with that auth provider.

## Motivation and Context

If a SAML IdP is used for authentication in more than one library within the same Palace Manager instance, it was possible to get a patron from another library when looking up the patron by their token.

[Jira PP-2890]

## How Has This Been Tested?

- Added a test that failed before the fix, but passes now.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/17599227450) passed.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
