### PR TITLE
Fix ValueError in calculate_work() when licensed_through is empty (PP-3977)

### DIFF
--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -1224,7 +1224,7 @@ class LicensePool(Base):
                 lp.work = None
                 if lp.presentation_edition:
                     lp.presentation_edition.work = None
-        else:
+        elif len(existing_works) == 1:
             # There is a consensus Work for this Identifier.
             [self.work] = existing_works
 

--- a/tests/manager/sqlalchemy/model/test_work.py
+++ b/tests/manager/sqlalchemy/model/test_work.py
@@ -2146,6 +2146,36 @@ class TestWorkConsolidation:
         assert p.presentation_edition == work.presentation_edition
         assert True == new
 
+    def test_calculate_work_does_not_raise_when_licensed_through_is_empty(
+        self, db: DatabaseTransactionFixture
+    ):
+        """Regression test: calculate_work() must not raise ValueError when
+        licensed_through is transiently empty (no existing works to unpack).
+
+        This could happen when the relationship collection is stale or has not
+        yet been populated, resulting in an empty ``existing_works`` set.  The
+        original code used a bare destructuring assignment
+        ``[self.work] = existing_works`` which raised
+        ``ValueError: not enough values to unpack (expected 1, got 0)``.
+        """
+        from unittest.mock import PropertyMock
+
+        edition, pool = db.edition(with_license_pool=True)
+
+        # Temporarily replace the licensed_through descriptor on the Identifier
+        # class so that it returns an empty list, simulating a transient state
+        # where the relationship collection has not yet been populated.
+        with patch.object(
+            type(pool.identifier),
+            "licensed_through",
+            new_callable=PropertyMock,
+            return_value=[],
+        ):
+            work, created = pool.calculate_work()
+
+        assert work is not None
+        assert created is True
+
     def test_calculate_work_bails_out_if_no_title(self, db: DatabaseTransactionFixture):
         e, p = db.edition(with_license_pool=True)
         e.title = None


### PR DESCRIPTION
# Fix ValueError in calculate_work() when licensed_through is transiently empty

## Description

Tighten the condition in `LicensePool.calculate_work()` that reads a consensus `Work` from `Identifier.licensed_through`. Change the bare `else:` to `elif len(existing_works) == 1:` so the destructuring assignment `[self.work] = existing_works` is only attempted when the set contains exactly one element.

## Motivation and Context

`LicensePool.calculate_work()` builds a set of existing works from all pools sharing the same identifier:

```python
existing_works = {x.work for x in self.identifier.licensed_through}
```

It then branches on the size of that set:

```python
if len(existing_works) > 1:
    # clear all works — inconsistent state
else:
    # "consensus" case — unpack the single work
    [self.work] = existing_works   # raises if the set is empty
```

The `else` branch is reached whenever `len(existing_works) <= 1`, including the empty case. When `licensed_through` is transiently empty — e.g. because the SQLAlchemy relationship collection has not yet been populated during a flush — the bare destructuring raises:

```
ValueError: not enough values to unpack (expected 1, got 0)
```

This was observed in production as a Celery task failure on `apply.bibliographic_apply`. With the fix, when the set is empty `self.work` is left unchanged and the method falls through to the existing "create a new Work" logic below.

## How Has This Been Tested?

Added `TestWorkConsolidation::test_calculate_work_does_not_raise_when_licensed_through_is_empty`, a regression test that temporarily mocks `Identifier.licensed_through` to return `[]` and asserts that `calculate_work()` returns a valid new `Work` without raising. The full `TestWorkConsolidation` suite (27 tests) was run and all pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.