### PR TITLE
Feature/fix deprecation warnings

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -41,15 +41,9 @@ timezone = UTC
 # The path separator used here should be the separator specified by "version_path_separator" below.
 # version_locations = %(here)s/bar:%(here)s/bat:alembic/versions
 
-# version path separator; As mentioned above, this is the character used to split
+# path separator; As mentioned above, this is the character used to split
 # version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
-# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
-# Valid values for version_path_separator are:
-#
-# version_path_separator = :
-# version_path_separator = ;
-# version_path_separator = space
-version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
+path_separator = os
 
 # the output encoding used when revision files
 # are written from script.py.mako

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ include_namespace_packages = true
 [tool.coverage.run]
 branch = true
 concurrency = ["multiprocessing", "thread"]
+# For some reason coverage wants to include this file, even though
+# it doesn't exist. I believe this a bug in either dependency-injector
+# or coverage, but it's not impacting us negatively, so we can just
+# tell coverage to ignore it, so we don't get a warning about it.
+omit = ["src/dependency_injector/providers.pxd", "src/dependency_injector/providers.pyx"]
 parallel = true
 relative_files = true
 source = ["src"]

--- a/src/palace/manager/integration/license/boundless/fulfillment.py
+++ b/src/palace/manager/integration/license/boundless/fulfillment.py
@@ -59,13 +59,15 @@ class BoundlessAcsFulfillment(UrlFulfillment, LoggerMixin):
         try:
             if self.verify:
                 # Actually verify the ssl certificates
-                ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+                ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
                 ssl_context.verify_mode = ssl.CERT_REQUIRED
                 ssl_context.check_hostname = True
                 ssl_context.load_verify_locations(cafile=certifi.where())
             else:
                 # Default context does no ssl verification
-                ssl_context = ssl.SSLContext()
+                ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                ssl_context.check_hostname = False
+                ssl_context.verify_mode = ssl.CERT_NONE
             req = urllib.request.Request(self.content_link)
             with urllib.request.urlopen(
                 req, timeout=20, context=ssl_context

--- a/src/palace/manager/integration/license/opds/opds1/extractor.py
+++ b/src/palace/manager/integration/license/opds/opds1/extractor.py
@@ -137,7 +137,9 @@ class Opds1Extractor(OpdsExtractor[OPDS1Feed, OPDS1Publication], BearerTokenDrmM
 
     @classmethod
     def _extract_last_update_date(cls, entry_fp: dict[str, Any]) -> datetime | None:
-        return cls._datetime(entry_fp, "updated_parsed")
+        if "updated_parsed" in entry_fp:
+            return cls._datetime(entry_fp, "updated_parsed")
+        return cls._datetime(entry_fp, "published_parsed")
 
     @staticmethod
     def _extract_publisher(entry_fp: dict[str, Any]) -> str | None:

--- a/src/palace/manager/util/resources.py
+++ b/src/palace/manager/util/resources.py
@@ -1,5 +1,10 @@
-from importlib.abc import Traversable
+import sys
 from importlib.resources import files
+
+if sys.version_info >= (3, 11):
+    from importlib.resources.abc import Traversable
+else:
+    from importlib.abc import Traversable
 
 
 def resources_dir(subdir: str) -> Traversable:


### PR DESCRIPTION
## Description

  This PR fixes several deprecation warnings that were appearing in the codebase:
  - Fixed Alembic configuration deprecation warning by updating alembic.ini
  - Fixed coverage/dependency injector warning when generating code coverage
  - Fixed feedparser deprecation warning related to base URL handling
  - Fixed SSLContext deprecation warning in Boundless fulfillment module
  - Fixed resources import path deprecation warning for importlib.resources

## Motivation and Context

  These deprecation warnings were causing noise in test output and development logs. Addressing them ensures:
  - Compatibility with newer versions of dependencies
  - Cleaner test and development output
  - Proactive maintenance before these deprecated features are removed in future versions

## How Has This Been Tested?

- Running unit tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
