### PR TITLE
Drop unused Celery per-task CloudWatch metrics (PP-4335)

### DIFF
--- a/src/palace/manager/celery/monitoring.py
+++ b/src/palace/manager/celery/monitoring.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -11,7 +10,7 @@ import boto3
 from boto3.exceptions import Boto3Error
 from botocore.exceptions import BotoCoreError
 from celery.events.snapshot import Polaroid
-from celery.events.state import State, Task
+from celery.events.state import State
 from kombu.transport.redis import PrefixedStrictRedis
 from redis import ConnectionPool
 
@@ -52,74 +51,6 @@ def value_metric(
     }
 
 
-def statistic_metric(
-    metric_name: str,
-    values: Sequence[float],
-    timestamp: datetime,
-    dimensions: dict[str, str],
-    unit: StandardUnitType = "Seconds",
-) -> MetricDatumTypeDef:
-    """
-    Format a metric for multiple values into the format expected by Cloudwatch. This
-    includes the statistic values for the maximum, minimum, sum, and sample count.
-
-    See Boto3 documentation:
-    https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudwatch/client/put_metric_data.html
-    """
-    return {
-        "MetricName": metric_name,
-        "StatisticValues": {
-            "Maximum": max(values),
-            "Minimum": min(values),
-            "SampleCount": len(values),
-            "Sum": sum(values),
-        },
-        "Timestamp": timestamp.isoformat(),
-        "Dimensions": metric_dimensions(dimensions),
-        "Unit": unit,
-    }
-
-
-@dataclass
-class TaskStats:
-    """
-    Tracks the number of tasks that have succeeded, failed, and how long they took to run
-    for a specific task, so we can report this out to Cloudwatch metrics.
-    """
-
-    succeeded: int = 0
-    failed: int = 0
-    runtime: list[float] = field(default_factory=list)
-
-    def update(self, task: Task) -> None:
-        if task.succeeded:
-            self.succeeded += 1
-            if task.runtime:
-                self.runtime.append(task.runtime)
-        if task.failed:
-            self.failed += 1
-
-    def metrics(
-        self, timestamp: datetime, dimensions: dict[str, str]
-    ) -> list[MetricDatumTypeDef]:
-        metric_data = [
-            value_metric("TaskSucceeded", self.succeeded, timestamp, dimensions),
-            value_metric("TaskFailed", self.failed, timestamp, dimensions),
-        ]
-
-        if self.runtime:
-            metric_data.append(
-                statistic_metric("TaskRuntime", self.runtime, timestamp, dimensions)
-            )
-
-        return metric_data
-
-    def reset(self) -> None:
-        self.succeeded = 0
-        self.failed = 0
-        self.runtime = []
-
-
 @dataclass(frozen=True)
 class QueueStats:
     """
@@ -139,7 +70,7 @@ class QueueStats:
 
 class Cloudwatch(Polaroid):
     """
-    Implements a Celery custom camera that sends task and queue statistics to Cloudwatch.
+    Implements a Celery custom camera that sends queue statistics to Cloudwatch.
 
     See Celery documentation for more information on custom cameras:
     https://docs.celeryq.dev/en/stable/userguide/monitoring.html#custom-camera
@@ -174,14 +105,6 @@ class Cloudwatch(Polaroid):
         self.namespace = self.app.conf.get("cloudwatch_statistics_namespace")
         self.upload_size = self.app.conf.get("cloudwatch_statistics_upload_size")
         self.queues = {queue.name for queue in self.app.conf.get("task_queues")}
-        self.tasks: defaultdict[str, TaskStats] = defaultdict(
-            TaskStats,
-            {
-                task: TaskStats()
-                for task in self.app.tasks.keys()
-                if not self.is_celery_task(task)
-            },
-        )
 
     @classmethod
     def get_redis_client(
@@ -192,39 +115,6 @@ class Cloudwatch(Polaroid):
             connection_pool=connection_pool, global_keyprefix=global_keyprefix
         )
 
-    @staticmethod
-    def is_celery_task(task_name: str) -> bool:
-        return task_name.startswith("celery.")
-
-    @staticmethod
-    def task_info_str(task: Task) -> str:
-        return ", ".join(
-            [
-                f"[{k}]:{v}"
-                for k, v in task.info(extra=["name", "sent", "started", "uuid"]).items()
-            ]
-        )
-
-    def reset_tasks(self) -> None:
-        for task in self.tasks.values():
-            task.reset()
-
-    def update_task_stats(self, state: State) -> None:
-        # Reset the task stats for each snapshot
-        self.reset_tasks()
-
-        # Update task stats for each task in the state
-        for task in state.tasks.values():
-            # Update task stats for each task
-            if task.name is None:
-                self.logger.warning(f"Task has no name. {self.task_info_str(task)}.")
-            elif self.is_celery_task(task.name):
-                # If this is an internal Celery task, we skip it entirely.
-                # We don't want to track internal Celery tasks.
-                continue
-            else:
-                self.tasks[task.name].update(task)
-
     def get_queue_stats(self) -> dict[str, QueueStats]:
         return {
             queue: QueueStats(self.redis_client.llen(queue)) for queue in self.queues
@@ -232,25 +122,14 @@ class Cloudwatch(Polaroid):
 
     def on_shutter(self, state: State) -> None:
         timestamp = utc_now()
-        self.update_task_stats(state)
-        queue_stats = self.get_queue_stats()
-
-        self.publish(self.tasks, queue_stats, timestamp)
+        self.publish(self.get_queue_stats(), timestamp)
 
     def publish(
         self,
-        tasks: dict[str, TaskStats],
         queues: dict[str, QueueStats],
         timestamp: datetime,
     ) -> None:
         metric_data = []
-        for task_name, task_stats in tasks.items():
-            metric_data.extend(
-                task_stats.metrics(
-                    timestamp, {"TaskName": task_name, "Manager": self.manager_name}
-                )
-            )
-
         for queue_name, queue_stats in queues.items():
             metric_data.extend(
                 queue_stats.metrics(

--- a/tests/manager/celery/test_monitoring.py
+++ b/tests/manager/celery/test_monitoring.py
@@ -1,43 +1,26 @@
 from unittest.mock import MagicMock, call, create_autospec, patch
-from uuid import uuid4
 
 import pytest
 from boto3.exceptions import Boto3Error
-from celery.events.state import State, Task
 from freezegun import freeze_time
 
 from palace.util.log import LogLevel
 
 from palace.manager.celery.celery import Celery
-from palace.manager.celery.monitoring import Cloudwatch, QueueStats, TaskStats
+from palace.manager.celery.monitoring import Cloudwatch, QueueStats
 
 
 class CloudwatchCameraFixture:
     def __init__(self, boto_client: MagicMock):
         self.app = create_autospec(Celery)
         self.configure_app()
-        self.app.tasks = {
-            "task1": MagicMock(),
-            "task2": MagicMock(),
-            "celery.built_in": MagicMock(),
-        }
         self.client = boto_client
-        self.state = create_autospec(State)
-        self.state.tasks = self.task_list(
-            [
-                self.mock_task("task1", runtime=1.0),
-                self.mock_task("task1", runtime=2.0),
-                self.mock_task("task2", succeeded=False, failed=True),
-                self.mock_task("task2", started=False, succeeded=False, uuid="uuid4"),
-                self.mock_task("celery.built_in", started=False, succeeded=False),
-            ]
-        )
         self._mock_get_redis: MagicMock | None = None
 
     def create_cloudwatch(self):
         with patch.object(Cloudwatch, "get_redis_client") as mock_get_redis:
             self._mock_get_redis = mock_get_redis
-            return Cloudwatch(state=self.state, app=self.app)
+            return Cloudwatch(state=MagicMock(), app=self.app)
 
     @property
     def mock_get_redis(self):
@@ -47,37 +30,10 @@ class CloudwatchCameraFixture:
             )
         return self._mock_get_redis
 
-    @staticmethod
-    def task_list(tasks: list[Task]) -> dict[str, Task]:
-        return {task.uuid: task for task in tasks}
-
     def mock_queue(self, name: str) -> MagicMock:
         queue = MagicMock()
         queue.name = name
         return queue
-
-    def mock_task(
-        self,
-        name: str | None = None,
-        *,
-        sent: bool = True,
-        started: bool = True,
-        succeeded: bool = True,
-        failed: bool = False,
-        runtime: float | None = None,
-        uuid: str | None = None,
-    ) -> Task:
-        if uuid is None:
-            uuid = str(uuid4())
-        return Task(
-            uuid=uuid,
-            name=name,
-            sent=sent,
-            started=started,
-            succeeded=succeeded,
-            failed=failed,
-            runtime=runtime,
-        )
 
     def configure_app(
         self,
@@ -107,80 +63,6 @@ class CloudwatchCameraFixture:
 def cloudwatch_camera():
     with patch("boto3.client") as boto_client:
         yield CloudwatchCameraFixture(boto_client)
-
-
-class TestTaskStats:
-    def test_update(self, cloudwatch_camera: CloudwatchCameraFixture):
-        stats = TaskStats()
-
-        mock_task = cloudwatch_camera.mock_task(runtime=1.0)
-        stats.update(mock_task)
-        assert stats.failed == 0
-        assert stats.succeeded == 1
-        assert stats.runtime == [1.0]
-
-        mock_task = cloudwatch_camera.mock_task(succeeded=False, failed=True)
-        stats.update(mock_task)
-        assert stats.failed == 1
-        assert stats.succeeded == 1
-        assert stats.runtime == [1.0]
-
-        mock_task = cloudwatch_camera.mock_task(runtime=2.0)
-        stats.update(mock_task)
-        assert stats.failed == 1
-        assert stats.succeeded == 2
-        assert stats.runtime == [1.0, 2.0]
-
-    def test_update_with_none_runtime(self, cloudwatch_camera: CloudwatchCameraFixture):
-        stats = TaskStats()
-        mock_task = cloudwatch_camera.mock_task()
-        stats.update(mock_task)
-        assert stats.failed == 0
-        assert stats.succeeded == 1
-        assert stats.runtime == []
-
-    def test_metrics(self):
-        stats = TaskStats(succeeded=2, failed=5, runtime=[3.5, 2.2])
-        timestamp = MagicMock()
-        dimensions = {"key": "value", "key2": "value2"}
-
-        expected_dimensions = [
-            {"Name": key, "Value": value} for key, value in dimensions.items()
-        ]
-
-        [succeeded_metric, failed_metric, runtime_metric] = stats.metrics(
-            timestamp, dimensions
-        )
-
-        assert succeeded_metric["MetricName"] == "TaskSucceeded"
-        assert succeeded_metric["Value"] == 2
-        assert succeeded_metric["Timestamp"] == timestamp.isoformat()
-        assert succeeded_metric["Dimensions"] == expected_dimensions
-        assert succeeded_metric["Unit"] == "Count"
-
-        assert failed_metric["MetricName"] == "TaskFailed"
-        assert failed_metric["Value"] == 5
-        assert failed_metric["Timestamp"] == timestamp.isoformat()
-        assert failed_metric["Dimensions"] == expected_dimensions
-        assert failed_metric["Unit"] == "Count"
-
-        assert runtime_metric["MetricName"] == "TaskRuntime"
-        assert runtime_metric["StatisticValues"] == {
-            "Maximum": 3.5,
-            "Minimum": 2.2,
-            "SampleCount": 2,
-            "Sum": 5.7,
-        }
-        assert runtime_metric["Timestamp"] == timestamp.isoformat()
-        assert runtime_metric["Dimensions"] == expected_dimensions
-        assert runtime_metric["Unit"] == "Seconds"
-
-    def test_metrics_with_empty_runtime(self):
-        stats = TaskStats(succeeded=2, failed=5, runtime=[])
-        [succeeded_metric, failed_metric] = stats.metrics(MagicMock(), {})
-
-        assert succeeded_metric["MetricName"] == "TaskSucceeded"
-        assert failed_metric["MetricName"] == "TaskFailed"
 
 
 class TestQueueStats:
@@ -238,86 +120,19 @@ class TestCloudwatch:
         cloudwatch.publish = mock_publish
         cloudwatch_camera.mock_get_redis.return_value.llen.return_value = 10
         with freeze_time("2021-01-01"):
-            cloudwatch.on_shutter(cloudwatch_camera.state)
+            cloudwatch.on_shutter(MagicMock())
         assert cloudwatch_camera.mock_get_redis.return_value.llen.call_count == 2
         cloudwatch_camera.mock_get_redis.return_value.llen.assert_has_calls(
             [call("queue1"), call("queue2")], any_order=True
         )
         mock_publish.assert_called_once()
-        [tasks, queues, time] = mock_publish.call_args.args
+        [queues, time] = mock_publish.call_args.args
 
-        assert tasks == {
-            "task1": TaskStats(succeeded=2, runtime=[1.0, 2.0]),
-            "task2": TaskStats(failed=1),
-        }
         assert queues == {
             "queue1": QueueStats(queued=10),
             "queue2": QueueStats(queued=10),
         }
         assert time.isoformat() == "2021-01-01T00:00:00+00:00"
-
-    def test_on_shutter_unknown_task_name(
-        self,
-        cloudwatch_camera: CloudwatchCameraFixture,
-    ):
-        # We can also handle the case where we see a task with an unknown name.
-        cloudwatch = cloudwatch_camera.create_cloudwatch()
-        mock_publish = create_autospec(cloudwatch.publish)
-        cloudwatch.publish = mock_publish
-        cloudwatch_camera.state.tasks = cloudwatch_camera.task_list(
-            [
-                cloudwatch_camera.mock_task(
-                    "unknown_task",
-                    failed=True,
-                    succeeded=False,
-                    uuid="uuid6",
-                ),
-            ]
-        )
-        cloudwatch.on_shutter(cloudwatch_camera.state)
-        [tasks, _, _] = mock_publish.call_args.args
-        assert tasks == {
-            "task1": TaskStats(),
-            "task2": TaskStats(),
-            "unknown_task": TaskStats(failed=1),
-        }
-
-    def test_on_shutter_no_task_name(
-        self,
-        cloudwatch_camera: CloudwatchCameraFixture,
-        caplog: pytest.LogCaptureFixture,
-    ):
-        # We can handle tasks with no name
-        caplog.set_level(LogLevel.warning)
-        cloudwatch = cloudwatch_camera.create_cloudwatch()
-        mock_publish = create_autospec(cloudwatch.publish)
-        cloudwatch.publish = mock_publish
-        cloudwatch_camera.state.tasks = cloudwatch_camera.task_list(
-            [
-                cloudwatch_camera.mock_task(None, started=True, uuid="uuid7"),
-                cloudwatch_camera.mock_task(None, started=True, uuid="uuid5"),
-            ]
-        )
-        cloudwatch.on_shutter(cloudwatch_camera.state)
-        [tasks, _, _] = mock_publish.call_args.args
-        assert tasks == {
-            "task1": TaskStats(),
-            "task2": TaskStats(),
-        }
-
-        # We log the information about tasks with no name
-        (
-            no_name_warning_1,
-            no_name_warning_2,
-        ) = caplog.messages
-        assert (
-            "Task has no name. [sent]:True, [started]:True, [uuid]:uuid7."
-            in no_name_warning_1
-        )
-        assert (
-            "Task has no name. [sent]:True, [started]:True, [uuid]:uuid5."
-            in no_name_warning_2
-        )
 
     def test_publish(
         self,
@@ -331,33 +146,29 @@ class TestCloudwatch:
             "ResponseMetadata": {"HTTPStatusCode": 200}
         }
         timestamp = MagicMock()
-        tasks = {"task1": TaskStats(succeeded=2, failed=5, runtime=[3.5, 2.2])}
         queues = {"queue1": QueueStats(queued=2)}
 
-        cloudwatch.publish(tasks, queues, timestamp)
+        cloudwatch.publish(queues, timestamp)
         mock_put_metric_data.assert_called_once()
         kwargs = mock_put_metric_data.call_args.kwargs
         assert kwargs["Namespace"] == "namespace"
-        expected = [
-            *tasks["task1"].metrics(
-                timestamp, {"TaskName": "task1", "Manager": "manager"}
-            ),
-            *queues["queue1"].metrics(
+        expected = list(
+            queues["queue1"].metrics(
                 timestamp, {"QueueName": "queue1", "Manager": "manager"}
-            ),
-        ]
+            )
+        )
 
         assert kwargs["MetricData"] == expected
 
         # If chunking is enabled, put_metric_data should be called multiple times. Once for each chunk.
         cloudwatch.upload_size = 1
         mock_put_metric_data.reset_mock()
-        cloudwatch.publish(tasks, queues, timestamp)
+        cloudwatch.publish(queues, timestamp)
         assert mock_put_metric_data.call_count == len(expected)
 
         # If there is an error, it should be logged.
         mock_put_metric_data.side_effect = Boto3Error("Boom")
-        cloudwatch.publish(tasks, queues, timestamp)
+        cloudwatch.publish(queues, timestamp)
         assert "Error sending metrics to Cloudwatch." in caplog.text
 
         # If dry run is enabled, no metrics should be sent and a log message should be generated.
@@ -365,6 +176,6 @@ class TestCloudwatch:
         caplog.set_level(LogLevel.info)
         cloudwatch.cloudwatch_client = None
         mock_put_metric_data.reset_mock()
-        cloudwatch.publish(tasks, queues, timestamp)
+        cloudwatch.publish(queues, timestamp)
         mock_put_metric_data.assert_not_called()
         assert "Dry run enabled. Not sending metrics to Cloudwatch." in caplog.text


### PR DESCRIPTION
## Description

Remove the `TaskSucceeded`, `TaskFailed`, and `TaskRuntime` custom CloudWatch metrics emitted by `Cloudwatch` in `src/palace/manager/celery/monitoring.py`, along with the `TaskStats` dataclass and the supporting `update_task_stats` / `reset_tasks` / `is_celery_task` / `task_info_str` machinery. `Cloudwatch.publish` now only takes `queues`.

`task_send_sent_event = True` in `service/celery/configuration.py` stays on — Celery still emits the events, we just stop translating them to CloudWatch. Worker overhead is negligible and turning the flag off is unrelated cleanup.

## Motivation and Context

These three metrics account for roughly 85% of the ~6,000 series in the Celery namespace (roughly $1,800/mo on the CloudWatch custom-metric tier). I thought they would be useful when I initially set up monitoring, but overtime as we have added more and more tasks, the number of metrics we monitor has exploded and we haven't been using them for any monitoring or alarms.

Audit findings: `TaskFailed` and `TaskRuntime` are referenced by **zero** alarms and **zero** dashboards; `TaskSucceeded` feeds a single widget on one manager. 

After deploy, no new datapoints are written to these series, which will immediately save us the custom metrics costs, additional savings on storage will phase in gradually as the abandoned series age out of the retention window.

## How Has This Been Tested?

- `tox -e py312-docker -- --no-cov tests/manager/celery/test_monitoring.py` — 6 tests pass.
- `mypy` clean.
- Pre-commit clean.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.