### PR TITLE
Reduce import log noise (PP-4036)

### DIFF
--- a/src/palace/manager/integration/license/overdrive/representation.py
+++ b/src/palace/manager/integration/license/overdrive/representation.py
@@ -483,7 +483,7 @@ class OverdriveRepresentationExtractor(LoggerMixin):
                 overdrive_medium
                 and overdrive_medium not in cls.overdrive_medium_to_simplified_medium
             ):
-                cls.logger().error(
+                cls.logger().debug(
                     "Could not process medium %s for %s", overdrive_medium, overdrive_id
                 )
 

--- a/src/palace/manager/util/http/async_http.py
+++ b/src/palace/manager/util/http/async_http.py
@@ -379,7 +379,7 @@ class AsyncClient(LoggerMixin):
         """
         try:
             response = await self._httpx_client.request(method, url, **kwargs)
-            self.log.info(
+            self.log.debug(
                 f"Request time for {url} took {response.elapsed.total_seconds():.2f} seconds"
             )
 


### PR DESCRIPTION
## Description
Now that we've moved OverDrive imports to celery we're seeing a significant increase in parallel processing.  This is leading to a significant increase in log size.  As part of an effort to keep the logs from overwhelming disks on the scripts instance, this update reduces the log level of two particularly noisy lines.

## Motivation and Context

https://ebce-lyrasis.atlassian.net/browse/PP-4036

## How Has This Been Tested?
Unit tests  pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
