### PR TITLE
Standardize SAML route path structure

### DIFF
--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -4,6 +4,7 @@ from functools import update_wrapper, wraps
 import flask
 from flask import Response, make_response, request
 from flask_cors.core import get_cors_options, set_cors_headers
+from werkzeug.exceptions import MethodNotAllowed
 
 from palace.manager.api.app import app
 from palace.manager.core.app_server import (
@@ -647,9 +648,15 @@ def saml_callback():
 
 # Deprecated: use /saml/callback instead.
 # NOTE: This route MUST remain registered as long as any IdP metadata references /saml_callback.
-@app.route("/saml_callback", methods=["POST"])
+# NOTE: Like `/saml/callback` for which this method is deprecated, this route supports only POST
+#  method. However, since it has only a single path segment, accessing it via GET or HEAD would fall
+#  back to the `@library_route("/", strict_slashes=False)` rule above, treating "saml_callback" as
+#  the library short name. To avoid that, we capture those methods and raise an exception for them.
+@app.route("/saml_callback", methods=["POST", "GET", "HEAD", "PATCH", "PUT", "DELETE"])
 @returns_problem_detail
 def saml_callback_deprecated():
+    if flask.request.method != "POST":
+        raise MethodNotAllowed(valid_methods=["POST"])
     log.warning(
         "Deprecated route /saml_callback called; update SP metadata to use /saml/callback."
     )

--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -1,3 +1,4 @@
+import logging
 from functools import update_wrapper, wraps
 
 import flask
@@ -13,6 +14,8 @@ from palace.manager.core.app_server import (
 )
 from palace.manager.sqlalchemy.hassessioncache import HasSessionCache
 from palace.manager.util.problem_detail import ProblemDetail
+
+log = logging.getLogger(__name__)
 
 
 @app.before_request
@@ -605,7 +608,7 @@ def oidc_backchannel_logout():
 
 
 # Route that redirects to the authentication URL for a SAML provider
-@library_route("/saml_authenticate")
+@library_route("/saml/authenticate")
 @has_library
 @returns_problem_detail
 def saml_authenticate():
@@ -614,18 +617,42 @@ def saml_authenticate():
     )
 
 
-# Redirect URI for SAML providers
-# NOTE: we cannot use @has_library decorator and append a library's name to saml_calback route
-# (e.g. https://cm.org/LIBRARY_NAME/saml_callback).
-# The URL of the SP's assertion consumer service (saml_callback) should be constant:
-# SP's metadata is registered in the IdP and cannot change.
-# If we try to append a library's name to the ACS's URL sent as a part of the SAML request,
-# the IdP will fail this request because the URL mentioned in the request and
-# the URL saved in the SP's metadata configured in this IdP will differ.
-# Library's name is passed as a part of the relay state and processed in SAMLController.saml_authentication_callback
-@app.route("/saml_callback", methods=["POST"])
+# Deprecated: use /saml/authenticate instead.
+@library_route("/saml_authenticate")
+@has_library
+@returns_problem_detail
+def saml_authenticate_deprecated():
+    log.warning(
+        "Deprecated route /saml_authenticate called; use /saml/authenticate instead."
+    )
+    return app.manager.saml_controller.saml_authentication_redirect(
+        flask.request.args, app.manager._db
+    )
+
+
+# Assertion consumer service (ACS) endpoint for SAML providers.
+# NOTE: we cannot use @has_library decorator and append a library's name to this route
+# (e.g. https://cm.org/LIBRARY_NAME/saml/callback).
+# The ACS URL must be constant: it is registered in IdP metadata and cannot change.
+# If we try to append a library's name to the ACS URL sent as a part of the SAML request,
+# the IdP will reject it because the URL in the request and the URL in SP metadata will differ.
+# Library name is passed as part of the relay state and processed in SAMLController.saml_authentication_callback.
+@app.route("/saml/callback", methods=["POST"])
 @returns_problem_detail
 def saml_callback():
+    return app.manager.saml_controller.saml_authentication_callback(
+        request, app.manager._db
+    )
+
+
+# Deprecated: use /saml/callback instead.
+# NOTE: This route MUST remain registered as long as any IdP metadata references /saml_callback.
+@app.route("/saml_callback", methods=["POST"])
+@returns_problem_detail
+def saml_callback_deprecated():
+    log.warning(
+        "Deprecated route /saml_callback called; update SP metadata to use /saml/callback."
+    )
     return app.manager.saml_controller.saml_authentication_callback(
         request, app.manager._db
     )

--- a/src/palace/manager/integration/patron_auth/saml/provider.py
+++ b/src/palace/manager/integration/patron_auth/saml/provider.py
@@ -118,7 +118,7 @@ class SAMLWebSSOAuthenticationProvider(
             "links": [
                 {
                     "rel" : "authenticate"
-                    "href": "https://circulation.library.org/saml_authenticate?provider=SAML+2.0?idp_entity_id=https%3A%2F%2Fidp.saml.net%2Fidp%2Fshibboleth",
+                    "href": "https://circulation.library.org/saml/authenticate?provider=SAML+2.0?idp_entity_id=https%3A%2F%2Fidp.saml.net%2Fidp%2Fshibboleth",
                     "display_names": [
                         {
                             "language": "en",

--- a/tests/fixtures/api_routes.py
+++ b/tests/fixtures/api_routes.py
@@ -169,8 +169,9 @@ class RouteTestFixture:
         # Locate the corresponding function in our mock app.
         mock_function = getattr(self.routes, function_name)
 
-        # Call it in the context of the mock app.
-        with self.controller_fixture.app.test_request_context():
+        # Call it in the context of the mock app, using the same HTTP method so that
+        # route functions that inspect flask.request.method see the correct value.
+        with self.controller_fixture.app.test_request_context(url, method=method):
             return mock_function(**kwargs)
 
     def assert_request_calls(self, url, method, *args, **kwargs):

--- a/tests/manager/api/test_routes.py
+++ b/tests/manager/api/test_routes.py
@@ -654,3 +654,4 @@ class TestSAMLRoutes:
                 http_method="POST",
             )
         assert "Deprecated route /saml_callback" in caplog.text
+        fixture.assert_supported_methods(url, "POST")

--- a/tests/manager/api/test_routes.py
+++ b/tests/manager/api/test_routes.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import MagicMock, patch
 
 import flask
@@ -604,3 +605,52 @@ class TestSAMLRoutes:
             http_method=http_method,
         )
         fixture.assert_supported_methods(url, "GET", "POST")
+
+    def test_saml_authenticate(self, fixture: RouteTestFixture):
+        url = "/LIBSHORTNAME/saml/authenticate"
+        fixture.assert_request_calls(
+            url,
+            fixture.controller.saml_authentication_redirect,
+            ImmutableMultiDict([]),
+            fixture.manager._db,
+        )
+        fixture.assert_supported_methods(url, "GET")
+
+    def test_saml_authenticate_deprecated(
+        self, fixture: RouteTestFixture, caplog: pytest.LogCaptureFixture
+    ):
+        url = "/LIBSHORTNAME/saml_authenticate"
+        with caplog.at_level(logging.WARNING, logger="palace.manager.api.routes"):
+            fixture.assert_request_calls(
+                url,
+                fixture.controller.saml_authentication_redirect,
+                ImmutableMultiDict([]),
+                fixture.manager._db,
+            )
+        assert "Deprecated route /saml_authenticate" in caplog.text
+        fixture.assert_supported_methods(url, "GET")
+
+    def test_saml_callback(self, fixture: RouteTestFixture):
+        url = "/saml/callback"
+        fixture.assert_request_calls(
+            url,
+            fixture.controller.saml_authentication_callback,
+            flask.request,
+            fixture.manager._db,
+            http_method="POST",
+        )
+        fixture.assert_supported_methods(url, "POST")
+
+    def test_saml_callback_deprecated(
+        self, fixture: RouteTestFixture, caplog: pytest.LogCaptureFixture
+    ):
+        url = "/saml_callback"
+        with caplog.at_level(logging.WARNING, logger="palace.manager.api.routes"):
+            fixture.assert_request_calls(
+                url,
+                fixture.controller.saml_authentication_callback,
+                flask.request,
+                fixture.manager._db,
+                http_method="POST",
+            )
+        assert "Deprecated route /saml_callback" in caplog.text

--- a/tests/manager/integration/patron_auth/saml/test_provider.py
+++ b/tests/manager/integration/patron_auth/saml/test_provider.py
@@ -5,6 +5,7 @@ from contextlib import nullcontext
 from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
+from flask import url_for
 from freezegun import freeze_time
 from werkzeug.datastructures import Authorization
 
@@ -336,6 +337,50 @@ class TestSAMLWebSSOAuthenticationProvider:
 
             # Assert
             assert expected_result == result
+
+    @pytest.mark.parametrize(
+        "endpoint, expected_path",
+        [
+            pytest.param("saml_authenticate", "/saml/authenticate", id="canonical"),
+            pytest.param(
+                "saml_authenticate_deprecated", "/saml_authenticate", id="deprecated"
+            ),
+        ],
+    )
+    def test_authenticate_route_url(
+        self,
+        controller_fixture: ControllerFixture,
+        endpoint: str,
+        expected_path: str,
+    ):
+        controller_fixture.app.config["SERVER_NAME"] = "localhost"
+        with controller_fixture.app.test_request_context("/"):
+            url = url_for(
+                endpoint,
+                _external=True,
+                library_short_name=controller_fixture.db.default_library().short_name,
+                provider="test",
+                idp_entity_id="test-idp",
+            )
+        assert expected_path in url
+
+    @pytest.mark.parametrize(
+        "endpoint, expected_path",
+        [
+            pytest.param("saml_callback", "/saml/callback", id="canonical"),
+            pytest.param("saml_callback_deprecated", "/saml_callback", id="deprecated"),
+        ],
+    )
+    def test_callback_route_url(
+        self,
+        controller_fixture: ControllerFixture,
+        endpoint: str,
+        expected_path: str,
+    ):
+        controller_fixture.app.config["SERVER_NAME"] = "localhost"
+        with controller_fixture.app.test_request_context("/"):
+            url = url_for(endpoint, _external=True)
+        assert expected_path in url
 
     @pytest.mark.parametrize(
         "subject, expected_result, patron_id_use_name_id, patron_id_attributes, patron_id_regular_expression",

--- a/tests/manager/integration/patron_auth/saml/test_provider.py
+++ b/tests/manager/integration/patron_auth/saml/test_provider.py
@@ -139,7 +139,7 @@ class TestSAMLWebSSOAuthenticationProvider:
                     "links": [
                         {
                             "rel": "authenticate",
-                            "href": "http://localhost/default/saml_authenticate?provider=SAML+2.0+Web+SSO&idp_entity_id=http://idp2.hilbertteam.net/idp/shibboleth",
+                            "href": "http://localhost/default/saml/authenticate?provider=SAML+2.0+Web+SSO&idp_entity_id=http://idp2.hilbertteam.net/idp/shibboleth",
                             "display_names": [
                                 {
                                     "value": saml_strings.IDP_1_UI_INFO_EN_DISPLAY_NAME,
@@ -208,7 +208,7 @@ class TestSAMLWebSSOAuthenticationProvider:
                     "links": [
                         {
                             "rel": "authenticate",
-                            "href": "http://localhost/default/saml_authenticate?provider=SAML+2.0+Web+SSO&idp_entity_id=http://idp2.hilbertteam.net/idp/shibboleth",
+                            "href": "http://localhost/default/saml/authenticate?provider=SAML+2.0+Web+SSO&idp_entity_id=http://idp2.hilbertteam.net/idp/shibboleth",
                             "display_names": [
                                 {
                                     "value": saml_strings.IDP_1_ORGANIZATION_EN_ORGANIZATION_DISPLAY_NAME,
@@ -244,7 +244,7 @@ class TestSAMLWebSSOAuthenticationProvider:
                     "links": [
                         {
                             "rel": "authenticate",
-                            "href": "http://localhost/default/saml_authenticate?provider=SAML+2.0+Web+SSO&idp_entity_id=http://idp1.hilbertteam.net/idp/shibboleth",
+                            "href": "http://localhost/default/saml/authenticate?provider=SAML+2.0+Web+SSO&idp_entity_id=http://idp1.hilbertteam.net/idp/shibboleth",
                             "display_names": [
                                 {
                                     "value": "Identity Provider #1",
@@ -258,7 +258,7 @@ class TestSAMLWebSSOAuthenticationProvider:
                         },
                         {
                             "rel": "authenticate",
-                            "href": "http://localhost/default/saml_authenticate?provider=SAML+2.0+Web+SSO&idp_entity_id=http://idp1.hilbertteam.net/idp/shibboleth",
+                            "href": "http://localhost/default/saml/authenticate?provider=SAML+2.0+Web+SSO&idp_entity_id=http://idp1.hilbertteam.net/idp/shibboleth",
                             "display_names": [
                                 {
                                     "value": "Identity Provider #2",


### PR DESCRIPTION
## Description

- Standardizes SAML endpoint paths so that they all start with "/saml/...", mirroring the approach used for the OIDC routes.
- Deprecates the existing routes that do not conform to this convention and logging uses of the deprecated routes.

## Motivation and Context

- Establishes a reliable convention and enable eventual move to "blueprint" style separation of routes.
- Aligns with OIDC routes.
- Logging uses of the deprecated routes will enable us to ensure that they are no longer being used before removing them.

## How Has This Been Tested?

- Tests updated for new routes and logging for the deprecated ones.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/25695340311) pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
