### PR TITLE
Add maxage to logrotate config

### DIFF
--- a/docker/services/logrotate/logrotate.d/celery.conf
+++ b/docker/services/logrotate/logrotate.d/celery.conf
@@ -6,4 +6,5 @@
     compress
     notifempty
     dateext
+    maxage 14
 }

--- a/docker/services/logrotate/logrotate.d/simplified.conf
+++ b/docker/services/logrotate/logrotate.d/simplified.conf
@@ -7,6 +7,7 @@
     delaycompress
     notifempty
     dateext
+    maxage 26
 }
 
 /var/log/uwsgi/*.log {
@@ -18,4 +19,5 @@
     delaycompress
     notifempty
     dateext
+    maxage 26
 }


### PR DESCRIPTION
## Description

Add the `maxage` parameter to logrotate configurations to automatically clean up old log files that exceed the specified age limits. This ensures that outdated logs from scripts that no longer run or other leftover log files are properly removed.

## Motivation and Context

This change improves log management by preventing the accumulation of old log files that are no longer needed. By setting maximum age limits:
  - Celery logs older than 14 days will be automatically removed
  - Simplified and uwsgi logs older than 26 days will be automatically removed

This should help with the disk space warnings we are getting from prod CM instances.

## How Has This Been Tested?

- Tough to validate before it gets rolled out.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
