### PR TITLE
Update AsyncClient backoff implementation

### DIFF
--- a/src/palace/manager/util/backoff.py
+++ b/src/palace/manager/util/backoff.py
@@ -9,7 +9,7 @@ def exponential_backoff(
     retries: int,
     *,
     max_time: float | None = None,
-    factor: float = 1.0,
+    factor: float = 3.0,
     base: float = 3.0,
     jitter: float = 0.3,
 ) -> float:
@@ -19,12 +19,19 @@ def exponential_backoff(
     The backoff includes some random jitter to prevent thundering herd, if
     many items are retrying at the same time.
 
+    The backoff time is calculated as:
+        backoff = factor * (base ** retries) * jitter_factor
+    where jitter_factor is a random value between (1 - jitter) and (1 + jitter).
+
+    This means that the 0th retry will always wait `factor` seconds, and each subsequent retry
+    will wait `base` times longer than the previous retry, with some random jitter applied.
+
     :param retries: The number of retries that have already been attempted.
     :param max_time: The maximum number of seconds to wait before the next retry. This is used as
         a cap on the backoff time, to prevent the backoff time from growing too large. If None, there
         is no cap. Default is None.
     :param factor: A factor to multiply the backoff time by. This can be used to adjust the
-        backoff time to be faster or slower. Default is 1.0. A backoff factor of 0 means no backoff.
+        backoff time to be faster or slower. Default is 3.0. A backoff factor of 0 means no backoff.
     :param base: The base value for the exponential calculation. Default is 3.0.
     :param jitter: The amount of jitter to apply to the backoff time. This is a percentage of the backoff
         time, and is used to add randomness to the backoff time. Default is 0.3 (+/- 30%).
@@ -44,8 +51,7 @@ def exponential_backoff(
     if max_time is not None and max_time <= 0:
         raise PalaceValueError("max_time must be non-negative")
 
-    attempt = retries + 1
-    base_delay: float = factor * (base**attempt)
+    base_delay: float = factor * (base**retries)
     jitter_factor = random.uniform(1 - jitter, 1 + jitter)
     backoff = base_delay * jitter_factor
     if max_time is not None:

--- a/tests/manager/integration/license/opds/test_importer.py
+++ b/tests/manager/integration/license/opds/test_importer.py
@@ -56,8 +56,8 @@ class TestOpdsImporter:
 
         # Use the real AsyncClient but with mocked transport via async_http_client fixture
 
-        # Set the backoff factor to 0 to avoid delays in tests
-        importer._async_http_client._backoff_factor = 0
+        # Set the backoff to None to avoid delays in tests
+        importer._async_http_client._backoff = None
 
         # Create a mock license with required structure
         def create_mock_license(identifier: str) -> License:
@@ -373,8 +373,8 @@ class TestOpdsImporter:
         registry = services_fixture.services.integration_registry().license_providers()
         importer = importer_from_collection(collection, registry)
 
-        # Set the backoff factor to 0 to avoid delays in tests
-        importer._async_http_client._backoff_factor = 0
+        # Set the backoff to None to avoid delays in tests
+        importer._async_http_client._backoff = None
 
         # Create a mock publication with licenses
         def create_mock_publication_with_license(


### PR DESCRIPTION
## Description

This PR updates the `AsyncClient` backoff implementation to provide more flexibility and update the backoff calculation logic. The changes replace the hardcoded backoff configuration with a customizable function-based approach.

## Motivation and Context

The previous implementation had a few issues:
1. The exponential backoff calculation was off by one (using `retries + 1` instead of `retries`)
    - This happened as part of https://github.com/ThePalaceProject/circulation/pull/2754, I added the new `factor` parameter, but I didn't start using `retries`.
    - This change aligns the backoff calculation with the one done in urllib3 and celery, so our back off is more standard.
    - Using the default parameters, the backoff values haven't changed at all since:
      - `1 * (3 ^ (x+1)) == 3 * (3 ^ x)`
3. The backoff configuration was limited to two parameters (`factor` and `max_backoff`), which didn't allow for full customization
    - We could add additional parameters, but it seems like we would continue to need to add new ones, so just passing a backoff function seems easier. Especially while this is still relatively unused.

This change:
- Fixes the backoff calculation to correctly start at `factor` seconds for the 0th retry
- Replaces `backoff_factor` and `max_backoff` parameters with a single `backoff` function parameter that takes the retry count and returns the wait time
- Updates tests to use `backoff=None` to avoid delays during testing
- Provides sensible defaults for both web and worker clients using `functools.partial`
  - The defaults for the worker are a little more aggressive then previously, but they have been working well in my testing.

## How Has This Been Tested?

- All existing tests pass with the new implementation
- Updated tests to verify the correct backoff calculation behavior

## Checklist

- [X] I have updated the documentation accordingly.
- [x] All new and existing tests passed.