### PR TITLE
Refine filtered categories description text

### DIFF
--- a/src/palace/manager/integration/configuration/library.py
+++ b/src/palace/manager/integration/configuration/library.py
@@ -412,7 +412,7 @@ class LibrarySettings(BaseSettings):
         list[str],
         LibraryFormMetadata(
             label="Filtered categories",
-            description="Content in these categories (genres) will be hidden from catalog browse and search results.",
+            description="Content in these categories (fiction genres and non-fiction subjects) will be hidden from catalog browse and search results.",
             type=FormFieldType.MENU,
             options=lambda _db: {name: name for name in sorted(genres.keys())},
             category="Content Filtering",


### PR DESCRIPTION
## Description

Refines the description for the "Filtered categories" library setting to clarify what the filter applies to. Follow-up to #3272.

Before:
> Content in these categories (genres) will be hidden from catalog browse and search results.

After:
> Content in these categories (fiction genres and non-fiction subjects) will be hidden from catalog browse and search results.

## Motivation and Context

Follow-up feedback on #3272 — the parenthetical "(genres)" understated the filter's scope. The new wording makes it clear to admins that both fiction genres and non-fiction subjects are covered.

## How Has This Been Tested?

No behavior changes — description string only. Existing tests pass unchanged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.