### PR TITLE
Fail and retry import if fetching license status documents fails (PP-2950)

### DIFF
--- a/src/palace/manager/integration/license/opds/importer.py
+++ b/src/palace/manager/integration/license/opds/importer.py
@@ -182,6 +182,9 @@ class OpdsImporter(Generic[FeedType, PublicationType], LoggerMixin):
         try:
             fetched_license_documents = await asyncio.gather(*tasks)
         except BadResponseException as e:
+            # If any task fails, we cancel all the outstanding tasks, so we aren't
+            # doing unnecessary fetches, then re-raise the exception to be handled
+            # by the caller.
             self.log.error(f"Failed to fetch license documents: {e}")
             for task in tasks:
                 task.cancel()

--- a/src/palace/manager/integration/license/opds/importer.py
+++ b/src/palace/manager/integration/license/opds/importer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Generic, Literal, TypeVar
@@ -166,7 +166,7 @@ class OpdsImporter(Generic[FeedType, PublicationType], LoggerMixin):
 
     async def _fetch_license_documents_concurrently(
         self,
-        results: list[tuple[IdentifierData, PublicationType, dict[str, str]]],
+        results: Sequence[tuple[IdentifierData, PublicationType, dict[str, str]]],
     ) -> list[tuple[IdentifierData, PublicationType, dict[str, LicenseInfo]]]:
         """
         Fetch license documents for multiple publications concurrently.


### PR DESCRIPTION
## Description

This PR modifies the OPDS license document import process to fail and retry the entire import operation when fetching license status documents fails with a BadResponseException. Previously, the importer would log a warning and continue with a None value when license document fetches failed, which could lead to incomplete imports.

## Motivation and Context

When importing OPDS feeds, the system fetches license documents to understand the availability and usage terms for digital content. If these fetches fail due to network issues or server problems, the previous behavior was to continue the import process without the license information. This could result in:

  - Incomplete license status information
  - Potential issues with patron access to content
  - Silent failures that are difficult to debug

While troubleshooting PP-2950, I saw that for UL we were getting a lot of 429 errors, which was leading to these publications being unavailable. Instead of this, I think its better to retry the import.

## How Has This Been Tested?

  - Added comprehensive unit tests in test_importer.py covering the failure scenarios
  - Tests verify that BadResponseException is properly propagated up from _fetch_license_document
  - Tests confirm that when one license document fetch fails, all other concurrent tasks are properly cancelled

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
