### PR TITLE
Coerce miscased a11y feature/hazard values with a warning (PP-4213)

### DIFF
--- a/packages/palace-opds/src/palace/opds/a11y.py
+++ b/packages/palace-opds/src/palace/opds/a11y.py
@@ -7,15 +7,57 @@ https://readium.org/webpub-manifest/schema/a11y.schema.json
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from enum import StrEnum, auto
 from functools import cached_property
 from typing import Any, cast
 
-from pydantic import Field, SerializerFunctionWrapHandler, model_serializer
+from pydantic import (
+    Field,
+    SerializerFunctionWrapHandler,
+    field_validator,
+    model_serializer,
+)
 
 from palace.opds.base import BaseOpdsModel
 from palace.opds.util import StrOrTuple, drop_if_falsy, obj_or_tuple_to_tuple
+
+_logger = logging.getLogger(__name__)
+
+
+def _coerce_enum_list(value: Any, enum_cls: type[StrEnum], field_name: str) -> Any:
+    """Coerce a list of strings to enum members, logging and dropping unknown values.
+
+    Performs a case-insensitive match against ``enum_cls`` values so that
+    publications with miscased entries (e.g. ``"TaggedPDF"`` instead of
+    ``"taggedPDF"``) still import. Unknown values are dropped with a warning
+    so they can be reported upstream.
+    """
+    if not isinstance(value, list):
+        return value
+    lookup = {member.value.lower(): member for member in enum_cls}
+    coerced: list[Any] = []
+    for item in value:
+        if isinstance(item, enum_cls):
+            coerced.append(item)
+            continue
+        if isinstance(item, str):
+            match = lookup.get(item.lower())
+            if match is not None:
+                if match.value != item:
+                    _logger.warning(
+                        "Coerced %s value %r to canonical %r",
+                        field_name,
+                        item,
+                        match.value,
+                    )
+                coerced.append(match)
+                continue
+            _logger.warning("Dropping unknown %s value %r", field_name, item)
+            continue
+        coerced.append(item)
+    return coerced
 
 
 class AccessMode(StrEnum):
@@ -205,6 +247,16 @@ class Accessibility(BaseOpdsModel):
     hazard: list[AccessibilityHazard] = Field(default_factory=list)
     certification: Certification | None = None
     summary: str | None = None
+
+    @field_validator("feature", mode="before")
+    @classmethod
+    def _coerce_features(cls, value: Any) -> Any:
+        return _coerce_enum_list(value, AccessibilityFeature, "feature")
+
+    @field_validator("hazard", mode="before")
+    @classmethod
+    def _coerce_hazards(cls, value: Any) -> Any:
+        return _coerce_enum_list(value, AccessibilityHazard, "hazard")
 
     @model_serializer(mode="wrap")
     def _serialize(self, serializer: SerializerFunctionWrapHandler) -> dict[str, Any]:

--- a/tests/palace_opds/test_a11y.py
+++ b/tests/palace_opds/test_a11y.py
@@ -1,7 +1,12 @@
 """Tests for accessibility metadata models."""
 
+import logging
+
+import pytest
+
 from palace.opds.a11y import (
     Accessibility,
+    AccessibilityFeature,
     AccessibilityHazard,
     Certification,
     Exemption,
@@ -106,3 +111,47 @@ class TestAccessibility:
         a11y = Accessibility()
         data = a11y.serialize()
         assert "exemption" not in data
+
+    def test_feature_miscased_coerced_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Miscased feature values are coerced to canonical form and logged."""
+        with caplog.at_level(logging.WARNING, logger="palace.opds.a11y"):
+            a11y = Accessibility.model_validate(
+                {"feature": ["TaggedPDF", "mathml", "ARIA"]}
+            )
+        assert a11y.feature == [
+            AccessibilityFeature.tagged_pdf,
+            AccessibilityFeature.math_ml,
+            AccessibilityFeature.ARIA,
+        ]
+        assert a11y.serialize()["feature"] == ["taggedPDF", "MathML", "ARIA"]
+        warnings = [r.getMessage() for r in caplog.records]
+        assert any("'TaggedPDF'" in m and "'taggedPDF'" in m for m in warnings)
+        assert any("'mathml'" in m and "'MathML'" in m for m in warnings)
+        # ARIA was already canonical, so no warning for it.
+        assert not any("'ARIA'" in m for m in warnings)
+
+    def test_feature_unknown_dropped_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unknown feature values are dropped and logged."""
+        with caplog.at_level(logging.WARNING, logger="palace.opds.a11y"):
+            a11y = Accessibility.model_validate(
+                {"feature": ["taggedPDF", "notARealFeature"]}
+            )
+        assert a11y.feature == [AccessibilityFeature.tagged_pdf]
+        warnings = [r.getMessage() for r in caplog.records]
+        assert any("Dropping" in m and "'notARealFeature'" in m for m in warnings)
+
+    def test_hazard_unknown_dropped_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unknown hazard values are dropped and logged."""
+        with caplog.at_level(logging.WARNING, logger="palace.opds.a11y"):
+            a11y = Accessibility.model_validate(
+                {"hazard": ["noFlashingHazard", "bogus"]}
+            )
+        assert a11y.hazard == [AccessibilityHazard.no_flashing_hazard]
+        warnings = [r.getMessage() for r in caplog.records]
+        assert any("Dropping" in m and "'bogus'" in m for m in warnings)


### PR DESCRIPTION
## Description

When parsing OPDS publications, miscased accessibility `feature`/`hazard` values previously failed `StrEnum` validation and caused the whole publication to be rejected. The `Accessibility` model now case-insensitively coerces these list entries to their canonical spec form, and drops unknown values rather than failing. Both branches log a `palace.opds.a11y` WARNING so the OPDS validator (which captures that logger) can surface them for upstream reporting.

## Motivation and Context

Found while investigating PP-4213. DeMarque publications include miscased entries — for example, `"TaggedPDF"` instead of the spec's `"taggedPDF"`:

```json
"accessibility": {
  "summary": "This publication lacks alternative text for non-text elements, but it otherwise meets WCAG 2.2 Level A. Furthermore, the publication generally has been produced to meet WCAG Level AA, but it has not been checked for color contrast within images.",
  "conformsTo": "http://www.idpf.org/epub/a11y/accessibility-20170105.html#wcag-a",
  "feature": [
    "readingOrder",
    "structuralNavigation",
    "tableOfContents",
    "index",
    "TaggedPDF",
    "ttsMarkup"
  ],
  "accessModeSufficient": ["textual"]
}
```

These publications now import successfully with the canonical value persisted, while leaving a warning trail so we can ask DeMarque to fix the source data.

## How Has This Been Tested?

Added unit tests in `tests/palace_opds/test_a11y.py` covering: miscased values are coerced to canonical form and emit a warning; already-canonical values produce no warning; unknown `feature` and `hazard` values are dropped with a warning. `tox -e py312-docker -- --no-cov tests/palace_opds/test_a11y.py` passes.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.