### PR TITLE
Add country/state geographic configuration for circulation events (PP-4044)

### DIFF
--- a/alembic/versions/20260422_a1b2c3d4e5f6_add_sitewide_settings_goal.py
+++ b/alembic/versions/20260422_a1b2c3d4e5f6_add_sitewide_settings_goal.py
@@ -1,0 +1,41 @@
+"""Add SITEWIDE_SETTINGS to Goals enum
+
+Revision ID: a1b2c3d4e5f6
+Revises: 23795e50c915
+Create Date: 2026-04-22 00:00:00.000000+00:00
+
+"""
+
+from alembic import op
+
+from palace.manager.util.migration.helpers import pg_update_enum
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "23795e50c915"
+branch_labels = None
+depends_on = None
+
+old_options = (
+    "PATRON_AUTH_GOAL",
+    "LICENSE_GOAL",
+    "DISCOVERY_GOAL",
+    "CATALOG_GOAL",
+    "METADATA_GOAL",
+)
+new_options = old_options + ("SITEWIDE_SETTINGS",)
+
+
+def upgrade() -> None:
+    pg_update_enum(
+        op, "integration_configurations", "goal", "goals", old_options, new_options
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DELETE FROM integration_configurations WHERE goal = 'SITEWIDE_SETTINGS'"
+    )
+    pg_update_enum(
+        op, "integration_configurations", "goal", "goals", new_options, old_options
+    )

--- a/src/palace/manager/api/admin/controller/__init__.py
+++ b/src/palace/manager/api/admin/controller/__init__.py
@@ -30,6 +30,9 @@ def setup_admin_controllers(manager: CirculationManager) -> None:
         DiscoveryServicesController,
     )
     from palace.manager.api.admin.controller.feed import FeedController
+    from palace.manager.api.admin.controller.global_settings import (
+        GlobalSettingsController,
+    )
     from palace.manager.api.admin.controller.individual_admin_settings import (
         IndividualAdminSettingsController,
     )
@@ -81,6 +84,7 @@ def setup_admin_controllers(manager: CirculationManager) -> None:
         manager._db, manager.services.integration_registry.license_providers()
     )
     manager.admin_library_settings_controller = LibrarySettingsController(manager)
+    manager.admin_global_settings_controller = GlobalSettingsController(manager._db)
     manager.admin_individual_admin_settings_controller = (
         IndividualAdminSettingsController(manager._db)
     )

--- a/src/palace/manager/api/admin/controller/global_settings.py
+++ b/src/palace/manager/api/admin/controller/global_settings.py
@@ -1,0 +1,93 @@
+"""Admin controller for global sitewide settings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import flask
+from flask import Response
+
+from palace.manager.api.admin.controller.base import AdminPermissionsControllerMixin
+from palace.manager.api.admin.form_data import ProcessFormData
+from palace.manager.integration.base import (
+    integration_settings_load,
+    integration_settings_update,
+)
+from palace.manager.integration.configuration.global_settings import (
+    GLOBAL_SETTINGS_PROTOCOL,
+    GlobalSettings,
+)
+from palace.manager.integration.goals import Goals
+from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
+from palace.manager.sqlalchemy.util import create, get_one
+from palace.manager.util.json import json_serializer
+from palace.manager.util.problem_detail import ProblemDetail, ProblemDetailException
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+_GLOBAL_SETTINGS_NAME = "Global Settings"
+
+
+class GlobalSettingsController(AdminPermissionsControllerMixin):
+    """
+    Admin controller for managing global sitewide settings.
+
+    These settings apply across the entire Palace Manager instance and serve
+    as defaults for all libraries. Library-level settings take precedence over
+    these global defaults.
+    """
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def _get_or_create_integration(self) -> IntegrationConfiguration:
+        """Return the single IntegrationConfiguration row for global settings, creating it if absent."""
+        integration = get_one(
+            self._db,
+            IntegrationConfiguration,
+            goal=Goals.SITEWIDE_SETTINGS,
+            protocol=GLOBAL_SETTINGS_PROTOCOL,
+        )
+        if integration is None:
+            integration, _ = create(
+                self._db,
+                IntegrationConfiguration,
+                goal=Goals.SITEWIDE_SETTINGS,
+                protocol=GLOBAL_SETTINGS_PROTOCOL,
+                name=_GLOBAL_SETTINGS_NAME,
+            )
+        assert integration is not None
+        return integration
+
+    def process_global_settings(self) -> Response | ProblemDetail:
+        try:
+            self.require_system_admin()
+            if flask.request.method == "GET":
+                return self._process_get()
+            else:
+                return self._process_post()
+        except ProblemDetailException as e:
+            self._db.rollback()
+            return e.problem_detail
+
+    def _process_get(self) -> Response:
+        integration = self._get_or_create_integration()
+        settings = integration_settings_load(GlobalSettings, integration)
+        return Response(
+            json_serializer(
+                {
+                    "settings": settings.model_dump(),
+                    "schema": GlobalSettings.configuration_form(self._db),
+                }
+            ),
+            status=200,
+            mimetype="application/json",
+        )
+
+    def _process_post(self) -> Response:
+        form_data = flask.request.form
+        validated = ProcessFormData.get_settings(GlobalSettings, form_data)
+        integration = self._get_or_create_integration()
+        integration_settings_update(GlobalSettings, integration, validated)
+        return Response("", 200)

--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -385,6 +385,14 @@ def get_quicksight_names():
     return app.manager.admin_quicksight_controller.get_dashboard_names()
 
 
+@app.route("/admin/global_settings", methods=["GET", "POST"])
+@returns_json_or_response_or_problem_detail
+@requires_admin
+@requires_csrf_token
+def global_settings():
+    return app.manager.admin_global_settings_controller.process_global_settings()
+
+
 @app.route("/admin/libraries", methods=["GET", "POST"])
 @returns_json_or_response_or_problem_detail
 @requires_admin

--- a/src/palace/manager/api/circulation_manager.py
+++ b/src/palace/manager/api/circulation_manager.py
@@ -86,6 +86,9 @@ if TYPE_CHECKING:
         DiscoveryServicesController,
     )
     from palace.manager.api.admin.controller.feed import FeedController
+    from palace.manager.api.admin.controller.global_settings import (
+        GlobalSettingsController,
+    )
     from palace.manager.api.admin.controller.individual_admin_settings import (
         IndividualAdminSettingsController,
     )
@@ -149,6 +152,7 @@ class CirculationManager(LoggerMixin):
     admin_patron_auth_services_controller: PatronAuthServicesController
     admin_collection_settings_controller: CollectionSettingsController
     admin_library_settings_controller: LibrarySettingsController
+    admin_global_settings_controller: GlobalSettingsController
     admin_individual_admin_settings_controller: IndividualAdminSettingsController
     admin_catalog_services_controller: CatalogServicesController
     admin_announcement_service: AnnouncementSettings

--- a/src/palace/manager/integration/configuration/global_settings.py
+++ b/src/palace/manager/integration/configuration/global_settings.py
@@ -1,0 +1,44 @@
+"""Global sitewide settings for a Palace Manager instance."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from palace.manager.integration.settings import BaseSettings, FormMetadata
+
+# Protocol string used to identify the global settings IntegrationConfiguration row.
+GLOBAL_SETTINGS_PROTOCOL = "global_settings"
+
+
+class GlobalSettings(BaseSettings):
+    """
+    Sitewide settings configurable by system admins for a Palace Manager instance.
+
+    These settings serve as defaults for all libraries in the instance and can be
+    overridden at the library level. New sitewide settings should be added here
+    rather than creating additional settings classes.
+    """
+
+    country: Annotated[
+        str,
+        FormMetadata(
+            label="Default country",
+            description=(
+                "The default country for circulation events in this Palace Manager instance. "
+                "Use ISO 3166-1 alpha-2 codes for countries (e.g. 'US' for United States, "
+                "'CA' for Canada). This default can be overridden per library."
+            ),
+        ),
+    ] = "US"
+
+    state: Annotated[
+        str,
+        FormMetadata(
+            label="Default state/province",
+            description=(
+                "The default state or province for circulation events in this Palace Manager "
+                "instance (e.g. 'New York', 'Ontario'). Use 'All' to indicate all "
+                "states/provinces. This default can be overridden per library."
+            ),
+        ),
+    ] = "All"

--- a/src/palace/manager/integration/configuration/library.py
+++ b/src/palace/manager/integration/configuration/library.py
@@ -546,6 +546,31 @@ class LibrarySettings(BaseSettings):
             level=Level.ALL_ACCESS,
         ),
     ] = None
+    country: Annotated[
+        str | None,
+        LibraryFormMetadata(
+            label="Country",
+            description=(
+                "The country for this library's circulation events. "
+                "Use ISO 3166-1 alpha-2 codes (e.g. 'US' for United States, 'CA' for Canada). "
+                "Leave blank to inherit the global default."
+            ),
+            category="Geographic Information",
+            level=Level.SYS_ADMIN_ONLY,
+        ),
+    ] = None
+    state: Annotated[
+        str | None,
+        LibraryFormMetadata(
+            label="State/Province",
+            description=(
+                "The state or province for this library's circulation events "
+                "(e.g. 'New York', 'Ontario'). Leave blank to inherit the global default."
+            ),
+            category="Geographic Information",
+            level=Level.SYS_ADMIN_ONLY,
+        ),
+    ] = None
 
     @model_validator(mode="after")
     def validate_require_help_email_or_website(self) -> Self:

--- a/src/palace/manager/integration/goals.py
+++ b/src/palace/manager/integration/goals.py
@@ -11,3 +11,4 @@ class Goals(Enum):
     DISCOVERY_GOAL = "discovery"
     CATALOG_GOAL = "catalog"
     METADATA_GOAL = "metadata"
+    SITEWIDE_SETTINGS = "sitewide_settings"

--- a/src/palace/manager/service/analytics/analytics.py
+++ b/src/palace/manager/service/analytics/analytics.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from palace.util.log import LoggerMixin
 
 from palace.manager.service.analytics.eventdata import AnalyticsEventData
+from palace.manager.service.analytics.geo import resolve_geo
 from palace.manager.service.analytics.local import LocalAnalyticsProvider
 from palace.manager.service.analytics.provider import AnalyticsProvider
 from palace.manager.service.analytics.s3 import S3AnalyticsProvider
@@ -56,6 +57,15 @@ class Analytics(LoggerMixin, AnalyticsProvider):
         patron: Patron | None = None,
     ) -> None:
         session = Session.object_session(library)
+        country, state = "US", "All"
+        if session is not None:
+            try:
+                country, state = resolve_geo(library, session)
+            except Exception as e:
+                self.log.warning(
+                    f"Unable to resolve geographic settings, using defaults: {repr(e)}",
+                    exc_info=e,
+                )
         event = AnalyticsEventData.create(
             library,
             license_pool,
@@ -64,6 +74,8 @@ class Analytics(LoggerMixin, AnalyticsProvider):
             old_value,
             new_value,
             patron,
+            country=country,
+            state=state,
         )
         self.collect(event, session=session)
 

--- a/src/palace/manager/service/analytics/eventdata.py
+++ b/src/palace/manager/service/analytics/eventdata.py
@@ -91,6 +91,8 @@ class AnalyticsEventData(BaseModel, LoggerMixin):
     open_access: bool | None
     user_agent: str | None
     patron_uuid: UUID | None
+    country: str
+    state: str
 
     model_config = ConfigDict(
         frozen=True,
@@ -107,6 +109,8 @@ class AnalyticsEventData(BaseModel, LoggerMixin):
         new_value: int | None = None,
         patron: Patron | None = None,
         user_agent: str | None = None,
+        country: str = "US",
+        state: str = "All",
     ) -> Self:
         if user_agent is None:
             try:
@@ -189,4 +193,6 @@ class AnalyticsEventData(BaseModel, LoggerMixin):
             open_access=license_pool.open_access if license_pool else None,
             user_agent=user_agent,
             patron_uuid=patron.uuid if patron else None,
+            country=country,
+            state=state,
         )

--- a/src/palace/manager/service/analytics/geo.py
+++ b/src/palace/manager/service/analytics/geo.py
@@ -1,0 +1,68 @@
+"""Geographic settings resolution for analytics events."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm import Session
+
+from palace.manager.integration.base import integration_settings_load
+from palace.manager.integration.configuration.global_settings import (
+    GLOBAL_SETTINGS_PROTOCOL,
+    GlobalSettings,
+)
+from palace.manager.integration.goals import Goals
+from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
+from palace.manager.sqlalchemy.util import get_one
+
+if TYPE_CHECKING:
+    from palace.manager.sqlalchemy.model.library import Library
+
+_ENV_DEFAULT_COUNTRY = "PALACE_DEFAULT_COUNTRY"
+_ENV_DEFAULT_STATE = "PALACE_DEFAULT_STATE"
+
+
+def resolve_geo(library: Library, session: Session) -> tuple[str, str]:
+    """
+    Resolve the (country, state) for a circulation event using a 3-tier hierarchy.
+
+    Resolution order (highest priority last):
+      1. Environment variables ``PALACE_DEFAULT_COUNTRY`` / ``PALACE_DEFAULT_STATE``
+         (hard-coded fallbacks: ``"US"`` / ``"All"``)
+      2. Sitewide :class:`GlobalSettings` stored in
+         :class:`~palace.manager.sqlalchemy.model.integration.IntegrationConfiguration`
+      3. Library-level ``country`` / ``state`` fields in
+         :class:`~palace.manager.integration.configuration.library.LibrarySettings`
+
+    :param library: The :class:`~palace.manager.sqlalchemy.model.library.Library` for
+        which an event is being recorded.
+    :param session: An active SQLAlchemy session.
+    :return: A ``(country, state)`` tuple; never ``None``.
+    """
+    # Tier 1 (lowest priority): env var defaults with hard-coded fallbacks
+    country: str = os.environ.get(_ENV_DEFAULT_COUNTRY, "US")
+    state: str = os.environ.get(_ENV_DEFAULT_STATE, "All")
+
+    # Tier 2: sitewide GlobalSettings stored in IntegrationConfiguration
+    global_integration = get_one(
+        session,
+        IntegrationConfiguration,
+        goal=Goals.SITEWIDE_SETTINGS,
+        protocol=GLOBAL_SETTINGS_PROTOCOL,
+    )
+    if global_integration is not None:
+        global_cfg = integration_settings_load(GlobalSettings, global_integration)
+        if global_cfg.country:
+            country = global_cfg.country
+        if global_cfg.state:
+            state = global_cfg.state
+
+    # Tier 3 (highest priority): library-level settings
+    lib_settings = library.settings
+    if lib_settings.country is not None:
+        country = lib_settings.country
+    if lib_settings.state is not None:
+        state = lib_settings.state
+
+    return country, state

--- a/tests/manager/api/admin/controller/test_global_settings.py
+++ b/tests/manager/api/admin/controller/test_global_settings.py
@@ -1,0 +1,120 @@
+"""Tests for GlobalSettingsController."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from werkzeug.datastructures import ImmutableMultiDict
+
+from palace.manager.api.admin.controller.global_settings import GlobalSettingsController
+from palace.manager.integration.base import integration_settings_load
+from palace.manager.integration.configuration.global_settings import (
+    GLOBAL_SETTINGS_PROTOCOL,
+    GlobalSettings,
+)
+from palace.manager.integration.goals import Goals
+from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
+from palace.manager.sqlalchemy.util import get_one
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.flask import FlaskAppFixture
+
+
+@pytest.fixture
+def controller(db: DatabaseTransactionFixture) -> GlobalSettingsController:
+    return GlobalSettingsController(db.session)
+
+
+class TestGlobalSettingsController:
+    def test_get_returns_defaults_when_no_row_exists(
+        self,
+        controller: GlobalSettingsController,
+        db: DatabaseTransactionFixture,
+        flask_app_fixture: FlaskAppFixture,
+    ) -> None:
+        with flask_app_fixture.test_request_context_system_admin("/"):
+            response = controller.process_global_settings()
+        assert response.status_code == 200
+        body = json.loads(response.data)
+        assert body["settings"]["country"] == "US"
+        assert body["settings"]["state"] == "All"
+        assert "schema" in body
+
+    def test_get_creates_integration_row_on_first_call(
+        self,
+        controller: GlobalSettingsController,
+        db: DatabaseTransactionFixture,
+        flask_app_fixture: FlaskAppFixture,
+    ) -> None:
+        assert (
+            get_one(
+                db.session,
+                IntegrationConfiguration,
+                goal=Goals.SITEWIDE_SETTINGS,
+                protocol=GLOBAL_SETTINGS_PROTOCOL,
+            )
+            is None
+        )
+        with flask_app_fixture.test_request_context_system_admin("/"):
+            controller.process_global_settings()
+        integration = get_one(
+            db.session,
+            IntegrationConfiguration,
+            goal=Goals.SITEWIDE_SETTINGS,
+            protocol=GLOBAL_SETTINGS_PROTOCOL,
+        )
+        assert integration is not None
+
+    def test_get_returns_existing_settings(
+        self,
+        controller: GlobalSettingsController,
+        db: DatabaseTransactionFixture,
+        flask_app_fixture: FlaskAppFixture,
+    ) -> None:
+        # POST first to set values, then GET to verify
+        form = ImmutableMultiDict([("country", "CA"), ("state", "Ontario")])
+        with flask_app_fixture.test_request_context_system_admin(
+            "/", method="POST", data=form
+        ):
+            controller.process_global_settings()
+        with flask_app_fixture.test_request_context_system_admin("/"):
+            response = controller.process_global_settings()
+        body = json.loads(response.data)
+        assert body["settings"]["country"] == "CA"
+        assert body["settings"]["state"] == "Ontario"
+
+    def test_post_updates_settings(
+        self,
+        controller: GlobalSettingsController,
+        db: DatabaseTransactionFixture,
+        flask_app_fixture: FlaskAppFixture,
+    ) -> None:
+        form = ImmutableMultiDict([("country", "GB"), ("state", "England")])
+        with flask_app_fixture.test_request_context_system_admin(
+            "/", method="POST", data=form
+        ):
+            response = controller.process_global_settings()
+        assert response.status_code == 200
+        integration = get_one(
+            db.session,
+            IntegrationConfiguration,
+            goal=Goals.SITEWIDE_SETTINGS,
+            protocol=GLOBAL_SETTINGS_PROTOCOL,
+        )
+        assert integration is not None
+        settings = integration_settings_load(GlobalSettings, integration)
+        assert settings.country == "GB"
+        assert settings.state == "England"
+
+    def test_non_system_admin_is_rejected(
+        self,
+        controller: GlobalSettingsController,
+        flask_app_fixture: FlaskAppFixture,
+    ) -> None:
+        # A non-admin request context (no admin set)
+        with flask_app_fixture.test_request_context("/"):
+            result = controller.process_global_settings()
+        # Returns a ProblemDetail, not a 200 Response
+        from palace.manager.util.problem_detail import ProblemDetail
+
+        assert isinstance(result, ProblemDetail)

--- a/tests/manager/integration/configuration/test_global_settings.py
+++ b/tests/manager/integration/configuration/test_global_settings.py
@@ -1,0 +1,37 @@
+"""Tests for GlobalSettings Pydantic class."""
+
+from __future__ import annotations
+
+from palace.manager.integration.configuration.global_settings import (
+    GLOBAL_SETTINGS_PROTOCOL,
+    GlobalSettings,
+)
+from tests.fixtures.database import DatabaseTransactionFixture
+
+
+class TestGlobalSettings:
+    def test_defaults(self) -> None:
+        settings = GlobalSettings()
+        assert settings.country == "US"
+        assert settings.state == "All"
+
+    def test_explicit_values(self) -> None:
+        settings = GlobalSettings(country="CA", state="Ontario")
+        assert settings.country == "CA"
+        assert settings.state == "Ontario"
+
+    def test_roundtrip(self) -> None:
+        settings = GlobalSettings(country="GB", state="England")
+        dumped = settings.model_dump()
+        reloaded = GlobalSettings.model_validate(dumped)
+        assert reloaded.country == "GB"
+        assert reloaded.state == "England"
+
+    def test_configuration_form(self, db: DatabaseTransactionFixture) -> None:
+        form = GlobalSettings.configuration_form(db.session)
+        keys = {field["key"] for field in form}
+        assert "country" in keys
+        assert "state" in keys
+
+    def test_protocol_constant(self) -> None:
+        assert GLOBAL_SETTINGS_PROTOCOL == "global_settings"

--- a/tests/manager/service/analytics/test_analytics.py
+++ b/tests/manager/service/analytics/test_analytics.py
@@ -51,7 +51,7 @@ class TestAnalytics:
 
         collected: list = []
         analytics = Analytics()
-        analytics.collect = lambda event, session=None: collected.append(event)  # type: ignore[method-assign]
+        analytics.collect = lambda event, session=None: collected.append(event)
         analytics.collect_event(library, pool, CirculationEvent.CM_CHECKOUT)
 
         assert len(collected) == 1
@@ -69,7 +69,7 @@ class TestAnalytics:
 
         collected: list = []
         analytics = Analytics()
-        analytics.collect = lambda event, session=None: collected.append(event)  # type: ignore[method-assign]
+        analytics.collect = lambda event, session=None: collected.append(event)
 
         with patch.object(
             analytics_module, "resolve_geo", side_effect=RuntimeError("boom")

--- a/tests/manager/service/analytics/test_analytics.py
+++ b/tests/manager/service/analytics/test_analytics.py
@@ -1,8 +1,13 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import pytest
+
+from palace.manager.service.analytics import analytics as analytics_module
 from palace.manager.service.analytics.analytics import Analytics
 from palace.manager.service.analytics.local import LocalAnalyticsProvider
 from palace.manager.service.analytics.s3 import S3AnalyticsProvider
+from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
+from tests.fixtures.database import DatabaseTransactionFixture
 
 
 class TestAnalytics:
@@ -31,3 +36,47 @@ class TestAnalytics:
         assert len(analytics.providers) == 2
         assert type(analytics.providers[0]) == LocalAnalyticsProvider
         assert type(analytics.providers[1]) == S3AnalyticsProvider
+
+    def test_collect_event_passes_geo_to_event_data(
+        self,
+        db: DatabaseTransactionFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """collect_event() resolves geo and passes country/state to AnalyticsEventData."""
+        library = db.default_library()
+        pool = db.licensepool(edition=db.edition())
+        library.settings_dict = dict(library.settings_dict)
+        library.settings_dict["country"] = "CA"
+        library.settings_dict["state"] = "Ontario"
+
+        collected: list = []
+        analytics = Analytics()
+        analytics.collect = lambda event, session=None: collected.append(event)  # type: ignore[method-assign]
+        analytics.collect_event(library, pool, CirculationEvent.CM_CHECKOUT)
+
+        assert len(collected) == 1
+        assert collected[0].country == "CA"
+        assert collected[0].state == "Ontario"
+
+    def test_collect_event_uses_fallback_if_resolve_geo_fails(
+        self,
+        db: DatabaseTransactionFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """collect_event() falls back to defaults and logs a warning when resolve_geo raises."""
+        library = db.default_library()
+        pool = db.licensepool(edition=db.edition())
+
+        collected: list = []
+        analytics = Analytics()
+        analytics.collect = lambda event, session=None: collected.append(event)  # type: ignore[method-assign]
+
+        with patch.object(
+            analytics_module, "resolve_geo", side_effect=RuntimeError("boom")
+        ):
+            analytics.collect_event(library, pool, CirculationEvent.CM_CHECKOUT)
+
+        assert len(collected) == 1
+        assert collected[0].country == "US"
+        assert collected[0].state == "All"
+        assert "Unable to resolve geographic settings" in caplog.text

--- a/tests/manager/service/analytics/test_eventdata.py
+++ b/tests/manager/service/analytics/test_eventdata.py
@@ -12,6 +12,30 @@ from tests.fixtures.flask import FlaskAppFixture
 
 
 class TestAnalyticsEventData:
+    def test_country_and_state_defaults(
+        self,
+        db: DatabaseTransactionFixture,
+    ) -> None:
+        """create() uses 'US'/'All' defaults when country/state are not provided."""
+        pool = db.licensepool(edition=db.edition())
+        library = db.default_library()
+        event = AnalyticsEventData.create(library, pool, CirculationEvent.CM_CHECKOUT)
+        assert event.country == "US"
+        assert event.state == "All"
+
+    def test_country_and_state_explicit(
+        self,
+        db: DatabaseTransactionFixture,
+    ) -> None:
+        """create() propagates explicitly provided country/state."""
+        pool = db.licensepool(edition=db.edition())
+        library = db.default_library()
+        event = AnalyticsEventData.create(
+            library, pool, CirculationEvent.CM_CHECKOUT, country="CA", state="Ontario"
+        )
+        assert event.country == "CA"
+        assert event.state == "Ontario"
+
     def test_user_agent(
         self,
         db: DatabaseTransactionFixture,

--- a/tests/manager/service/analytics/test_geo.py
+++ b/tests/manager/service/analytics/test_geo.py
@@ -1,0 +1,107 @@
+"""Tests for geographic settings resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from palace.manager.integration.base import integration_settings_update
+from palace.manager.integration.configuration.global_settings import (
+    GLOBAL_SETTINGS_PROTOCOL,
+    GlobalSettings,
+)
+from palace.manager.integration.goals import Goals
+from palace.manager.service.analytics.geo import (
+    _ENV_DEFAULT_COUNTRY,
+    _ENV_DEFAULT_STATE,
+    resolve_geo,
+)
+from palace.manager.sqlalchemy.model.integration import IntegrationConfiguration
+from palace.manager.sqlalchemy.util import create
+from tests.fixtures.database import DatabaseTransactionFixture
+
+
+def _make_global_integration(
+    db: DatabaseTransactionFixture,
+    country: str = "US",
+    state: str = "All",
+) -> IntegrationConfiguration:
+    integration, _ = create(
+        db.session,
+        IntegrationConfiguration,
+        goal=Goals.SITEWIDE_SETTINGS,
+        protocol=GLOBAL_SETTINGS_PROTOCOL,
+        name="Global Settings",
+    )
+    settings = GlobalSettings(country=country, state=state)
+    integration_settings_update(GlobalSettings, integration, settings)
+    return integration
+
+
+class TestResolveGeo:
+    def test_env_var_defaults(
+        self,
+        db: DatabaseTransactionFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Returns env-var values when no DB rows exist."""
+        monkeypatch.setenv(_ENV_DEFAULT_COUNTRY, "CA")
+        monkeypatch.setenv(_ENV_DEFAULT_STATE, "Ontario")
+        library = db.default_library()
+        country, state = resolve_geo(library, db.session)
+        assert country == "CA"
+        assert state == "Ontario"
+
+    def test_hard_coded_fallbacks(
+        self,
+        db: DatabaseTransactionFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Falls back to 'US'/'All' when env vars are absent and no DB rows exist."""
+        monkeypatch.delenv(_ENV_DEFAULT_COUNTRY, raising=False)
+        monkeypatch.delenv(_ENV_DEFAULT_STATE, raising=False)
+        library = db.default_library()
+        country, state = resolve_geo(library, db.session)
+        assert country == "US"
+        assert state == "All"
+
+    def test_global_settings_override_env(
+        self,
+        db: DatabaseTransactionFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sitewide GlobalSettings take precedence over env vars."""
+        monkeypatch.setenv(_ENV_DEFAULT_COUNTRY, "MX")
+        monkeypatch.setenv(_ENV_DEFAULT_STATE, "Jalisco")
+        _make_global_integration(db, country="CA", state="British Columbia")
+        library = db.default_library()
+        country, state = resolve_geo(library, db.session)
+        assert country == "CA"
+        assert state == "British Columbia"
+
+    def test_library_settings_override_global(
+        self,
+        db: DatabaseTransactionFixture,
+    ) -> None:
+        """Library-level settings take precedence over sitewide GlobalSettings."""
+        _make_global_integration(db, country="CA", state="Ontario")
+        library = db.default_library()
+        library.settings_dict = dict(library.settings_dict)
+        library.settings_dict["country"] = "US"
+        library.settings_dict["state"] = "New York"
+        country, state = resolve_geo(library, db.session)
+        assert country == "US"
+        assert state == "New York"
+
+    def test_library_partial_override(
+        self,
+        db: DatabaseTransactionFixture,
+    ) -> None:
+        """Library-level override of only country falls back to global for state."""
+        _make_global_integration(db, country="CA", state="Ontario")
+        library = db.default_library()
+        library.settings_dict = dict(library.settings_dict)
+        library.settings_dict["country"] = "US"
+        # state not set on library — falls back to global "Ontario"
+        country, state = resolve_geo(library, db.session)
+        assert country == "US"
+        assert state == "Ontario"


### PR DESCRIPTION
## Description

Adds first-class country and state fields to the analytics pipeline, replacing the fragile convention of parsing geographic data from CM instance names.

**3-tier resolution hierarchy (lowest to highest priority):**
1. Environment variables: `PALACE_DEFAULT_COUNTRY` (default `US`) and `PALACE_DEFAULT_STATE` (default `All`) — documented in `cursor.env`
2. CM instance-level global settings stored in DB, configurable by system admins via new `GET/POST /admin/global_settings` endpoint
3. Per-library override fields (`country`, `state`) on `LibrarySettings`, visible to system admins only

`country` and `state` are embedded as top-level keys in every `AnalyticsEventData` event written to S3 JSON, then consumed by the AWS Glue ETL job into Redshift.

## Motivation and Context

Canadian libraries use a `can-<province>` naming convention in the hosting-playbook, which is unreliable for Redshift geo data. This makes country and state explicit, admin-configurable values propagated through the analytics pipeline.

**New files:**
- `src/palace/manager/integration/configuration/global_settings.py` — `GlobalSettings(BaseSettings)` with `country`/`state`
- `src/palace/manager/service/analytics/geo.py` — `resolve_geo()` 3-tier resolution
- `src/palace/manager/api/admin/controller/global_settings.py` — `GlobalSettingsController`
- `alembic/versions/20260422_a1b2c3d4e5f6_add_sitewide_settings_goal.py` — adds `SITEWIDE_SETTINGS` to PostgreSQL `goals` ENUM

**Modified files:**
- `src/palace/manager/integration/goals.py` — `SITEWIDE_SETTINGS` enum value
- `src/palace/manager/integration/configuration/library.py` — `country`/`state` optional fields (sys-admin only)
- `src/palace/manager/service/analytics/eventdata.py` — `country`/`state` on `AnalyticsEventData`
- `src/palace/manager/service/analytics/analytics.py` — calls `resolve_geo()` in `collect_event()`
- `src/palace/manager/api/admin/controller/__init__.py` — wires `GlobalSettingsController`
- `src/palace/manager/api/admin/routes.py` — `/admin/global_settings` route

## How Has This Been Tested?

- Unit tests added for all new modules: `test_geo.py`, `test_global_settings.py` (configuration), `test_global_settings.py` (controller)
- Existing analytics tests extended: `test_analytics.py`, `test_eventdata.py`
- All mypy checks pass
- All non-DB unit tests pass

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.