### PR TITLE
Fix sqlalchemy warnings in tests

### DIFF
--- a/src/palace/manager/api/admin/controller/admin_search.py
+++ b/src/palace/manager/api/admin/controller/admin_search.py
@@ -65,14 +65,14 @@ class AdminSearchController(AdminController):
 
         # Concrete values
         subjects_list = list(
-            classification_query.group_by(Subject.name).values(
+            classification_query.group_by(Subject.name).with_entities(
                 func.distinct(Subject.name), func.count(Subject.name)
             )
         )
         subjects = self._unzip(subjects_list)
 
         audiences_list = list(
-            classification_query.group_by(Subject.audience).values(
+            classification_query.group_by(Subject.audience).with_entities(
                 func.distinct(Subject.audience), func.count(Subject.audience)
             )
         )
@@ -81,19 +81,19 @@ class AdminSearchController(AdminController):
         genres_list = list(
             classification_query.join(Subject.genre)
             .group_by(Genre.name)
-            .values(func.distinct(Genre.name), func.count(Genre.name))
+            .with_entities(func.distinct(Genre.name), func.count(Genre.name))
         )
         genres = self._unzip(genres_list)
 
         distributors_list = list(
             editions_query.join(Edition.data_source)
             .group_by(DataSource.name)
-            .values(func.distinct(DataSource.name), func.count(DataSource.name))
+            .with_entities(func.distinct(DataSource.name), func.count(DataSource.name))
         )
         distributors = self._unzip(distributors_list)
 
         languages_list = list(
-            editions_query.group_by(Edition.language).values(
+            editions_query.group_by(Edition.language).with_entities(
                 func.distinct(Edition.language), func.count(Edition.language)
             )
         )
@@ -107,7 +107,7 @@ class AdminSearchController(AdminController):
         languages = self._unzip(converted_languages_list)
 
         publishers_list = list(
-            editions_query.group_by(Edition.publisher).values(
+            editions_query.group_by(Edition.publisher).with_entities(
                 func.distinct(Edition.publisher), func.count(Edition.publisher)
             )
         )

--- a/src/palace/manager/api/admin/dashboard_stats.py
+++ b/src/palace/manager/api/admin/dashboard_stats.py
@@ -325,15 +325,15 @@ class Statistics:
         union_query = union(
             cls._loans_or_holds_query(Loan).add_columns(Patron.id.label("patron_id")),
             cls._loans_or_holds_query(Hold).add_columns(Patron.id.label("patron_id")),
-        )
+        ).subquery()
 
         return (
             select(
-                func.count(distinct(union_query.columns["patron_id"])).label("count"),
-                union_query.columns["library_id"],
+                func.count(distinct(union_query.c["patron_id"])).label("count"),
+                union_query.c["library_id"],
             )
             .select_from(union_query)
-            .group_by(union_query.columns["library_id"])
+            .group_by(union_query.c["library_id"])
         )
 
     def _gather_patron_stats(

--- a/src/palace/manager/celery/tasks/reaper.py
+++ b/src/palace/manager/celery/tasks/reaper.py
@@ -301,12 +301,12 @@ def reap_loans_or_holds_in_inactive_collections(
     """
     active_colls = Collection.active_collections_filter(
         sa_select=select(Collection.id)
-    ).subquery("active_collections")
+    ).scalar_subquery()
     ids_to_delete = (
         select(deletion_class.id)
         .join(LicensePool)
         .where(LicensePool.collection_id.not_in(active_colls))
-        .subquery()
+        .scalar_subquery()
     )
     deletion_query = delete(deletion_class).where(deletion_class.id.in_(ids_to_delete))
 

--- a/src/palace/manager/core/entrypoint.py
+++ b/src/palace/manager/core/entrypoint.py
@@ -116,6 +116,8 @@ class MediumEntryPoint(EntryPoint):
         """
         from palace.manager.sqlalchemy.model.edition import Edition
 
+        # The query should already have the necessary joins.
+        # We just filter by Edition.medium.
         return qu.filter(Edition.medium == cls.INTERNAL_NAME)
 
     @classmethod

--- a/src/palace/manager/core/entrypoint.py
+++ b/src/palace/manager/core/entrypoint.py
@@ -116,8 +116,6 @@ class MediumEntryPoint(EntryPoint):
         """
         from palace.manager.sqlalchemy.model.edition import Edition
 
-        # The query should already have the necessary joins.
-        # We just filter by Edition.medium.
         return qu.filter(Edition.medium == cls.INTERNAL_NAME)
 
     @classmethod

--- a/src/palace/manager/core/equivalents_coverage.py
+++ b/src/palace/manager/core/equivalents_coverage.py
@@ -94,7 +94,7 @@ class EquivalentIdentifiersCoverageProvider(BaseCoverageProvider):
         qu = (
             qu.select_from(Identifier)
             .where(Identifier.id.in_(identifier_ids))
-            .column(Identifier.id)
+            .add_columns(Identifier.id)
         )
 
         chained_identifiers = self._db.execute(qu).fetchall()

--- a/src/palace/manager/sqlalchemy/model/circulationevent.py
+++ b/src/palace/manager/sqlalchemy/model/circulationevent.py
@@ -20,6 +20,7 @@ class CirculationEvent(Base):
     """
 
     __tablename__ = "circulationevents"
+    __mapper_args__ = {"confirm_deleted_rows": False}
 
     # Used to explicitly tag an event as happening at an unknown time.
     NO_DATE = object()

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -125,6 +125,7 @@ class License(Base, LicenseFunctions):
     """
 
     __tablename__ = "licenses"
+    __mapper_args__ = {"confirm_deleted_rows": False}
     id: Mapped[int] = Column(Integer, primary_key=True)
 
     identifier = Column(Unicode)
@@ -212,6 +213,7 @@ class LicensePool(Base):
     UNLIMITED_ACCESS = -1
 
     __tablename__ = "licensepools"
+    __mapper_args__ = {"confirm_deleted_rows": False}
     id: Mapped[int] = Column(Integer, primary_key=True)
 
     # A LicensePool may be associated with a Work. (If it's not, no one

--- a/src/palace/manager/sqlalchemy/model/patron.py
+++ b/src/palace/manager/sqlalchemy/model/patron.py
@@ -503,6 +503,7 @@ Index("ix_patron_library_id_username", Patron.library_id, Patron.username)
 
 class Loan(Base, LoanAndHoldMixin):
     __tablename__ = "loans"
+    __mapper_args__ = {"confirm_deleted_rows": False}
     id: Mapped[int] = Column(Integer, primary_key=True)
 
     patron_id: Mapped[int] = Column(
@@ -561,6 +562,7 @@ class Hold(Base, LoanAndHoldMixin):
     """A patron is in line to check out a book."""
 
     __tablename__ = "holds"
+    __mapper_args__ = {"confirm_deleted_rows": False}
     id: Mapped[int] = Column(Integer, primary_key=True)
     patron_id: Mapped[int] = Column(
         Integer,

--- a/src/palace/manager/sqlalchemy/model/work.py
+++ b/src/palace/manager/sqlalchemy/model/work.py
@@ -707,8 +707,9 @@ class Work(Base, LoggerMixin):
 
         covers = (
             _db.query(Resource)
-            .join(Hyperlink.identifier)
-            .join(Identifier.licensed_through)
+            .join(Hyperlink, Hyperlink.resource_id == Resource.id)
+            .join(Identifier, Hyperlink.identifier_id == Identifier.id)
+            .join(LicensePool, Identifier.id == LicensePool.identifier_id)
             .filter(Resource.url.in_(cover_urls), LicensePool.work_id.in_(work_ids))
         )
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -483,7 +483,8 @@ class DatabaseTransactionFixture:
         # Roll back all database changes that happened during this
         # test, whether in the session that was just closed or some
         # other session.
-        self._transaction.rollback()
+        if self._transaction.is_active:
+            self._transaction.rollback()
 
         Configuration.SITE_CONFIGURATION_LAST_UPDATE = None
         Configuration.LAST_CHECKED_FOR_SITE_CONFIGURATION_UPDATE = None

--- a/tests/manager/celery/tasks/test_playtime_entries.py
+++ b/tests/manager/celery/tasks/test_playtime_entries.py
@@ -331,7 +331,7 @@ class TestSumPlaytimeEntriesTask:
         assert list(
             db.session.query(PlaytimeEntry)
             .order_by(PlaytimeEntry.id)
-            .values(PlaytimeEntry.tracking_id)
+            .with_entities(PlaytimeEntry.tracking_id)
         ) == [("4",), ("5",)]
 
     def test_deleted_related_rows(

--- a/tests/manager/core/test_entrypoint.py
+++ b/tests/manager/core/test_entrypoint.py
@@ -9,6 +9,7 @@ from palace.manager.core.entrypoint import (
 )
 from palace.manager.search.external_search import Filter
 from palace.manager.sqlalchemy.model.edition import Edition
+from palace.manager.sqlalchemy.model.licensing import LicensePool
 from palace.manager.sqlalchemy.model.work import Work
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.library import LibraryFixture
@@ -99,8 +100,6 @@ class TestEverythingEntryPoint:
 class TestMediumEntryPoint:
     def test_modify_database_query(self, db: DatabaseTransactionFixture):
         # Create a video, and a entry point that contains videos.
-        from palace.manager.sqlalchemy.model.licensing import LicensePool
-
         work = db.work(with_license_pool=True)
         work.license_pools[0].presentation_edition.medium = Edition.VIDEO_MEDIUM
 

--- a/tests/manager/service/integration_registry/test_base.py
+++ b/tests/manager/service/integration_registry/test_base.py
@@ -253,8 +253,8 @@ def test_registry_configurations_query() -> None:
 
     # Produces a select query, that looks for the integration by goal and protocol
     selected = registry.configurations_query(MockIntegration)
-    assert len(selected.froms) == 1
-    assert selected.froms[0] == IntegrationConfiguration.__table__
+    assert len(selected.get_final_froms()) == 1
+    assert selected.get_final_froms()[0] == IntegrationConfiguration.__table__
     assert len(selected.whereclause.clauses) == 2
     goal_clause, protocol_clause = selected.whereclause.clauses
     assert goal_clause.left.name == "goal"
@@ -269,8 +269,8 @@ def test_registry_configurations_query() -> None:
     registry.register(MockIntegration, aliases=["test", "test2"])
     for protocol in (MockIntegration, "test"):
         selected = registry.configurations_query(protocol)
-        assert len(selected.froms) == 1
-        assert selected.froms[0] == IntegrationConfiguration.__table__
+        assert len(selected.get_final_froms()) == 1
+        assert selected.get_final_froms()[0] == IntegrationConfiguration.__table__
         assert len(selected.whereclause.clauses) == 2
         goal_clause, protocol_clause = selected.whereclause.clauses
         assert goal_clause.left.name == "goal"

--- a/tests/manager/sqlalchemy/model/test_lane.py
+++ b/tests/manager/sqlalchemy/model/test_lane.py
@@ -3184,7 +3184,8 @@ class TestDatabaseBackedWorkList:
                 worklist = DatabaseBackedWorkList()
                 worklist.initialize(db.default_library(), **initialize_kwargs)
             qu, clauses = worklist.bibliographic_filter_clauses(db.session, original_qu)
-            qu = qu.filter(and_(*clauses))
+            if clauses:
+                qu = qu.filter(and_(*clauses))
             expect_titles = sorted(x.sort_title for x in expect_books)
             actual_titles = sorted(x.sort_title for x in qu)
             assert expect_titles == actual_titles


### PR DESCRIPTION
## Description

This PR addresses SQLAlchemy deprecation warnings throughout the codebase by updating query patterns to use the recommended SQLAlchemy 2.0 syntax.

## Motivation and Context

  SQLAlchemy 2.0 deprecated certain query patterns and implicit behaviors. This PR updates our code to:
  - Replace deprecated .values() method with .with_entities()
  - Use explicit join conditions instead of implicit relationship-based joins
  - Add proper __mapper_args__ configuration to ignore deletes that happen via database cascades, rather then within SQLAlchemy.

## How Has This Been Tested?

- Running tests in CI

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
