### PR TITLE
Run Overdrive import every 3 hours, offset from OPDS2+ODL (PP-4337)

### DIFF
--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -269,7 +269,10 @@ def beat_schedule() -> dict[str, Any]:
         },
         "overdrive_import_all_collections": {
             "task": overdrive.import_all_collections.name,
-            "schedule": crontab(minute="*/15"),  # Run every 15 minutes
+            # Run every 3 hours at minute 15, offset 1.5h from the OPDS2+ODL
+            # import (which runs at minute 45 every 3 hours) so the two
+            # large metadata syncs don't compete for the default queue.
+            "schedule": crontab(minute="15", hour="2-23/3"),
         },
         "overdrive_reap_all_collections": {
             "task": overdrive.reap_all_collections.name,


### PR DESCRIPTION
## Description

Change `overdrive_import_all_collections` from `crontab(minute="*/15")` (every 15 minutes) to `crontab(minute="15", hour="2-23/3")` — every 3 hours at minute 15, offset 1.5h from the OPDS2+ODL beat tick (which runs at minute 45 every 3 hours).

## Motivation and Context

We've been seeing a steady trickle of `LockNotAcquired` errors raised by `opds_odl.import_collection` in production. The lock errors aren't a bug in ODL, they're the canary that ODL's 3-hour beat tick is firing while the previous chain is still walking pages. The underlying cause is that Overdrive's import is saturating the `default` Celery queue, so ODL pages can't get scheduler time between `task.replace()` calls and the chain stretches past its 3-hour window.

Data from CloudWatch Logs Insights for the prod accounts:

### Top consumers of the `default` queue (worker-hours, last 12h)

| Task | Hours | Runs |
|---|---|---|
| `overdrive.import_collection` | **16.54** | 12,060 |
| `search.index_works` | 5.46 | 10,611 |
| `work.classify_unchecked_subjects` | 3.95 | 23 |
| `patron_activity.sync_patron_activity` | 1.86 | 7,957 |
| `overdrive.reap_collection` | 1.64 | 5,284 |
| `opds_odl.import_collection` | **0.61** | 752 |

### Overdrive's share of the `default` queue, per CM

| CM | default total | overdrive | OD % |
|---|---|---|---|
| ct-connecticut | 5.66h | 4.99h | **88%** |
| vt-vermont | 3.77h | 3.77h | **100%** |
| nj-newjersey | 2.92h | 2.45h | **84%** |
| ri-rhodeisland | 0.67h | 0.67h | **100%** |
| il-illinois | 0.40h | 0.40h | **100%** |
| ca-california | 4.64h | 2.01h | 43% |
| wa-washington | 0.96h | 0.56h | 59% |
| ga-georgia | 2.32h | 0.76h | 33% |

On ct-connecticut, 2,884 Overdrive page-tasks executed in 12 hours vs. 25 ODL page-tasks. ODL barely gets a turn.

### Overdrive import duration is already on a ~3h cycle in practice (last 24h)

| CM | completions | sum_elapsed_h | median_min | p90_min | max_min | avg concurrent chains |
|---|---|---|---|---|---|---|
| nj-newjersey | 2,042 | 1,479 | 6.6 | 158 | 659 (11h) | 61.6 |
| ct-connecticut | 4,276 | 1,378 | 0.3 | 43 | 523 (8.7h) | 57.4 |
| ga-georgia | 954 | 879 | 8.9 | 215 | 322 | 36.6 |
| ca-california | 2,818 | 842 | 5.0 | 49 | 1,380 (23h) | 35.1 |

`sum_elapsed_h` is the total wall-clock time of every Overdrive `import_collection` chain completed in the window; "avg concurrent chains" = that sum divided by the 24h window, i.e. the expected number of Overdrive chains in flight at any moment. On NJ the Overdrive queue is effectively never idle — ~62 chains alive at all times.

For the heavy collections (Georgia Advantage, NJ MAIN, CT, CA Advantage), the median gap between one chain finishing and the next starting is 7–10 minutes — i.e. the 15-minute beat re-fires as soon as the workflow lock releases, and Overdrive runs continuously. The workflow lock prevents redundant chains, but the cadence is short enough that one chain ends, ~7 minutes later the next starts, indefinitely. Heavy parents already cycle every ~3 hours regardless of the beat cadence because the chain itself (parent pagination + chord of children) takes that long.

Aligning Overdrive's cadence with ODL's matches the duration each cycle actually takes, gives the `default` queue deterministic idle windows where ODL/search can drain.

The 1.5h offset (Overdrive at minute 15 of hours 2, 5, 8, 11, 14, 17, 20, 23; ODL at minute 45 of hours 0, 3, 6, 9, 12, 15, 18, 21) spreads the two largest metadata syncs across the schedule.

## How Has This Been Tested?

Verified the `crontab` expression resolves to the intended fire times:

```
>>> from celery.schedules import crontab
>>> c = crontab(minute="15", hour="2-23/3")
>>> sorted(c.hour)
[2, 5, 8, 11, 14, 17, 20, 23]
>>> sorted(c.minute)
[15]
```

Config-only change; no tests cover the beat schedule. Will monitor the `default` queue throughput and the rate of `opds_odl.import_collection` `LockNotAcquired` errors after deploy.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.