### PR TITLE
Add SAML template parameter support for OPDS2 token authentication (PP-2990)

### DIFF
--- a/src/palace/manager/integration/license/opds/opds2/api.py
+++ b/src/palace/manager/integration/license/opds/opds2/api.py
@@ -44,9 +44,7 @@ class TemplateVariable(StrEnum):
 SAML_TEMPLATE_VARIABLES: frozenset[str] = frozenset(
     var for var in TemplateVariable if var.startswith("saml_")
 )
-SUPPORTED_TEMPLATE_VARIABLES: frozenset[str] = frozenset(
-    var for var in TemplateVariable
-)
+SUPPORTED_TEMPLATE_VARIABLES: frozenset[str] = frozenset(TemplateVariable)
 
 
 class OPDS2API(BaseOPDSAPI):

--- a/src/palace/manager/integration/license/opds/opds2/api.py
+++ b/src/palace/manager/integration/license/opds/opds2/api.py
@@ -77,6 +77,10 @@ class OPDS2API(BaseOPDSAPI):
     ) -> tuple[str | None, list[str] | None]:
         """Get the SAML token arguments for a patron
 
+        This method extracts values for the SAML-related members of TemplateVariable
+        (SAML_ENTITY_ID and SAML_PERSON_SCOPED_AFFILIATION). If / when we need to
+        support additional SAML attributes, they can be added here.
+
         :param patron: The patron to get parameters for
 
         :return: A tuple containing the SAML entity ID and a list of person scoped affiliations,

--- a/src/palace/manager/integration/license/opds/opds2/api.py
+++ b/src/palace/manager/integration/license/opds/opds2/api.py
@@ -94,9 +94,6 @@ class OPDS2API(BaseOPDSAPI):
 
         saml_subject = self.saml_credential_manager.extract_saml_token(saml_credential)
 
-        if not saml_subject:
-            return None, None
-
         entity_id = saml_subject.idp
         person_scoped_affiliation = None
 

--- a/src/palace/manager/integration/license/opds/opds2/api.py
+++ b/src/palace/manager/integration/license/opds/opds2/api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from collections.abc import MutableSet
+
 from celery.canvas import Signature
 from sqlalchemy.orm import Session
 from typing_extensions import Unpack
@@ -13,6 +16,7 @@ from palace.manager.integration.license.opds.opds2.settings import (
     OPDS2ImporterLibrarySettings,
     OPDS2ImporterSettings,
 )
+from palace.manager.integration.patron_auth.saml.metadata.model import SAMLAttributeType
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.licensing import (
@@ -20,7 +24,29 @@ from palace.manager.sqlalchemy.model.licensing import (
     LicensePoolDeliveryMechanism,
 )
 from palace.manager.sqlalchemy.model.patron import Patron
+from palace.manager.util.http.exception import BadResponseException
 from palace.manager.util.http.http import HTTP
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
+
+
+class TemplateVariable(StrEnum):
+    """Supported template variables for OPDS2 token authentication URLs."""
+
+    PATRON_ID = "patron_id"
+    SAML_ENTITY_ID = "saml_entity_id"
+    SAML_PERSON_SCOPED_AFFILIATION = "saml_person_scoped_affiliation"
+
+
+SAML_TEMPLATE_VARIABLES: frozenset[str] = frozenset(
+    var for var in TemplateVariable if var.startswith("saml_")
+)
+SUPPORTED_TEMPLATE_VARIABLES: frozenset[str] = frozenset(
+    var for var in TemplateVariable
+)
 
 
 class OPDS2API(BaseOPDSAPI):
@@ -48,28 +74,158 @@ class OPDS2API(BaseOPDSAPI):
             collection.integration_configuration.context.get(self.TOKEN_AUTH_CONFIG_KEY)
         )
 
-    @classmethod
-    def get_authentication_token(
-        cls, patron: Patron, datasource: DataSource, token_auth_url: str
-    ) -> str:
-        """Get the authentication token for a patron"""
-        log = cls.logger()
+    def _get_saml_token_template_parameters(
+        self, patron: Patron
+    ) -> tuple[str | None, list[str] | None]:
+        """Get the SAML token arguments for a patron
 
-        patron_id = patron.identifier_to_remote_service(datasource)
-        url = URITemplate(token_auth_url).expand(patron_id=patron_id)
-        response = HTTP.get_with_timeout(url)
-        if response.status_code != 200:
-            log.error(
-                f"Could not authenticate the patron (authorization identifier: '{patron.authorization_identifier}' "
-                f"external identifier: '{patron_id}'): {str(response.content)}"
+        :param patron: The patron to get parameters for
+
+        :return: A tuple containing the SAML entity ID and a list of person scoped affiliations,
+            or (None, None) if the patron has no SAML credentials, or they cannot be
+            extracted.
+        """
+        saml_credential = self.saml_credential_manager.lookup_saml_token_by_patron(
+            self._db, patron
+        )
+
+        if not saml_credential:
+            return None, None
+
+        saml_subject = self.saml_credential_manager.extract_saml_token(saml_credential)
+
+        if not saml_subject:
+            return None, None
+
+        entity_id = saml_subject.idp
+        person_scoped_affiliation = None
+
+        if (
+            saml_subject.attribute_statement
+            and saml_subject.attribute_statement.attributes
+        ):
+            scoped_affiliation_attr = saml_subject.attribute_statement.attributes.get(
+                SAMLAttributeType.eduPersonScopedAffiliation.name
             )
-            raise CannotFulfill()
 
-        # The response should be the JWT token, not wrapped in any format like JSON
-        token = response.text
+            if scoped_affiliation_attr:
+                person_scoped_affiliation = scoped_affiliation_attr.values
+
+        return entity_id, person_scoped_affiliation
+
+    def _build_template_parameters(
+        self, patron: Patron, datasource: DataSource, variable_names: MutableSet[str]
+    ) -> dict[str, str | list[str]]:
+        """Build template parameters based on what the template requires.
+
+        :param patron: The patron to get parameters for
+        :param datasource: The datasource for patron_id lookup
+        :param variable_names: Set of variable names from the URI template
+
+        :return: Dictionary of template parameters
+
+        :raises CannotFulfill: If template requires SAML parameters but patron lacks them
+        """
+        parameters: dict[str, str | list[str]] = {}
+
+        requested_variables = variable_names & SUPPORTED_TEMPLATE_VARIABLES
+
+        if TemplateVariable.PATRON_ID in requested_variables:
+            patron_id = patron.identifier_to_remote_service(datasource)
+            parameters[TemplateVariable.PATRON_ID] = patron_id
+
+        # Handle SAML template variables if any are requested.
+        # The logic here ensures that if the template requires SAML parameters, the patron
+        # must have ALL required SAML credentials. Partial data is not accepted - if the
+        # template asks for both entity_id and affiliation, the patron must have both.
+        if requested_saml_variables := (SAML_TEMPLATE_VARIABLES & requested_variables):
+            # Fetch patron's SAML credentials
+            entity_id, person_scoped_affiliation = (
+                self._get_saml_token_template_parameters(patron)
+            )
+
+            # Try to add each requested SAML variable to parameters
+            if TemplateVariable.SAML_ENTITY_ID in requested_variables and entity_id:
+                parameters[TemplateVariable.SAML_ENTITY_ID] = entity_id
+
+            if (
+                TemplateVariable.SAML_PERSON_SCOPED_AFFILIATION in requested_variables
+                and person_scoped_affiliation
+            ):
+                parameters[TemplateVariable.SAML_PERSON_SCOPED_AFFILIATION] = (
+                    person_scoped_affiliation
+                )
+
+            # Check if any requested SAML variables are still missing from parameters.
+            # This will be true if the patron lacks the required SAML credentials.
+            missing_saml_variables = requested_saml_variables - parameters.keys()
+            if missing_saml_variables:
+                self.log.error(
+                    f"Template requires SAML parameters {', '.join(requested_saml_variables)}, "
+                    f"but patron (authorization identifier: '{patron.authorization_identifier}') "
+                    f"is missing: {', '.join(missing_saml_variables)}."
+                )
+                raise CannotFulfill()
+
+        return parameters
+
+    def get_authentication_token(
+        self, patron: Patron, datasource: DataSource, token_auth_url: str
+    ) -> str:
+        """Get the authentication token for a patron from a token authentication endpoint.
+
+        The token authentication URL is a URI template that may include template variables
+        defined in TemplateVariable. Supported variables include patron_id, saml_entity_id,
+        and saml_person_scoped_affiliation. This method will expand the template with the
+        appropriate values based on the patron's credentials and make an HTTP GET request
+        to retrieve the authentication token.
+
+        :param patron: The patron to authenticate
+        :param datasource: The datasource for patron identifier lookup
+        :param token_auth_url: URI template for the token endpoint. See TemplateVariable
+            for supported template variables.
+
+        :return: The authentication token as a string
+
+        :raises CannotFulfill: If the token endpoint returns a non-2xx status code, an empty
+            response, or if the template requires SAML parameters but the patron lacks the
+            necessary SAML credentials
+        """
+        # Parse template and build parameters
+        template = URITemplate(token_auth_url)
+        parameters = self._build_template_parameters(
+            patron, datasource, template.variable_names
+        )
+
+        # Expand template and make request
+        # We need a type ignore here because of an upstream type issue.
+        # See: https://github.com/python-hyper/uritemplate/pull/130
+        url = template.expand(parameters)  # type: ignore[arg-type]
+        try:
+            response = HTTP.get_with_timeout(url, allowed_response_codes=["2xx"])
+        except BadResponseException as e:
+            response = e.response
+            self.log.error(
+                f"Could not authenticate the patron (authorization identifier: '{patron.authorization_identifier}'). "
+                f"Bad status code {response.status_code} from {url} expected 2xx.",
+                extra={
+                    "palace_response_content": response.content,
+                    "palace_response_status_code": response.status_code,
+                    "palace_template_parameters": parameters,
+                },
+            )
+            raise CannotFulfill() from e
+
+        # The response should be a token in plain text, that we are able to pass as-is
+        # to the fulfillment URL.
+        token = response.text.strip() if response.text else None
         if not token:
-            log.error(
-                f"Could not authenticate the patron({patron_id}): {str(response.content)}"
+            self.log.error(
+                f"Could not authenticate the patron (authorization identifier: '{patron.authorization_identifier}'). "
+                f"Empty response from {url}, expected an authentication token.",
+                extra={
+                    "palace_template_parameters": parameters,
+                },
             )
             raise CannotFulfill()
 

--- a/tests/manager/integration/license/opds/opds2/test_api.py
+++ b/tests/manager/integration/license/opds/opds2/test_api.py
@@ -259,6 +259,23 @@ class TestOpds2Api:
                 ["saml_person_scoped_affiliation"],
                 id="has_entity_id_only_requires_both",
             ),
+            pytest.param(
+                "http://example.org/token?aff={saml_person_scoped_affiliation}",
+                SAMLSubject(
+                    idp="https://idp.example.org/shibboleth",
+                    name_id=None,
+                    attribute_statement=SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.givenName.name,
+                                values=["John"],
+                            )
+                        ]
+                    ),
+                ),
+                ["saml_person_scoped_affiliation"],
+                id="has_other_attributes_but_missing_affiliation",
+            ),
         ],
     )
     def test_get_authentication_token_missing_saml_credentials(

--- a/tests/manager/integration/license/opds/opds2/test_api.py
+++ b/tests/manager/integration/license/opds/opds2/test_api.py
@@ -7,6 +7,12 @@ from palace.manager.api.circulation.exceptions import CannotFulfill
 from palace.manager.api.circulation.fulfillment import Fulfillment, RedirectFulfillment
 from palace.manager.celery.tasks import opds2 as opds2_celery
 from palace.manager.integration.license.opds.opds2.api import OPDS2API
+from palace.manager.integration.patron_auth.saml.metadata.model import (
+    SAMLAttribute,
+    SAMLAttributeStatement,
+    SAMLAttributeType,
+    SAMLSubject,
+)
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.licensing import (
@@ -126,7 +132,7 @@ class TestOpds2Api:
 
     def test_get_authentication_token(self, opds2_api_fixture: Opds2ApiFixture):
         opds2_api_fixture.queue_default_auth_token_response()
-        token = OPDS2API.get_authentication_token(
+        token = opds2_api_fixture.api.get_authentication_token(
             opds2_api_fixture.patron, opds2_api_fixture.data_source, ""
         )
 
@@ -134,22 +140,32 @@ class TestOpds2Api:
         assert len(opds2_api_fixture.http_client.requests) == 1
 
     def test_get_authentication_token_400_response(
-        self, opds2_api_fixture: Opds2ApiFixture
+        self, opds2_api_fixture: Opds2ApiFixture, caplog: pytest.LogCaptureFixture
     ):
         opds2_api_fixture.http_client.queue_response(400, content="error")
         with pytest.raises(CannotFulfill):
-            OPDS2API.get_authentication_token(
+            opds2_api_fixture.api.get_authentication_token(
                 opds2_api_fixture.patron, opds2_api_fixture.data_source, ""
             )
 
+        # Verify detailed error message is logged
+        assert "Could not authenticate the patron" in caplog.text
+        assert "Bad status code 400" in caplog.text
+        assert "expected 2xx" in caplog.text
+
     def test_get_authentication_token_bad_response(
-        self, opds2_api_fixture: Opds2ApiFixture
+        self, opds2_api_fixture: Opds2ApiFixture, caplog: pytest.LogCaptureFixture
     ):
         opds2_api_fixture.http_client.queue_response(200, content="")
         with pytest.raises(CannotFulfill):
-            OPDS2API.get_authentication_token(
+            opds2_api_fixture.api.get_authentication_token(
                 opds2_api_fixture.patron, opds2_api_fixture.data_source, ""
             )
+
+        # Verify detailed error message is logged
+        assert "Could not authenticate the patron" in caplog.text
+        assert "Empty response from" in caplog.text
+        assert "expected an authentication token" in caplog.text
 
     def test_import_task(self) -> None:
         collection_id = MagicMock()
@@ -159,3 +175,146 @@ class TestOpds2Api:
 
         mock_import.s.assert_called_once_with(collection_id, force=force)
         assert result == mock_import.s.return_value
+
+    def test_get_authentication_token_with_saml_parameters(
+        self, opds2_api_fixture: Opds2ApiFixture
+    ):
+        """Test get_authentication_token expands SAML parameters in URL templates"""
+        # Create SAML credentials with full data (entity ID and affiliation)
+        attributes = [
+            SAMLAttribute(
+                name=SAMLAttributeType.eduPersonScopedAffiliation.name,
+                values=["faculty@example.edu", "member@example.edu"],
+            )
+        ]
+        attribute_statement = SAMLAttributeStatement(attributes)
+        saml_subject = SAMLSubject(
+            idp="https://idp.example.org/shibboleth",
+            name_id=None,
+            attribute_statement=attribute_statement,
+        )
+
+        # Create credential for the patron
+        opds2_api_fixture.api.saml_credential_manager.create_saml_token(
+            opds2_api_fixture.api._db, opds2_api_fixture.patron, saml_subject
+        )
+
+        # Test 1: Template with only saml_entity_id
+        opds2_api_fixture.queue_default_auth_token_response()
+        token = opds2_api_fixture.api.get_authentication_token(
+            opds2_api_fixture.patron,
+            opds2_api_fixture.data_source,
+            "http://example.org/token?idp={saml_entity_id}",
+        )
+        assert token == "plaintext-auth-token"
+        called_url = opds2_api_fixture.http_client.requests[0]
+        assert (
+            called_url
+            == "http://example.org/token?idp=https%3A%2F%2Fidp.example.org%2Fshibboleth"
+        )
+
+        # Test 2: Template with both saml_entity_id and saml_person_scoped_affiliation
+        opds2_api_fixture.http_client.requests.clear()
+        opds2_api_fixture.queue_default_auth_token_response()
+        token = opds2_api_fixture.api.get_authentication_token(
+            opds2_api_fixture.patron,
+            opds2_api_fixture.data_source,
+            "http://example.org/token?idp={saml_entity_id}&affiliation={saml_person_scoped_affiliation}",
+        )
+        assert token == "plaintext-auth-token"
+        called_url = opds2_api_fixture.http_client.requests[0]
+        assert (
+            called_url
+            == "http://example.org/token?idp=https%3A%2F%2Fidp.example.org%2Fshibboleth&affiliation=faculty%40example.edu,member%40example.edu"
+        )
+
+    @pytest.mark.parametrize(
+        "template_url,saml_subject,expected_missing",
+        [
+            pytest.param(
+                "http://example.org/token?idp={saml_entity_id}",
+                None,
+                ["saml_entity_id"],
+                id="no_credentials_requires_entity_id",
+            ),
+            pytest.param(
+                "http://example.org/token?aff={saml_person_scoped_affiliation}",
+                None,
+                ["saml_person_scoped_affiliation"],
+                id="no_credentials_requires_affiliation",
+            ),
+            pytest.param(
+                "http://example.org/token?idp={saml_entity_id}&aff={saml_person_scoped_affiliation}",
+                None,
+                ["saml_entity_id", "saml_person_scoped_affiliation"],
+                id="no_credentials_requires_both",
+            ),
+            pytest.param(
+                "http://example.org/token?idp={saml_entity_id}&aff={saml_person_scoped_affiliation}",
+                SAMLSubject(
+                    idp="https://idp.example.org/shibboleth",
+                    name_id=None,
+                    attribute_statement=None,
+                ),
+                ["saml_person_scoped_affiliation"],
+                id="has_entity_id_only_requires_both",
+            ),
+        ],
+    )
+    def test_get_authentication_token_missing_saml_credentials(
+        self,
+        opds2_api_fixture: Opds2ApiFixture,
+        caplog: pytest.LogCaptureFixture,
+        template_url: str,
+        saml_subject: SAMLSubject | None,
+        expected_missing: list[str],
+    ):
+        """Test that we fail when template requires SAML params but patron lacks them"""
+        # Set up SAML credentials if provided
+        if saml_subject:
+            opds2_api_fixture.api.saml_credential_manager.create_saml_token(
+                opds2_api_fixture.api._db, opds2_api_fixture.patron, saml_subject
+            )
+
+        # Attempt to get token should fail
+        with pytest.raises(CannotFulfill):
+            opds2_api_fixture.api.get_authentication_token(
+                opds2_api_fixture.patron,
+                opds2_api_fixture.data_source,
+                template_url,
+            )
+
+        # Verify the error was logged with details about what's missing
+        assert "Template requires SAML parameters" in caplog.text
+        assert "is missing:" in caplog.text
+        # Check each expected missing variable appears in the log (order may vary)
+        for missing_var in expected_missing:
+            assert missing_var in caplog.text
+
+    def test_get_authentication_token_no_patron_id_in_template(
+        self, opds2_api_fixture: Opds2ApiFixture
+    ):
+        """Test that we don't fetch patron_id if template doesn't need it"""
+        # Queue the response
+        opds2_api_fixture.queue_default_auth_token_response()
+
+        # Mock identifier_to_remote_service to ensure it's not called
+        with patch.object(
+            opds2_api_fixture.patron, "identifier_to_remote_service"
+        ) as mock_identifier:
+            # Template has no variables, so no patron_id lookup should occur
+            token = opds2_api_fixture.api.get_authentication_token(
+                opds2_api_fixture.patron,
+                opds2_api_fixture.data_source,
+                "http://example.org/token?key=value",
+            )
+
+            # Verify identifier_to_remote_service was NOT called
+            mock_identifier.assert_not_called()
+
+        assert token == "plaintext-auth-token"
+        assert len(opds2_api_fixture.http_client.requests) == 1
+
+        # Verify the URL was called without patron_id
+        called_url = opds2_api_fixture.http_client.requests[0]
+        assert called_url == "http://example.org/token?key=value"


### PR DESCRIPTION
## Description

- Added `TemplateVariable` enum defining supported template variables: `patron_id`, `saml_entity_id`, and `saml_person_scoped_affiliation`
- Refactored `get_authentication_token` from classmethod to instance method to support SAML credential lookups
- Implemented `_build_template_parameters` method that intelligently fetches only the data required by the template
- Enhanced error handling with detailed logging including structured extra fields for debugging
- Added support for multiple SAML affiliations (passed as comma-separated values)

## Motivation and Context

**Jira:** PP-2990

This PR adds support for SAML template parameters in OPDS2 token authentication URLs. Token authentication endpoints can now receive SAML identity information when authenticating patrons, enabling content providers to make authorization decisions based on the patron's identity provider attributes.

Needed for upcoming Taylor & Francis integration.

## How Has This Been Tested?

- New tests
- Running tests in CI

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.