### PR TITLE
Fix KeyError when Overdrive API response missing 'products' key (PP-3379)

### DIFF
--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -711,6 +711,13 @@ class OverdriveAPI(
             async_task_list = list()
             response_products = data.get("products")
             if response_products is None:
+                self.log.warning(
+                    f"Overdrive response missing 'products' key for endpoint {endpoint.url}.",
+                    extra={
+                        "palace_response_data": data,
+                        "palace_response_status_code": response.status_code,
+                    },
+                )
                 raise BadResponseException(
                     endpoint.url,
                     f"Overdrive response missing 'products' key. Response data: {data}",

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -712,8 +712,11 @@ class OverdriveAPI(
             response_products = data.get("products")
             if response_products is None:
                 self.log.warning(
-                    f"Overdrive response missing 'products' key for endpoint {endpoint.url}. "
-                    f"Response data: {data}"
+                    f"Overdrive response missing 'products' key for endpoint {endpoint.url}."
+                    extra={
+                        "palace_response_data": data,
+                        "palace_response_status_code": response.status_code,
+                    },
                 )
                 return [], next_endpoint
             for product in response_products:

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -712,10 +712,8 @@ class OverdriveAPI(
             response_products = data.get("products")
             if response_products is None:
                 self.log.warning(
-                    "Overdrive response missing 'products' key for endpoint %s. "
-                    "Response data: %s",
-                    endpoint.url,
-                    data,
+                    f"Overdrive response missing 'products' key for endpoint {endpoint.url}. "
+                    f"Response data: {data}"
                 )
                 return [], next_endpoint
             for product in response_products:

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -711,14 +711,11 @@ class OverdriveAPI(
             async_task_list = list()
             response_products = data.get("products")
             if response_products is None:
-                self.log.warning(
-                    f"Overdrive response missing 'products' key for endpoint {endpoint.url}."
-                    extra={
-                        "palace_response_data": data,
-                        "palace_response_status_code": response.status_code,
-                    },
+                raise BadResponseException(
+                    endpoint.url,
+                    f"Overdrive response missing 'products' key. Response data: {data}",
+                    response,
                 )
-                return [], next_endpoint
             for product in response_products:
                 identifier = product["id"].lower()
                 books[identifier] = product

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -709,7 +709,15 @@ class OverdriveAPI(
                 BookInfoEndpoint(next_url) if next_url else None
             )
             async_task_list = list()
-            response_products = data["products"]
+            response_products = data.get("products")
+            if response_products is None:
+                self.log.warning(
+                    "Overdrive response missing 'products' key for endpoint %s. "
+                    "Response data: %s",
+                    endpoint.url,
+                    data,
+                )
+                return [], next_endpoint
             for product in response_products:
                 identifier = product["id"].lower()
                 books[identifier] = product

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -2893,3 +2893,20 @@ class TestSyncBookshelf:
         assert data[0]["id"]
         assert data[0].get("metadata", None) is None
         assert data[0].get("availabilityV2", None) is None
+
+    async def test_fetch_book_info_list_missing_products_key(
+        self,
+        overdrive_api_fixture: OverdriveAPIFixture,
+    ):
+        """When the Overdrive API returns a response without a 'products' key,
+        we log a warning and return an empty list rather than raising a KeyError."""
+        api = overdrive_api_fixture.api
+        mock_async_client = overdrive_api_fixture.mock_async_client
+
+        mock_async_client.queue_response(200, content={"no_products_key": True})
+
+        initial_endpoint = api.book_info_initial_endpoint(start=None, page_size=1)
+        data, next_endpoint = await api.fetch_book_info_list(initial_endpoint)
+
+        assert data == []
+        assert next_endpoint is None

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -2899,14 +2899,12 @@ class TestSyncBookshelf:
         overdrive_api_fixture: OverdriveAPIFixture,
     ):
         """When the Overdrive API returns a response without a 'products' key,
-        we log a warning and return an empty list rather than raising a KeyError."""
+        a BadResponseException is raised so the Celery task can retry."""
         api = overdrive_api_fixture.api
         mock_async_client = overdrive_api_fixture.mock_async_client
 
         mock_async_client.queue_response(200, content={"no_products_key": True})
 
         initial_endpoint = api.book_info_initial_endpoint(start=None, page_size=1)
-        data, next_endpoint = await api.fetch_book_info_list(initial_endpoint)
-
-        assert data == []
-        assert next_endpoint is None
+        with pytest.raises(BadResponseException, match="missing 'products' key"):
+            await api.fetch_book_info_list(initial_endpoint)


### PR DESCRIPTION
## Description

Handle the case where the Overdrive API returns a response without a
`"products"` key in `fetch_book_info_list`. Previously, this caused an
unhandled `KeyError` that crashed the `overdrive.import_collection`
Celery task entirely. The fix uses `.get("products")` and logs a warning
with the endpoint URL and response body when the key is absent, then
raises a BadResponseException.  The assumption here is that the issue
is transient and will be resolved on a retry.  We've logged a warning with the 
response object to help us easily understand what's in the response.

## Motivation and Context
https://ebce-lyrasis.atlassian.net/browse/PP-3979

The `overdrive.import_collection` task was raising: KeyError: 'products'

at `api.py` line 674 whenever the Overdrive API returned a response
without the expected `"products"` key. This killed the entire task,
blocking collection imports for affected libraries.
## How Has This Been Tested?
Added a new unit test `test_fetch_book_info_list_missing_products_key`
in `TestSyncBookshelf`. All existing `test_fetch_book_info_list*` tests
continue to pass.
## Checklist
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
