### PR TITLE
Fix ValueError in calculate_work with retryable InconsistentLicensePoolState (PP-3977)

### DIFF
--- a/packages/palace-util/src/palace/util/exceptions.py
+++ b/packages/palace-util/src/palace/util/exceptions.py
@@ -33,3 +33,12 @@ class PalaceValueError(BasePalaceException, ValueError): ...
 
 
 class PalaceTypeError(BasePalaceException, TypeError): ...
+
+
+class InconsistentLicensePoolState(BasePalaceException):
+    """Raised when a LicensePool is in a transient inconsistent state.
+
+    For example, its Identifier has no associated pools visible in the current
+    session. This is typically caused by a parallel-import race condition and
+    the operation should be retried.
+    """

--- a/src/palace/manager/celery/tasks/apply.py
+++ b/src/palace/manager/celery/tasks/apply.py
@@ -6,6 +6,8 @@ from typing import Any, Protocol
 
 from celery import shared_task
 
+from palace.util.exceptions import InconsistentLicensePoolState
+
 from palace.manager.celery.task import Task
 from palace.manager.celery.utils import load_from_id, validate_not_none
 from palace.manager.data_layer.bibliographic import BibliographicData
@@ -41,7 +43,7 @@ _validate_primary_identifier = partial(
 @shared_task(
     queue=QueueNames.apply,
     bind=True,
-    autoretry_for=(LockNotAcquired,),
+    autoretry_for=(LockNotAcquired, InconsistentLicensePoolState),
     max_retries=5,
     retry_backoff=60,
     retry_backoff_max=15 * 60,
@@ -72,7 +74,7 @@ def circulation_apply(
 @shared_task(
     queue=QueueNames.apply,
     bind=True,
-    autoretry_for=(LockNotAcquired,),
+    autoretry_for=(LockNotAcquired, InconsistentLicensePoolState),
     max_retries=5,
     retry_backoff=60,
     retry_backoff_max=15 * 60,

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -1235,9 +1235,20 @@ class LicensePool(Base):
                 lp.work = None
                 if lp.presentation_edition:
                     lp.presentation_edition.work = None
-        else:
+        elif existing_works:
             # There is a consensus Work for this Identifier.
             [self.work] = existing_works
+        else:
+            # licensed_through is empty — the session doesn't yet see any pools
+            # for this identifier. This is a transient race condition during
+            # parallel imports; raising here allows the Celery task to retry.
+            from palace.util.exceptions import InconsistentLicensePoolState
+
+            raise InconsistentLicensePoolState(
+                f"No LicensePools found for identifier {self.identifier!r} in "
+                "licensed_through — this is likely a transient session state "
+                "issue caused by a parallel import; the task should be retried."
+            )
 
         if self.work:
             # This pool is already associated with a Work. Use that

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -32,7 +32,7 @@ from sqlalchemy.sql import ColumnElement
 
 from palace.opds.odl.info import LicenseStatus
 from palace.util.datetime_helpers import utc_now
-from palace.util.exceptions import BasePalaceException
+from palace.util.exceptions import BasePalaceException, InconsistentLicensePoolState
 
 from palace.manager.api.circulation.exceptions import CannotHold, CannotLoan
 from palace.manager.sqlalchemy.constants import (
@@ -1242,8 +1242,6 @@ class LicensePool(Base):
             # licensed_through is empty — the session doesn't yet see any pools
             # for this identifier. This is a transient race condition during
             # parallel imports; raising here allows the Celery task to retry.
-            from palace.util.exceptions import InconsistentLicensePoolState
-
             raise InconsistentLicensePoolState(
                 f"No LicensePools found for identifier {self.identifier!r} in "
                 "licensed_through — this is likely a transient session state "

--- a/tests/manager/celery/tasks/test_apply.py
+++ b/tests/manager/celery/tasks/test_apply.py
@@ -1,6 +1,8 @@
+from unittest.mock import patch
+
 import pytest
 
-from palace.util.exceptions import PalaceTypeError
+from palace.util.exceptions import InconsistentLicensePoolState, PalaceTypeError
 
 from palace.manager.celery.tasks import apply
 from palace.manager.data_layer.bibliographic import BibliographicData
@@ -121,6 +123,37 @@ class TestBibliographicApply:
             apply.bibliographic_apply.delay(data, edition.id, None).wait()
 
         # Make sure the task was retried
+        assert (
+            retry_mock.retry_count == 5 + 1
+        )  # 5 retries + the final call before failing
+
+    def test_inconsistent_license_pool_state_retried(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        redis_fixture: RedisFixture,
+    ) -> None:
+        edition = db.edition()
+        data = BibliographicData(
+            data_source_name="Test Data Source",
+            primary_identifier_data=IdentifierData.from_identifier(
+                edition.primary_identifier
+            ),
+        )
+
+        with (
+            patch.object(
+                data,
+                "apply",
+                side_effect=InconsistentLicensePoolState(
+                    "simulated empty licensed_through"
+                ),
+            ),
+            celery_fixture.patch_retry_backoff() as retry_mock,
+            pytest.raises(InconsistentLicensePoolState),
+        ):
+            apply.bibliographic_apply.delay(data, edition.id, None).wait()
+
         assert (
             retry_mock.retry_count == 5 + 1
         )  # 5 retries + the final call before failing

--- a/tests/manager/celery/tasks/test_apply.py
+++ b/tests/manager/celery/tasks/test_apply.py
@@ -142,8 +142,9 @@ class TestBibliographicApply:
         )
 
         with (
+            # BibliographicData is a frozen Pydantic model; patch the class, not the instance.
             patch.object(
-                data,
+                BibliographicData,
                 "apply",
                 side_effect=InconsistentLicensePoolState(
                     "simulated empty licensed_through"

--- a/tests/manager/sqlalchemy/model/test_work.py
+++ b/tests/manager/sqlalchemy/model/test_work.py
@@ -1,7 +1,7 @@
 import datetime
 from contextlib import nullcontext
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import opensearchpy
 import pytest
@@ -2156,10 +2156,14 @@ class TestWorkConsolidation:
         hasn't yet seen the pool for this identifier (transient parallel-import state).
         """
         e, p = db.edition(with_license_pool=True)
-        # Simulate a session that sees no pools yet for this identifier
-        p.identifier.licensed_through = []
-        with pytest.raises(InconsistentLicensePoolState):
-            p.calculate_work()
+        p.set_presentation_edition()
+        # Patch via PropertyMock to avoid triggering SQLAlchemy's backref cascade,
+        # which would clear pool.identifier if we assigned [] directly.
+        with patch.object(
+            Identifier, "licensed_through", new_callable=PropertyMock, return_value=[]
+        ):
+            with pytest.raises(InconsistentLicensePoolState):
+                p.calculate_work(known_edition=p.presentation_edition)
 
     def test_calculate_work_bails_out_if_no_title(self, db: DatabaseTransactionFixture):
         e, p = db.edition(with_license_pool=True)

--- a/tests/manager/sqlalchemy/model/test_work.py
+++ b/tests/manager/sqlalchemy/model/test_work.py
@@ -10,7 +10,7 @@ from pytest import LogCaptureFixture
 from sqlalchemy import select
 
 from palace.util.datetime_helpers import datetime_utc, from_timestamp, utc_now
-from palace.util.exceptions import BasePalaceException
+from palace.util.exceptions import BasePalaceException, InconsistentLicensePoolState
 from palace.util.log import LogLevel
 
 from palace.manager.core.classifier import Classifier, Fantasy, Romance, Science_Fiction
@@ -2146,6 +2146,20 @@ class TestWorkConsolidation:
         work, new = p.calculate_work()
         assert p.presentation_edition == work.presentation_edition
         assert True == new
+
+    def test_calculate_work_raises_on_empty_licensed_through(
+        self, db: DatabaseTransactionFixture
+    ):
+        """calculate_work raises InconsistentLicensePoolState when licensed_through is empty.
+
+        This guards against silently creating a duplicate Work when the session
+        hasn't yet seen the pool for this identifier (transient parallel-import state).
+        """
+        e, p = db.edition(with_license_pool=True)
+        # Simulate a session that sees no pools yet for this identifier
+        p.identifier.licensed_through = []
+        with pytest.raises(InconsistentLicensePoolState):
+            p.calculate_work()
 
     def test_calculate_work_bails_out_if_no_title(self, db: DatabaseTransactionFixture):
         e, p = db.edition(with_license_pool=True)


### PR DESCRIPTION
## Description

Replace the bare set-unpack `[self.work] = existing_works` in `LicensePool.calculate_work()` with an explicit guard. When `existing_works` is empty, raise a new `InconsistentLicensePoolState` exception (a `BasePalaceException` subclass) instead of crashing with an unhandled `ValueError`. Both Celery apply tasks now include `InconsistentLicensePoolState` in `autoretry_for`, so the task retries up to 5 times with backoff.

## Motivation and Context
JIRA: PP-3977

A widespread `ValueError: not enough values to unpack (expected 1, got 0)` was observed across many circulation manager instances, correlated with OverDrive-only imports. The crash occurs at:

```
licensing.py, calculate_work:
    [self.work] = existing_works   # ValueError when set is empty
```

`existing_works` is built from `self.identifier.licensed_through`. It is empty when the Celery session loads the Identifier (and its eagerly-joined `licensed_through` relationship) before a sibling import transaction commits, leaving the relationship snapshot empty. Silently continuing would create a duplicate Work; retrying allows the next attempt to see the committed pool.

## How Has This Been Tested?

- `test_calculate_work_raises_on_empty_licensed_through` — verifies `InconsistentLicensePoolState` is raised when `licensed_through` is empty.
- `test_inconsistent_license_pool_state_retried` — verifies the task retries 5 times and re-raises after exhausting retries.
- `mypy` — passes with no new errors.

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.