### PR TITLE
Default OPDS2+ODL skipped_license_formats to empty (PP-4044)

### DIFF
--- a/src/palace/manager/integration/license/opds/odl/settings.py
+++ b/src/palace/manager/integration/license/opds/odl/settings.py
@@ -99,7 +99,7 @@ class OPDS2WithODLSettings(OPDS2ImporterSettings):
             type=FormFieldType.LIST,
             required=False,
         ),
-    ] = ["text/html"]
+    ] = []
 
     loan_limit: Annotated[
         PositiveInt | None,

--- a/tests/manager/celery/tasks/test_opds_odl.py
+++ b/tests/manager/celery/tasks/test_opds_odl.py
@@ -823,7 +823,7 @@ class TestImportCollection:
         assert 10 == moby_dick_license_pool.licenses_owned
         assert 10 == moby_dick_license_pool.licenses_available
 
-        assert 2 == len(moby_dick_license_pool.delivery_mechanisms)
+        assert 3 == len(moby_dick_license_pool.delivery_mechanisms)
 
         moby_dick_epub_adobe_drm_delivery_mechanism = opds2_with_odl_import_fixture.get_delivery_mechanism_by_drm_scheme_and_content_type(
             moby_dick_license_pool.delivery_mechanisms,
@@ -838,6 +838,13 @@ class TestImportCollection:
             DeliveryMechanism.LCP_DRM,
         )
         assert moby_dick_epub_lcp_drm_delivery_mechanism is not None
+
+        moby_dick_streaming_delivery_mechanism = opds2_with_odl_import_fixture.get_delivery_mechanism_by_drm_scheme_and_content_type(
+            moby_dick_license_pool.delivery_mechanisms,
+            DeliveryMechanism.STREAMING_TEXT_CONTENT_TYPE,
+            DeliveryMechanism.STREAMING_DRM,
+        )
+        assert moby_dick_streaming_delivery_mechanism is not None
 
         assert 1 == len(moby_dick_license_pool.licenses)
         [moby_dick_license] = moby_dick_license_pool.licenses
@@ -910,7 +917,7 @@ class TestImportCollection:
         assert 1 == license_pool.licenses_owned
         assert 1 == license_pool.licenses_available
 
-        assert 2 == len(license_pool.delivery_mechanisms)
+        assert 3 == len(license_pool.delivery_mechanisms)
 
         lcp_delivery_mechanism = opds2_with_odl_import_fixture.get_delivery_mechanism_by_drm_scheme_and_content_type(
             license_pool.delivery_mechanisms,
@@ -925,6 +932,13 @@ class TestImportCollection:
             DeliveryMechanism.FEEDBOOKS_AUDIOBOOK_DRM,
         )
         assert feedbooks_delivery_mechanism is not None
+
+        streaming_delivery_mechanism = opds2_with_odl_import_fixture.get_delivery_mechanism_by_drm_scheme_and_content_type(
+            license_pool.delivery_mechanisms,
+            DeliveryMechanism.STREAMING_AUDIO_CONTENT_TYPE,
+            DeliveryMechanism.STREAMING_DRM,
+        )
+        assert streaming_delivery_mechanism is not None
 
     @freeze_time("2016-01-01T00:00:00+00:00")
     def test_import_audiobook_no_streaming(


### PR DESCRIPTION
## Description

Change the default value of `OPDS2WithODLSettings.skipped_license_formats` from `["text/html"]` to `[]`. ODL 2.0 integrations will no longer suppress the `text/html` license format by default, which means the streaming delivery mechanism (`STREAMING_DRM`) will be emitted for those titles.

## Motivation and Context

PP-4044. We want streaming web-reader delivery to be active by default for ODL integrations.

A production audit of the `integration_configurations.settings` JSONB column across our environments confirmed that every existing ODL 2.0 row either omits `skipped_license_formats` or already stores `[]` — none store the previous `["text/html"]` default explicitly. Rows that omit the key will pick up the new default and start emitting streaming formats; that behavior change is the goal, and because nothing stores the old default explicitly we don't need a data migration to clear it out.

## How Has This Been Tested?

Existing extractor tests in `tests/manager/integration/license/opds/odl/test_extractor.py` continue to cover the explicit-skip path. The change is a single default-value flip; behavior under explicit configuration is unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.