### PR TITLE
Fix flaky test__recalculate_holds_for_licensepool test

### DIFF
--- a/tests/manager/celery/tasks/test_opds_odl.py
+++ b/tests/manager/celery/tasks/test_opds_odl.py
@@ -104,10 +104,14 @@ class OpdsTaskFixture:
     def holds(
         self, collection: Collection, pool: LicensePool | None = None
     ) -> tuple[set[int], set[int]]:
+        # IMPORTANT: Each hold must have a unique start time to ensure deterministic ordering.
+        # The get_active_holds() method orders holds by start time, and if multiple holds
+        # have the same start time, the database may return them in any order, causing
+        # flaky test failures when positions are recalculated.
         expired_holds = {
             self.hold(
                 collection,
-                start=self.two_weeks_ago,
+                start=self.two_weeks_ago + timedelta(seconds=idx),
                 end=self.yesterday,
                 position=0,
                 pool=pool,
@@ -127,7 +131,7 @@ class OpdsTaskFixture:
         not_ready_non_expired_holds = {
             self.hold(
                 collection,
-                start=self.yesterday,
+                start=self.yesterday + timedelta(seconds=idx),
                 end=self.tomorrow,
                 position=idx,
                 pool=pool,


### PR DESCRIPTION
## Description

Fixed a flaky test in `test_opds_odl.py::test__recalculate_holds_for_licensepool` that was failing intermittently in CI (approximately 1 in 30 runs).

## Motivation and Context

The test was failing with the following error:
```
assert current_holds[-1].position == len(current_holds)
assert 19 == 20
```

This was caused by non-deterministic ordering of holds when multiple holds had identical `start` timestamps. The `get_active_holds()` method orders holds by start time, but when multiple holds share the same timestamp, the database may return them in any order, causing position assignments to vary between test runs.

## How Has This Been Tested?

- Added small time increments (seconds) to ensure each hold has a unique start time
- Added explanatory comments to prevent future developers from encountering the same issue
- Ran the specific test multiple times locally to verify it no longer fails
- Ran the full test suite for `test_opds_odl.py` to ensure no regressions

The fix ensures deterministic ordering by giving each hold a unique start timestamp, eliminating the race condition.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.