### PR TITLE
Prevent Overdrive double-start by adding workflow lock guard to import_collection_group (PP-4025)

### DIFF
--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -240,7 +240,7 @@ def import_collection_group(
     import_all: bool = False,
     modified_since: datetime.datetime | None = None,
     start_time: datetime.datetime | None = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | ImportSkippedPayload:
     """Import an Overdrive collection and all its child (Advantage) collections.
 
     This task orchestrates the import of a parent Overdrive collection and chains

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -261,8 +261,20 @@ def import_collection_group(
                           See import_collection docstring for detailed behavior.
     :param start_time: The datetime when this import began. Used to update the
                       collection's timestamp. If None, uses current time.
-    :return: Dictionary containing the chain_id for tracking the async import chain.
+    :return: Dictionary containing the chain_id for tracking the async import chain,
+             or an import-skipped payload if another workflow is already in progress.
     """
+    redis = task.services.redis().client()
+    # Defense-in-depth: skip chain creation if a workflow is already running.
+    # This prevents redundant chains from being queued when the workflow lock
+    # expires between pages and a new Beat tick fires before import_collection
+    # can re-acquire and enforce the first-page guard itself.
+    if import_workflow_lock(redis, collection_id, str(uuid4())).locked():
+        task.log.info(
+            f"OverDrive import skipped for collection {collection_id}: "
+            "another import is already in progress (skipping at group level)."
+        )
+        return _import_skipped_payload()
 
     result = chain(
         import_collection.s(

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -721,6 +721,31 @@ class TestImportCollectionGroup:
         assert call_args["modified_since"] == modified_since
         assert call_args["start_time"] == start_time
 
+    @patch("palace.manager.celery.tasks.overdrive.chain")
+    @patch("palace.manager.celery.tasks.overdrive.import_collection")
+    @patch("palace.manager.celery.tasks.overdrive.import_result_router")
+    def test_import_collection_group_skips_when_lock_held(
+        self,
+        mock_router: MagicMock,
+        mock_import_collection: MagicMock,
+        mock_chain: MagicMock,
+        overdrive_import_fixture: OverdriveImportFixture,
+        redis_fixture: RedisFixture,
+    ):
+        """When the workflow lock is held, import_collection_group skips chain creation."""
+        collection = overdrive_import_fixture.collection
+        lock_value = str(uuid4())
+        workflow_lock = import_workflow_lock(
+            redis_fixture.client, collection.id, lock_value
+        )
+        workflow_lock.acquire()
+
+        result = overdrive.import_collection_group.delay(collection.id).wait()
+
+        mock_chain.assert_not_called()
+        assert result == overdrive._import_skipped_payload()
+        workflow_lock.release()
+
 
 class TestImportResultRouter:
     """Tests for the import_result_router Celery task."""


### PR DESCRIPTION
## Description
Add a workflow lock guard at the `import_collection_group` level to prevent
redundant Overdrive import chains from being created while another workflow
is already in progress.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-4025

When Celery Beat fires every 15 minutes, `import_all_collections` →
`import_collection_group` would unconditionally create and enqueue a new
`import_collection` chain for each collection. The only duplicate-start
guard lived inside `import_collection` itself (first-page check against
the workflow lock).
If the workflow lock (2-hour TTL) expired between pages — for example due
to a queue backlog — a subsequent Beat tick could create a brand-new chain
that acquired a fresh lock and started a full-history import concurrently
with the still-queued continuation pages of the original import. Both would
log `Modified since: None` and process from epoch, causing duplicate work
and unexpected behavior.
The fix adds a `locked()` check in `import_collection_group` before chain
creation. If the workflow lock key already exists in Redis (regardless of
which UUID holds it), the task returns the import-skipped payload without
creating a chain. The `import_collection`-level guard remains the
definitive enforcement point; this is defense-in-depth.

## How Has This Been Tested?
Added `test_import_collection_group_skips_when_lock_held` to
`TestImportCollectionGroup`, which pre-acquires the workflow lock in Redis
and asserts that `import_collection_group` returns the skip payload without
calling `chain`. All existing `TestImportCollectionGroup` tests continue to
pass.

## Checklist
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.