### PR TITLE
Fix flaky test in LibraryAllTitleReportTable

### DIFF
--- a/tests/manager/reporting/tables/test_library_all_title.py
+++ b/tests/manager/reporting/tables/test_library_all_title.py
@@ -79,7 +79,12 @@ class TestLibraryAllTitleReportTable:
                     mock_execute.return_value = iter([])
                     # This is the actual call we're testing.
                     list(table.rows)
-                    mock_params.assert_called_once_with(integration_ids=integration_ids)
+                    mock_params.assert_called_once()
+                    # Check that the integration_ids match, regardless of order.
+                    actual_integration_ids = mock_params.call_args.kwargs[
+                        "integration_ids"
+                    ]
+                    assert set(actual_integration_ids) == set(integration_ids)
 
                     mock_execute.assert_called_once_with(mock_statement)
 


### PR DESCRIPTION
## Description

Fixed a flaky test in `test_included_collections` that was failing intermittently due to non-deterministic ordering of integration IDs.

## Motivation and Context

The test was comparing `integration_ids` as ordered lists when verifying mock calls, but the order of IDs returned from the database query is not guaranteed. This caused random test failures when the IDs appeared in a different order.

The fix changes the assertion to compare sets instead of lists, making the test order-independent while still verifying the correct integration IDs are passed.

## How Has This Been Tested?

The existing test suite validates the fix. The test now passes consistently regardless of the order in which integration IDs are returned.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.