### PR TITLE
Drop unused pydantic[email] extra from palace-opds

### DIFF
--- a/packages/palace-opds/pyproject.toml
+++ b/packages/palace-opds/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{name = "The Palace Project", email = "info@thepalaceproject.org"}]
 dependencies = [
     "palace-util",
     "pycountry>=26.2.16,<27",
-    "pydantic[email]>=2.12,<3",
+    "pydantic>=2.12,<3",
     "uritemplate==4.2.0",
 ]
 description = "Pydantic models for OPDS 2.0, RWPM, ODL, LCP, and Palace Project extensions."

--- a/uv.lock
+++ b/uv.lock
@@ -2233,7 +2233,7 @@ source = { editable = "packages/palace-opds" }
 dependencies = [
     { name = "palace-util" },
     { name = "pycountry" },
-    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic" },
     { name = "uritemplate" },
 ]
 
@@ -2241,7 +2241,7 @@ dependencies = [
 requires-dist = [
     { name = "palace-util", editable = "packages/palace-util" },
     { name = "pycountry", specifier = ">=26.2.16,<27" },
-    { name = "pydantic", extras = ["email"], specifier = ">=2.12,<3" },
+    { name = "pydantic", specifier = ">=2.12,<3" },
     { name = "uritemplate", specifier = "==4.2.0" },
 ]
 


### PR DESCRIPTION
## Description

`palace-opds`'s `pyproject.toml` declared `pydantic[email]` but nothing in the package uses `EmailStr` / `email_validator` — the only email field (the LCP license owner email in `palace.opds.lcp.license`) is a plain `str`. Drop the extra so anyone installing `palace-opds` standalone doesn't pull in `email-validator` and its transitive deps.

## How Has This Been Tested?

- `uv lock` — only the palace-opds edge changed; no other resolution churn.
- `mypy` passes.
- `pytest tests/palace_opds` — 174 tests pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.