### PR TITLE
Fix flaky WorkList.test_initialize test

### DIFF
--- a/tests/manager/sqlalchemy/model/test_lane.py
+++ b/tests/manager/sqlalchemy/model/test_lane.py
@@ -1756,10 +1756,10 @@ class TestWorkList:
 
         # Only the library's active collections are associated
         # with the WorkList.
-        assert default_library.associated_collections == [
+        assert set(default_library.associated_collections) == {
             active_collection,
             inactive_collection,
-        ]
+        }
         assert default_library.active_collections == [active_collection]
         assert set(wl.collection_ids) == {
             x.id for x in default_library.active_collections


### PR DESCRIPTION
## Description

Fixed a flaky test in `TestWorkList.test_initialize` that was failing intermittently in CI. Changed the assertion for `associated_collections` from list comparison to set comparison to make it order-independent.

## Motivation and Context

The test was comparing `associated_collections` as a list with expected order `[active_collection, inactive_collection]`, but the underlying database query doesn't guarantee ordering. This caused the test to fail intermittently when the collections were returned in different order (e.g., `[inactive_collection, active_collection]`).

The fix makes the test robust against query result ordering, which is not guaranteed by the database.

## How Has This Been Tested?

- Ran the specific test multiple times locally to verify it passes consistently
- The fix aligns with existing patterns in the same test (lines 1764-1766, 1770) that already use set comparisons
- All pre-commit hooks passed

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.