### PR TITLE
Run Overdrive reap once a day instead of every hour (PP-4337)

### DIFF
--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -273,7 +273,7 @@ def beat_schedule() -> dict[str, Any]:
         },
         "overdrive_reap_all_collections": {
             "task": overdrive.reap_all_collections.name,
-            "schedule": crontab(minute="0"),  # Run every hour
+            "schedule": crontab(minute="0", hour="23"),  # Once a day at 11:00 PM
         },
     }
 


### PR DESCRIPTION
## Description

Change `overdrive_reap_all_collections` from `crontab(minute="0")` (every hour) to `crontab(minute="0", hour="23")` (once a day at 23:00 UTC).

## Motivation and Context

While investigating Celery `LockNotAcquired` errors on `opds_odl.import_collection` (see #3340), I traced the contention back to Overdrive saturating the `default` queue and discovered that my initial worker-time accounting was significantly under-reading reality.

### The measurement gap

CloudWatch Insights queries against `Task X[id] succeeded in Ys` log lines miss every `task.replace()`-driven page or batch — those are logged as `Task X[id] ignored` with no duration string. For tasks like Overdrive `reap_collection` that paginate over thousands of identifiers via `task.replace()`, only the *final* batch shows up in succeeded counts.

Fleet-wide counts over 12 hours:

| Task | succeeded (counted) | ignored (missed) | total runs |
|---|---|---|---|
| **overdrive.reap_collection** | 5,284 | **129,022** | 134,306 |
| overdrive.import_collection | 12,060 | 29,206 | 41,266 |
| search.search_reindex | 25 | 11,544 | 11,569 |
| opds_odl.import_collection | 752 | 6,655 | 7,407 |

`reap_collection` was under-counted by ~25×.

### What reap actually costs

Sampling per-event durations (received → finished, including ignored events) on `tpp-prod-zeta` over 33 minutes:

| Task | events | total sec | avg concurrent workers busy | per-event p75 / p90 |
|---|---|---|---|---|
| overdrive.reap_collection | 321 | 3,084 | **1.56** | 21s / 23s |
| overdrive.import_collection | 382 | 1,527 | 0.77 | 5s / 7s |

The distribution of reap batches is bimodal: ~50% complete in 0–1s (workflow-lock-skip early returns) and ~25% take 21–23s of real work — 50 sequential synchronous HTTP calls to OverDrive's availability endpoint per batch (`api.update_licensepool(identifier.identifier)` in a for-loop, src/palace/manager/celery/tasks/overdrive.py:594).

Extrapolated fleet-wide for a 12h window, real reap work is on the order of **~370 worker-hours** — substantially more than the `overdrive.import_collection` chain work I previously identified as the dominant consumer.

### Why hourly reap is overkill

Reap's purpose is to detect titles that have left the OverDrive collection. Title removals don't happen on an hourly cadence; detecting them ~24 hours after the fact is fine. Hourly reap also means a heavy reap cycle (which can take hours wall-clock for a collection with tens of thousands of titles) is essentially always running — the workflow lock skips the in-cycle beat ticks, so freshness is already much worse than "1 hour" in practice on heavy CMs.

### Choice of time

23:00 UTC sits in a relatively quiet block between `work.classify_unchecked_subjects` at 22:30 and `full_search_reindex` at 00:10, giving the reap cycle a clear lane to start before the early-morning reaper / import block kicks off at 02:00–05:00.

## How Has This Been Tested?

Going to have to deploy this out and monitor queues to see how it works in practice.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.