### PR TITLE
Convert Overdrive API responses to pydantic models (PP-3175)

### DIFF
--- a/src/palace/manager/integration/license/overdrive/advantage.py
+++ b/src/palace/manager/integration/license/overdrive/advantage.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Generator
 from typing import Self
 
@@ -10,6 +9,7 @@ from sqlalchemy.orm import Session
 from palace.manager.integration.base import integration_settings_update
 from palace.manager.integration.goals import Goals
 from palace.manager.integration.license.overdrive.constants import OVERDRIVE_LABEL
+from palace.manager.integration.license.overdrive.model import AdvantageAccountsResponse
 from palace.manager.integration.license.overdrive.settings import OverdriveChildSettings
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
@@ -35,7 +35,7 @@ class OverdriveAdvantageAccount:
         self.token = token
 
     @classmethod
-    def from_representation(cls, content: str) -> Generator[Self]:
+    def from_representation(cls, content: str | bytes) -> Generator[Self]:
         """Turn the representation of an advantageAccounts link into a list of
         OverdriveAdvantageAccount objects.
 
@@ -43,20 +43,14 @@ class OverdriveAdvantageAccount:
             link.
         :yield: A sequence of OverdriveAdvantageAccount objects.
         """
-        data = json.loads(content)
-        parent_id = str(data.get("id"))
-        accounts = data.get("advantageAccounts", {})
-        for account in accounts:
-            name = account["name"]
-            products_link = account["links"]["products"]["href"]
-            library_id = str(account.get("id"))
-            name = account.get("name")
-            token = account.get("collectionToken")
+        data = AdvantageAccountsResponse.model_validate_json(content)
+        parent_id = str(data.id)
+        for account in data.advantage_accounts:
             yield cls(
                 parent_library_id=parent_id,
-                library_id=library_id,
-                name=name,
-                token=token,
+                library_id=str(account.id),
+                name=account.name,
+                token=account.collection_token,
             )
 
     def to_collection(self, _db: Session) -> tuple[Collection, Collection]:

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -88,6 +88,7 @@ from palace.manager.integration.license.overdrive.model import (
     Format,
     Hold as HoldResponse,
     Holds as HoldsResponse,
+    LibraryResponse,
     PatronInformation,
     PatronRequestCallable,
     _overdrive_field_request,
@@ -413,19 +414,21 @@ class OverdriveAPI(
             return cached.token
 
         library = self.get_library()
-        error = library.get("errorCode")
-        if error:
-            message = library.get("message")
+        if library.error_code:
             raise CannotLoadConfiguration(
-                f"Overdrive credentials are valid but could not fetch library: {message}"
+                f"Overdrive credentials are valid but could not fetch library: {library.message}"
                 f' - collection: "{self.collection.name}"'
             )
-        token = cast(str, library["collectionToken"])
+        if library.collection_token is None:
+            raise CannotLoadConfiguration(
+                f"Overdrive library response missing collectionToken"
+                f' - collection: "{self.collection.name}"'
+            )
         self._cached_collection_token = OverdriveToken(
-            token=token,
+            token=library.collection_token,
             expires=utc_now() + self.COLLECTION_TOKEN_MAX_AGE,
         )
-        return token
+        return library.collection_token
 
     @property
     def data_source(self) -> DataSource:
@@ -557,7 +560,7 @@ class OverdriveAPI(
             endpoint = self.LIBRARY_ENDPOINT
         return self.endpoint(endpoint, **args)
 
-    def get_library(self) -> dict[str, Any]:
+    def get_library(self) -> LibraryResponse:
         """Get basic information about the collection, including
         a link to the titles in the collection.
 
@@ -575,7 +578,7 @@ class OverdriveAPI(
                 exception_handler=Representation.reraise_exception,
                 max_age=self.LIBRARY_MAX_AGE,
             )
-            return json.loads(representation.content)  # type: ignore[no-any-return]
+            return LibraryResponse.model_validate_json(representation.content)
 
     def get_advantage_accounts(self) -> Generator[OverdriveAdvantageAccount]:
         """Find all the Overdrive Advantage accounts managed by this library.
@@ -587,14 +590,10 @@ class OverdriveAPI(
         :yield: A sequence of OverdriveAdvantageAccount objects.
         """
         library = self.get_library()
-        links = library.get("links", {})
-        advantage = links.get("advantageAccounts")
-        if advantage:
+        advantage_url = library.advantage_accounts_url
+        if advantage_url:
             # This library has Overdrive Advantage accounts, or at
             # least a link where some may be found.
-            advantage_url = advantage.get("href")
-            if not advantage_url:
-                return
             representation, cached = Representation.get(
                 self._db,
                 advantage_url,

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -80,6 +80,7 @@ from palace.manager.integration.license.overdrive.fulfillment import (
     OverdriveManifestFulfillment,
 )
 from palace.manager.integration.license.overdrive.model import (
+    Availability,
     BaseOverdriveModel,
     Checkout,
     Checkouts,
@@ -1744,25 +1745,31 @@ class OverdriveAPI(
                 status_code,
             )
             return None, None, False
-        book.update(json.loads(content))
 
-        # Update book_id now that we know we have new data.
-        book_id = book["id"]
+        availability = Availability.model_validate_json(content)
+
+        # Use the caller-provided ID for LicensePool lookup. This is always
+        # set because circulation_lookup creates dict(id=book_id) when called
+        # with a string, and book-list dicts always include "id".
+        resolved_book_id = cast(str, book.get("id"))
+
         license_pool, is_new = LicensePool.for_foreign_id(
             self._db,
             DataSource.OVERDRIVE,
             Identifier.OVERDRIVE_ID,
-            cast(str, book_id),
+            resolved_book_id,
             collection=self.collection,
         )
         if is_new or not license_pool.work:
-            # Either this is the first time we've seen this book or its doesn't
+            # Either this is the first time we've seen this book or it doesn't
             # have an associated work. Make sure its identifier has bibliographic coverage.
             self.overdrive_bibliographic_coverage_provider.ensure_coverage(
                 license_pool.identifier, force=True
             )
 
-        return self.update_licensepool_with_book_info(book, license_pool, is_new)
+        return self.update_licensepool_with_book_info(
+            availability, resolved_book_id, license_pool, is_new
+        )
 
     # Alias for the CirculationAPI interface
     def update_availability(self, licensepool: LicensePool) -> None:
@@ -1780,18 +1787,26 @@ class OverdriveAPI(
         )
 
     def update_licensepool_with_book_info(
-        self, book: dict[str, Any], license_pool: LicensePool, is_new_pool: bool
+        self,
+        availability: Availability,
+        book_id: str,
+        license_pool: LicensePool,
+        is_new_pool: bool,
     ) -> tuple[LicensePool, bool, bool]:
-        """Update a book's LicensePool with information from a JSON
-        representation of its circulation info.
+        """Update a book's LicensePool with information from an availability document.
 
         Then, create an Edition and make sure it has bibliographic
         coverage. If the new Edition is the only candidate for the
         pool's presentation_edition, promote it to presentation
         status.
+
+        :param availability: The parsed Overdrive availability document.
+        :param book_id: The Overdrive product ID for this book.
+        :param license_pool: The LicensePool to update.
+        :param is_new_pool: Whether this is a newly created LicensePool.
         """
         extractor = OverdriveRepresentationExtractor(self)
-        circulation = extractor.book_info_to_circulation(book)
+        circulation = extractor.book_info_to_circulation(availability, book_id=book_id)
         lp, circulation_changed = circulation.apply(self._db, license_pool.collection)
         if lp is not None:
             license_pool = lp

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -7,7 +7,7 @@ from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from functools import partial
 from threading import RLock
-from typing import Any, NamedTuple, Unpack, cast, overload
+from typing import Any, NamedTuple, Unpack, overload
 from urllib.parse import urlsplit
 
 import flask
@@ -1750,7 +1750,10 @@ class OverdriveAPI(
         # Use the caller-provided ID for LicensePool lookup. This is always
         # set because circulation_lookup creates dict(id=book_id) when called
         # with a string, and book-list dicts always include "id".
-        resolved_book_id = cast(str, book.get("id"))
+        resolved_book_id = book.get("id")
+        assert (
+            resolved_book_id is not None
+        ), f"Book dict missing required 'id' key: {book}"
 
         license_pool, is_new = LicensePool.for_foreign_id(
             self._db,

--- a/src/palace/manager/integration/license/overdrive/importer.py
+++ b/src/palace/manager/integration/license/overdrive/importer.py
@@ -20,6 +20,7 @@ from palace.manager.integration.license.overdrive.api import (
     BookInfoEndpoint,
     OverdriveAPI,
 )
+from palace.manager.integration.license.overdrive.model import Availability
 from palace.manager.integration.license.overdrive.representation import (
     OverdriveRepresentationExtractor,
 )
@@ -163,8 +164,8 @@ class OverdriveImporter(LoggerMixin):
 
         # availability needs to be checked/updated in all but a few instances so it is
         # probably not worth the compute time to save ourselves a handful of unnecessary updates.
-        availability = book.get("availabilityV2", None)
-        if not availability:
+        availability_data = book.get("availabilityV2", None)
+        if not availability_data:
             # This is a rare and probably transient case where the availabilityV2
             # was not retrieved due to a 404 from OD.
             self.log.warning(
@@ -172,6 +173,7 @@ class OverdriveImporter(LoggerMixin):
                 f"arise when the OD returns a 404 for the availability url."
             )
         else:
+            availability = Availability.model_validate(availability_data)
             circulation = self._extractor.book_info_to_circulation(availability)
             # The circulation should never be null here because there is a non-null entry for availabilityV2 in the
             # book dictionary.  Mypy complains without an assertion or type hints.

--- a/src/palace/manager/integration/license/overdrive/model.py
+++ b/src/palace/manager/integration/license/overdrive/model.py
@@ -498,6 +498,54 @@ class PatronInformation(BaseOverdriveModel):
     actions: list[dict[str, Action]] = Field(default_factory=list)
 
 
+class LibraryResponse(BaseOverdriveModel):
+    """
+    Response from the Overdrive library endpoint.
+
+    See: https://developer.overdrive.com/apis/library
+
+    A successful response contains a ``collectionToken`` and optionally
+    a ``links`` dict (which may include an ``advantageAccounts`` entry).
+    An error response contains an ``errorCode`` and ``message`` instead.
+    """
+
+    collection_token: str | None = Field(None, alias="collectionToken")
+    links: dict[str, Link] = Field(default_factory=dict)
+    error_code: str | None = Field(None, alias="errorCode")
+    message: str | None = None
+
+    @property
+    def advantage_accounts_url(self) -> str | None:
+        """Return the href for the advantageAccounts link, or None if absent."""
+        link = self.links.get("advantageAccounts")
+        return link.href if link else None
+
+
+class AdvantageAccountEntry(BaseOverdriveModel):
+    """
+    A single Overdrive Advantage account entry within an advantage accounts response.
+
+    See: https://developer.overdrive.com/apis/advantage-accounts
+    """
+
+    id: int
+    name: str
+    collection_token: str = Field(..., alias="collectionToken")
+
+
+class AdvantageAccountsResponse(BaseOverdriveModel):
+    """
+    Response from the Overdrive advantage accounts endpoint.
+
+    See: https://developer.overdrive.com/apis/advantage-accounts
+    """
+
+    id: int
+    advantage_accounts: list[AdvantageAccountEntry] = Field(
+        default_factory=list, alias="advantageAccounts"
+    )
+
+
 class AvailabilityType(StrEnum):
     """Availability type for a title in an Overdrive collection."""
 

--- a/src/palace/manager/integration/license/overdrive/model.py
+++ b/src/palace/manager/integration/license/overdrive/model.py
@@ -1,6 +1,7 @@
 import json
 import re
 import typing
+from enum import StrEnum
 from functools import cached_property
 from typing import Protocol, Self, overload
 from urllib.parse import quote_plus
@@ -495,3 +496,49 @@ class PatronInformation(BaseOverdriveModel):
         default_factory=dict, alias="linkTemplates"
     )
     actions: list[dict[str, Action]] = Field(default_factory=list)
+
+
+class AvailabilityType(StrEnum):
+    """Availability type for a title in an Overdrive collection."""
+
+    NORMAL = "Normal"
+    ALWAYS_AVAILABLE = "AlwaysAvailable"
+    LIMITED_AVAILABILITY = "LimitedAvailability"
+
+
+class AvailabilityAccount(BaseOverdriveModel):
+    """
+    Per-library copy availability within an Overdrive availability document.
+
+    See: https://developer.overdrive.com/apis/library-availability-new
+    """
+
+    id: int
+    copies_owned: NonNegativeInt = Field(0, alias="copiesOwned")
+    copies_available: NonNegativeInt = Field(0, alias="copiesAvailable")
+    shared: bool = False
+
+
+class Availability(BaseOverdriveModel):
+    """
+    Availability information for a single title.
+
+    This model is used for both successful availability responses and error
+    responses (e.g. ``errorCode: "NotFound"``). Because error responses do not
+    include ``reserveId``, that field is optional. Callers that receive an error
+    response must supply the book ID from context via the ``book_id`` parameter
+    of :meth:`OverdriveRepresentationExtractor.book_info_to_circulation`.
+
+    See: https://developer.overdrive.com/apis/library-availability-new
+    """
+
+    reserve_id: str | None = Field(None, alias="reserveId")
+    accounts: list[AvailabilityAccount] = Field(default_factory=list)
+    availability_type: AvailabilityType | None = Field(None, alias="availabilityType")
+    available: bool = False
+    copies_available: NonNegativeInt | None = Field(None, alias="copiesAvailable")
+    copies_owned: NonNegativeInt | None = Field(None, alias="copiesOwned")
+    number_of_holds: NonNegativeInt = Field(0, alias="numberOfHolds")
+    is_owned_by_collections: bool | None = Field(None, alias="isOwnedByCollections")
+    error_code: str | None = Field(None, alias="errorCode")
+    links: dict[str, Link] = Field(default_factory=dict)

--- a/src/palace/manager/integration/license/overdrive/representation.py
+++ b/src/palace/manager/integration/license/overdrive/representation.py
@@ -22,6 +22,10 @@ from palace.manager.data_layer.subject import SubjectData
 from palace.manager.integration.license.overdrive.constants import (
     OVERDRIVE_MAIN_ACCOUNT_ID,
 )
+from palace.manager.integration.license.overdrive.model import (
+    Availability,
+    AvailabilityAccount,
+)
 from palace.manager.integration.license.overdrive.util import _make_link_safe
 from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.classification import Classification, Subject
@@ -221,31 +225,41 @@ class OverdriveRepresentationExtractor(LoggerMixin):
                 processed.append(cls.overdrive_role_to_simplified_role[x])
         return processed
 
-    def book_info_to_circulation(self, book: dict[str, Any]) -> CirculationData:
-        """Note:  The json data passed into this method is from a different file/stream
-        from the json data that goes into the book_info_to_metadata() method.
+    def book_info_to_circulation(
+        self, availability: Availability, book_id: str | None = None
+    ) -> CirculationData:
+        """Convert an Overdrive availability document into a :class:`CirculationData` object.
+
+        Note: The availability data passed into this method is from a different
+        API endpoint than the metadata data that goes into
+        :meth:`book_info_to_bibliographic`.
+
+        :param availability: The parsed Overdrive availability document.
+        :param book_id: Optional Overdrive ID to use when the availability
+            document does not include a ``reserveId`` (e.g. a NotFound error
+            response).  If neither ``availability.reserve_id`` nor ``book_id``
+            is present, a :exc:`PalaceValueError` is raised.
         """
-        # In Overdrive, 'reserved' books show up as books on
-        # hold. There is no separate notion of reserved books.
+        # In Overdrive, 'reserved' books show up as books on hold.
         licenses_reserved = 0
 
         licenses_owned = None
         licenses_available = None
         patrons_in_hold_queue = None
 
-        # TODO: The only reason this works for a NotFound error is the
-        # circulation code sticks the known book ID into `book` ahead
-        # of time. That's a code smell indicating that this system
-        # needs to be refactored.
-        if "reserveId" in book and not "id" in book:
-            book["id"] = book["reserveId"]
-        if not "id" in book:
-            self.log.error("Book has no ID: %r", book)
+        # book_id takes precedence over the document's reserveId so that the
+        # caller can override the identifier (e.g. after a circulation lookup
+        # where the caller already knows the book's ID). Fall back to reserveId
+        # when no external book_id is provided (e.g. from the importer).
+        overdrive_id = book_id or availability.reserve_id
+        if not overdrive_id:
+            self.log.error("Availability has no ID: %r", availability)
             raise PalaceValueError("Book must have an id to be processed")
-        overdrive_id = book["id"]
+
         primary_identifier = IdentifierData(
             type=Identifier.OVERDRIVE_ID, identifier=overdrive_id
         )
+
         # TODO: We might be able to use this information to avoid the
         # need for explicit configuration of Advantage collections, or
         # at least to keep Advantage collections more up-to-date than
@@ -263,28 +277,24 @@ class OverdriveRepresentationExtractor(LoggerMixin):
         # similarly, though those can abruptly become unavailable, so
         # UNLIMITED_ACCESS is probably not appropriate.
 
-        error_code = book.get("errorCode")
         # TODO: It's not clear what other error codes there might be.
         # The current behavior will respond to errors other than
         # NotFound by leaving the book alone, but this might not be
         # the right behavior.
-        if error_code == "NotFound":
+        if availability.error_code == "NotFound":
             licenses_owned = 0
             licenses_available = 0
             patrons_in_hold_queue = 0
-        elif book.get("isOwnedByCollections") is not False:
+        elif availability.is_owned_by_collections is not False:
             # We own this book.
             licenses_owned = 0
             licenses_available = 0
 
-            for account in self._get_applicable_accounts(book.get("accounts", [])):
-                licenses_owned += int(account.get("copiesOwned", 0))
-                licenses_available += int(account.get("copiesAvailable", 0))
+            for account in self._get_applicable_accounts(availability.accounts):
+                licenses_owned += account.copies_owned
+                licenses_available += account.copies_available
 
-            if "numberOfHolds" in book:
-                if patrons_in_hold_queue is None:
-                    patrons_in_hold_queue = 0
-                patrons_in_hold_queue += book["numberOfHolds"]
+            patrons_in_hold_queue = availability.number_of_holds
 
         if licenses_owned is None:
             license_status = None
@@ -304,38 +314,26 @@ class OverdriveRepresentationExtractor(LoggerMixin):
         )
 
     def _get_applicable_accounts(
-        self, accounts: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+        self, accounts: list[AvailabilityAccount]
+    ) -> list[AvailabilityAccount]:
+        """Return the accounts from the availability document that apply to the
+        current Overdrive collection context.
+
+        For a parent collection, returns accounts for the main OverDrive
+        "library" and any sub-account with sharing enabled.
+
+        For a child Overdrive Advantage collection, returns only the account
+        matching that child's library ID (excluding shared copies, which are
+        counted with the parent).
         """
-        Returns those accounts from the accounts array that apply the
-        current overdrive collection context.
-
-        If this is an overdrive parent collection, we want to return accounts
-        associated with the main OverDrive "library" and any non-main account
-        with sharing enabled.
-
-        If this is a child OverDrive collection, then we return only the
-        account associated with that child's OverDrive Advantage "library".
-        Additionally, we want to exclude the account if it is "shared" since
-        we will be counting it with the parent collection.
-        """
-
         if self.library_id == OVERDRIVE_MAIN_ACCOUNT_ID:
-            # this is a parent collection
-            filtered_result = filter(
-                lambda account: account.get("id") == OVERDRIVE_MAIN_ACCOUNT_ID
-                or account.get("shared", False),
-                accounts,
-            )
+            # parent collection
+            return [
+                a for a in accounts if a.id == OVERDRIVE_MAIN_ACCOUNT_ID or a.shared
+            ]
         else:
-            # this is child collection
-            filtered_result = filter(
-                lambda account: account.get("id") == self.library_id
-                and not account.get("shared", False),
-                accounts,
-            )
-
-        return list(filtered_result)
+            # child Advantage collection
+            return [a for a in accounts if a.id == self.library_id and not a.shared]
 
     @classmethod
     def image_link_to_linkdata(

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -45,6 +45,7 @@ from palace.manager.integration.license.overdrive.model import (
     Availability,
     Checkout,
     Format,
+    LibraryResponse,
     Link,
 )
 from palace.manager.integration.license.overdrive.representation import (
@@ -273,11 +274,10 @@ class TestOverdriveAPI:
         with patch.object(
             OverdriveAPI,
             "get_library",
-            return_value={
-                "errorCode": "Some error",
-                "message": "Some message.",
-                "token": "abc-def-ghi",
-            },
+            return_value=LibraryResponse(
+                errorCode="Some error",
+                message="Some message.",
+            ),
         ):
             # Just instantiating the API doesn't cause this error.
             api = OverdriveAPI(db.session, collection)
@@ -1555,7 +1555,9 @@ class TestOverdriveAPI:
 
     def test_collection_token(self, db: DatabaseTransactionFixture) -> None:
         api = OverdriveAPI(db.session, db.collection(protocol=OverdriveAPI))
-        mock_get_library = MagicMock(return_value={"collectionToken": "abc"})
+        mock_get_library = MagicMock(
+            return_value=LibraryResponse(collectionToken="abc")
+        )
         api.get_library = mock_get_library
 
         # Cache is empty on first access — get_library is called.
@@ -1576,8 +1578,8 @@ class TestOverdriveAPI:
         api = OverdriveAPI(db.session, db.collection(protocol=OverdriveAPI))
         mock_get_library = MagicMock(
             side_effect=[
-                {"collectionToken": "old-token"},
-                {"collectionToken": "new-token"},
+                LibraryResponse(collectionToken="old-token"),
+                LibraryResponse(collectionToken="new-token"),
             ]
         )
         api.get_library = mock_get_library
@@ -1600,7 +1602,9 @@ class TestOverdriveAPI:
         """An errorCode in the library response raises CannotLoadConfiguration."""
         api = OverdriveAPI(db.session, db.collection(protocol=OverdriveAPI))
         api.get_library = MagicMock(
-            return_value={"errorCode": "NotFound", "message": "bad credentials"}
+            return_value=LibraryResponse(
+                errorCode="NotFound", message="bad credentials"
+            )
         )
         with pytest.raises(CannotLoadConfiguration, match="bad credentials"):
             api.collection_token

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -41,7 +41,12 @@ from palace.manager.integration.license.overdrive.exception import (
 from palace.manager.integration.license.overdrive.fulfillment import (
     OverdriveManifestFulfillment,
 )
-from palace.manager.integration.license.overdrive.model import Checkout, Format, Link
+from palace.manager.integration.license.overdrive.model import (
+    Availability,
+    Checkout,
+    Format,
+    Link,
+)
 from palace.manager.integration.license.overdrive.representation import (
     OverdriveRepresentationExtractor,
 )
@@ -1779,6 +1784,7 @@ class TestOverdriveAPI:
         # Make it look like the availability information is for the
         # newly created Identifier.
         raw["reserveId"] = identifier.identifier
+        availability = Availability.model_validate(raw)
 
         pool, was_new = LicensePool.for_foreign_id(
             db.session,
@@ -1793,7 +1799,7 @@ class TestOverdriveAPI:
             was_new,
             changed,
         ) = overdrive_api_fixture.api.update_licensepool_with_book_info(
-            raw, pool, was_new
+            availability, identifier.identifier, pool, was_new
         )
         assert was_new is True
         assert changed is True
@@ -1822,7 +1828,7 @@ class TestOverdriveAPI:
 
         # Make it look like the availability information is for the
         # newly created LicensePool.
-        raw["id"] = pool.identifier.identifier
+        availability = Availability.model_validate(raw)
 
         wr.title = "The real title."
         assert pool.licenses_owned == 1
@@ -1835,7 +1841,7 @@ class TestOverdriveAPI:
             was_new,
             changed,
         ) = overdrive_api_fixture.api.update_licensepool_with_book_info(
-            raw, pool, False
+            availability, pool.identifier.identifier, pool, False
         )
         assert was_new is False
         assert changed is True
@@ -1867,7 +1873,7 @@ class TestOverdriveAPI:
         # Make it look like the availability information is for the
         # old pool's Identifier.
         identifier = old_pool.identifier
-        raw["id"] = identifier.identifier
+        availability = Availability.model_validate(raw)
 
         new_pool, was_new = LicensePool.for_foreign_id(
             db.session,
@@ -1886,7 +1892,7 @@ class TestOverdriveAPI:
             was_new,
             changed,
         ) = overdrive_api_fixture.api.update_licensepool_with_book_info(
-            raw, new_pool, was_new
+            availability, identifier.identifier, new_pool, was_new
         )
         assert new_pool is not None
         assert was_new is True
@@ -1901,7 +1907,7 @@ class TestOverdriveAPI:
             "overdrive_availability_information_holds.json"
         )
         identifier = db.identifier(identifier_type=Identifier.OVERDRIVE_ID)
-        raw["id"] = identifier.identifier
+        availability = Availability.model_validate(raw)
 
         license_pool, is_new = LicensePool.for_foreign_id(
             db.session,
@@ -1915,7 +1921,7 @@ class TestOverdriveAPI:
             was_new,
             changed,
         ) = overdrive_api_fixture.api.update_licensepool_with_book_info(
-            raw, license_pool, is_new
+            availability, identifier.identifier, license_pool, is_new
         )
         assert pool.patrons_in_hold_queue == 10
         assert changed is True

--- a/tests/manager/integration/license/overdrive/test_model.py
+++ b/tests/manager/integration/license/overdrive/test_model.py
@@ -28,6 +28,8 @@ from palace.manager.integration.license.overdrive.exception import (
 from palace.manager.integration.license.overdrive.model import (
     Action,
     ActionField,
+    AdvantageAccountEntry,
+    AdvantageAccountsResponse,
     Availability,
     AvailabilityAccount,
     AvailabilityType,
@@ -37,6 +39,7 @@ from palace.manager.integration.license.overdrive.model import (
     Format,
     Hold,
     Holds,
+    LibraryResponse,
     LinkTemplate,
     PatronInformation,
 )
@@ -693,3 +696,90 @@ class TestAvailability:
         assert account.copies_owned == 0
         assert account.copies_available == 0
         assert account.shared is False
+
+
+class TestLibraryResponse:
+    def test_successful_response(self) -> None:
+        """A successful response with a collectionToken and links parses correctly."""
+        library = LibraryResponse.model_validate(
+            {
+                "collectionToken": "abc123",
+                "links": {
+                    "advantageAccounts": {
+                        "href": "https://example.com/advantageAccounts",
+                        "type": "application/json",
+                    }
+                },
+            }
+        )
+
+        assert library.collection_token == "abc123"
+        assert library.error_code is None
+        assert library.message is None
+        assert library.advantage_accounts_url == "https://example.com/advantageAccounts"
+
+    def test_no_links(self) -> None:
+        """A response with no links returns None for advantage_accounts_url."""
+        library = LibraryResponse.model_validate({"collectionToken": "token"})
+
+        assert library.collection_token == "token"
+        assert library.links == {}
+        assert library.advantage_accounts_url is None
+
+    def test_error_response(self) -> None:
+        """An error response parses errorCode and message correctly."""
+        library = LibraryResponse.model_validate(
+            {"errorCode": "NotFound", "message": "Library not found"}
+        )
+
+        assert library.error_code == "NotFound"
+        assert library.message == "Library not found"
+        assert library.collection_token is None
+        assert library.advantage_accounts_url is None
+
+    def test_advantage_accounts_url_missing_key(self) -> None:
+        """Links dict without an advantageAccounts key returns None."""
+        library = LibraryResponse.model_validate(
+            {
+                "collectionToken": "tok",
+                "links": {"self": {"href": "https://example.com", "type": "text/html"}},
+            }
+        )
+
+        assert library.advantage_accounts_url is None
+
+
+class TestAdvantageAccountsResponse:
+    def test_from_json_fixture(
+        self, overdrive_files_fixture: OverdriveFilesFixture
+    ) -> None:
+        """Parse the advantage_accounts.json fixture into the pydantic model."""
+        response = AdvantageAccountsResponse.model_validate_json(
+            overdrive_files_fixture.sample_data("advantage_accounts.json")
+        )
+
+        assert response.id == 1225
+        assert len(response.advantage_accounts) == 2
+
+        by_id = {a.id: a for a in response.advantage_accounts}
+        assert by_id[3].name == "The Other Side of Town Library"
+        assert by_id[3].collection_token == "v1L2B2gAAAK8BAAA1x"
+        assert by_id[9].name == "The Common Community Library"
+        assert by_id[9].collection_token == "v1L2B2gAAAKoBAAA1B"
+
+    def test_empty_advantage_accounts(self) -> None:
+        """An advantage accounts response with no accounts defaults to empty list."""
+        response = AdvantageAccountsResponse.model_validate({"id": 42})
+
+        assert response.id == 42
+        assert response.advantage_accounts == []
+
+    def test_advantage_account_entry(self) -> None:
+        """AdvantageAccountEntry parses id, name, and collectionToken."""
+        entry = AdvantageAccountEntry.model_validate(
+            {"id": 7, "name": "My Library", "collectionToken": "tok789"}
+        )
+
+        assert entry.id == 7
+        assert entry.name == "My Library"
+        assert entry.collection_token == "tok789"

--- a/tests/manager/integration/license/overdrive/test_model.py
+++ b/tests/manager/integration/license/overdrive/test_model.py
@@ -28,6 +28,9 @@ from palace.manager.integration.license.overdrive.exception import (
 from palace.manager.integration.license.overdrive.model import (
     Action,
     ActionField,
+    Availability,
+    AvailabilityAccount,
+    AvailabilityType,
     Checkout,
     Checkouts,
     ErrorResponse,
@@ -600,3 +603,93 @@ class TestPatronInformation:
 
         assert "checkouts" in patron_information.links
         assert "search" in patron_information.link_templates
+
+
+class TestAvailability:
+    def test_normal_availability(
+        self, overdrive_files_fixture: OverdriveFilesFixture
+    ) -> None:
+        availability = Availability.model_validate_json(
+            overdrive_files_fixture.sample_data(
+                "overdrive_availability_information.json"
+            )
+        )
+
+        assert availability.reserve_id == "2a005d55-a417-4053-b90d-7a38ca6d2065"
+        assert availability.availability_type == AvailabilityType.NORMAL
+        assert availability.available is False
+        assert availability.copies_available == 1
+        assert availability.copies_owned == 5
+        assert availability.number_of_holds == 0
+        assert availability.error_code is None
+        assert availability.is_owned_by_collections is None
+        assert len(availability.accounts) == 1
+
+        account = availability.accounts[0]
+        assert account.id == -1
+        assert account.copies_available == 1
+        assert account.copies_owned == 5
+        assert account.shared is False
+
+        assert "self" in availability.links
+
+    def test_availability_with_holds(
+        self, overdrive_files_fixture: OverdriveFilesFixture
+    ) -> None:
+        availability = Availability.model_validate_json(
+            overdrive_files_fixture.sample_data(
+                "overdrive_availability_information_holds.json"
+            )
+        )
+
+        assert availability.number_of_holds == 10
+        assert availability.copies_available == 0
+        assert availability.copies_owned == 5
+
+    def test_advantage_availability(
+        self, overdrive_files_fixture: OverdriveFilesFixture
+    ) -> None:
+        availability = Availability.model_validate_json(
+            overdrive_files_fixture.sample_data("overdrive_availability_advantage.json")
+        )
+
+        assert availability.available is True
+        assert len(availability.accounts) == 3
+
+        accounts_by_id = {a.id: a for a in availability.accounts}
+        assert accounts_by_id[61].copies_owned == 1
+        assert accounts_by_id[61].copies_available == 1
+        assert accounts_by_id[61].shared is False
+        assert accounts_by_id[63].copies_owned == 8
+        assert accounts_by_id[63].copies_available == 8
+        assert accounts_by_id[63].shared is True
+        assert accounts_by_id[-1].copies_owned == 2
+        assert accounts_by_id[-1].copies_available == 2
+
+    def test_not_found_error(
+        self, overdrive_files_fixture: OverdriveFilesFixture
+    ) -> None:
+        # A NotFound error response has no reserveId or accounts — it parses
+        # cleanly with all availability fields defaulted.
+        availability = Availability.model_validate_json(
+            overdrive_files_fixture.sample_data("overdrive_availability_not_found.json")
+        )
+
+        assert availability.reserve_id is None
+        assert availability.error_code == "NotFound"
+        assert availability.accounts == []
+        assert availability.copies_owned is None
+        assert availability.copies_available is None
+
+    def test_availability_type_enum(self) -> None:
+        for value in ("Normal", "AlwaysAvailable", "LimitedAvailability"):
+            availability = Availability.model_validate(
+                {"reserveId": "abc", "availabilityType": value}
+            )
+            assert availability.availability_type == AvailabilityType(value)
+
+    def test_availability_account_defaults(self) -> None:
+        account = AvailabilityAccount.model_validate({"id": 5})
+        assert account.copies_owned == 0
+        assert account.copies_available == 0
+        assert account.shared is False

--- a/tests/manager/integration/license/overdrive/test_representation.py
+++ b/tests/manager/integration/license/overdrive/test_representation.py
@@ -11,6 +11,7 @@ from palace.util.exceptions import PalaceValueError
 
 from palace.manager.data_layer.format import FormatData
 from palace.manager.data_layer.link import LinkData
+from palace.manager.integration.license.overdrive.model import Availability
 from palace.manager.integration.license.overdrive.representation import (
     OverdriveRepresentationExtractor,
 )
@@ -74,13 +75,14 @@ class TestOverdriveRepresentationExtractor:
         assert expect == OverdriveRepresentationExtractor.link(raw, "first")
 
     def test_book_info_to_circulation(self, overdrive_api_fixture: OverdriveAPIFixture):
-        # Tests that can convert an overdrive json block into a CirculationData object.
+        # Tests that can convert an overdrive availability document into a CirculationData object.
         fixture = overdrive_api_fixture
         session = overdrive_api_fixture.db.session
 
-        raw, info = fixture.sample_json("overdrive_availability_information_2.json")
+        raw, _ = fixture.sample_json("overdrive_availability_information_2.json")
+        availability = Availability.model_validate_json(raw)
         extractor = OverdriveRepresentationExtractor(fixture.api)
-        circulationdata = extractor.book_info_to_circulation(info)
+        circulationdata = extractor.book_info_to_circulation(availability)
 
         # NOTE: It's not realistic for licenses_available and
         # patrons_in_hold_queue to both be nonzero; this is just to
@@ -107,12 +109,13 @@ class TestOverdriveRepresentationExtractor:
         # different information from the same API responses as "main" Overdrive
         # accounts.
         fixture = overdrive_api_fixture
-        raw, info = fixture.sample_json("overdrive_availability_advantage.json")
+        raw, _ = fixture.sample_json("overdrive_availability_advantage.json")
+        availability = Availability.model_validate_json(raw)
 
         extractor = OverdriveRepresentationExtractor(fixture.api)
         # Calling in the context of a main account should return a count of
         # the main account and any shared sub account owned and available.
-        consortial_data = extractor.book_info_to_circulation(info)
+        consortial_data = extractor.book_info_to_circulation(availability)
         assert 10 == consortial_data.licenses_owned
         assert 10 == consortial_data.licenses_available
         assert LicensePoolStatus.ACTIVE == consortial_data.status
@@ -120,7 +123,7 @@ class TestOverdriveRepresentationExtractor:
         # Pretend to be an API for an Overdrive Advantage collection with
         # library ID 61.
         extractor = OverdriveRepresentationExtractor(MagicMock(advantage_library_id=61))
-        advantage_data = extractor.book_info_to_circulation(info)
+        advantage_data = extractor.book_info_to_circulation(availability)
         assert 1 == advantage_data.licenses_owned
         assert 1 == advantage_data.licenses_available
         assert LicensePoolStatus.ACTIVE == advantage_data.status
@@ -139,14 +142,14 @@ class TestOverdriveRepresentationExtractor:
         # CirculationData object at all, but this shouldn't happen in
         # a real scenario.
         extractor = OverdriveRepresentationExtractor(MagicMock(advantage_library_id=62))
-        advantage_data = extractor.book_info_to_circulation(info)
+        advantage_data = extractor.book_info_to_circulation(availability)
         assert 0 == advantage_data.licenses_owned
         assert 0 == advantage_data.licenses_available
 
         # Pretend to be an API for an Overdrive Advantage collection with
         # library ID 63 which contains shared copies.
         extractor = OverdriveRepresentationExtractor(MagicMock(advantage_library_id=63))
-        advantage_data = extractor.book_info_to_circulation(info)
+        advantage_data = extractor.book_info_to_circulation(availability)
         # since these copies are shared and counted as part of the main
         # context we do not count them here.
         assert 0 == advantage_data.licenses_owned
@@ -157,24 +160,23 @@ class TestOverdriveRepresentationExtractor:
     ):
         fixture = overdrive_api_fixture
         transaction = fixture.db
-        raw, info = fixture.sample_json("overdrive_availability_not_found.json")
+        raw, _ = fixture.sample_json("overdrive_availability_not_found.json")
+        availability = Availability.model_validate_json(raw)
 
-        # By default, a "NotFound" error can't be converted to a
-        # CirculationData object, because we don't know _which_ book it
-        # was that wasn't found.
+        # A "NotFound" error response has no reserveId. Without a book_id
+        # override we cannot identify the book.
         extractor = OverdriveRepresentationExtractor(fixture.api)
-        m = extractor.book_info_to_circulation
         with pytest.raises(
             PalaceValueError, match="Book must have an id to be processed"
         ):
-            m(info)
+            extractor.book_info_to_circulation(availability)
 
-        # However, if an ID was added to `info` ahead of time (as the
-        # circulation code does), we do know, and we can create a
-        # CirculationData.
+        # When the caller supplies the known book ID (as circulation code does
+        # via update_licensepool), we can produce a valid CirculationData.
         identifier = transaction.identifier(identifier_type=Identifier.OVERDRIVE_ID)
-        info["id"] = identifier.identifier
-        data = m(info)
+        data = extractor.book_info_to_circulation(
+            availability, book_id=identifier.identifier
+        )
         assert identifier == data.load_primary_identifier(transaction.session)
         assert 0 == data.licenses_owned
         assert 0 == data.licenses_available
@@ -195,13 +197,15 @@ class TestOverdriveRepresentationExtractor:
         fixture = overdrive_api_fixture
         extractor = OverdriveRepresentationExtractor(fixture.api)
 
-        # Create a mock info object that has neither an error code nor isOwnedByCollections
-        info = {
-            "id": "test-id-12345",
-            "isOwnedByCollections": False,  # Not owned, no error code
-        }
+        # isOwnedByCollections=False means the collection does not own this book.
+        availability = Availability.model_validate(
+            {
+                "reserveId": "test-id-12345",
+                "isOwnedByCollections": False,
+            }
+        )
 
-        data = extractor.book_info_to_circulation(info)
+        data = extractor.book_info_to_circulation(availability)
 
         # When we don't own the book and there's no error, licenses_owned is None
         assert data.licenses_owned is None


### PR DESCRIPTION
## Description

This PR is the second of three that convert Overdrive API dict-based responses to typed, validated Pydantic models (following the `BaseOverdriveModel` conventions already used by `Checkout`, `Holds`, etc.).

This PR covers the **library endpoint** and **advantage accounts endpoint** responses.

### New models (`model.py`)

- **`LibraryResponse`** — response from `/v1/libraries/{id}`: `collectionToken`, `links`, `errorCode`, `message`, plus a `advantage_accounts_url` property that extracts the href from `links["advantageAccounts"]`
- **`AdvantageAccountEntry`** — a single entry within an advantage accounts response: `id`, `name`, `collectionToken`
- **`AdvantageAccountsResponse`** — response from the advantage accounts endpoint: `id`, `advantageAccounts`

### Previous PR (first of three)

- **`AvailabilityType`**, **`AvailabilityAccount`**, **`Availability`** — availability endpoint response
- **`representation.py`**: `book_info_to_circulation(availability: Availability, book_id: str | None = None)`
- **`api.py`**: `update_licensepool` calls `Availability.model_validate_json(content)`
- **`importer.py`**: `availabilityV2` dict validated via `Availability.model_validate(...)`

### Refactors (this PR)

- **`api.py`**: `get_library()` return type changed from `dict[str, Any]` to `LibraryResponse`. The `collection_token` property and `get_advantage_accounts()` updated to use attribute access instead of dict `.get()` calls.
- **`advantage.py`**: `OverdriveAdvantageAccount.from_representation()` replaces manual `json.loads` + dict traversal with `AdvantageAccountsResponse.model_validate_json()`. The `json` import is removed.

### Tests

- `TestLibraryResponse` added to `test_model.py` (4 tests): successful response, no-links response, error response, missing `advantageAccounts` key.
- `TestAdvantageAccountsResponse` added to `test_model.py` (3 tests): full fixture parse, empty accounts default, single entry parse.
- `test_api.py` updated — four `get_library` mocks that returned raw dicts now return `LibraryResponse` objects.

## Motivation and Context

Replacing raw `dict[str, Any]` responses with Pydantic models gives us validated, typed access to API data, eliminates scattered `.get()` calls with implicit `None` defaults, and makes the data contract explicit and self-documenting.

Jira: PP-3175

## How Has This Been Tested?

- All new models tested in `test_model.py` via `model_validate` / `model_validate_json` against both inline data and fixture files.
- Existing `test_api.py` and `test_advantage.py` tests updated and passing.
- `mypy` reports no issues on all changed source files.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

