### PR TITLE
Include UNLIMITED pools in reaper's existing-identifiers query (PP-4267)

### DIFF
--- a/src/palace/manager/celery/tasks/identifiers.py
+++ b/src/palace/manager/celery/tasks/identifiers.py
@@ -2,7 +2,7 @@ from functools import partial
 
 from celery import shared_task
 from celery.canvas import Signature, chord
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import raiseload
 
 from palace.util.exceptions import PalaceValueError
@@ -21,14 +21,20 @@ from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import (
     LicensePool,
     LicensePoolStatus,
+    LicensePoolType,
 )
 
 
 @shared_task(queue=QueueNames.default, bind=True)
 def existing_available_identifiers(task: Task, collection_id: int) -> IdentifierSet:
     """
-    Retrieves all identifiers that have available licensepools (where licenses_available > 0 and
-    licenses_owned > 0) in the specified collection and returns them as a Redis IdentifierSet.
+    Retrieves all identifiers in the specified collection whose license pools are
+    currently available, returning them as a Redis IdentifierSet.
+
+    A pool is considered available if it is an UNLIMITED pool with ACTIVE status,
+    or a metered/aggregated pool with non-zero owned and available license counts.
+    UNLIMITED pools always have licenses_owned and licenses_available set to 0,
+    so they need to be matched on status instead.
 
     This function is designed to be used as part of a chord operation that identifies and
     marks identifiers not present in a distributor's feed as unavailable.
@@ -46,8 +52,17 @@ def existing_available_identifiers(task: Task, collection_id: int) -> Identifier
                 .join(LicensePool)
                 .where(
                     LicensePool.collection_id == collection_id,
-                    LicensePool.licenses_available != 0,
-                    LicensePool.licenses_owned != 0,
+                    or_(
+                        and_(
+                            LicensePool.type == LicensePoolType.UNLIMITED,
+                            LicensePool.status == LicensePoolStatus.ACTIVE,
+                        ),
+                        and_(
+                            LicensePool.type != LicensePoolType.UNLIMITED,
+                            LicensePool.licenses_available != 0,
+                            LicensePool.licenses_owned != 0,
+                        ),
+                    ),
                 )
                 .options(raiseload("*"))
             )

--- a/tests/manager/celery/tasks/test_identifiers.py
+++ b/tests/manager/celery/tasks/test_identifiers.py
@@ -12,7 +12,11 @@ from palace.manager.celery.tasks import identifiers
 from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.service.redis.models.set import IdentifierSet, RedisSetKwargs
 from palace.manager.sqlalchemy.model.collection import Collection
-from palace.manager.sqlalchemy.model.licensing import LicensePool
+from palace.manager.sqlalchemy.model.licensing import (
+    LicensePool,
+    LicensePoolStatus,
+    LicensePoolType,
+)
 from tests.fixtures.celery import CeleryFixture
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.redis import RedisFixture
@@ -98,6 +102,43 @@ class TestExistingAvailableIdentifiers:
         assert len(identifier_set) == len(license_pools)
         assert identifier_set.get() == identifier_tasks_fixture.identifiers(
             license_pools
+        )
+
+    def test_unlimited_pools_included(
+        self,
+        db: DatabaseTransactionFixture,
+        identifier_tasks_fixture: IdentifierTasksFixture,
+    ) -> None:
+        """
+        UNLIMITED license pools always have licenses_owned and licenses_available
+        set to 0, so they must be matched on status, not on license counts.
+        Without this, reaping is silently a no-op for OPDS for Distributors and
+        any other feed that produces UNLIMITED pools.
+        """
+        collection = db.collection()
+        active_pools = [
+            db.licensepool(edition=None, collection=collection, unlimited_access=True)
+            for _ in range(3)
+        ]
+        for pool in active_pools:
+            pool.status = LicensePoolStatus.ACTIVE
+            assert pool.type == LicensePoolType.UNLIMITED
+            assert pool.licenses_owned == 0
+            assert pool.licenses_available == 0
+
+        # A REMOVED unlimited pool should not be considered available.
+        removed_pool = db.licensepool(
+            edition=None, collection=collection, unlimited_access=True
+        )
+        removed_pool.status = LicensePoolStatus.REMOVED
+
+        response = identifiers.existing_available_identifiers.delay(
+            collection.id
+        ).wait()
+        identifier_set = identifier_tasks_fixture.set_from_response(response)
+
+        assert identifier_set.get() == identifier_tasks_fixture.identifiers(
+            active_pools
         )
 
     def test_cleanup_on_exception(


### PR DESCRIPTION
## Description

Fix `existing_available_identifiers` so it correctly considers `LicensePoolType.UNLIMITED` pools as available. The query previously filtered on `licenses_available != 0 AND licenses_owned != 0`, but UNLIMITED pools have both columns forced to `0` in `CirculationData.apply`, so they were always excluded. The query now matches UNLIMITED pools on `status == ACTIVE` while keeping the original license-count check for metered/aggregated pools.

Added `TestExistingAvailableIdentifiers.test_unlimited_pools_included` covering the new branch, including a REMOVED unlimited pool decoy.

## Motivation and Context

The reap chord (`create_mark_unavailable_chord`) runs `existing_available_identifiers` and the active-identifiers signature in parallel, then diffs the two sets in `mark_identifiers_unavailable`. Because the existing-set query never matched any UNLIMITED pool, the "before" set was always empty, the underlying Redis key was never created, and `mark_identifiers_unavailable` short-circuited with:

```
WARNING palace.manager.celery.tasks.identifiers.mark_identifiers_unavailable: Existing identifiers set does not exist in Redis. No identifiers to mark as unavailable.
```

Net effect: **reaping has been a silent no-op for OPDS for Distributors collections** (and any other importer that produces UNLIMITED pools — opds1/opds2/opds_odl etc.) — no withdrawn titles have been marked `REMOVED` by the reaper.

The bug was introduced when `LicensePoolType.UNLIMITED` started zeroing the count columns (PP-2992) without updating the older identifiers reaper query (PP-2469).

JIRA: PP-4267

## How Has This Been Tested?

- New regression test `test_unlimited_pools_included` builds three ACTIVE UNLIMITED pools plus one REMOVED UNLIMITED pool and asserts only the active three are returned. Fails on `main`, passes with the fix.
- Existing tests in `TestExistingAvailableIdentifiers` continue to pass (metered behavior unchanged).
- `mypy` clean.

## Checklist

- [x] All new and existing tests passed.