### PR TITLE
Fix flaky CI integration test runit race condition

### DIFF
--- a/docker/ci/check_service_status.sh
+++ b/docker/ci/check_service_status.sh
@@ -16,11 +16,20 @@ function check_service_status()
   # The location of the runit service should be passed.
   service="$2"
 
-  # Wait up to 15 seconds for the service file to exist
+  # Wait up to 15 seconds for the service directory to exist
   timeout --foreground 15s docker compose exec "$container" bash -c "until test -e $service; do sleep 1; done"
   file_status=$?
   if [[ "$file_status" != 0 ]]; then
-    echo "  FAIL: $service file does not exist after waiting"
+    echo "  FAIL: $service does not exist after waiting"
+    exit 1
+  fi
+
+  # Wait up to 15 seconds for runit to finish initializing the service
+  # (the supervise/ok control file is created after the service directory)
+  timeout --foreground 15s docker compose exec "$container" bash -c "until test -e $service/supervise/ok; do sleep 1; done"
+  supervise_status=$?
+  if [[ "$supervise_status" != 0 ]]; then
+    echo "  FAIL: $service/supervise/ok does not exist after waiting"
     exit 1
   fi
 


### PR DESCRIPTION
## Description

Wait for runit's `supervise/ok` control file to exist before running `sv check` in `check_service_status`, preventing transient CI failures caused by a race condition during service initialization.

## Motivation and Context

The Docker Build integration test intermittently fails with:

```
warning: /etc/service/nginx: unable to open supervise/ok: file does not exist
```

For example: https://github.com/ThePalaceProject/circulation/actions/runs/24252904229/job/70817150086

The `check_service_status` function waits for the service directory (e.g. `/etc/service/nginx`) to exist, then immediately runs `sv check`. However, runit creates the `supervise/ok` control file *after* the service directory appears, so there's a brief window where `sv check` fails because supervision hasn't been fully initialized yet.

The fix adds a second wait loop for `supervise/ok` to exist before running `sv check`, closing the race window.

## How Has This Been Tested?

- Reviewed runit's initialization sequence to confirm `supervise/ok` is the correct file to wait for
- The fix follows the same pattern as the existing wait loop for the service directory

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.