### PR TITLE
Add retry count tracking to AsyncClient responses

### DIFF
--- a/src/palace/manager/util/backoff.py
+++ b/src/palace/manager/util/backoff.py
@@ -9,7 +9,7 @@ def exponential_backoff(
     retries: int,
     *,
     max_time: float | None = None,
-    factor: float = 1.0,
+    factor: float = 3.0,
     base: float = 3.0,
     jitter: float = 0.3,
 ) -> float:
@@ -19,12 +19,19 @@ def exponential_backoff(
     The backoff includes some random jitter to prevent thundering herd, if
     many items are retrying at the same time.
 
+    The backoff time is calculated as:
+        backoff = factor * (base ** retries) * jitter_factor
+    where jitter_factor is a random value between (1 - jitter) and (1 + jitter).
+
+    This means that the 0th retry will always wait `factor` seconds, and each subsequent retry
+    will wait `base` times longer than the previous retry, with some random jitter applied.
+
     :param retries: The number of retries that have already been attempted.
     :param max_time: The maximum number of seconds to wait before the next retry. This is used as
         a cap on the backoff time, to prevent the backoff time from growing too large. If None, there
         is no cap. Default is None.
     :param factor: A factor to multiply the backoff time by. This can be used to adjust the
-        backoff time to be faster or slower. Default is 1.0. A backoff factor of 0 means no backoff.
+        backoff time to be faster or slower. Default is 3.0. A backoff factor of 0 means no backoff.
     :param base: The base value for the exponential calculation. Default is 3.0.
     :param jitter: The amount of jitter to apply to the backoff time. This is a percentage of the backoff
         time, and is used to add randomness to the backoff time. Default is 0.3 (+/- 30%).
@@ -44,8 +51,7 @@ def exponential_backoff(
     if max_time is not None and max_time <= 0:
         raise PalaceValueError("max_time must be non-negative")
 
-    attempt = retries + 1
-    base_delay: float = factor * (base**attempt)
+    base_delay: float = factor * (base**retries)
     jitter_factor = random.uniform(1 - jitter, 1 + jitter)
     backoff = base_delay * jitter_factor
     if max_time is not None:

--- a/tests/manager/integration/license/opds/test_importer.py
+++ b/tests/manager/integration/license/opds/test_importer.py
@@ -56,8 +56,8 @@ class TestOpdsImporter:
 
         # Use the real AsyncClient but with mocked transport via async_http_client fixture
 
-        # Set the backoff factor to 0 to avoid delays in tests
-        importer._async_http_client._backoff_factor = 0
+        # Set the backoff to None to avoid delays in tests
+        importer._async_http_client._backoff = None
 
         # Create a mock license with required structure
         def create_mock_license(identifier: str) -> License:
@@ -373,8 +373,8 @@ class TestOpdsImporter:
         registry = services_fixture.services.integration_registry().license_providers()
         importer = importer_from_collection(collection, registry)
 
-        # Set the backoff factor to 0 to avoid delays in tests
-        importer._async_http_client._backoff_factor = 0
+        # Set the backoff to None to avoid delays in tests
+        importer._async_http_client._backoff = None
 
         # Create a mock publication with licenses
         def create_mock_publication_with_license(


### PR DESCRIPTION
## Description

This PR adds retry count tracking to the `AsyncClient` class, storing the number of retry attempts in `response.extensions["retry_count"]` for successful requests. This provides visibility into how many retries were performed for each HTTP request, which is valuable for debugging and monitoring.

## Motivation and Context

I needed this while working on PP-2950, not just for exceptions, but its helpful to know the retry count on successes as well. This builds on top of https://github.com/ThePalaceProject/circulation/pull/2762

## How Has This Been Tested?

Added comprehensive test coverage in `tests/manager/util/http/test_async_http.py`:
- `test_retry_count_tracking_in_response`: Verifies retry count is tracked correctly for successful responses after retries
- `test_retry_count_tracking_on_failure`: Verifies retry count is tracked when requests ultimately fail after exhausting retries
- `test_retry_count_zero_on_immediate_success`: Verifies retry count is 0 when request succeeds on first attempt

All tests pass successfully with the new implementation.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.