### PR TITLE
Fix flakey overdrive import integration test race condition

### DIFF
--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -1191,7 +1191,15 @@ class TestIntegration:
             # Wait for the import chain to complete. The import_collection_group task
             # starts an async chain and returns immediately with the chain_id. We need
             # to wait for that chain to finish before processing apply tasks.
-            AsyncResult(result["chain_id"]).wait()
+            chain_result = AsyncResult(result["chain_id"]).wait()
+
+            # The chain's last task (import_result_router) fires off
+            # import_children_and_cleanup_chord asynchronously. We must wait for
+            # that chord to finish as well, otherwise its worker thread may still
+            # hold a savepoint on the shared test session when we call
+            # process_apply_queue(), causing a ResourceClosedError.
+            if chord_id := chain_result.get("chord_id"):
+                AsyncResult(chord_id).wait()
 
             # Process the queued apply tasks synchronously. The import task fires off
             # bibliographic_apply and circulation_apply tasks asynchronously, which are


### PR DESCRIPTION
## Description

Fix a race condition in `test_full_import_flow_with_parent_identifiers_and_overdrive_data` that caused intermittent `ResourceClosedError` failures.

The test was only waiting for the import chain (`import_collection` → `import_result_router`) to complete, but `import_result_router` fires `import_children_and_cleanup_chord` asynchronously. That task uses the shared test session via `task.session()`, so when `process_apply_queue()` ran while it was still executing, two threads used the same non-thread-safe SQLAlchemy session, corrupting the transaction state.

The fix captures the chain result and waits for the chord returned by `import_result_router` before processing the apply queue, ensuring all session-using tasks have finished.

## Motivation and Context

This test was failing intermittently in CI. Example failure:
https://github.com/ThePalaceProject/circulation/actions/runs/24146382857/job/70461240223

## How Has This Been Tested?

This is a fix for a flakey test caused by a race condition. The fix ensures proper synchronization by waiting for all async tasks that use the shared session to complete before the test proceeds to use the session.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.