### PR TITLE
Fix race condition in IntegrationConfiguration.context_update (PP-2787)

### DIFF
--- a/tests/manager/sqlalchemy/model/test_integration.py
+++ b/tests/manager/sqlalchemy/model/test_integration.py
@@ -1,5 +1,10 @@
+import pytest
+from sqlalchemy.orm import Session
+
+from palace.manager.core.exceptions import PalaceValueError
 from palace.manager.integration.goals import Goals
-from tests.fixtures.database import DatabaseTransactionFixture
+from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
+from tests.fixtures.database import DatabaseFixture, DatabaseTransactionFixture
 
 
 class TestIntegrationConfiguration:
@@ -70,3 +75,121 @@ class TestIntegrationConfiguration:
             "    Settings:",
             "      password: super secret",
         ]
+
+    def test_context_update_basic(self, db: DatabaseTransactionFixture) -> None:
+        """Test basic context_update functionality"""
+        integration = db.integration_configuration(
+            name="test_integration", protocol="test_protocol", goal=Goals.DISCOVERY_GOAL
+        )
+        integration.context = {"key1": "value1"}
+
+        # Update with new keys
+        integration.context_update({"key2": "value2", "key3": "value3"})
+
+        # Verify the context was updated
+        assert integration.context == {
+            "key1": "value1",
+            "key2": "value2",
+            "key3": "value3",
+        }
+
+        # Verify it persists in the database
+        db.session.expire(integration)
+        db.session.refresh(integration)
+        assert integration.context == {
+            "key1": "value1",
+            "key2": "value2",
+            "key3": "value3",
+        }
+
+    def test_context_update_overwrite(self, db: DatabaseTransactionFixture) -> None:
+        """Test that context_update overwrites existing keys"""
+        integration = db.integration_configuration(
+            name="test_integration", protocol="test_protocol", goal=Goals.DISCOVERY_GOAL
+        )
+        integration.context = {"key1": "value1", "key2": "value2"}
+
+        # Update with overlapping keys
+        integration.context_update({"key2": "new_value2", "key3": "value3"})
+
+        # Verify the context was updated correctly
+        assert integration.context == {
+            "key1": "value1",
+            "key2": "new_value2",
+            "key3": "value3",
+        }
+
+    def test_context_update_no_session(self, db: DatabaseTransactionFixture) -> None:
+        """Test that context_update raises an error if object is not bound to a session"""
+        integration = IntegrationConfiguration(
+            name="test_integration",
+            protocol="test_protocol",
+            goal=Goals.DISCOVERY_GOAL,
+        )
+
+        # Should raise PalaceValueError because object is not in a session
+        with pytest.raises(PalaceValueError, match="not bound to a session"):
+            integration.context_update({"key": "value"})
+
+    def test_context_update_atomic(self, function_database: DatabaseFixture) -> None:
+        """
+        Test that context_update uses atomic database operations and prevents lost updates.
+
+        This test simulates concurrent updates from two separate sessions to verify
+        that the atomic JSONB || operator prevents the race condition where one
+        update could overwrite another.
+
+        Note: This test uses the function_database fixture to make sure we can manipulate
+        sessions directly.
+        """
+        # Create the integration in one session and commit
+        with Session(bind=function_database.engine) as setup_session:
+            integration = IntegrationConfiguration(
+                name="test_integration",
+                protocol="test_protocol",
+                goal=Goals.DISCOVERY_GOAL,
+            )
+            integration.context = {"initial": "value"}
+            setup_session.add(integration)
+            setup_session.commit()
+            integration_id = integration.id
+
+        # Simulate concurrent updates from two different sessions
+        with (
+            Session(bind=function_database.engine) as session1,
+            Session(bind=function_database.engine) as session2,
+        ):
+            # Both sessions load the same integration
+            integration1 = session1.get(IntegrationConfiguration, integration_id)
+            integration2 = session2.get(IntegrationConfiguration, integration_id)
+
+            assert integration1 is not None
+            assert integration2 is not None
+
+            # Both see the initial state
+            assert integration1.context == {"initial": "value"}
+            assert integration2.context == {"initial": "value"}
+
+            # Session 1 updates with key1
+            integration1.context_update({"key1": "value1"})
+            session1.commit()
+
+            # Session 2 updates with key2 (without seeing session1's changes yet)
+            # With the old implementation, this would overwrite key1
+            # With the atomic implementation, both updates are preserved
+            integration2.context_update({"key2": "value2"})
+            session2.commit()
+
+        # Verify both updates are present (no lost updates)
+        with Session(bind=function_database.engine) as verify_session:
+            final_integration = verify_session.get(
+                IntegrationConfiguration, integration_id
+            )
+            assert final_integration is not None
+
+            # Both updates should be preserved due to atomic JSONB || operation
+            assert final_integration.context == {
+                "initial": "value",
+                "key1": "value1",
+                "key2": "value2",
+            }


### PR DESCRIPTION
## Description

Fixed a race condition in `IntegrationConfiguration.context_update` that could cause lost updates when multiple processes modified the context simultaneously.

The method now uses PostgreSQL's JSONB concatenation operator (`||`) for atomic database-level merging instead of in-memory updates.

## Motivation and Context

The original implementation used a read-modify-write pattern:
```python
self.context.update(new_context)
flag_modified(self, "context")
```

This created a race condition where:
1. Process A reads context: `{"key1": "val1"}`
2. Process B reads context: `{"key1": "val1"}`
3. Process A updates: `{"key1": "val1", "key2": "val2"}` and commits
4. Process B updates: `{"key1": "val1", "key3": "val3"}` and commits
5. Result: `{"key1": "val1", "key3": "val3"}` ❌ **key2 is lost!**

This couldn't happen as we currently use the context, since only one Celery task can update it at a time. In PP-2787 I want to use `context` to store the last time a collection was reaped, and this expanded use means that we need to be more aware of data races. 

## How Has This Been Tested?

- ✅ Added `test_context_update_basic` - tests basic functionality
- ✅ Added `test_context_update_overwrite` - tests overwriting existing keys
- ✅ Added `test_context_update_no_session` - tests error handling
- ✅ Added `test_context_update_atomic` - **simulates concurrent updates from separate database sessions** to verify that both updates are preserved
- ✅ All existing tests pass, including `test_auth_token_feed` which uses this method
- ✅ Type checking passes with mypy

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.