### PR TITLE
Library title-level report (PP-1888)

### DIFF
--- a/src/palace/manager/api/admin/problem_details.py
+++ b/src/palace/manager/api/admin/problem_details.py
@@ -46,6 +46,13 @@ INVALID_EDIT = pd(
     _("There was a problem with the edited metadata."),
 )
 
+INVALID_REPORT_KEY = pd(
+    "http://palaceproject.io/terms/problem/invalid-report-key",
+    400,
+    _("Invalid report key"),
+    _("No currently defined report is associated with the specified key."),
+)
+
 METADATA_REFRESH_PENDING = pd(
     "http://librarysimplified.org/terms/problem/metadata-refresh-pending",
     201,

--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -689,6 +689,14 @@ def generate_inventory_report():
     return app.manager.admin_report_controller.generate_inventory_report()
 
 
+@library_route("/admin/reports/<report_key>", methods=["POST"])
+@has_library
+@returns_json_or_response_or_problem_detail
+@requires_admin
+def generate_report(report_key: str):
+    return app.manager.admin_report_controller.generate_report(report_key=report_key)
+
+
 @app.route("/admin/sign_in_again")
 def admin_sign_in_again():
     """Allows an  admin with expired credentials to sign back in

--- a/src/palace/manager/celery/tasks/reports.py
+++ b/src/palace/manager/celery/tasks/reports.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from celery import shared_task
+from typing_extensions import Unpack
+
+from palace.manager.celery.task import Task
+from palace.manager.reporting.reports.library_collection import (
+    LibraryCollectionReport,
+    LibraryReportKwargs,
+    LibraryTitleLevelReport,
+)
+from palace.manager.service.celery.celery import QueueNames
+
+REPORT_KEY_MAPPING: dict[str, type[LibraryCollectionReport]] = {
+    report.KEY: report
+    for report in [
+        LibraryTitleLevelReport,
+    ]
+}
+
+
+@shared_task(queue=QueueNames.high, bind=True)
+def generate_report(
+    task: Task, *, key: str, **kwargs: Unpack[LibraryReportKwargs]
+) -> bool:
+    with task.session() as session:
+        report_class = REPORT_KEY_MAPPING[key]
+        report = report_class.from_task(task, **kwargs)
+        success = report.run(session=session)
+        if not success:
+            task.log.error(
+                f"Report task failed: '{report.title}' ({report.key}) for <{report.email_address}>. "
+                f"(request ID: {report.request_id}, task ID: {task.id})"
+            )
+        return success

--- a/src/palace/manager/reporting/reports/library_collection.py
+++ b/src/palace/manager/reporting/reports/library_collection.py
@@ -16,6 +16,7 @@ from typing_extensions import Unpack
 from palace.manager.celery.task import Task
 from palace.manager.core.exceptions import IntegrationException
 from palace.manager.reporting.model import ReportTable, TTabularDataProcessor
+from palace.manager.reporting.tables.library_all_title import LibraryAllTitleReportTable
 from palace.manager.reporting.util import (
     RequestIdLoggerAdapter,
     TimestampFormat,
@@ -402,3 +403,9 @@ class LibraryCollectionReport(LoggerMixin):
             )
             self.send_error_notification()
             return False
+
+
+class LibraryTitleLevelReport(LibraryCollectionReport):
+    KEY = "title-level-report"
+    TITLE = "Title-Level Report"
+    TABLE_CLASSES = [LibraryAllTitleReportTable]


### PR DESCRIPTION
## Description

- Adds a library title-level report based on the `LibraryAllTitleReportTable`.
- Adds a new `/admin/reports/<report_key>` endpoint through which a properly configured report may be requested by their keys.
- Adds a `generate_reports` celery task that will be used to run reports requested through the endpoint.

**Note**: This PR depends on #2750. It should not be merged before that one has made it in.

## Motivation and Context

Provides the report capability requested on PP-1888.

## How Has This Been Tested?

- **Still needs tests**

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
