### PR TITLE
Fix flaky tests with associated_collections ordering

### DIFF
--- a/tests/manager/api/controller/test_crawlfeed.py
+++ b/tests/manager/api/controller/test_crawlfeed.py
@@ -85,10 +85,10 @@ class TestCrawlableFeed:
         lane = kwargs.pop("worklist")
         assert isinstance(lane, CrawlableCollectionBasedLane)
         assert library.id == lane.library_id
-        assert library.associated_collections == [
+        assert set(library.associated_collections) == {
             active_collection,
             inactive_collection,
-        ]
+        }
         assert library.active_collections == [active_collection]
         assert set(lane.collection_ids) == {x.id for x in library.active_collections}
         assert {} == kwargs

--- a/tests/manager/search/test_external_search.py
+++ b/tests/manager/search/test_external_search.py
@@ -3683,10 +3683,10 @@ class TestFilter:
 
         # Only the active collections for a library will be included in
         # the search filter.
-        assert library.associated_collections == [
+        assert set(library.associated_collections) == {
             active_collection,
             inactive_collection,
-        ]
+        }
         assert library.active_collections == [active_collection]
 
         filter = Filter.from_worklist(session, inherits, facets)

--- a/tests/manager/sqlalchemy/model/test_lane.py
+++ b/tests/manager/sqlalchemy/model/test_lane.py
@@ -1756,10 +1756,10 @@ class TestWorkList:
 
         # Only the library's active collections are associated
         # with the WorkList.
-        assert default_library.associated_collections == [
+        assert set(default_library.associated_collections) == {
             active_collection,
             inactive_collection,
-        ]
+        }
         assert default_library.active_collections == [active_collection]
         assert set(wl.collection_ids) == {
             x.id for x in default_library.active_collections
@@ -2947,10 +2947,10 @@ class TestDatabaseBackedWorkList:
         inactive_collection.associated_libraries = [default_library]
         wl.initialize(default_library)
 
-        assert default_library.associated_collections == [
+        assert set(default_library.associated_collections) == {
             active_collection,
             inactive_collection,
-        ]
+        }
         assert default_library.active_collections == [active_collection]
         assert 2 == wl.works_from_database(db.session).count()
 

--- a/tests/manager/sqlalchemy/model/test_lane.py
+++ b/tests/manager/sqlalchemy/model/test_lane.py
@@ -2891,10 +2891,10 @@ class TestDatabaseBackedWorkList:
         # from the library's active collections.
         wl = DatabaseBackedWorkList()
         wl.initialize(default_library)
-        assert default_library.associated_collections == [
+        assert set(default_library.associated_collections) == {
             active_collection,
             inactive_collection,
-        ]
+        }
         assert default_library.active_collections == [active_collection]
         assert 2 == wl.works_from_database(db.session).count()
 


### PR DESCRIPTION
## Description

Fixed multiple flaky tests that were occasionally failing in CI due to non-deterministic collection ordering.

Five test assertions were comparing `associated_collections` using list comparisons (order-dependent), but the database doesn't guarantee a specific order for these collections. This caused intermittent failures in CI when the collections were returned in a different order.

Changed all assertions to use set comparisons instead for consistency.

## Motivation and Context

These tests were failing intermittently in CI with assertion errors showing that collections were in a different order than expected. The fixes ensure all affected tests are stable regardless of the database query result ordering.

## How Has This Been Tested?

- Ran all affected test classes locally:
  - `TestDatabaseBackedWorkList` - 8 tests passed
  - `TestCrawlableFeed::test_crawlable_library_feed` - passed
  - `TestFilter::test_from_worklist` - passed
- Tests run in CI
- All changes are minimal and only affect test assertion logic, not application code
- Pattern is consistent with existing set comparisons already used in the same test files

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.