### PR TITLE
Correctly log SAML patron id extraction failure (PP-3020)

### DIFF
--- a/src/palace/manager/integration/patron_auth/saml/controller.py
+++ b/src/palace/manager/integration/patron_auth/saml/controller.py
@@ -15,6 +15,7 @@ from flask_babel import lazy_gettext as _
 from palace.manager.util.problem_detail import (
     ProblemDetail,
     ProblemDetail as pd,
+    ProblemDetailException,
     json as pd_json,
 )
 
@@ -336,9 +337,10 @@ class SAMLController:
         if isinstance(subject, ProblemDetail):
             return self._redirect_with_error(redirect_uri, subject)
 
-        response = provider.saml_callback(db, subject)
-        if isinstance(response, ProblemDetail):
-            return self._redirect_with_error(redirect_uri, response)
+        try:
+            response = provider.saml_callback(db, subject)
+        except ProblemDetailException as e:
+            return self._redirect_with_error(redirect_uri, e.problem_detail)
 
         provider_token, patron, patron_data = response
 


### PR DESCRIPTION
## Description

- Updates the SAML patron id extractor to correctly log a failure error message when we are unable to extract a patron auth id from the asserted SAML subject with the current configuration.
- Adds some type hints.
- Raise `ProblemDetailException` instead of returning a union with `ProblemDetail` in order to simplify a return type.

## Motivation and Context

Makes it easier to detect patron id extraction errors in the logs. Before this change, the extractor logged an INFO level message indicating that extraction was complete and which included the extracted id or the empty string if none was found. The difference was subtle enough, that it was not clear when an extraction error occurred.

[Jira PP-3020]

## How Has This Been Tested?

- Existing tests were modified to:
  - accommodate the move from returning a `ProblemDetail` to raising a `ProblemDetailException`.
  - verify the success and failure error messages.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/18333363968) pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
