### PR TITLE
Add frozendict convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ through mobile and web applications.
 - Whenever possible use immutable datastructures for global and class constants.
 - Whenever creating an alembic revision, always use `alembic revision` to create the revision file with the
   upgrade/downgrade stubs.
+- When creating immutable dictionaries, use the `frozendict` function unless directed otherwise.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ through mobile and web applications.
 - Whenever possible use immutable datastructures for global and class constants.
 - Whenever creating an alembic revision, always use `alembic revision` to create the revision file with the
   upgrade/downgrade stubs.
-- When creating immutable dictionaries, use the `frozendict` function unless directed otherwise.
+- When creating immutable dictionaries, use `frozendict` unless directed otherwise.
 
 ## Project Structure
 


### PR DESCRIPTION
## Description

Add an instruction to CLAUDE.md specifying that `frozendict` should be used when creating immutable dictionaries, unless directed otherwise.

## Motivation and Context

This makes the immutable dictionary convention explicit and consistent with the existing guideline to use immutable datastructures for global and class constants.

## How Has This Been Tested?

Documentation-only change; no tests required.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.