### PR TITLE
Add Retry-After header support to AsyncClient (PP-2950)

### DIFF
--- a/src/palace/manager/util/http/base.py
+++ b/src/palace/manager/util/http/base.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Collection
+from email.utils import parsedate_to_datetime
 from typing import Literal, TypeVar
 
 import httpx
 import requests
 
 from palace import manager
+from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.http.exception import BadResponseException
 
 # In case an app version is not present, we can use this version as a fallback
@@ -107,3 +109,34 @@ def raise_for_bad_response(
             response=response,
         )
     return response
+
+
+def parse_retry_after(header_value: str | None) -> float | None:
+    """
+    Parse the Retry-After header value and return the delay in seconds.
+
+    The Retry-After header can be in two formats:
+    1. A delay in seconds (e.g., "120")
+    2. An HTTP-date (e.g., "Fri, 31 Dec 1999 23:59:59 GMT")
+
+    :param header_value: The Retry-After header value
+    :return: The delay in seconds, or None if the header is invalid or missing
+    """
+    if not header_value:
+        return None
+
+    # First, try to parse as an integer (delay-seconds)
+    try:
+        return float(header_value)
+    except ValueError:
+        pass
+
+    # Try to parse as HTTP-date
+    try:
+        retry_date = parsedate_to_datetime(header_value)
+        delay = (retry_date - utc_now()).total_seconds()
+        # Return delay only if it's positive (future date)
+        return max(0, delay)
+    except (TypeError, ValueError, AttributeError):
+        # Invalid date format
+        return None

--- a/src/palace/manager/util/http/base.py
+++ b/src/palace/manager/util/http/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Collection
 from email.utils import parsedate_to_datetime
 from typing import Literal, TypeVar
@@ -111,6 +112,9 @@ def raise_for_bad_response(
     return response
 
 
+log = logging.getLogger(__name__)
+
+
 def parse_retry_after(header_value: str | None) -> float | None:
     """
     Parse the Retry-After header value and return the delay in seconds.
@@ -139,4 +143,5 @@ def parse_retry_after(header_value: str | None) -> float | None:
         return max(0, delay)
     except (TypeError, ValueError, AttributeError):
         # Invalid date format
+        log.warning(f"Invalid Retry-After header format: {header_value}")
         return None

--- a/tests/manager/util/http/test_base.py
+++ b/tests/manager/util/http/test_base.py
@@ -33,6 +33,7 @@ class TestParseRetryAfter:
         result = parse_retry_after(date_str)
         # Should be approximately 60 seconds, allowing for slight timing differences
         # due to rounding since the time is captured at second resolution
+        assert result is not None
         assert 59 < result <= 60
 
     @freeze_time()

--- a/tests/manager/util/http/test_base.py
+++ b/tests/manager/util/http/test_base.py
@@ -1,7 +1,51 @@
-from palace.manager.util.http.base import get_series
+from palace.manager.util.http.base import get_series, parse_retry_after
 
 
 def test_get_series() -> None:
     assert get_series(201) == "2xx"
     assert get_series(399) == "3xx"
     assert get_series(500) == "5xx"
+
+
+class TestParseRetryAfter:
+    """Tests for the parse_retry_after helper function."""
+
+    def test_parse_retry_after_seconds(self):
+        """Test parsing delay-seconds format."""
+        assert parse_retry_after("120") == 120.0
+        assert parse_retry_after("0") == 0.0
+        assert parse_retry_after("3.5") == 3.5
+
+    def test_parse_retry_after_http_date(self):
+        """Test parsing HTTP-date format."""
+        from datetime import datetime, timedelta, timezone
+
+        # Create a date 60 seconds in the future
+        future = datetime.now(timezone.utc) + timedelta(seconds=60)
+        date_str = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+        result = parse_retry_after(date_str)
+        # Should be approximately 60 seconds (allow small variance)
+        assert result is not None
+        assert 58 <= result <= 62
+
+    def test_parse_retry_after_past_date(self):
+        """Test that past dates return 0."""
+        from datetime import datetime, timedelta, timezone
+
+        # Create a date 60 seconds in the past
+        past = datetime.now(timezone.utc) - timedelta(seconds=60)
+        date_str = past.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+        result = parse_retry_after(date_str)
+        assert result == 0  # Past dates should return 0
+
+    def test_parse_retry_after_invalid(self):
+        """Test invalid Retry-After values return None."""
+        assert parse_retry_after(None) is None
+        assert parse_retry_after("") is None
+        assert parse_retry_after("invalid") is None
+        assert parse_retry_after("not-a-number") is None
+        assert (
+            parse_retry_after("Mon, 32 Jan 2024 25:61:61 GMT") is None
+        )  # Invalid date

--- a/tests/manager/util/http/test_base.py
+++ b/tests/manager/util/http/test_base.py
@@ -1,3 +1,10 @@
+from datetime import timedelta
+
+import pytest
+from freezegun import freeze_time
+
+from palace.manager.service.logging.configuration import LogLevel
+from palace.manager.util.datetime_helpers import utc_now
 from palace.manager.util.http.base import get_series, parse_retry_after
 
 
@@ -10,42 +17,50 @@ def test_get_series() -> None:
 class TestParseRetryAfter:
     """Tests for the parse_retry_after helper function."""
 
-    def test_parse_retry_after_seconds(self):
+    def test_parse_retry_after_seconds(self) -> None:
         """Test parsing delay-seconds format."""
         assert parse_retry_after("120") == 120.0
         assert parse_retry_after("0") == 0.0
         assert parse_retry_after("3.5") == 3.5
 
-    def test_parse_retry_after_http_date(self):
+    @freeze_time()
+    def test_parse_retry_after_http_date(self) -> None:
         """Test parsing HTTP-date format."""
-        from datetime import datetime, timedelta, timezone
-
         # Create a date 60 seconds in the future
-        future = datetime.now(timezone.utc) + timedelta(seconds=60)
+        future = utc_now() + timedelta(seconds=60)
         date_str = future.strftime("%a, %d %b %Y %H:%M:%S GMT")
 
         result = parse_retry_after(date_str)
-        # Should be approximately 60 seconds (allow small variance)
-        assert result is not None
-        assert 58 <= result <= 62
+        # Should be approximately 60 seconds, allowing for slight timing differences
+        # due to rounding since the time is captured at second resolution
+        assert 59 < result <= 60
 
-    def test_parse_retry_after_past_date(self):
+    @freeze_time()
+    def test_parse_retry_after_past_date(self) -> None:
         """Test that past dates return 0."""
-        from datetime import datetime, timedelta, timezone
-
         # Create a date 60 seconds in the past
-        past = datetime.now(timezone.utc) - timedelta(seconds=60)
+        past = utc_now() - timedelta(seconds=60)
         date_str = past.strftime("%a, %d %b %Y %H:%M:%S GMT")
 
         result = parse_retry_after(date_str)
         assert result == 0  # Past dates should return 0
 
-    def test_parse_retry_after_invalid(self):
+    @pytest.mark.parametrize(
+        "header_value",
+        [
+            None,
+            "",
+            "invalid",
+            "not-a-number",
+            pytest.param("Mon, 32 Jan 2024 25:61:61 GMT", id="Bad date format"),
+            pytest.param("Tue, 29 Oct 2024 16:56:32", id="Non-GMT timezone"),
+        ],
+    )
+    def test_parse_retry_after_invalid(
+        self, caplog: pytest.LogCaptureFixture, header_value: str | None
+    ) -> None:
         """Test invalid Retry-After values return None."""
-        assert parse_retry_after(None) is None
-        assert parse_retry_after("") is None
-        assert parse_retry_after("invalid") is None
-        assert parse_retry_after("not-a-number") is None
-        assert (
-            parse_retry_after("Mon, 32 Jan 2024 25:61:61 GMT") is None
-        )  # Invalid date
+        caplog.set_level(LogLevel.warning)
+        assert parse_retry_after(header_value) is None
+        if header_value:
+            assert "Invalid Retry-After header format" in caplog.text


### PR DESCRIPTION
## Description

This PR adds support for the Retry-After HTTP header in `AsyncClient`, allowing the client to respect server-specified retry delays when encountering rate limits or temporary unavailability.

## Motivation and Context

Getting UL harvesting to work with our new AsyncClient in PP-2950 has been a bit of a journey. I ended up going down a few different paths that didn't work. After doing a bunch of testing, they are returning `Retry-After` headers, and when we respect these headers, I am finally able to successfully harvest the whole feed locally. 🎉 

Building on the backoff implementation in https://github.com/ThePalaceProject/circulation/pull/2762, this adds intelligent retry behaviour by parsing and respecting the Retry-After header sent by servers. 

The implementation:
- Supports both delay-seconds and HTTP-date formats for Retry-After headers specified in the RFC
- Uses the larger of the calculated backoff and Retry-After delay
- Includes a configurable maximum delay cap to prevent excessive waits
- Can be disabled if needed via the `respect_retry_after` parameter

## How Has This Been Tested?

Added new unit tests covering:
- Retry-After with delay-seconds format
- Retry-After with HTTP-date format  
- Comparison logic between backoff and Retry-After delays
- Maximum delay capping behavior
- Disabling Retry-After support
- Invalid header handling

All existing and new tests pass.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.