### PR TITLE
Add Claude Code PR review workflow

### DIFF
--- a/.github/pr_review_prompt.md
+++ b/.github/pr_review_prompt.md
@@ -1,0 +1,52 @@
+Review pull request #{{PR_NUMBER}} in this repository as a senior Python engineer familiar with the Palace
+Manager codebase (Flask, SQLAlchemy, Pydantic, Celery, pytest). The conventions to enforce are documented in
+CLAUDE.md at the repo root — read it before reviewing.
+
+Process:
+
+1. Read CLAUDE.md to ground yourself in project conventions.
+2. Fetch the PR diff with `gh pr diff {{PR_NUMBER}}` and the PR metadata with `gh pr view {{PR_NUMBER}}`.
+3. Use Read/Glob/Grep to inspect surrounding code in the repo when context is needed to judge a change.
+4. Review the changes the way a thoughtful human reviewer would.
+
+Posting the review:
+
+- For each line-specific finding, call `mcp__github_inline_comment__create_inline_comment` with
+  `confirmed: true` to post an inline comment anchored to the relevant file and line in the PR diff. Group
+  multi-line ranges into a single comment.
+- Your final assistant message will be posted automatically as a sticky PR comment by the workflow — make
+  that message the overall review summary. It should give an overall assessment, and call out cross-cutting
+  concerns.
+- Do NOT approve or request changes — leave merge decisions to humans.
+
+Comment severity — prefix each inline comment body so the author can triage quickly:
+
+- `Nit:` — small, subjective, often personal-preference. Author is free to ignore. Use sparingly; when in
+  doubt, skip it rather than post.
+    - Example: `Nit: could pull this into a helper since the same pattern appears above.`
+- `Minor:` — a real concern but doesn't change behavior or introduce a bug (readability, maintainability,
+  narrow edge case, weak test coverage for a low-risk path). Author may still choose to ignore.
+    - Example: `Minor: this try/except swallows ValueError; consider narrowing or logging so the failure
+      isn't silent.`
+- No prefix — correctness bugs, security issues, data loss risks, broken contracts, convention violations
+  from CLAUDE.md, or anything the author really should address before merge.
+- Do not invent other prefixes (no `Major:`, `Blocker:`, `Question:`, etc.). Unprefixed = the serious stuff.
+
+What to look for:
+
+- Correctness bugs, race conditions, N+1 queries, missing error handling at boundaries.
+- Violations of CLAUDE.md conventions (exception base classes, type hints, immutability of constants,
+  LoggerMixin usage, deprecated `core/`/`scripts/` dirs, etc.).
+- Missing or weak tests for new behavior; tests that mock things that should hit real fixtures.
+- Security issues (injection, auth bypass, unsafe deserialization, secrets in code).
+- Public API changes that lack the `incompatible changes` label, or migrations that lack the
+  `DB migration` label.
+
+What to skip:
+
+- Formatting and style issues — pre-commit handles those; do not post them even as `Nit:`.
+- Praise comments and restating what the diff already shows.
+- Speculative refactors unrelated to the change.
+
+If the PR looks clean, skip inline comments and just write a short summary saying so. Be specific and cite
+file:line in the summary when referencing issues.

--- a/.github/pr_review_prompt.md
+++ b/.github/pr_review_prompt.md
@@ -1,52 +1,17 @@
-Review pull request #{{PR_NUMBER}} in this repository as a senior Python engineer familiar with the Palace
-Manager codebase (Flask, SQLAlchemy, Pydantic, Celery, pytest). The conventions to enforce are documented in
-CLAUDE.md at the repo root — read it before reviewing.
+Post line-specific findings as inline comments via
+`mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) —
+do not collapse them into the sticky summary.
 
-Process:
+Prefix each inline comment by severity:
 
-1. Read CLAUDE.md to ground yourself in project conventions.
-2. Fetch the PR diff with `gh pr diff {{PR_NUMBER}}` and the PR metadata with `gh pr view {{PR_NUMBER}}`.
-3. Use Read/Glob/Grep to inspect surrounding code in the repo when context is needed to judge a change.
-4. Review the changes the way a thoughtful human reviewer would.
+- `Nit:` — subjective / personal preference; use sparingly.
+- `Minor:` — real concern but not a bug or behavior change. CLAUDE.md convention violations typically
+  fall into this category.
+- No prefix — Anything more serious that doesn't fall into the other two severity buckets.
 
-Posting the review:
+Skip formatting and style findings entirely — pre-commit handles those.
 
-- For each line-specific finding, call `mcp__github_inline_comment__create_inline_comment` with
-  `confirmed: true` to post an inline comment anchored to the relevant file and line in the PR diff. Group
-  multi-line ranges into a single comment.
-- Your final assistant message will be posted automatically as a sticky PR comment by the workflow — make
-  that message the overall review summary. It should give an overall assessment, and call out cross-cutting
-  concerns.
-- Do NOT approve or request changes — leave merge decisions to humans.
-
-Comment severity — prefix each inline comment body so the author can triage quickly:
-
-- `Nit:` — small, subjective, often personal-preference. Author is free to ignore. Use sparingly; when in
-  doubt, skip it rather than post.
-    - Example: `Nit: could pull this into a helper since the same pattern appears above.`
-- `Minor:` — a real concern but doesn't change behavior or introduce a bug (readability, maintainability,
-  narrow edge case, weak test coverage for a low-risk path). Author may still choose to ignore.
-    - Example: `Minor: this try/except swallows ValueError; consider narrowing or logging so the failure
-      isn't silent.`
-- No prefix — correctness bugs, security issues, data loss risks, broken contracts, convention violations
-  from CLAUDE.md, or anything the author really should address before merge.
-- Do not invent other prefixes (no `Major:`, `Blocker:`, `Question:`, etc.). Unprefixed = the serious stuff.
-
-What to look for:
-
-- Correctness bugs, race conditions, N+1 queries, missing error handling at boundaries.
-- Violations of CLAUDE.md conventions (exception base classes, type hints, immutability of constants,
-  LoggerMixin usage, deprecated `core/`/`scripts/` dirs, etc.).
-- Missing or weak tests for new behavior; tests that mock things that should hit real fixtures.
-- Security issues (injection, auth bypass, unsafe deserialization, secrets in code).
-- Public API changes that lack the `incompatible changes` label, or migrations that lack the
-  `DB migration` label.
-
-What to skip:
-
-- Formatting and style issues — pre-commit handles those; do not post them even as `Nit:`.
-- Praise comments and restating what the diff already shows.
-- Speculative refactors unrelated to the change.
-
-If the PR looks clean, skip inline comments and just write a short summary saying so. Be specific and cite
-file:line in the summary when referencing issues.
+Your sticky review comment is the OVERALL summary, not a restatement of the
+inline comments: give a high-level take and flag cross-cutting concerns only.
+Do not repeat anything already covered inline. It should be succinct, one or two
+paragraphs maximum.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,17 +20,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Load review prompt
         id: load_prompt
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           {
             echo 'prompt<<PROMPT_EOF'
-            sed "s/{{PR_NUMBER}}/${PR_NUMBER}/g" .github/pr_review_prompt.md
+            cat .github/pr_review_prompt.md
             echo 'PROMPT_EOF'
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,7 +34,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           use_sticky_comment: true
           track_progress: true
           claude_args: >

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run Claude Code review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           use_sticky_comment: true
           track_progress: true

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,46 @@
+name: Claude PR Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude Review
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Load review prompt
+        id: load_prompt
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          {
+            echo 'prompt<<PROMPT_EOF'
+            sed "s/{{PR_NUMBER}}/${PR_NUMBER}/g" .github/pr_review_prompt.md
+            echo 'PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_sticky_comment: true
+          track_progress: true
+          claude_args: >
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"
+          prompt: ${{ steps.load_prompt.outputs.prompt }}


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow that runs `anthropics/claude-code-action@v1` on every pull request
(excluding dependabot) to post inline code review comments and a sticky summary, similar to a
human reviewer.

- **Auth**: `CLAUDE_CODE_OAUTH_TOKEN` repo secret (generate via `claude setup-token` on a Pro/Max
  subscription); `github_token` is wired through the action input.
- **Review mechanics**: line-specific findings go through the GitHub MCP
  `create_inline_comment` tool; the overall summary rides on `use_sticky_comment: true`, so
  re-runs update the same comment instead of stacking. `track_progress: true` surfaces Claude's
  plan in that same sticky comment while it runs.
- **Model**: uses the action's default model to start — easy to pin later if we want consistency.

The review prompt lives in its own file at `.github/pr_review_prompt.md` so it can be iterated on
independently of the workflow and reused by other tools. It's deliberately short: the action's
built-in system prompt already instructs Claude to read CLAUDE.md, fetch the PR diff, and post a
review, so the file only codifies project-specific bits — the inline-comment MCP tool, the
`Nit:`/`Minor:`/unprefixed severity convention, the "summary is not a restatement of inline
comments" rule, and the "skip formatting" skip rule.

This is a fresh PR after `chore/claude-pr-review-workflow` was closed; the branch was renamed to
avoid reopening it. Same three commits.

## Motivation and Context

Gives us an always-on second set of eyes on PRs. Catches low-hanging correctness, security, and
CLAUDE.md-convention issues before a human reviewer spends time on them, and lets the human
reviewer focus on judgment calls.

## How Has This Been Tested?

Iterated against the prior closed PR — the trimmed prompt fixed the "summary restates every
inline comment" behavior seen there. Expect further prompt tuning as we observe more real reviews.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.