### PR TITLE
Improve type hints for OPDS API classes (PP-2787)

### DIFF
--- a/src/palace/manager/integration/license/opds/base/api.py
+++ b/src/palace/manager/integration/license/opds/base/api.py
@@ -4,7 +4,7 @@ import urllib
 from abc import ABC
 
 from sqlalchemy.orm import Session
-from typing_extensions import Unpack
+from typing_extensions import TypeVar, Unpack
 
 from palace.manager.api.circulation.base import BaseCirculationAPI
 from palace.manager.api.circulation.data import HoldInfo, LoanInfo
@@ -34,9 +34,14 @@ from palace.manager.sqlalchemy.model.licensing import (
 )
 from palace.manager.sqlalchemy.model.patron import Patron
 
+BaseOPDSApiSettingsT = TypeVar("BaseOPDSApiSettingsT", bound=OPDSImporterSettings)
+BaseOPDSLibrarySettingsT = TypeVar(
+    "BaseOPDSLibrarySettingsT", bound=OPDSImporterLibrarySettings
+)
+
 
 class BaseOPDSAPI(
-    BaseCirculationAPI[OPDSImporterSettings, OPDSImporterLibrarySettings], ABC
+    BaseCirculationAPI[BaseOPDSApiSettingsT, BaseOPDSLibrarySettingsT], ABC
 ):
     def __init__(self, _db: Session, collection: Collection):
         super().__init__(_db, collection)

--- a/src/palace/manager/integration/license/opds/opds1/api.py
+++ b/src/palace/manager/integration/license/opds/opds1/api.py
@@ -9,7 +9,7 @@ from palace.manager.integration.license.opds.opds1.settings import (
 )
 
 
-class OPDSAPI(BaseOPDSAPI):
+class OPDSAPI(BaseOPDSAPI[OPDSImporterSettings, OPDSImporterLibrarySettings]):
     @classmethod
     def settings_class(cls) -> type[OPDSImporterSettings]:
         return OPDSImporterSettings

--- a/src/palace/manager/integration/license/opds/opds2/api.py
+++ b/src/palace/manager/integration/license/opds/opds2/api.py
@@ -47,7 +47,7 @@ SAML_TEMPLATE_VARIABLES: frozenset[str] = frozenset(
 SUPPORTED_TEMPLATE_VARIABLES: frozenset[str] = frozenset(TemplateVariable)
 
 
-class OPDS2API(BaseOPDSAPI):
+class OPDS2API(BaseOPDSAPI[OPDS2ImporterSettings, OPDS2ImporterLibrarySettings]):
     TOKEN_AUTH_CONFIG_KEY = "token_auth_endpoint"
 
     @classmethod


### PR DESCRIPTION
## Description

Improved type hints for OPDS API classes by:
- Added TypeVar definitions (`BaseOPDSApiSettingsT` and `BaseOPDSLibrarySettingsT`) to properly parameterize the generic `BaseOPDSAPI` class
- Explicitly specified type parameters in `OPDSAPI` and `OPDS2API` classes

These changes make the type relationships clearer and enable better type checking throughout the OPDS integration code.

## Motivation and Context

These typing improvements are needed for PP-2787. While not directly part of that ticket, they are required dependencies for the PR work on that ticket.

## How Has This Been Tested?

- Type checking with `mypy` passes
- No functional changes to the code
- Existing tests continue to pass

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.