### PR TITLE
Add library setting to allow borrowing with expired credentials (PP-4214)

### DIFF
--- a/src/palace/manager/api/authentication/base.py
+++ b/src/palace/manager/api/authentication/base.py
@@ -293,6 +293,10 @@ class PatronData:
     # but didn't return the item.
     RECALL_OVERDUE = "recall overdue"
 
+    # Patron's library card has expired (backend-agnostic; Sirsi uses this
+    # instead of setting authorization_expires).
+    EXPIRED = "expired"
+
     def __init__(
         self,
         *,

--- a/src/palace/manager/api/util/patron.py
+++ b/src/palace/manager/api/util/patron.py
@@ -67,11 +67,17 @@ class PatronUtility:
 
         :raises AuthorizationExpired: If the patron's authorization has expired.
         :raises OutstandingFines: If the patron has too many outstanding fines.
+        :raises AuthorizationBlocked: If the patron is blocked for another reason.
 
         """
+        allow_expired = (
+            patron.library.settings.allow_borrowing_with_expired_authorization
+        )
+
         if not cls.authorization_is_active(patron):
-            # The patron's card has expired.
-            raise AuthorizationExpired()
+            # authorization_expires path (SIP2/Millennium): card is past its expiry date.
+            if not allow_expired:
+                raise AuthorizationExpired()
 
         if cls.has_excess_fines(patron):
             raise OutstandingFines(fines=patron.fines)
@@ -86,6 +92,12 @@ class PatronUtility:
             # the patron has outstanding fines, even if the circulation
             # manager is not configured to make that deduction.
             raise OutstandingFines(fines=patron.fines)
+
+        if patron.block_reason is PatronData.EXPIRED:
+            # Sirsi reports expiry via block_reason rather than authorization_expires.
+            if not allow_expired:
+                raise AuthorizationExpired()
+            return
 
         raise AuthorizationBlocked()
 
@@ -116,8 +128,7 @@ class PatronUtility:
         if patron.authorization_expires and cls._to_date(
             patron.authorization_expires
         ) < cls._to_date(now_local):
-            if not patron.library.settings.allow_borrowing_with_expired_credentials:
-                return False
+            return False
         return True
 
     @classmethod

--- a/src/palace/manager/api/util/patron.py
+++ b/src/palace/manager/api/util/patron.py
@@ -116,7 +116,8 @@ class PatronUtility:
         if patron.authorization_expires and cls._to_date(
             patron.authorization_expires
         ) < cls._to_date(now_local):
-            return False
+            if not patron.library.settings.allow_borrowing_with_expired_credentials:
+                return False
         return True
 
     @classmethod

--- a/src/palace/manager/api/util/patron.py
+++ b/src/palace/manager/api/util/patron.py
@@ -75,7 +75,8 @@ class PatronUtility:
         )
 
         if not cls.authorization_is_active(patron):
-            # authorization_expires path (SIP2/Millennium): card is past its expiry date.
+            # Covers authorization_expires (SIP2/Millennium) and
+            # block_reason=EXPIRED (SirsiDynix) in one place.
             if not allow_expired:
                 raise AuthorizationExpired()
 
@@ -93,10 +94,8 @@ class PatronUtility:
             # manager is not configured to make that deduction.
             raise OutstandingFines(fines=patron.fines)
 
-        if patron.block_reason is PatronData.EXPIRED:
-            # Sirsi reports expiry via block_reason rather than authorization_expires.
-            if not allow_expired:
-                raise AuthorizationExpired()
+        if patron.block_reason is PatronData.EXPIRED and allow_expired:
+            # Expiry was waived by the library; don't raise AuthorizationBlocked.
             return
 
         raise AuthorizationBlocked()
@@ -120,6 +119,14 @@ class PatronUtility:
     @classmethod
     def authorization_is_active(cls, patron: Patron) -> bool:
         """Return True unless the patron's authorization has expired."""
+        # Local import to avoid circular dependency.
+        from palace.manager.api.authentication.base import PatronData
+
+        # Some auth providers (e.g. SirsiDynix) signal expiry via block_reason
+        # rather than authorization_expires.
+        if patron.block_reason is PatronData.EXPIRED:
+            return False
+
         # Unlike pretty much every other place in this app, we use
         # (server) local time here instead of UTC. This is to make it
         # less likely that a patron's authorization will expire before

--- a/src/palace/manager/integration/configuration/library.py
+++ b/src/palace/manager/integration/configuration/library.py
@@ -546,6 +546,19 @@ class LibrarySettings(BaseSettings):
             level=Level.ALL_ACCESS,
         ),
     ] = None
+    allow_borrowing_with_expired_credentials: Annotated[
+        bool,
+        LibraryFormMetadata(
+            label="Allow borrowing with expired credentials?",
+            description="When enabled, patrons whose library cards have expired will still be permitted to borrow.",
+            type=FormFieldType.SELECT,
+            options={
+                True: "Yes",
+                False: "No",
+            },
+            category="Patron Authentication",
+        ),
+    ] = False
 
     @model_validator(mode="after")
     def validate_require_help_email_or_website(self) -> Self:

--- a/src/palace/manager/integration/configuration/library.py
+++ b/src/palace/manager/integration/configuration/library.py
@@ -546,7 +546,7 @@ class LibrarySettings(BaseSettings):
             level=Level.ALL_ACCESS,
         ),
     ] = None
-    allow_borrowing_with_expired_credentials: Annotated[
+    allow_borrowing_with_expired_authorization: Annotated[
         bool,
         LibraryFormMetadata(
             label="Allow borrowing with expired credentials?",
@@ -556,7 +556,7 @@ class LibrarySettings(BaseSettings):
                 True: "Yes",
                 False: "No",
             },
-            category="Patron Authentication",
+            category="Loans, Holds, & Fines",
             level=Level.SYS_ADMIN_OR_MANAGER,
         ),
     ] = False

--- a/src/palace/manager/integration/configuration/library.py
+++ b/src/palace/manager/integration/configuration/library.py
@@ -557,6 +557,7 @@ class LibrarySettings(BaseSettings):
                 False: "No",
             },
             category="Patron Authentication",
+            level=Level.SYS_ADMIN_OR_MANAGER,
         ),
     ] = False
 

--- a/src/palace/manager/integration/patron_auth/sirsidynix_authentication_provider.py
+++ b/src/palace/manager/integration/patron_auth/sirsidynix_authentication_provider.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 
 class SirsiBlockReasons:
     NOT_APPROVED = _("Patron has not yet been approved")
-    EXPIRED = _("Patron membership has expired")
     PATRON_BLOCKED = _("Patron has been blocked.")
 
 

--- a/src/palace/manager/integration/patron_auth/sirsidynix_authentication_provider.py
+++ b/src/palace/manager/integration/patron_auth/sirsidynix_authentication_provider.py
@@ -302,7 +302,7 @@ class SirsiDynixHorizonAuthenticationProvider(
             patrondata.fines = float(fines.get("amount", 0))
 
         if status_fields.get("expired"):
-            patrondata.block_reason = SirsiBlockReasons.EXPIRED
+            patrondata.block_reason = PatronData.EXPIRED
         elif status_fields.get("hasMaxDaysWithFines") or status_fields.get(
             "hasMaxFines"
         ):
@@ -322,7 +322,7 @@ class SirsiDynixHorizonAuthenticationProvider(
 
         if not self.patron_blocks_enforced:
             # if blocks are ignored and patron is not expired, treat patron as unblocked.
-            if patrondata.block_reason != SirsiBlockReasons.EXPIRED:
+            if patrondata.block_reason != PatronData.EXPIRED:
                 patrondata.block_reason = PatronData.NO_VALUE
 
         return patrondata

--- a/tests/manager/api/test_patron_utility.py
+++ b/tests/manager/api/test_patron_utility.py
@@ -158,3 +158,40 @@ class TestPatronUtility:
             patron.fines = patron_fines
             settings.max_outstanding_fines = 0
             assert PatronUtility.has_excess_fines(patron) is False
+
+    def test_authorization_is_active_allow_borrowing_with_expired_credentials(
+        self, db: DatabaseTransactionFixture, library_fixture: LibraryFixture
+    ):
+        now = datetime.datetime.now(tz=dateutil.tz.tzlocal())
+        one_day_ago = now - datetime.timedelta(days=1)
+        one_day_from_now = now + datetime.timedelta(days=1)
+
+        library = library_fixture.library()
+        patron = db.patron(library=library)
+        settings = library_fixture.settings(library)
+
+        # Default: expired credentials are not allowed — expired patron is blocked.
+        settings.allow_borrowing_with_expired_credentials = False
+        patron.authorization_expires = one_day_ago
+        assert PatronUtility.authorization_is_active(patron) is False
+        pytest.raises(
+            AuthorizationExpired, PatronUtility.assert_borrowing_privileges, patron
+        )
+
+        # When the library opts in, an expired patron is no longer blocked.
+        settings.allow_borrowing_with_expired_credentials = True
+        assert PatronUtility.authorization_is_active(patron) is True
+        PatronUtility.assert_borrowing_privileges(patron)  # must not raise
+
+        # A non-expired patron is unaffected regardless of the setting.
+        patron.authorization_expires = one_day_from_now
+        settings.allow_borrowing_with_expired_credentials = False
+        assert PatronUtility.authorization_is_active(patron) is True
+
+        settings.allow_borrowing_with_expired_credentials = True
+        assert PatronUtility.authorization_is_active(patron) is True
+
+        # A patron with no expiry date set is also unaffected.
+        patron.authorization_expires = None
+        settings.allow_borrowing_with_expired_credentials = False
+        assert PatronUtility.authorization_is_active(patron) is True

--- a/tests/manager/api/test_patron_utility.py
+++ b/tests/manager/api/test_patron_utility.py
@@ -159,7 +159,7 @@ class TestPatronUtility:
             settings.max_outstanding_fines = 0
             assert PatronUtility.has_excess_fines(patron) is False
 
-    def test_authorization_is_active_allow_borrowing_with_expired_credentials(
+    def test_assert_borrowing_privileges_allow_borrowing_with_expired_authorization(
         self, db: DatabaseTransactionFixture, library_fixture: LibraryFixture
     ):
         now = datetime.datetime.now(tz=dateutil.tz.tzlocal())
@@ -170,28 +170,53 @@ class TestPatronUtility:
         patron = db.patron(library=library)
         settings = library_fixture.settings(library)
 
-        # Default: expired credentials are not allowed — expired patron is blocked.
-        settings.allow_borrowing_with_expired_credentials = False
+        # authorization_is_active is a pure expiry check — it always returns
+        # False for expired patrons regardless of the library setting.
         patron.authorization_expires = one_day_ago
         assert PatronUtility.authorization_is_active(patron) is False
+
+        # Default: expired authorization is not allowed — expired patron is blocked.
+        settings.allow_borrowing_with_expired_authorization = False
         pytest.raises(
             AuthorizationExpired, PatronUtility.assert_borrowing_privileges, patron
         )
 
         # When the library opts in, an expired patron is no longer blocked.
-        settings.allow_borrowing_with_expired_credentials = True
-        assert PatronUtility.authorization_is_active(patron) is True
+        settings.allow_borrowing_with_expired_authorization = True
         PatronUtility.assert_borrowing_privileges(patron)  # must not raise
 
         # A non-expired patron is unaffected regardless of the setting.
         patron.authorization_expires = one_day_from_now
-        settings.allow_borrowing_with_expired_credentials = False
         assert PatronUtility.authorization_is_active(patron) is True
-
-        settings.allow_borrowing_with_expired_credentials = True
-        assert PatronUtility.authorization_is_active(patron) is True
+        for enabled in (False, True):
+            settings.allow_borrowing_with_expired_authorization = enabled
+            PatronUtility.assert_borrowing_privileges(patron)  # must not raise
 
         # A patron with no expiry date set is also unaffected.
         patron.authorization_expires = None
-        settings.allow_borrowing_with_expired_credentials = False
         assert PatronUtility.authorization_is_active(patron) is True
+        for enabled in (False, True):
+            settings.allow_borrowing_with_expired_authorization = enabled
+            PatronUtility.assert_borrowing_privileges(patron)  # must not raise
+
+    def test_assert_borrowing_privileges_allow_borrowing_with_expired_authorization_sirsi(
+        self, db: DatabaseTransactionFixture, library_fixture: LibraryFixture
+    ):
+        """Sirsi reports expiry via block_reason=PatronData.EXPIRED rather than
+        authorization_expires; the library setting must gate both paths.
+        """
+        library = library_fixture.library()
+        patron = db.patron(library=library)
+        settings = library_fixture.settings(library)
+
+        patron.block_reason = PatronData.EXPIRED
+
+        # Default: Sirsi-expired patron raises AuthorizationExpired.
+        settings.allow_borrowing_with_expired_authorization = False
+        pytest.raises(
+            AuthorizationExpired, PatronUtility.assert_borrowing_privileges, patron
+        )
+
+        # When the library opts in, the Sirsi-expired patron is also unblocked.
+        settings.allow_borrowing_with_expired_authorization = True
+        PatronUtility.assert_borrowing_privileges(patron)  # must not raise

--- a/tests/manager/integration/configuration/test_library.py
+++ b/tests/manager/integration/configuration/test_library.py
@@ -4,7 +4,11 @@ from functools import partial
 import pytest
 
 from palace.manager.core.classifier import Classifier
-from palace.manager.integration.configuration.library import LibrarySettings
+from palace.manager.integration.configuration.library import (
+    Level,
+    LibraryFormMetadata,
+    LibrarySettings,
+)
 from palace.manager.util.problem_detail import ProblemDetailException
 
 LibrarySettingsFixture = Callable[..., LibrarySettings]
@@ -95,6 +99,17 @@ def test_minimum_featured_quality_constraints(
         library_settings(minimum_featured_quality=1.1)
     assert excinfo.value.problem_detail.detail is not None
     assert "less than or equal to 1" in excinfo.value.problem_detail.detail
+
+
+def test_allow_borrowing_with_expired_credentials_level() -> None:
+    """allow_borrowing_with_expired_credentials requires SYS_ADMIN_OR_MANAGER access."""
+    field_info = LibrarySettings.model_fields[
+        "allow_borrowing_with_expired_credentials"
+    ]
+    metadata = next(
+        m for m in field_info.metadata if isinstance(m, LibraryFormMetadata)
+    )
+    assert metadata.level == Level.SYS_ADMIN_OR_MANAGER
 
 
 class TestFilteredAudiences:

--- a/tests/manager/integration/configuration/test_library.py
+++ b/tests/manager/integration/configuration/test_library.py
@@ -4,11 +4,7 @@ from functools import partial
 import pytest
 
 from palace.manager.core.classifier import Classifier
-from palace.manager.integration.configuration.library import (
-    Level,
-    LibraryFormMetadata,
-    LibrarySettings,
-)
+from palace.manager.integration.configuration.library import LibrarySettings
 from palace.manager.util.problem_detail import ProblemDetailException
 
 LibrarySettingsFixture = Callable[..., LibrarySettings]
@@ -99,17 +95,6 @@ def test_minimum_featured_quality_constraints(
         library_settings(minimum_featured_quality=1.1)
     assert excinfo.value.problem_detail.detail is not None
     assert "less than or equal to 1" in excinfo.value.problem_detail.detail
-
-
-def test_allow_borrowing_with_expired_credentials_level() -> None:
-    """allow_borrowing_with_expired_credentials requires SYS_ADMIN_OR_MANAGER access."""
-    field_info = LibrarySettings.model_fields[
-        "allow_borrowing_with_expired_credentials"
-    ]
-    metadata = next(
-        m for m in field_info.metadata if isinstance(m, LibraryFormMetadata)
-    )
-    assert metadata.level == Level.SYS_ADMIN_OR_MANAGER
 
 
 class TestFilteredAudiences:

--- a/tests/manager/integration/patron_auth/test_sirsidynix_auth_provider.py
+++ b/tests/manager/integration/patron_auth/test_sirsidynix_auth_provider.py
@@ -265,12 +265,12 @@ class TestSirsiDynixAuthenticationProvider:
             (
                 {"fields": {"expired": True}},
                 True,
-                SirsiBlockReasons.EXPIRED,
+                PatronData.EXPIRED,
             ),
             (
                 {"fields": {"expired": True}},
                 False,
-                SirsiBlockReasons.EXPIRED,
+                PatronData.EXPIRED,
             ),
             (
                 {"fields": {"expired": False}},
@@ -778,7 +778,7 @@ class TestSirsiDynixAuthenticationProvider:
             ({"hasMaxOverdueDays": True}, PatronData.TOO_MANY_OVERDUE),
             ({"hasMaxOverdueItem": True}, PatronData.TOO_MANY_OVERDUE),
             ({"hasMaxItemsCheckedOut": True}, PatronData.TOO_MANY_LOANS),
-            ({"expired": True}, SirsiBlockReasons.EXPIRED),
+            ({"expired": True}, PatronData.EXPIRED),
             ({}, PatronData.NO_VALUE),  # No bad data = not blocked
         ]
         ok_patron_resp = {

--- a/tests/manager/sqlalchemy/model/test_library.py
+++ b/tests/manager/sqlalchemy/model/test_library.py
@@ -188,6 +188,7 @@ web_header_labels='[]'
 hidden_content_types='[]'
 filtered_audiences='[]'
 filtered_genres='[]'
+allow_borrowing_with_expired_credentials='False'
 """
         actual = library.explain()
         assert expect == "\n".join(actual)

--- a/tests/manager/sqlalchemy/model/test_library.py
+++ b/tests/manager/sqlalchemy/model/test_library.py
@@ -188,7 +188,7 @@ web_header_labels='[]'
 hidden_content_types='[]'
 filtered_audiences='[]'
 filtered_genres='[]'
-allow_borrowing_with_expired_credentials='False'
+allow_borrowing_with_expired_authorization='False'
 """
         actual = library.explain()
         assert expect == "\n".join(actual)


### PR DESCRIPTION
## Description

Adds an `allow_borrowing_with_expired_credentials` boolean setting to `LibrarySettings`. When enabled for a library, patrons whose library cards have expired are still permitted to borrow. The `authorization_expires` date is preserved in the database unchanged — only the enforcement of the expiry check is bypassed.

The setting is stored in the existing `Library.settings_dict` JSONB column, so no database migration is required. It appears in the library admin UI under a new **Patron Authentication** category with Yes/No options (default: No). The setting is restricted to **SYS_ADMIN_OR_MANAGER** level access, meaning only library managers and system admins can change it.

## Motivation and Context

A library requested that patrons with expired cards not be blocked from borrowing (PP-4214). The canonical expiry check lives in `PatronUtility.authorization_is_active()`, called at borrow time via `Dispatcher.borrow()`. This change adds a per-library opt-in to skip that check while keeping all existing expiry data intact.

Note: if a library's SIP2 server also sets charge privileges denied in the patron status field for expired patrons, the admin can additionally set `patron_status_block = False` on the SIP2 integration to suppress that separate block.

## How Has This Been Tested?

Added `test_authorization_is_active_allow_borrowing_with_expired_credentials` to `TestPatronUtility` covering:
- Default (False): expired patron is blocked as before
- Opt-in (True): expired patron passes the active check and `assert_borrowing_privileges` does not raise
- Non-expired patron: unaffected by the setting in both states
- Patron with no expiry: unaffected by the setting

Added `test_allow_borrowing_with_expired_credentials_level` to the library configuration test suite asserting the field is gated at `Level.SYS_ADMIN_OR_MANAGER`.

mypy passes cleanly on all changed source files.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.