### PR TITLE
Rename "Filtered genres" setting to "Filtered categories" (PP-4074)

### DIFF
--- a/src/palace/manager/integration/configuration/library.py
+++ b/src/palace/manager/integration/configuration/library.py
@@ -405,11 +405,14 @@ class LibrarySettings(BaseSettings):
             level=Level.SYS_ADMIN_OR_MANAGER,
         ),
     ] = []
+    # UI label says "Filtered categories" (renamed in PP-4074), but the variable stays
+    # `filtered_genres` because the values it matches against are called genres elsewhere
+    # in the codebase.
     filtered_genres: Annotated[
         list[str],
         LibraryFormMetadata(
-            label="Filtered genres",
-            description="Content in these genres will be hidden from catalog browse and search results.",
+            label="Filtered categories",
+            description="Content in these categories (genres) will be hidden from catalog browse and search results.",
             type=FormFieldType.MENU,
             options=lambda _db: {name: name for name in sorted(genres.keys())},
             category="Content Filtering",


### PR DESCRIPTION
## Description

Renames the user-facing label for the library setting previously shown as "Filtered genres" to "Filtered categories". The description is updated to match, with "(genres)" kept as a parenthetical hint. The underlying Pydantic field name `filtered_genres` is intentionally unchanged — the values it filters against are referred to as genres throughout the codebase, so renaming the variable would create a wider divergence than it would resolve. A comment on the field documents this.

## Motivation and Context

PP-4074 asked for the admin-facing terminology to say "categories" instead of "genres". This PR makes the UI-only change.

## How Has This Been Tested?

No behavior changes — label/description strings only. Existing tests pass unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.