### PR TITLE
Update logrotate config to rotate on size and add full timestamps (PP-4035)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,9 @@ FROM ${BASE_IMAGE} AS common
 # Copy startup scripts
 COPY docker/startup /etc/my_init.d/
 
-# Setup logrotate
+# Setup logrotate and run it hourly instead of daily
 COPY --chmod=644 docker/services/logrotate /etc/
+RUN mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
 
 # Copy our poetry files into the image and install our dependencies.
 COPY --chown=palace:palace poetry.lock pyproject.toml /var/www/circulation/

--- a/docker/services/logrotate/logrotate.d/celery.conf
+++ b/docker/services/logrotate/logrotate.d/celery.conf
@@ -1,10 +1,12 @@
 /var/log/celery/*.log {
     missingok
     daily
+    maxsize 500M
     create 0660 palace adm
     rotate 7
     compress
     notifempty
     dateext
+    dateformat -%Y%m%dT%H%M%S
     maxage 14
 }

--- a/docker/services/logrotate/logrotate.d/simplified.conf
+++ b/docker/services/logrotate/logrotate.d/simplified.conf
@@ -1,23 +1,27 @@
 /var/log/simplified/*.log {
     missingok
     daily
+    maxsize 500M
     rotate 13
     copytruncate
     compress
     delaycompress
     notifempty
     dateext
+    dateformat -%Y%m%dT%H%M%S
     maxage 26
 }
 
 /var/log/uwsgi/*.log {
     missingok
     daily
+    maxsize 500M
     rotate 13
     copytruncate
     compress
     delaycompress
     notifempty
     dateext
+    dateformat -%Y%m%dT%H%M%S
     maxage 26
 }


### PR DESCRIPTION
## Description

Updates the logrotate configuration for circulation containers with two changes:

- **Size-based rotation**: Adds `maxsize 500M` to the `simplified`, `uwsgi`, and `celery` log configs. Logs will now rotate when they reach 500MB *or* at the daily schedule, whichever comes first.
- **Full timestamps on compressed archives**: Adds `dateformat -%Y%m%dT%H%M%S` to all three log configs so rotated `.gz` files include a full timestamp (e.g. `app.log-20260409T143022.gz`) rather than just the date.
- **Hourly logrotate invocation**: Moves the logrotate cron script from `/etc/cron.daily` to `/etc/cron.hourly` in the Dockerfile so the 500MB size threshold is checked hourly rather than once per day.

## Motivation and Context

https://ebce-lyrasis.atlassian.net/browse/PP-4035

Previously, logs were only rotated on a daily schedule with no size cap, which could allow log files to grow very large between rotations resulting in some script instances running out of disk space  This change ensures large log files are caught within an hour of hitting 500MB.

## How Has This Been Tested?

Configuration changes only — verified by inspection of the logrotate directives.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.