### PR TITLE
Fix revoke links missing from OPDS2 feeds (PP-4056)

### DIFF
--- a/src/palace/manager/feed/serializer/opds2.py
+++ b/src/palace/manager/feed/serializer/opds2.py
@@ -242,9 +242,7 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]], LoggerMixin):
             )
 
         for acquisition in data.acquisition_links:
-            acq_link = self._serialize_acquisition_link(acquisition)
-            if acq_link is not None:
-                links.append(acq_link)
+            links.append(self._serialize_acquisition_link(acquisition))
         return links
 
     def _serialize_link(self, link: Link) -> opds2.Link:
@@ -255,14 +253,11 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]], LoggerMixin):
             title=link.title,
         )
 
-    def _serialize_acquisition_link(self, link: Acquisition) -> opds2.Link | None:
-        link_type = self._acquisition_link_type(link)
-        if link_type is None:
-            return None
+    def _serialize_acquisition_link(self, link: Acquisition) -> opds2.Link:
         return self._link(
             href=link.href,
             rel=link.rel or opds2.AcquisitionLinkRelations.acquisition,
-            type=link_type,
+            type=self._resolve_type(link.type),
             title=link.title,
             properties=self._serialize_acquisition_properties(link),
             templated=link.templated,
@@ -479,16 +474,6 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]], LoggerMixin):
             )
         return groups
 
-    def _acquisition_link_type(self, link: Acquisition) -> str | None:
-        if link.type:
-            return self._resolve_type(link.type)
-        for indirect in link.indirect_acquisitions:
-            indirect_type = self._resolve_type(indirect.type)
-            if indirect_type:
-                return indirect_type
-        self.log.error(f"Skipping acquisition link without type: {link.href}")
-        return None
-
     def _availability_state(self, link: Acquisition) -> opds2.AvailabilityState | None:
         if link.is_loan:
             return opds2.AvailabilityState.ready
@@ -542,7 +527,7 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]], LoggerMixin):
         *,
         href: str,
         rel: str,
-        type: str,
+        type: str | None = None,
         title: str | None = None,
         properties: opds2.LinkProperties,
         templated: bool = False,

--- a/src/palace/manager/feed/serializer/opds2.py
+++ b/src/palace/manager/feed/serializer/opds2.py
@@ -227,15 +227,11 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]], LoggerMixin):
             if link.rel is None:
                 self.log.warning(f"Skipping OPDS2 link without rel: {link.href}")
                 continue
-            resolved_type = self._resolve_type(link.type)
-            if resolved_type is None:
-                self.log.error(f"Skipping OPDS2 link without type: {link.href}")
-                continue
             links.append(
                 self._link(
                     href=link.href,
                     rel=link.rel,
-                    type=resolved_type,
+                    type=self._resolve_type(link.type),
                     title=link.title,
                     properties=self._link_properties(),
                 )

--- a/src/palace/manager/feed/serializer/opds2.py
+++ b/src/palace/manager/feed/serializer/opds2.py
@@ -224,9 +224,6 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]], LoggerMixin):
     def _serialize_publication_links(self, data: WorkEntryData) -> list[opds2.Link]:
         links: list[opds2.Link] = []
         for link in data.other_links:
-            if link.rel is None:
-                self.log.warning(f"Skipping OPDS2 link without rel: {link.href}")
-                continue
             links.append(
                 self._link(
                     href=link.href,
@@ -353,18 +350,9 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]], LoggerMixin):
         return json.dumps(data, indent=2)
 
     def _serialize_feed_links(self, feed: FeedData) -> list[opds2.Link]:
-        links: list[opds2.Link] = []
-        for link in feed.links:
-            strict = self._serialize_feed_link(link)
-            if strict is not None:
-                links.append(strict)
+        return [self._serialize_feed_link(link) for link in feed.links]
 
-        return links
-
-    def _serialize_feed_link(self, link: Link) -> opds2.Link | None:
-        if link.rel is None:
-            self.log.warning(f"Skipping OPDS2 feed link without rel: {link.href}")
-            return None
+    def _serialize_feed_link(self, link: Link) -> opds2.Link:
         resolved_type = self._resolve_type(link.type)
         return self._link(
             href=link.href,
@@ -522,7 +510,7 @@ class OPDS2Serializer(SerializerInterface[dict[str, Any]], LoggerMixin):
         self,
         *,
         href: str,
-        rel: str,
+        rel: str | None = None,
         type: str | None = None,
         title: str | None = None,
         properties: opds2.LinkProperties,

--- a/tests/manager/feed/test_opds2_serializer.py
+++ b/tests/manager/feed/test_opds2_serializer.py
@@ -533,8 +533,8 @@ class TestOPDS2Serializer:
         result = json.loads(serialized)
         assert result["metadata"]["title"] == "Feed"
 
-    def test_publication_links_skip_without_rel(self):
-        """Other links without a rel attribute are skipped."""
+    def test_publication_links_without_rel(self):
+        """Other links without a rel attribute are still serialized."""
         serializer = OPDS2Serializer()
         data = WorkEntryData(
             title="Test",
@@ -552,9 +552,8 @@ class TestOPDS2Serializer:
             ],
         )
         entry = serializer.serialize_work_entry(data)
-        # The other_link without rel should be skipped; only the acquisition link remains
         link_hrefs = [link["href"] for link in entry["links"]]
-        assert "http://no-rel" not in link_hrefs
+        assert "http://no-rel" in link_hrefs
         assert "http://acq" in link_hrefs
 
     def test_publication_links_without_type(self):
@@ -610,7 +609,7 @@ class TestOPDS2Serializer:
         assert "indirectAcquisition" not in result.get("properties", {})
 
     def test_feed_link_without_rel(self):
-        """Feed links without a rel attribute are skipped."""
+        """Feed links without a rel attribute are still serialized."""
         feed = FeedData(
             metadata=FeedMetadata(title="Feed", id="http://feed"),
         )
@@ -623,7 +622,7 @@ class TestOPDS2Serializer:
         result = json.loads(serialized)
         link_hrefs = [link["href"] for link in result["links"]]
         assert "http://feed" in link_hrefs
-        assert "http://no-rel" not in link_hrefs
+        assert "http://no-rel" in link_hrefs
 
     def test_facet_group_with_single_link_skipped(self):
         """A facet group with fewer than 2 links is skipped."""

--- a/tests/manager/feed/test_opds2_serializer.py
+++ b/tests/manager/feed/test_opds2_serializer.py
@@ -557,8 +557,8 @@ class TestOPDS2Serializer:
         assert "http://no-rel" not in link_hrefs
         assert "http://acq" in link_hrefs
 
-    def test_publication_links_skip_without_type(self):
-        """Other links without a type attribute are skipped."""
+    def test_publication_links_without_type(self):
+        """Other links without a type attribute are still serialized."""
         serializer = OPDS2Serializer()
         data = WorkEntryData(
             title="Test",
@@ -577,7 +577,7 @@ class TestOPDS2Serializer:
         )
         entry = serializer.serialize_work_entry(data)
         link_hrefs = [link["href"] for link in entry["links"]]
-        assert "http://no-type" not in link_hrefs
+        assert "http://no-type" in link_hrefs
 
     def test_acquisition_link_without_type(self):
         """An acquisition link with no type is still serialized."""

--- a/tests/manager/feed/test_opds2_serializer.py
+++ b/tests/manager/feed/test_opds2_serializer.py
@@ -579,8 +579,8 @@ class TestOPDS2Serializer:
         link_hrefs = [link["href"] for link in entry["links"]]
         assert "http://no-type" not in link_hrefs
 
-    def test_acquisition_link_type_returns_none(self):
-        """An acquisition link with no type and no indirect types returns None."""
+    def test_acquisition_link_without_type(self):
+        """An acquisition link with no type is still serialized."""
         serializer = OPDS2Serializer()
         acquisition = Acquisition(
             href="http://no-type",
@@ -589,39 +589,9 @@ class TestOPDS2Serializer:
             indirect_acquisitions=[],
         )
         result = serializer._serialize_acquisition_link(acquisition)
-        assert result is None
-
-    def test_acquisition_link_type_fallback_to_indirect(self):
-        """When an acquisition link has no direct type, falls back to the first indirect type."""
-        serializer = OPDS2Serializer()
-        acquisition = Acquisition(
-            href="http://indirect-type",
-            rel="acquisition",
-            type=None,
-            indirect_acquisitions=[
-                IndirectAcquisition(type="application/epub+zip"),
-            ],
-        )
-        result = serializer._serialize_acquisition_link(acquisition)
-        assert result is not None
         dumped = result.serialize()
-        assert dumped["type"] == "application/epub+zip"
-
-    def test_acquisition_link_type_fallback_to_semantic_indirect(self):
-        """Semantic indirect types are resolved when direct type is missing."""
-        serializer = OPDS2Serializer()
-        acquisition = Acquisition(
-            href="http://indirect-type",
-            rel="acquisition",
-            type=None,
-            indirect_acquisitions=[
-                IndirectAcquisition(type=LinkContentType.OPDS_ENTRY),
-            ],
-        )
-        result = serializer._serialize_acquisition_link(acquisition)
-        assert result is not None
-        dumped = result.serialize()
-        assert dumped["type"] == opds2.BasePublication.content_type()
+        assert dumped["href"] == "http://no-type"
+        assert "type" not in dumped
 
     def test_indirect_acquisition_without_type(self):
         """An indirect acquisition with type=None is skipped."""
@@ -832,23 +802,22 @@ class TestOPDS2Serializer:
         entry = serializer.serialize_work_entry(data)
         assert entry["metadata"]["@type"] == "http://schema.org/Book"
 
-    def test_acquisition_link_skipped_returns_none_in_publication_links(self):
-        """When _serialize_acquisition_link returns None, no link is appended."""
+    def test_acquisition_link_without_type_in_publication_links(self):
+        """Acquisition links without a type are still included in publication links."""
         serializer = OPDS2Serializer()
         data = WorkEntryData(
             title="Test",
             identifier="urn:id",
             image_links=[Link(href="http://image", rel="image", type="image/png")],
             acquisition_links=[
-                # This acquisition has no type and no indirect type, so it returns None
                 Acquisition(
-                    href="http://bad-acq",
+                    href="http://no-type-acq",
                     rel="acquisition",
                     type=None,
                     indirect_acquisitions=[],
                 ),
                 Acquisition(
-                    href="http://good-acq",
+                    href="http://typed-acq",
                     rel=OPDSFeed.OPEN_ACCESS_REL,
                     type="application/epub+zip",
                 ),
@@ -856,8 +825,8 @@ class TestOPDS2Serializer:
         )
         entry = serializer.serialize_work_entry(data)
         link_hrefs = [link["href"] for link in entry["links"]]
-        assert "http://bad-acq" not in link_hrefs
-        assert "http://good-acq" in link_hrefs
+        assert "http://no-type-acq" in link_hrefs
+        assert "http://typed-acq" in link_hrefs
 
     def test_facet_link_without_title_is_skipped(self):
         """Facet links without a title are skipped and an error is logged."""
@@ -1028,13 +997,13 @@ class TestOPDS2Serializer:
     def test_acquisition_link_resolves_link_content_type(self):
         """Acquisition links with LinkContentType.OPDS_ENTRY are resolved."""
         serializer = OPDS2Serializer()
-        link = Acquisition(
+        acquisition = Acquisition(
             href="http://example.com/borrow",
             rel="http://opds-spec.org/acquisition/borrow",
             type=LinkContentType.OPDS_ENTRY,
         )
-        result = serializer._acquisition_link_type(link)
-        assert result == opds2.BasePublication.content_type()
+        result = serializer._serialize_acquisition_link(acquisition)
+        assert result.type == opds2.BasePublication.content_type()
 
     def test_publication_links_resolve_link_content_type(self):
         """Publication other_links with LinkContentType are resolved."""


### PR DESCRIPTION
## Description

Remove the unnecessary type requirement from `_serialize_acquisition_link` in the OPDS2 serializer that was silently dropping links without a media type. This was filtering out revoke links for holds and checkouts, preventing integration partners from being able to cancel holds or return titles early via OPDS2 feeds.

## Motivation and Context

An integration partner reported that revoke links were no longer appearing in OPDS2 loan feeds.

The regression was introduced in #3027, which added `_acquisition_link_type()` a gate in `_serialize_acquisition_link` that required all acquisition links to have a media type, returning `None` and dropping the entire link otherwise. Revoke links are intentionally created without a type (they aren't content delivery links), so they were being silently dropped with only a log error. 

At the time of #3027, the OPDS2 Pydantic models used `StrictLink` which required both `rel` and `type`. However, in #3137, we removed `StrictLink` and replaced it with `opds2.Link`, which has `type` as optional — matching the [OPDS 2.0 spec](https://drafts.opds.io/opds-2.0.html) and the [Readium WebPub Manifest link schema](https://readium.org/webpub-manifest/schema/link.schema.json) where only `href` is required. That PR also renamed `_strict_link()` to `_link()` in the serializer, but did not update `_serialize_acquisition_link` to remove its now-redundant type gate.

Since the underlying `opds2.Link` model already accepts `None` for `type`, the `_acquisition_link_type` check is no longer needed and can simply be removed.

JIRA: PP-3056

## How Has This Been Tested?

- Updated existing OPDS2 serializer tests to verify links without a type are now serialized rather than dropped
- All 40 tests in `test_opds2_serializer.py` pass
- mypy passes with no errors

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.