### PR TITLE
Install palace-manager editable in the container (PP-4076)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,10 +27,8 @@ RUN uv sync --frozen --no-dev --no-install-workspace
 
 COPY --chown=palace:palace . /var/www/circulation
 
-# Install the project itself as a non-editable install. Omitting
-# --no-install-project (and passing --no-editable) is the recommended
-# pattern for production Docker builds with uv.
-RUN uv sync --frozen --no-dev --no-editable
+# Install the project itself as an editable install.
+RUN uv sync --frozen --no-dev
 
 ###############################################################################
 ## Circ-exec Image


### PR DESCRIPTION
## Description

Drop `--no-editable` from the final `uv sync` in `docker/Dockerfile` so `palace-manager` is installed editably in the container — same behavior we had under Poetry.

## Motivation and Context

Found while checking the uv changes that rolled out to Minotaur last night. The Poetry → uv migration in #3221 switched the in-container install from editable (Poetry's default) to non-editable (`uv sync --no-editable`). That change quietly broke `palace.manager.scripts.startup`'s discovery of the `startup_tasks/` directory:

```
Startup tasks directory /var/www/circulation/env/lib/python3.12/startup_tasks does not exist; skipping.
```

The script resolves `STARTUP_TASKS_DIR` via `Path(__file__).parents[4]`, which assumes `startup.py` is at `${root}/src/palace/manager/scripts/startup.py` (editable install). Under `--no-editable`, `startup.py` lives inside `site-packages` and `parents[4]` resolves to `env/lib/python3.12/` instead of the project root, so `startup_tasks/` is never found.

Restoring the editable install fixes the immediate breakage and matches the previous behavior. It also has the minor side benefit of making in-container debugging easier — you can edit files in place without rebuilding the image.

## Future work

Eventually we'd like to build `palace-manager` as a proper non-editable package that can be published the same way `palace-util` and `palace-opds` will be. Several path-resolution issues need to be sorted out first (alembic migrations, startup scripts, and similar file-layout assumptions) before that's feasible. For now, editable install is the simpler and safer choice.

## How Has This Been Tested?

- Built the image locally and confirmed `startup.py` now resolves `STARTUP_TASKS_DIR` to `/var/www/circulation/startup_tasks`.
- Existing startup task (`2026_02_17_force_re_harvest_all_opds_for_distributors.py`) is picked up.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.