### PR TITLE
Set explicit target Python versions for black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,13 @@ repos:
     hooks:
       - id: black
         name: Run black
+        args:
+          - -t
+          - py312
+          - -t
+          - py313
+          - -t
+          - py314
 
   - repo: https://github.com/PyCQA/isort
     rev: 6.0.1

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -73,7 +73,7 @@ def run_migrations_online() -> None:
             config.get_section(config.config_ini_section),
             prefix="sqlalchemy.",
             poolclass=pool.NullPool,
-            **{"url": Configuration.database_url()}
+            **{"url": Configuration.database_url()},
         )
 
     with connectable.connect() as connection:

--- a/src/palace/manager/api/annotations.py
+++ b/src/palace/manager/api/annotations.py
@@ -218,7 +218,7 @@ class AnnotationParser:
             identifier=identifier,
             motivation=motivation,
             on_multiple="interchangeable",
-            **extra_kwargs
+            **extra_kwargs,
         )
         annotation.target = target
         if content:

--- a/src/palace/manager/api/web_publication_manifest.py
+++ b/src/palace/manager/api/web_publication_manifest.py
@@ -132,7 +132,7 @@ class FindawayManifest(AudiobookManifest):
                 title=item.title,
                 duration=item.duration,
                 type=item.media_type,
-                **kwargs
+                **kwargs,
             )
             total_duration += item.duration
 

--- a/src/palace/manager/core/coverage.py
+++ b/src/palace/manager/core/coverage.py
@@ -300,7 +300,7 @@ class BaseCoverageProvider:
             self.service_name,
             Timestamp.COVERAGE_PROVIDER_TYPE,
             collection=self.collection,
-            **kwargs
+            **kwargs,
         )
         timestamp.apply(self._db)
         self._db.commit()
@@ -615,7 +615,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
         collection=None,
         input_identifiers=None,
         replacement_policy=None,
-        **kwargs
+        **kwargs,
     ):
         """Constructor.
 
@@ -1016,7 +1016,7 @@ class IdentifierCoverageProvider(BaseCoverageProvider):
             operation=self.operation,
             identifiers=self.input_identifiers,
             collection=self.collection_or_not,
-            **kwargs
+            **kwargs,
         )
 
         if identifiers:

--- a/tests/fixtures/marc.py
+++ b/tests/fixtures/marc.py
@@ -95,7 +95,7 @@ class MarcExporterFixture:
         collection: Collection | None | Literal[False] = False,
         library: Library | None | Literal[False] = False,
         created: datetime.datetime | None = None,
-        since: datetime.datetime | None = None
+        since: datetime.datetime | None = None,
     ) -> MarcFile:
         collection = collection if collection is not False else self.collection1
         library = library if library is not False else self.library1

--- a/tests/manager/api/authentication/patron_blocking_rules/test_patron_blocking.py
+++ b/tests/manager/api/authentication/patron_blocking_rules/test_patron_blocking.py
@@ -420,15 +420,18 @@ class TestBasicAuthenticationProvider:
             )
         ]
 
-        with patch.object(
-            _ConcreteBlockingProvider,
-            "log",
-            new_callable=PropertyMock,
-            return_value=mock_log,
-        ), patch.object(
-            _ConcreteBlockingProvider,
-            "_do_authenticate",
-            return_value=(mock_patron, {}),
+        with (
+            patch.object(
+                _ConcreteBlockingProvider,
+                "log",
+                new_callable=PropertyMock,
+                return_value=mock_log,
+            ),
+            patch.object(
+                _ConcreteBlockingProvider,
+                "_do_authenticate",
+                return_value=(mock_patron, {}),
+            ),
         ):
             result = provider.authenticate(MagicMock(), {})
 
@@ -439,8 +442,10 @@ class TestBasicAuthenticationProvider:
         mock_log.info.assert_any_call("Patron blocking rules evaluation attempted")
 
     def test_blocking_not_applied_when_do_authenticate_returns_none(self) -> None:
-        """When _do_authenticate returns None (bad credentials), blocking rules
-        are not evaluated — None is passed through."""
+        """
+        When _do_authenticate returns None (bad credentials), blocking rules
+        are not evaluated — None is passed through.
+        """
         provider = MagicMock(spec=BasicAuthenticationProvider)
         provider.patron_blocking_rules = [
             PatronBlockingRule(name="block-all", rule="True")
@@ -454,8 +459,10 @@ class TestBasicAuthenticationProvider:
     def test_blocking_not_applied_when_do_authenticate_returns_problem_detail(
         self,
     ) -> None:
-        """When _do_authenticate itself returns a ProblemDetail (e.g. connection
-        failure), blocking rules are not evaluated — the original error is returned."""
+        """
+        When _do_authenticate itself returns a ProblemDetail (e.g. connection
+        failure), blocking rules are not evaluated — the original error is returned.
+        """
         provider = MagicMock(spec=BasicAuthenticationProvider)
         provider.patron_blocking_rules = [
             PatronBlockingRule(name="block-all", rule="True")
@@ -478,15 +485,18 @@ class TestBasicAuthenticationProvider:
             PatronBlockingRule(name="never-block", rule="False")
         ]
 
-        with patch.object(
-            _ConcreteBlockingProvider,
-            "log",
-            new_callable=PropertyMock,
-            return_value=mock_log,
-        ), patch.object(
-            _ConcreteBlockingProvider,
-            "_do_authenticate",
-            return_value=(mock_patron, {}),
+        with (
+            patch.object(
+                _ConcreteBlockingProvider,
+                "log",
+                new_callable=PropertyMock,
+                return_value=mock_log,
+            ),
+            patch.object(
+                _ConcreteBlockingProvider,
+                "_do_authenticate",
+                return_value=(mock_patron, {}),
+            ),
         ):
             result = provider.authenticate(MagicMock(), {})
 

--- a/tests/manager/scripts/test_integration_test.py
+++ b/tests/manager/scripts/test_integration_test.py
@@ -77,11 +77,12 @@ class TestIntegrationTest:
             assert decrypted_data == content
 
     def test__run_test(self, integration_test: IntegrationTestFixture):
-        with patch(
-            "palace.manager.scripts.integration_test.HTTP.request_with_timeout"
-        ) as request, patch.object(
-            integration_test.script, "_test_ssl_validity"
-        ) as test_ssl:
+        with (
+            patch(
+                "palace.manager.scripts.integration_test.HTTP.request_with_timeout"
+            ) as request,
+            patch.object(integration_test.script, "_test_ssl_validity") as test_ssl,
+        ):
             request.return_value = Mock(
                 status_code=204, json=lambda: dict(status="created")
             )
@@ -141,13 +142,16 @@ class TestIntegrationTest:
 
     def test_encrypt(self, integration_test: IntegrationTestFixture):
         script = integration_test.script
-        with patch.object(script, "_read_config") as read_config, patch(
-            "palace.manager.scripts.integration_test.read_file_bytes"
-        ) as read_file_bytes, patch(
-            "palace.manager.scripts.integration_test.CryptAESCBC", spec=CryptAESCBC
-        ) as aes, patch(
-            "palace.manager.scripts.integration_test.open"
-        ) as open:
+        with (
+            patch.object(script, "_read_config") as read_config,
+            patch(
+                "palace.manager.scripts.integration_test.read_file_bytes"
+            ) as read_file_bytes,
+            patch(
+                "palace.manager.scripts.integration_test.CryptAESCBC", spec=CryptAESCBC
+            ) as aes,
+            patch("palace.manager.scripts.integration_test.open") as open,
+        ):
             read_file_bytes.return_value = b"filebytes"
             read_config.return_value = b"7 bytes"
             aes().encrypt.return_value = b"encrypted bytes"
@@ -190,9 +194,10 @@ class TestIntegrationTest:
             generate_key_file=None,
             encrypt_file=None,
         )
-        with patch.object(script, "_run_test") as run_test, patch.object(
-            script, "_read_config"
-        ) as read_config:
+        with (
+            patch.object(script, "_run_test") as run_test,
+            patch.object(script, "_read_config") as read_config,
+        ):
             read_config.return_value = BASIC_YAML_DICT
             script.do_run()
 
@@ -210,11 +215,14 @@ class TestIntegrationTest:
             script.do_run()
 
     def test__test_ssl_validity(self, integration_test: IntegrationTestFixture):
-        with patch(
-            "palace.manager.scripts.integration_test.get_server_certificate"
-        ) as get_cert, patch(
-            "palace.manager.scripts.integration_test.load_certificate"
-        ) as load_cert:
+        with (
+            patch(
+                "palace.manager.scripts.integration_test.get_server_certificate"
+            ) as get_cert,
+            patch(
+                "palace.manager.scripts.integration_test.load_certificate"
+            ) as load_cert,
+        ):
             test = IntegrationTestDetails("Test", endpoint="https://localhost:543/path")
 
             load_cert.return_value = Mock(get_notAfter=lambda: b"21000101000000Z")

--- a/tests/manager/scripts/test_suppress.py
+++ b/tests/manager/scripts/test_suppress.py
@@ -528,9 +528,10 @@ class TestSuppressWorkForLibraryScript:
         )
 
         script = SuppressWorkForLibraryScript(db.session)
-        with patch.object(
-            db.session, "commit", side_effect=Exception("DB error")
-        ), patch.object(db.session, "rollback") as mock_rollback:
+        with (
+            patch.object(db.session, "commit", side_effect=Exception("DB error")),
+            patch.object(db.session, "rollback") as mock_rollback,
+        ):
             with pytest.raises(Exception, match="DB error"):
                 script.do_run(
                     ["--library", test_library.short_name, "--file", str(csv_file)]
@@ -545,9 +546,12 @@ class TestSuppressWorkForLibraryScript:
         identifier = work.presentation_edition.primary_identifier
 
         script = SuppressWorkForLibraryScript(db.session)
-        with patch.object(
-            script, "suppress_work", side_effect=RuntimeError("unexpected")
-        ), patch.object(db.session, "rollback") as mock_rollback:
+        with (
+            patch.object(
+                script, "suppress_work", side_effect=RuntimeError("unexpected")
+            ),
+            patch.object(db.session, "rollback") as mock_rollback,
+        ):
             with pytest.raises(RuntimeError, match="unexpected"):
                 script.do_run(
                     [


### PR DESCRIPTION
## Description

Explicitly set `-t py312`, `-t py313`, and `-t py314` target version flags for black in the pre-commit configuration, and apply the resulting formatting changes.

## Motivation and Context

In #3221, a change to `python-requires` in `pyproject.toml` allows black to auto-detect the supported Python versions. This auto-detection brings in unexpected formatting changes (parenthesized `with` statements, trailing commas on `**kwargs`, etc.). By explicitly setting the target versions in pre-commit and applying the formatting changes here, we can land #3221 without mixing unrelated formatting noise into that PR.

Reference: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#t-target-version

## How Has This Been Tested?

- `pre-commit run -a` passes cleanly with the updated configuration.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.