### PR TITLE
Update elapsed_time_logging exception behavior (PP-2950)

### DIFF
--- a/src/palace/manager/util/log.py
+++ b/src/palace/manager/util/log.py
@@ -85,12 +85,23 @@ def elapsed_time_logging(
     if not skip_start:
         log_method(f"{prefix}Starting...")
     tic = time.perf_counter()
+    exception_raised = None
     try:
         yield
+    except Exception as e:
+        exception_raised = e.__class__.__name__
+        raise
     finally:
         toc = time.perf_counter()
         elapsed_time = toc - tic
-        log_method(f"{prefix}Completed. (elapsed time: {elapsed_time:0.4f} seconds)")
+        completion_message = (
+            f"Failed (raised {exception_raised})"
+            if exception_raised is not None
+            else "Completed"
+        )
+        log_method(
+            f"{prefix}{completion_message}. (elapsed time: {elapsed_time:0.4f} seconds)"
+        )
 
 
 def logger_for_cls(cls: type[object]) -> logging.Logger:


### PR DESCRIPTION
## Description

Improves the `elapsed_time_logging` context manager to differentiate between successful and failed operations in log messages. When an exception is raised within the context manager, the completion message now indicates the failure and includes the exception class name.

I noticed this while working on PP-2950, digging through log messages for that PR, it was a bit deceiving that that the time logged always said "Completed", even though the requests were failing.

## Motivation and Context

Previously, the `elapsed_time_logging` context manager would always log "Completed" regardless of whether the operation succeeded or failed. 

## How Has This Been Tested?

While working on this I added unit tests in tests/manager/util/test_log.py covering:
  - Basic successful operation logging
  - Exception handling with proper failure messages
  - Various configuration options (`message_prefix`, `skip_start`)
  - Nested context manager usage
  - Integration with actual Python loggers
  - Elapsed time formatting validation

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
