### PR TITLE
Adjust Palace Marketplace juvenile book audience classification thresholds

### DIFF
--- a/alembic/versions/20260427_05a95c828149_reset_checked_for_all_fbjuv_subjects.py
+++ b/alembic/versions/20260427_05a95c828149_reset_checked_for_all_fbjuv_subjects.py
@@ -1,0 +1,47 @@
+"""reset_checked_for_all_fbjuv_subjects
+
+Palace Marketplace sends BISAC codes with an "FBJUV" prefix (e.g. FBJUV000000,
+FBJUV009000N). The previous migration only targeted a specific set of known
+identifiers. This migration casts a wider net by resetting checked=False for
+every BISAC subject whose identifier starts with "FBJUV", ensuring the
+classify_unchecked_subjects task reclassifies any remaining affected subjects
+with the corrected scrubber.
+
+Revision ID: 05a95c828149
+Revises: 45f74fdcec18
+Create Date: 2026-04-27 20:17:51.182730+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from palace.manager.util.migration.helpers import migration_logger
+
+# revision identifiers, used by Alembic.
+revision = "05a95c828149"
+down_revision = "45f74fdcec18"
+branch_labels = None
+depends_on = None
+
+log = migration_logger(revision)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    result = conn.execute(
+        sa.text(
+            "UPDATE subjects "
+            "SET checked = false "
+            "WHERE type = 'BISAC' "
+            "  AND identifier LIKE 'FBJUV%' "
+            "RETURNING id, identifier"
+        )
+    )
+    for row in result:
+        log.info(f"Reset checked=False for subject id={row[0]} identifier={row[1]!r}")
+
+
+def downgrade() -> None:
+    pass

--- a/src/palace/manager/core/classifier/work.py
+++ b/src/palace/manager/core/classifier/work.py
@@ -396,7 +396,7 @@ class WorkClassifier:
         audience = default_audience
 
         # A book will be classified as a young adult or childrens'
-        # book when the weight of that audience is more than twice the
+        # book when the weight of that audience is at least twice the
         # combined weight of the 'adult' and 'adults only' audiences.
         # If that combined weight is zero, then any amount of evidence
         # is sufficient.
@@ -418,11 +418,11 @@ class WorkClassifier:
             and all_ages_weight > total_juvenile_weight
         ):
             audience = Classifier.AUDIENCE_ALL_AGES
-        elif children_weight > threshold and children_weight > ya_weight:
+        elif children_weight >= threshold and children_weight > ya_weight:
             audience = Classifier.AUDIENCE_CHILDREN
-        elif ya_weight > threshold:
+        elif ya_weight >= threshold:
             audience = Classifier.AUDIENCE_YOUNG_ADULT
-        elif total_juvenile_weight > threshold:
+        elif total_juvenile_weight >= threshold:
             # Neither weight passes the threshold on its own, but
             # combined they do pass the threshold. Go with
             # 'Young Adult' to be safe.

--- a/tests/manager/core/classifiers/test_classifier.py
+++ b/tests/manager/core/classifiers/test_classifier.py
@@ -568,7 +568,7 @@ class TestWorkClassifier:
 
         # Now it's overwhelmingly likely to be a YA book.
         del data.classifier.audience_weights[Classifier.AUDIENCE_CHILDREN]
-        data.classifier.audience_weights[Classifier.AUDIENCE_YOUNG_ADULT] = 23
+        data.classifier.audience_weights[Classifier.AUDIENCE_YOUNG_ADULT] = 22
         assert Classifier.AUDIENCE_YOUNG_ADULT == data.classifier.audience()
 
     def test_ya_book_when_childrens_and_ya_combined_beat_adult(

--- a/tests/manager/core/classifiers/test_classifier.py
+++ b/tests/manager/core/classifiers/test_classifier.py
@@ -557,13 +557,13 @@ class TestWorkClassifier:
         data.classifier.audience_weights = {
             Classifier.AUDIENCE_ADULT: 10,
             Classifier.AUDIENCE_ADULTS_ONLY: 1,
-            Classifier.AUDIENCE_CHILDREN: 22,
+            Classifier.AUDIENCE_CHILDREN: 21,
         }
         assert Classifier.AUDIENCE_ADULT == data.classifier.audience()
 
-        # Now it's overwhelming. (the 'children' weight is more than twice
+        # Now it's overwhelming. (the 'children' weight is at least twice
         # the combined 'adult' + 'adults only' weight.
-        data.classifier.audience_weights[Classifier.AUDIENCE_CHILDREN] = 23
+        data.classifier.audience_weights[Classifier.AUDIENCE_CHILDREN] = 22
         assert Classifier.AUDIENCE_CHILDREN == data.classifier.audience()
 
         # Now it's overwhelmingly likely to be a YA book.


### PR DESCRIPTION
## Description
This is a follow on PR to #3284.  After doing some tests I realized that not all of the books identified in the original JIRA (PP-4128) ticket were fixed.  After some more investigation,  it became clear that the migration needed to touch a wider swath of subjects and the JV audience threshold needed a minor adjustment.

So this PR contains two fixes to correctly classify juvenile books from Palace Marketplace as Children rather than Adult:

1. **Migration**: Resets `checked=False` for all BISAC subjects whose identifier starts with `FBJUV`. The previous migration (45f74fdcec18) only targeted a specific set of N-suffix codes; this broader pass catches remaining subjects (e.g. `FBJUV000000`, `FBJUV037000`) that were classified before the FB-prefix scrubber fix landed.

2. **Audience threshold**: Changes the juvenile audience threshold from strictly greater than (`>`) to at least (`>=`) twice the adult weight. Palace Marketplace sends `FBFIC000000` (a generic "Fiction / General" parent category) alongside `FBJUV*` codes for juvenile books, which produced exactly 2× the adult weight in children votes — enough to tie but not enough to win under the old strict check. Applies consistently to the Children, YA, and combined-juvenile checks.

## Motivation and Context
Books from Palace Marketplace with `FBJUV*` BISAC codes and a single `FBFIC000000` code were being classified as Adult because:
- `FBJUV` subjects last classified before the FB-prefix scrubber fix still had `audience=Adult` stored
- Once those were corrected, `FBFIC000000` (1 adult vote) produced a threshold of 2, which the 2 children votes could not exceed under the strict `>` check

## How Has This Been Tested?

- Traced classification logic manually against real subject data from affected books
- Updated the boundary-case unit test in `TestWorkClassifier` to reflect the new `>=` semantics
- Verified mypy reports no issues on changed files

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.