### PR TITLE
Add no_retry_status_codes parameter and retry count tracking to AsyncClient (PP-2950)

### DIFF
--- a/src/palace/manager/util/http/async_http.py
+++ b/src/palace/manager/util/http/async_http.py
@@ -414,6 +414,8 @@ class AsyncClient(LoggerMixin):
                         should_retry = False
 
                 if not should_retry or attempt >= max_retries:
+                    # Update the retry count before re-raising
+                    e.retry_count = attempt
                     raise e
 
                 # Calculate backoff time

--- a/src/palace/manager/util/http/base.py
+++ b/src/palace/manager/util/http/base.py
@@ -96,7 +96,7 @@ def raise_for_bad_response(
     ):
         error_message = (
             "Got status code %%s from external server, but can only continue on: %s."
-            % ", ".join(sorted(list(map(str, allowed_response_codes))))
+            % (", ".join(sorted(list(map(str, allowed_response_codes)))),)
         )
 
     if error_message:

--- a/src/palace/manager/util/http/base.py
+++ b/src/palace/manager/util/http/base.py
@@ -42,6 +42,20 @@ def get_series(status_code: int) -> ResponseCodesStringLiterals:
     return f"{int(status_code) // 100}xx"  # type: ignore[return-value]
 
 
+def status_code_matches(status_code: int, code_collection: ResponseCodesTypes) -> bool:
+    """Check if a status code matches any value in a collection.
+
+    :param status_code: The HTTP status code to check
+    :param code_collection: Collection of status codes or series (e.g., "4xx")
+    :return: True if the status code matches any value in the collection
+    """
+    code_str = str(status_code)
+    series = get_series(status_code)
+    collection_str = list(map(str, code_collection))
+
+    return code_str in collection_str or series in collection_str
+
+
 T = TypeVar("T", requests.Response, httpx.Response)
 
 
@@ -64,37 +78,31 @@ def raise_for_bad_response(
     :param disallowed_response_codes The values passed are added to 5xx, as
         http status codes that would generate BadResponseExceptions.
     """
-    allowed_response_codes_str = list(map(str, allowed_response_codes))
-    disallowed_response_codes_str = list(map(str, disallowed_response_codes))
-
-    series = get_series(response.status_code)
-    code = str(response.status_code)
-
-    if code in allowed_response_codes_str or series in allowed_response_codes_str:
+    if status_code_matches(response.status_code, allowed_response_codes):
         # The code or series has been explicitly allowed. Allow
         # the request to be processed.
         return response
 
     error_message = None
-    if (
-        series == "5xx"
-        or code in disallowed_response_codes_str
-        or series in disallowed_response_codes_str
+    series = get_series(response.status_code)
+
+    if series == "5xx" or status_code_matches(
+        response.status_code, disallowed_response_codes
     ):
         # Unless explicitly allowed, the 5xx series always results in an exception.
         error_message = BadResponseException.BAD_STATUS_CODE_MESSAGE
-    elif allowed_response_codes_str and not (
-        code in allowed_response_codes_str or series in allowed_response_codes_str
+    elif allowed_response_codes and not status_code_matches(
+        response.status_code, allowed_response_codes
     ):
         error_message = (
             "Got status code %%s from external server, but can only continue on: %s."
-            % (", ".join(sorted(allowed_response_codes_str)),)
+            % ", ".join(sorted(list(map(str, allowed_response_codes))))
         )
 
     if error_message:
         raise BadResponseException(
             str(url),
-            error_message % code,
+            error_message % response.status_code,
             debug_message=f"Response content: {response.text}",
             response=response,
         )

--- a/src/palace/manager/util/http/exception.py
+++ b/src/palace/manager/util/http/exception.py
@@ -85,11 +85,17 @@ class BadResponseException(RemoteIntegrationException, Generic[T]):
         message: str,
         response: T,
         debug_message: str | None = None,
+        retry_count: int | None = None,
     ):
         """Indicate that a remote integration has failed.
 
-        `param url_or_service` The name of the service that failed
+        :param url_or_service: The name of the service that failed
            (e.g. "Overdrive"), or the specific URL that had the problem.
+        :param message: The error message
+        :param response: The HTTP response object
+        :param debug_message: Optional debug message
+        :param retry_count: Number of times the request was retried before failing,
+            or None if retry tracking is not available
         """
         if debug_message is None:
             debug_message = (
@@ -98,6 +104,7 @@ class BadResponseException(RemoteIntegrationException, Generic[T]):
 
         super().__init__(url_or_service, message, debug_message)
         self.response: T = response
+        self.retry_count: int | None = retry_count
 
     @classmethod
     def bad_status_code(cls, url: str, response: T) -> Self:
@@ -128,3 +135,22 @@ class RequestTimedOut(RequestNetworkException):
     title = _("Timeout")
     detail = _("The server made a request to %(service)s, and that request timed out.")
     internal_message = "Timeout accessing %s: %s"
+
+    def __init__(
+        self,
+        url_or_service: str,
+        message: str,
+        debug_message: str | None = None,
+        retry_count: int | None = None,
+    ) -> None:
+        """Indicate that a request timed out.
+
+        :param url_or_service: The name of the service that failed
+           (e.g. "Overdrive"), or the specific URL that had the problem.
+        :param message: The error message
+        :param debug_message: Optional debug message
+        :param retry_count: Number of times the request was retried before failing,
+            or None if retry tracking is not available
+        """
+        super().__init__(url_or_service, message, debug_message)
+        self.retry_count: int | None = retry_count

--- a/tests/manager/util/http/test_exception.py
+++ b/tests/manager/util/http/test_exception.py
@@ -107,6 +107,26 @@ class TestBadResponseException:
         )
         assert problem_detail.status_code == 502
 
+    def test_retry_count(self):
+        """Test that retry_count is tracked properly."""
+        response = MockRequestsResponse(500, content="Server Error")
+
+        # Test without retry_count (should default to None)
+        exc_no_retry = BadResponseException("http://url/", "Error message", response)
+        assert exc_no_retry.retry_count is None
+
+        # Test with explicit retry_count of 0
+        exc_zero_retries = BadResponseException(
+            "http://url/", "Error message", response, retry_count=0
+        )
+        assert exc_zero_retries.retry_count == 0
+
+        # Test with retry_count > 0
+        exc_with_retries = BadResponseException(
+            "http://url/", "Error message", response, retry_count=3
+        )
+        assert exc_with_retries.retry_count == 3
+
     def test_bad_status_code(self):
         response = MockRequestsResponse(500, content="Internal Server Error!")
         exc = BadResponseException.bad_status_code("http://url/", response)
@@ -156,6 +176,24 @@ class TestRequestTimedOut:
         )
         assert detail.status_code == 502
         assert detail.debug_message == "Timeout accessing http://url/: I give up"
+
+    def test_retry_count(self):
+        """Test that retry_count is tracked properly."""
+        # Test without retry_count (should default to None)
+        exc_no_retry = RequestTimedOut("http://url/", "Timeout occurred")
+        assert exc_no_retry.retry_count is None
+
+        # Test with explicit retry_count of 0
+        exc_zero_retries = RequestTimedOut(
+            "http://url/", "Timeout occurred", retry_count=0
+        )
+        assert exc_zero_retries.retry_count == 0
+
+        # Test with retry_count > 0
+        exc_with_retries = RequestTimedOut(
+            "http://url/", "Timeout occurred", retry_count=2
+        )
+        assert exc_with_retries.retry_count == 2
 
 
 class TestRequestNetworkException:


### PR DESCRIPTION
## Description

This PR adds two important features to the `AsyncClient` HTTP client:

1. **`no_retry_status_codes` parameter**: Allows specific HTTP status codes to skip retry attempts, even if they would normally trigger retries. This is useful for handling status codes like 404 (Not Found) or 429 (Too Many Requests) where retries are not beneficial.

2. **Retry count tracking in exceptions**: `BadResponseException` and `RequestTimedOut` now include an optional `retry_count` attribute that tracks how many retry attempts were made before the request failed. The count is `None` when retry tracking is not available (e.g., exceptions raised from other code paths), making it clear when retry information is available versus when it's not tracked.

## Motivation and Context

- Previously, all failed requests would retry based solely on the status code being in the 5xx range or in `disallowed_response_codes`. This could lead to unnecessary retries for status codes like 404 or 429.
- When debugging failed requests, there was no way to know if or how many times a request was retried before failing.

This causes problems, even with a backoff when using Async that became evident in PP-2950. In the case we are doing 100 requests async. If say 50 of them fail with status code 429. We re-queue them all to retry after some backoff. We do use jitter to space them, but those 50 requests will then all hit at once again +/- the amount of jitter applied. In some cases this won't work. 

Having these additional parameters will allow us to handle the retry case on a more granular level.

Note: This isn't used yet, but I think it will be helpful, and if we keep getting 429 back from UL in PP-2950 I can use it to implement a different retry strategy for 429 responses.

## How Has This Been Tested?

- Added comprehensive unit tests in `test_async_http.py` covering:
  - Basic `no_retry_status_codes` functionality at request and client levels
  - Series notation support (e.g., "5xx")
  - Interaction with timeout exceptions (correctly unaffected by `no_retry_status_codes`)
  - Retry count tracking with values of None, 0, and positive integers
- Added exception-specific tests in `test_exception.py` for retry count attribute
- Unit tests passing in CI

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.