### PR TITLE
Handle license expiration in async Celery task, enable change tracking for ODL pools (PP-4177)

### DIFF
--- a/bin/expire_licenses
+++ b/bin/expire_licenses
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+"""
+Queues the expire_licenses Celery task to process any license pools
+with licenses that have expired since the pool was last updated.
+"""
+from palace.manager.scripts.license_expiration import ExpireLicensesScript
+
+ExpireLicensesScript().run()

--- a/bin/expire_licenses
+++ b/bin/expire_licenses
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-"""
-Queues the expire_licenses Celery task to process any license pools
-with licenses that have expired since the pool was last updated.
-"""
-from palace.manager.scripts.license_expiration import ExpireLicensesScript
-
-ExpireLicensesScript().run()

--- a/bin/update_expired_licenses
+++ b/bin/update_expired_licenses
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+"""
+Queues the update_expired_licenses Celery task to process any license pools
+with licenses that have expired since the pool was last updated.
+"""
+from palace.manager.scripts.license_expiration import UpdateExpiredLicensesScript
+
+UpdateExpiredLicensesScript().run()

--- a/bin/update_expired_licenses
+++ b/bin/update_expired_licenses
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 Queues the update_expired_licenses Celery task to process any license pools
-with licenses that have expired since the pool was last updated.
+with licenses that have expired since the pool was last checked.
 """
 from palace.manager.scripts.license_expiration import UpdateExpiredLicensesScript
 

--- a/src/palace/manager/celery/tasks/license_expiration.py
+++ b/src/palace/manager/celery/tasks/license_expiration.py
@@ -13,7 +13,7 @@ from palace.manager.sqlalchemy.model.licensing import License, LicensePool
 
 
 @shared_task(queue=QueueNames.default, bind=True)
-def expire_licenses(task: Task) -> None:
+def update_expired_licenses(task: Task) -> None:
     """Find pools with newly-expired licenses and recalculate their availability.
 
     A pool is considered stale when any of its licenses has an ``expires`` timestamp at or

--- a/src/palace/manager/celery/tasks/license_expiration.py
+++ b/src/palace/manager/celery/tasks/license_expiration.py
@@ -42,11 +42,15 @@ def expire_licenses(task: Task) -> None:
             task.log.info("No pools with newly-expired licenses found.")
             return
 
-        pools = session.scalars(
-            select(LicensePool)
-            .where(LicensePool.id.in_(stale_pool_ids))
-            .options(selectinload(LicensePool.licenses))
-        ).all()
+        pools = (
+            session.scalars(
+                select(LicensePool)
+                .where(LicensePool.id.in_(stale_pool_ids))
+                .options(selectinload(LicensePool.licenses))
+            )
+            .unique()
+            .all()
+        )
 
         for pool in pools:
             pool.update_availability_from_licenses(as_of=now)

--- a/src/palace/manager/celery/tasks/license_expiration.py
+++ b/src/palace/manager/celery/tasks/license_expiration.py
@@ -17,9 +17,10 @@ def update_expired_licenses(task: Task) -> None:
     """Find pools with newly-expired licenses and recalculate their availability.
 
     A pool is considered stale when any of its licenses has an ``expires`` timestamp at or
-    before the current time AND the pool's ``updated_at`` predates that expiry — meaning
+    before the current time AND the pool's ``last_checked`` predates that expiry — meaning
     the expiry occurred after the last availability calculation and has not yet been
-    accounted for.
+    accounted for. ``update_availability_from_licenses(as_of=now)`` advances
+    ``last_checked`` to ``now``, so processed pools are automatically excluded on the next run.
     """
     now = utc_now()
 
@@ -31,8 +32,8 @@ def update_expired_licenses(task: Task) -> None:
             .where(License.expires <= now)
             .where(
                 or_(
-                    LicensePool.updated_at.is_(None),
-                    LicensePool.updated_at < License.expires,
+                    LicensePool.last_checked.is_(None),
+                    LicensePool.last_checked < License.expires,
                 )
             )
             .distinct()
@@ -54,7 +55,6 @@ def update_expired_licenses(task: Task) -> None:
 
         for pool in pools:
             pool.update_availability_from_licenses(as_of=now)
-            pool.updated_at = now
 
     task.log.info(
         f"Updated availability for {pluralize(len(pools), 'license pool')} with expired licenses."

--- a/src/palace/manager/celery/tasks/license_expiration.py
+++ b/src/palace/manager/celery/tasks/license_expiration.py
@@ -1,0 +1,56 @@
+"""Celery task for processing ODL license expirations."""
+
+from celery import shared_task
+from sqlalchemy import or_, select
+from sqlalchemy.orm import selectinload
+
+from palace.util.datetime_helpers import utc_now
+from palace.util.log import pluralize
+
+from palace.manager.celery.task import Task
+from palace.manager.service.celery.celery import QueueNames
+from palace.manager.sqlalchemy.model.licensing import License, LicensePool
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def expire_licenses(task: Task) -> None:
+    """Find AGGREGATED pools with newly-expired licenses and recalculate their availability.
+
+    A pool is considered stale when any of its licenses has an ``expires`` timestamp at or
+    before the current time AND the pool's ``updated_at`` predates that expiry — meaning
+    the expiry occurred after the last availability calculation and has not yet been
+    accounted for.
+    """
+    now = utc_now()
+
+    with task.transaction() as session:
+        stale_pool_ids = session.scalars(
+            select(License.license_pool_id)
+            .join(LicensePool, License.license_pool_id == LicensePool.id)
+            .where(License.expires.is_not(None))
+            .where(License.expires <= now)
+            .where(
+                or_(
+                    LicensePool.updated_at.is_(None),
+                    LicensePool.updated_at < License.expires,
+                )
+            )
+            .distinct()
+        ).all()
+
+        if not stale_pool_ids:
+            task.log.info("No pools with newly-expired licenses found.")
+            return
+
+        pools = session.scalars(
+            select(LicensePool)
+            .where(LicensePool.id.in_(stale_pool_ids))
+            .options(selectinload(LicensePool.licenses))
+        ).all()
+
+        for pool in pools:
+            pool.update_availability_from_licenses(as_of=now)
+
+    task.log.info(
+        f"Updated availability for {pluralize(len(pools), 'license pool')} with expired licenses."
+    )

--- a/src/palace/manager/celery/tasks/license_expiration.py
+++ b/src/palace/manager/celery/tasks/license_expiration.py
@@ -14,7 +14,7 @@ from palace.manager.sqlalchemy.model.licensing import License, LicensePool
 
 @shared_task(queue=QueueNames.default, bind=True)
 def expire_licenses(task: Task) -> None:
-    """Find AGGREGATED pools with newly-expired licenses and recalculate their availability.
+    """Find pools with newly-expired licenses and recalculate their availability.
 
     A pool is considered stale when any of its licenses has an ``expires`` timestamp at or
     before the current time AND the pool's ``updated_at`` predates that expiry — meaning

--- a/src/palace/manager/celery/tasks/license_expiration.py
+++ b/src/palace/manager/celery/tasks/license_expiration.py
@@ -54,6 +54,7 @@ def expire_licenses(task: Task) -> None:
 
         for pool in pools:
             pool.update_availability_from_licenses(as_of=now)
+            pool.updated_at = now
 
     task.log.info(
         f"Updated availability for {pluralize(len(pools), 'license pool')} with expired licenses."

--- a/src/palace/manager/data_layer/circulation.py
+++ b/src/palace/manager/data_layer/circulation.py
@@ -220,14 +220,9 @@ class CirculationData(BaseMutableData):
         pool = None
         if collection:
             pool, ignore = self.license_pool(_db, collection)
-            # Skip circulation data update if the content hasn't changed, UNLESS we
-            # have individual license objects that may have expired since the last
-            # import (ODL-style pools). License expiry is time-dependent and cannot
-            # be detected by content hashing alone.
-            if (
-                not replace.even_if_not_apparently_updated
-                and self.licenses is None
-                and not self.should_apply_to(pool)
+            # Skip circulation data update if the content hasn't changed.
+            if not replace.even_if_not_apparently_updated and not self.should_apply_to(
+                pool
             ):
                 self.log.info(
                     f"Publication {self.primary_identifier_data} circulation data has not changed since "
@@ -309,8 +304,7 @@ class CirculationData(BaseMutableData):
         changed_lp_type = False
         changed_lp_status = False
         # The early return above already filtered out pools whose content hash has
-        # not changed (for non-ODL pools when a collection is provided). If we reach
-        # this point with a pool, we know we need to apply the availability data.
+        # not changed. If we reach this point with a pool, we know we need to apply the availability data.
         if pool:
             # Update availability information. This may result in
             # the issuance of additional circulation events.
@@ -402,16 +396,9 @@ class CirculationData(BaseMutableData):
         for this object's primary identifier in *collection* and delegates to
         :meth:`~palace.manager.data_layer.base.mutable.BaseMutableData.should_apply_to`.
 
-        ODL-style pools that carry individual :attr:`licenses` are always considered to
-        need application because license availability can change over time as licenses expire
-        independently of any feed content change, and that expiry cannot be detected by
-        content hashing alone.
-
         :param session: Active database session used to look up the pool.
         :param collection: The collection the pool belongs to.
         :return: ``True`` if the data needs to be applied, ``False`` if it can be skipped.
         """
-        if self.licenses is not None:
-            return True
         pool, _ = self.license_pool(session, collection, autocreate=False)
         return self.should_apply_to(pool)

--- a/src/palace/manager/scripts/license_expiration.py
+++ b/src/palace/manager/scripts/license_expiration.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+from palace.manager.celery.tasks.license_expiration import expire_licenses
+from palace.manager.scripts.base import Script
+
+
+class ExpireLicensesScript(Script):
+    """Manually kick off the expire_licenses Celery task."""
+
+    def do_run(self, *args: Any, **kwargs: Any) -> None:
+        expire_licenses.delay()
+        self.log.info(
+            'The "expire_licenses" task has been queued for execution. See the celery logs '
+            "for details about task execution."
+        )

--- a/src/palace/manager/scripts/license_expiration.py
+++ b/src/palace/manager/scripts/license_expiration.py
@@ -1,15 +1,15 @@
 from typing import Any
 
-from palace.manager.celery.tasks.license_expiration import expire_licenses
+from palace.manager.celery.tasks.license_expiration import update_expired_licenses
 from palace.manager.scripts.base import Script
 
 
-class ExpireLicensesScript(Script):
-    """Manually kick off the expire_licenses Celery task."""
+class UpdateExpiredLicensesScript(Script):
+    """Manually kick off the update_expired_licenses Celery task."""
 
     def do_run(self, *args: Any, **kwargs: Any) -> None:
-        expire_licenses.delay()
+        update_expired_licenses.delay()
         self.log.info(
-            'The "expire_licenses" task has been queued for execution. See the celery logs '
+            'The "update_expired_licenses" task has been queued for execution. See the celery logs '
             "for details about task execution."
         )

--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -85,7 +85,9 @@ def beat_schedule() -> dict[str, Any]:
                 minute="30",
                 hour="1",
             ),  # Run every day at 1:30 AM
-        },
+            "schedule": crontab(
+                minute="30",
+            ),  # Run every hour at 30 minutes past the hour
         "opds2_odl_remove_expired_holds": {
             "task": opds_odl.remove_expired_holds.name,
             "schedule": crontab(

--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -83,11 +83,8 @@ def beat_schedule() -> dict[str, Any]:
             "task": license_expiration.expire_licenses.name,
             "schedule": crontab(
                 minute="30",
-                hour="1",
-            ),  # Run every day at 1:30 AM
-            "schedule": crontab(
-                minute="30",
             ),  # Run every hour at 30 minutes past the hour
+        },
         "opds2_odl_remove_expired_holds": {
             "task": opds_odl.remove_expired_holds.name,
             "schedule": crontab(

--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -39,6 +39,7 @@ def beat_schedule() -> dict[str, Any]:
     """
     from palace.manager.celery.tasks import (
         boundless,
+        license_expiration,
         marc,
         notifications,
         novelist,
@@ -77,6 +78,13 @@ def beat_schedule() -> dict[str, Any]:
                 hour="1",
                 minute="0",
             ),  # Run every day at 1:00 AM
+        },
+        "expire_odl_licenses": {
+            "task": license_expiration.expire_licenses.name,
+            "schedule": crontab(
+                minute="30",
+                hour="1",
+            ),  # Run every day at 1:30 AM
         },
         "opds2_odl_remove_expired_holds": {
             "task": opds_odl.remove_expired_holds.name,

--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -79,8 +79,8 @@ def beat_schedule() -> dict[str, Any]:
                 minute="0",
             ),  # Run every day at 1:00 AM
         },
-        "expire_odl_licenses": {
-            "task": license_expiration.expire_licenses.name,
+        "update_expired_licenses": {
+            "task": license_expiration.update_expired_licenses.name,
             "schedule": crontab(
                 minute="30",
             ),  # Run every hour at 30 minutes past the hour

--- a/tests/manager/celery/tasks/test_license_expiration.py
+++ b/tests/manager/celery/tasks/test_license_expiration.py
@@ -84,8 +84,9 @@ class TestExpireLicenses:
         expire_licenses.delay().wait()
 
         db.session.refresh(pool)
-        # Still 0 — the task correctly skipped this pool
-        assert pool.licenses_available == 0
+        # updated_at is unchanged — proves the pool was skipped, not just that the
+        # result happened to be 0 (which an expired license would also produce).
+        assert pool.updated_at == last_updated
 
     @freeze_time()
     def test_multiple_pools_only_stale_updated(

--- a/tests/manager/celery/tasks/test_license_expiration.py
+++ b/tests/manager/celery/tasks/test_license_expiration.py
@@ -125,5 +125,6 @@ class TestUpdateExpiredLicenses:
 
         # Stale pool recalculated — expired license contributes 0
         assert stale_pool.licenses_available == 0
-        # Current pool untouched
+        # Current pool untouched — last_checked unchanged proves it was skipped
         assert current_pool.licenses_available == 0
+        assert current_pool.last_checked == after_expiry

--- a/tests/manager/celery/tasks/test_license_expiration.py
+++ b/tests/manager/celery/tasks/test_license_expiration.py
@@ -50,8 +50,8 @@ class TestUpdateExpiredLicenses:
         db.license(pool, expires=None, checkouts_available=3, terms_concurrency=3)
         db.license(pool, expires=expired_at, checkouts_available=2, terms_concurrency=2)
 
-        # Simulate the pool being last updated before the expiry
-        pool.updated_at = last_updated
+        # Simulate the pool being last checked before the expiry
+        pool.last_checked = last_updated
         pool.licenses_available = 5  # stale — includes the now-expired license
 
         update_expired_licenses.delay().wait()
@@ -59,7 +59,7 @@ class TestUpdateExpiredLicenses:
         db.session.refresh(pool)
         # Only the active license contributes to availability
         assert pool.licenses_available == 3
-        assert pool.updated_at == now
+        assert pool.last_checked == now
 
     @freeze_time()
     def test_already_processed_expiry_skipped(
@@ -67,10 +67,10 @@ class TestUpdateExpiredLicenses:
         db: DatabaseTransactionFixture,
         celery_fixture: CeleryFixture,
     ) -> None:
-        """A pool whose updated_at is after the license's expiry is not re-processed."""
+        """A pool whose last_checked is after the license's expiry is not re-processed."""
         now = utc_now()
         expired_at = now - datetime.timedelta(hours=2)
-        last_updated = now - datetime.timedelta(hours=1)  # updated AFTER expiry
+        last_updated = now - datetime.timedelta(hours=1)  # checked AFTER expiry
 
         edition = db.edition()
         pool = db.licensepool(edition)
@@ -78,15 +78,15 @@ class TestUpdateExpiredLicenses:
         db.license(pool, expires=expired_at, checkouts_available=2, terms_concurrency=2)
 
         # Pool already accounts for the expiry
-        pool.updated_at = last_updated
+        pool.last_checked = last_updated
         pool.licenses_available = 0
 
         update_expired_licenses.delay().wait()
 
         db.session.refresh(pool)
-        # updated_at is unchanged — proves the pool was skipped, not just that the
+        # last_checked is unchanged — proves the pool was skipped, not just that the
         # result happened to be 0 (which an expired license would also produce).
-        assert pool.updated_at == last_updated
+        assert pool.last_checked == last_updated
 
     @freeze_time()
     def test_multiple_pools_only_stale_updated(
@@ -106,7 +106,7 @@ class TestUpdateExpiredLicenses:
         db.license(
             stale_pool, expires=expired_at, checkouts_available=3, terms_concurrency=3
         )
-        stale_pool.updated_at = before_expiry
+        stale_pool.last_checked = before_expiry
         stale_pool.licenses_available = 3  # stale
 
         edition2 = db.edition()
@@ -115,7 +115,7 @@ class TestUpdateExpiredLicenses:
         db.license(
             current_pool, expires=expired_at, checkouts_available=0, terms_concurrency=2
         )
-        current_pool.updated_at = after_expiry
+        current_pool.last_checked = after_expiry
         current_pool.licenses_available = 0  # already up to date
 
         update_expired_licenses.delay().wait()

--- a/tests/manager/celery/tasks/test_license_expiration.py
+++ b/tests/manager/celery/tasks/test_license_expiration.py
@@ -59,6 +59,7 @@ class TestExpireLicenses:
         db.session.refresh(pool)
         # Only the active license contributes to availability
         assert pool.licenses_available == 3
+        assert pool.updated_at == now
 
     @freeze_time()
     def test_already_processed_expiry_skipped(

--- a/tests/manager/celery/tasks/test_license_expiration.py
+++ b/tests/manager/celery/tasks/test_license_expiration.py
@@ -123,8 +123,9 @@ class TestUpdateExpiredLicenses:
         db.session.refresh(stale_pool)
         db.session.refresh(current_pool)
 
-        # Stale pool recalculated — expired license contributes 0
+        # Stale pool recalculated — expired license contributes 0; last_checked advanced
         assert stale_pool.licenses_available == 0
+        assert stale_pool.last_checked == now
         # Current pool untouched — last_checked unchanged proves it was skipped
         assert current_pool.licenses_available == 0
         assert current_pool.last_checked == after_expiry

--- a/tests/manager/celery/tasks/test_license_expiration.py
+++ b/tests/manager/celery/tasks/test_license_expiration.py
@@ -1,0 +1,127 @@
+import datetime
+
+from freezegun import freeze_time
+
+from palace.util.datetime_helpers import utc_now
+
+from palace.manager.celery.tasks.license_expiration import expire_licenses
+from palace.manager.sqlalchemy.model.licensing import LicensePoolType
+from tests.fixtures.celery import CeleryFixture
+from tests.fixtures.database import DatabaseTransactionFixture
+
+
+class TestExpireLicenses:
+    def test_no_expired_licenses(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+    ) -> None:
+        """Task runs cleanly when no licenses have expired."""
+        edition = db.edition()
+        pool = db.licensepool(edition)
+        pool.type = LicensePoolType.AGGREGATED
+        future = utc_now() + datetime.timedelta(days=30)
+        db.license(pool, expires=future, checkouts_available=5)
+        pool.update_availability_from_licenses()
+
+        original_available = pool.licenses_available
+
+        expire_licenses.delay().wait()
+
+        db.session.refresh(pool)
+        assert pool.licenses_available == original_available
+
+    @freeze_time()
+    def test_pool_with_newly_expired_license(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+    ) -> None:
+        """A pool whose license expired after the last update has its availability recalculated."""
+        now = utc_now()
+        expired_at = now - datetime.timedelta(hours=1)
+        last_updated = now - datetime.timedelta(hours=2)
+
+        edition = db.edition()
+        pool = db.licensepool(edition)
+        pool.type = LicensePoolType.AGGREGATED
+
+        # One active license, one that has already expired
+        db.license(pool, expires=None, checkouts_available=3, terms_concurrency=3)
+        db.license(pool, expires=expired_at, checkouts_available=2, terms_concurrency=2)
+
+        # Simulate the pool being last updated before the expiry
+        pool.updated_at = last_updated
+        pool.licenses_available = 5  # stale — includes the now-expired license
+
+        expire_licenses.delay().wait()
+
+        db.session.refresh(pool)
+        # Only the active license contributes to availability
+        assert pool.licenses_available == 3
+
+    @freeze_time()
+    def test_already_processed_expiry_skipped(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+    ) -> None:
+        """A pool whose updated_at is after the license's expiry is not re-processed."""
+        now = utc_now()
+        expired_at = now - datetime.timedelta(hours=2)
+        last_updated = now - datetime.timedelta(hours=1)  # updated AFTER expiry
+
+        edition = db.edition()
+        pool = db.licensepool(edition)
+        pool.type = LicensePoolType.AGGREGATED
+        db.license(pool, expires=expired_at, checkouts_available=2, terms_concurrency=2)
+
+        # Pool already accounts for the expiry
+        pool.updated_at = last_updated
+        pool.licenses_available = 0
+
+        expire_licenses.delay().wait()
+
+        db.session.refresh(pool)
+        # Still 0 — the task correctly skipped this pool
+        assert pool.licenses_available == 0
+
+    @freeze_time()
+    def test_multiple_pools_only_stale_updated(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+    ) -> None:
+        """Only pools with unprocessed expirations are updated; already-current pools are skipped."""
+        now = utc_now()
+        expired_at = now - datetime.timedelta(hours=1)
+        before_expiry = now - datetime.timedelta(hours=2)
+        after_expiry = now - datetime.timedelta(minutes=30)
+
+        edition1 = db.edition()
+        stale_pool = db.licensepool(edition1)
+        stale_pool.type = LicensePoolType.AGGREGATED
+        db.license(
+            stale_pool, expires=expired_at, checkouts_available=3, terms_concurrency=3
+        )
+        stale_pool.updated_at = before_expiry
+        stale_pool.licenses_available = 3  # stale
+
+        edition2 = db.edition()
+        current_pool = db.licensepool(edition2)
+        current_pool.type = LicensePoolType.AGGREGATED
+        db.license(
+            current_pool, expires=expired_at, checkouts_available=0, terms_concurrency=2
+        )
+        current_pool.updated_at = after_expiry
+        current_pool.licenses_available = 0  # already up to date
+
+        expire_licenses.delay().wait()
+
+        db.session.refresh(stale_pool)
+        db.session.refresh(current_pool)
+
+        # Stale pool recalculated — expired license contributes 0
+        assert stale_pool.licenses_available == 0
+        # Current pool untouched
+        assert current_pool.licenses_available == 0

--- a/tests/manager/celery/tasks/test_license_expiration.py
+++ b/tests/manager/celery/tasks/test_license_expiration.py
@@ -4,13 +4,13 @@ from freezegun import freeze_time
 
 from palace.util.datetime_helpers import utc_now
 
-from palace.manager.celery.tasks.license_expiration import expire_licenses
+from palace.manager.celery.tasks.license_expiration import update_expired_licenses
 from palace.manager.sqlalchemy.model.licensing import LicensePoolType
 from tests.fixtures.celery import CeleryFixture
 from tests.fixtures.database import DatabaseTransactionFixture
 
 
-class TestExpireLicenses:
+class TestUpdateExpiredLicenses:
     def test_no_expired_licenses(
         self,
         db: DatabaseTransactionFixture,
@@ -26,7 +26,7 @@ class TestExpireLicenses:
 
         original_available = pool.licenses_available
 
-        expire_licenses.delay().wait()
+        update_expired_licenses.delay().wait()
 
         db.session.refresh(pool)
         assert pool.licenses_available == original_available
@@ -54,7 +54,7 @@ class TestExpireLicenses:
         pool.updated_at = last_updated
         pool.licenses_available = 5  # stale — includes the now-expired license
 
-        expire_licenses.delay().wait()
+        update_expired_licenses.delay().wait()
 
         db.session.refresh(pool)
         # Only the active license contributes to availability
@@ -81,7 +81,7 @@ class TestExpireLicenses:
         pool.updated_at = last_updated
         pool.licenses_available = 0
 
-        expire_licenses.delay().wait()
+        update_expired_licenses.delay().wait()
 
         db.session.refresh(pool)
         # updated_at is unchanged — proves the pool was skipped, not just that the
@@ -118,7 +118,7 @@ class TestExpireLicenses:
         current_pool.updated_at = after_expiry
         current_pool.licenses_available = 0  # already up to date
 
-        expire_licenses.delay().wait()
+        update_expired_licenses.delay().wait()
 
         db.session.refresh(stale_pool)
         db.session.refresh(current_pool)

--- a/tests/manager/celery/tasks/test_opds_odl.py
+++ b/tests/manager/celery/tasks/test_opds_odl.py
@@ -1423,7 +1423,9 @@ class TestImportCollection:
             [imported_license] = imported_pool.licenses
             assert imported_license.is_inactive is False
 
-        # Reimport the license when it is expired
+        # Reimport the license when it is expired — the feed content is unchanged so the
+        # importer skips the update via hash-based change detection. Availability counts
+        # are recalculated by the expire_licenses Celery task, not by the importer.
         with freeze_time(license_expiry + timedelta(days=1)):
             # Import the test feed.
             (
@@ -1437,13 +1439,14 @@ class TestImportCollection:
             assert len(imported_works) == 1
             assert len(imported_pools) == 1
 
-            # Ensure that the license pool was successfully created, with no available copies.
+            # The import skipped the availability update because the feed hash is unchanged.
+            # The pool still reflects the pre-expiry state; expire_licenses will correct it.
             [imported_pool] = imported_pools
-            assert imported_pool.licenses_owned == 0
-            assert imported_pool.licenses_available == 0
+            assert imported_pool.licenses_owned == 1
+            assert imported_pool.licenses_available == 1
             assert len(imported_pool.licenses) == 1
 
-            # Ensure the license was imported and is expired.
+            # The license object itself correctly reports as inactive (time-based check).
             [imported_license] = imported_pool.licenses
             assert imported_license.is_inactive is True
 

--- a/tests/manager/celery/tasks/test_opds_odl.py
+++ b/tests/manager/celery/tasks/test_opds_odl.py
@@ -1425,7 +1425,7 @@ class TestImportCollection:
 
         # Reimport the license when it is expired — the feed content is unchanged so the
         # importer skips the update via hash-based change detection. Availability counts
-        # are recalculated by the expire_licenses Celery task, not by the importer.
+        # are recalculated by the update_expired_licenses Celery task, not by the importer.
         with freeze_time(license_expiry + timedelta(days=1)):
             # Import the test feed.
             (
@@ -1440,7 +1440,7 @@ class TestImportCollection:
             assert len(imported_pools) == 1
 
             # The import skipped the availability update because the feed hash is unchanged.
-            # The pool still reflects the pre-expiry state; expire_licenses will correct it.
+            # The pool still reflects the pre-expiry state; update_expired_licenses will correct it.
             [imported_pool] = imported_pools
             assert imported_pool.licenses_owned == 1
             assert imported_pool.licenses_available == 1

--- a/tests/manager/data_layer/test_circulation.py
+++ b/tests/manager/data_layer/test_circulation.py
@@ -951,6 +951,51 @@ class TestCirculationData:
         pool.updated_at_data_hash = circulation.calculate_hash()
         assert circulation.needs_apply(db.session, collection) is False
 
+    def test_needs_apply_aggregated_pool_uses_hash(
+        self, db: DatabaseTransactionFixture
+    ):
+        """AGGREGATED (ODL-style) pools participate in change tracking like any other pool.
+
+        Previously, pools with individual licenses always returned True regardless of the
+        content hash. Now the hash check applies uniformly; license expiry is handled by
+        a dedicated Celery task instead.
+        """
+        collection = db.collection()
+        today = utc_now()
+        one_day_ago = today - datetime.timedelta(days=1)
+        two_days_ago = today - datetime.timedelta(days=2)
+
+        license_data = LicenseData(
+            identifier="license-1",
+            checkout_url="https://example.com/checkout",
+            status_url="https://example.com/status",
+            status=LicenseStatus.available,
+            checkouts_available=5,
+        )
+        circulation = CirculationData(
+            data_source_name="Test data source",
+            primary_identifier_data=IdentifierData(
+                type="test identifier", identifier="3"
+            ),
+            updated_at=one_day_ago,
+            licenses=[license_data],
+            type=LicensePoolType.AGGREGATED,
+        )
+
+        # Pool doesn't exist yet — should apply
+        assert circulation.needs_apply(db.session, collection) is True
+
+        pool, _ = circulation.license_pool(db.session, collection, autocreate=True)
+        pool.updated_at = two_days_ago
+        pool.updated_at_data_hash = circulation.calculate_hash()
+
+        # Hash matches even though pool has individual licenses — should skip
+        assert circulation.needs_apply(db.session, collection) is False
+
+        # Pool is older than the data and hash differs — should apply
+        pool.updated_at_data_hash = "stale-hash"
+        assert circulation.needs_apply(db.session, collection) is True
+
     @pytest.mark.parametrize(
         "initial_type,new_type,expected_type",
         [

--- a/tests/manager/scripts/test_license_expiration.py
+++ b/tests/manager/scripts/test_license_expiration.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+import pytest
+
+from palace.util.log import LogLevel
+
+from palace.manager.scripts.license_expiration import UpdateExpiredLicensesScript
+from tests.fixtures.database import DatabaseTransactionFixture
+
+
+class TestUpdateExpiredLicensesScript:
+    def test_queues_task(
+        self,
+        db: DatabaseTransactionFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(LogLevel.info)
+        with patch(
+            "palace.manager.scripts.license_expiration.update_expired_licenses"
+        ) as task_mock:
+            UpdateExpiredLicensesScript(db.session).run()
+            assert task_mock.delay.call_count == 1
+            assert (
+                'The "update_expired_licenses" task has been queued for execution.'
+                in caplog.text
+            )


### PR DESCRIPTION
## Description

Introduces a dedicated Celery task (`update_expired_licenses`) that processes ODL license expirations, and removes the carve-out that prevented AGGREGATED pools from participating in content-hash-based change tracking.

## Motivation and Context

ODL-style (`AGGREGATED`) license pools carry individual `License` rows with `expires` timestamps. Because expiry is time-dependent, a pool's availability can drop to zero without the vendor feed changing at all — making hash-based change detection blind to it.

The previous workaround forced every import pass to always re-process AGGREGATED pools, bypassing the hash check entirely (the `self.licenses is None` guard in `CirculationData.apply()` and an early `return True` in `needs_apply()`). This had two downsides:

1. ODL pools could never skip unchanged imports — every feed poll triggered a full re-apply.
2. Time-based expiry concerns were tangled into the import pipeline rather than being handled as a scheduled concern.

**Fix:** Remove the carve-out so ODL pools participate in normal hash-based change tracking, and add a dedicated Celery task that finds pools where a license expired after the pool was last checked, then calls `update_availability_from_licenses()` on each stale pool.

### New task: `update_expired_licenses`

Scheduled hourly at :30 (every hour at 30 minutes past the hour). Uses a targeted query to find only pools that need updating:

- License has `expires <= now` (it has expired)
- Pool's `last_checked < license.expires` (the expiry occurred after the last availability recalculation)

`update_availability_from_licenses(as_of=now)` advances `last_checked` to `now`, so processed pools are automatically excluded on the next run. The `updated_at` importer freshness sentinel is never touched by this task.

This is O(newly-stale pools) rather than O(all AGGREGATED pools), so it scales efficiently even as the ODL catalog grows.

A `bin/update_expired_licenses` script is also provided for manual invocation.

## How Has This Been Tested?

- `mypy` passes clean on all modified and new files.
- New test class `TestUpdateExpiredLicenses` (`tests/manager/celery/tasks/test_license_expiration.py`) covers:
  - No expired licenses: pool unchanged
  - Stale pool (license expired after last check): availability recalculated downward; `last_checked` advanced to `now`
  - Already-processed expiry: pool correctly skipped; `last_checked` unchanged
  - Mixed multi-pool scenario: only stale pool updated; current pool's `last_checked` unchanged
- New `TestUpdateExpiredLicensesScript` (`tests/manager/scripts/test_license_expiration.py`) verifies the script queues the task and logs the confirmation message.
- New test `test_needs_apply_aggregated_pool_uses_hash` (`tests/manager/data_layer/test_circulation.py`) confirms AGGREGATED pools now go through the normal hash check rather than always returning `True`.
- Full DB-dependent suite: `tox -e py312-docker -- --no-cov tests/manager/data_layer/test_circulation.py tests/manager/celery/tasks/test_license_expiration.py tests/manager/scripts/test_license_expiration.py`

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.