### PR TITLE
Remove OverdriveFormatSweep monitor (PP-3305)

### DIFF
--- a/bin/overdrive_format_sweep
+++ b/bin/overdrive_format_sweep
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-"""Sweep through our Overdrive collections updating delivery mechanisms."""
-
-from palace.manager.integration.license.overdrive.monitor import OverdriveFormatSweep
-from palace.manager.scripts.monitor import RunCollectionMonitorScript
-
-RunCollectionMonitorScript(OverdriveFormatSweep).run()

--- a/docker/services/cron/cron.d/circulation
+++ b/docker/services/cron/cron.d/circulation
@@ -27,7 +27,6 @@ HOME=/var/www/circulation
 # Overdrive
 #
 */15 * * * * root bin/run overdrive_reaper >> /var/log/cron.log 2>&1
-0 4 * * * root bin/run overdrive_format_sweep >> /var/log/cron.log 2>&1
 
 # Auto update lists
 # Every hour between 7AM - 1AM

--- a/src/palace/manager/integration/license/overdrive/monitor.py
+++ b/src/palace/manager/integration/license/overdrive/monitor.py
@@ -30,30 +30,3 @@ class OverdriveCollectionReaper(IdentifierSweepMonitor):
 
     def process_item(self, identifier: Identifier) -> None:
         self.api.update_licensepool(identifier.identifier)
-
-
-class OverdriveFormatSweep(IdentifierSweepMonitor):
-    """Check the current formats of every Overdrive book
-    in our collection.
-    """
-
-    SERVICE_NAME = "Overdrive Format Sweep"
-    DEFAULT_BATCH_SIZE = 10
-    PROTOCOL = OverdriveAPI.label()
-
-    def __init__(
-        self,
-        _db: Session,
-        collection: Collection,
-        api_class: type[OverdriveAPI] = OverdriveAPI,
-    ) -> None:
-        super().__init__(_db, collection)
-        self.api = api_class(_db, collection)
-
-    def process_item(self, identifier: Identifier) -> None:
-        pools = identifier.licensed_through
-        for pool in pools:
-            self.api.update_formats(pool)
-            # if there are multiple pools they should all have the same formats
-            # so we break after processing the first one
-            break

--- a/tests/manager/integration/license/overdrive/test_monitor.py
+++ b/tests/manager/integration/license/overdrive/test_monitor.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from typing import cast
-
 from palace.manager.integration.license.overdrive.monitor import (
     OverdriveCollectionReaper,
-    OverdriveFormatSweep,
 )
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.overdrive import OverdriveAPIFixture
@@ -19,49 +16,3 @@ class TestReaper:
         monitor = OverdriveCollectionReaper(
             db.session, overdrive_api_fixture.collection, api_class=MockOverdriveAPI
         )
-
-
-class TestOverdriveFormatSweep:
-    def test_process_item(self, overdrive_api_fixture: OverdriveAPIFixture):
-        db = overdrive_api_fixture.db
-        # Validate the standard CollectionMonitor interface.
-        monitor = OverdriveFormatSweep(
-            db.session, overdrive_api_fixture.collection, api_class=MockOverdriveAPI
-        )
-        overdrive_api_fixture.queue_collection_token()
-        # We're not testing that the work actually gets done (that's
-        # tested in test_update_formats), only that the monitor
-        # implements the expected process_item API without crashing.
-        overdrive_api_fixture.mock_http.queue_response(404)
-        edition, pool = db.edition(with_license_pool=True)
-        monitor.process_item(pool.identifier)
-
-    def test_process_item_multiple_licence_pools(
-        self, overdrive_api_fixture: OverdriveAPIFixture
-    ):
-        db = overdrive_api_fixture.db
-        # Make sure that we only call update_formats once when an item
-        # is part of multiple licensepools.
-
-        class MockApi(MockOverdriveAPI):
-            update_format_calls = 0
-
-            def update_formats(self, licensepool):
-                self.update_format_calls += 1
-
-        monitor = OverdriveFormatSweep(
-            db.session, overdrive_api_fixture.collection, api_class=MockApi
-        )
-        overdrive_api_fixture.queue_collection_token()
-        overdrive_api_fixture.mock_http.queue_response(404)
-        mock_api = cast(MockApi, monitor.api)
-
-        edition = db.edition()
-        collection1 = db.collection(name="Collection 1")
-        pool1 = db.licensepool(edition, collection=collection1)
-
-        collection2 = db.collection(name="Collection 2")
-        pool2 = db.licensepool(edition, collection=collection2)
-
-        monitor.process_item(pool1.identifier)
-        assert mock_api.update_format_calls == 1


### PR DESCRIPTION
## Description

Removes the `OverdriveFormatSweep` monitor, its bin script, cron entry, and associated tests.

## Motivation and Context

The format sweep was disabled in early 2025 because Overdrive stopped providing new delivery mechanisms for ebooks beyond `application/epub+zip` — with no new formats to discover, the daily sweep was pointless. Additionally, format data is already covered by the regular metadata import path: the same metadata endpoint embeds format information, and the existing monitors apply it via hash-based change detection whenever Overdrive reports a change.  

## How Has This Been Tested?

- Confirmed no remaining references to `OverdriveFormatSweep` or `overdrive_format_sweep` in source, tests, bin, or docker config
- `mypy` passes on both modified files
- All pre-commit hooks passed

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.