### PR TITLE
Add QueueOldestAge CloudWatch metric for Celery queues (PP-4336)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -325,6 +325,7 @@ disallow_subclassing_any = false
 disallow_untyped_decorators = false
 module = [
     "palace.manager.celery.*",
+    "palace.manager.service.celery.*",
 ]
 
 [[tool.mypy.overrides]]

--- a/src/palace/manager/celery/monitoring.py
+++ b/src/palace/manager/celery/monitoring.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -54,18 +55,30 @@ def value_metric(
 @dataclass(frozen=True)
 class QueueStats:
     """
-    Tracks the number of tasks queued for a specific queue, so we can
-    report this out to Cloudwatch metrics.
+    Tracks the number of tasks queued for a specific queue and the age of the
+    oldest waiting task, so we can report these out to Cloudwatch metrics.
     """
 
     queued: int
+    oldest_age_seconds: int | None = None
 
     def metrics(
         self, timestamp: datetime, dimensions: dict[str, str]
     ) -> list[MetricDatumTypeDef]:
-        return [
+        metric_data = [
             value_metric("QueueWaiting", self.queued, timestamp, dimensions),
         ]
+        if self.oldest_age_seconds is not None:
+            metric_data.append(
+                value_metric(
+                    "QueueOldestAge",
+                    self.oldest_age_seconds,
+                    timestamp,
+                    dimensions,
+                    unit="Seconds",
+                )
+            )
+        return metric_data
 
 
 class Cloudwatch(Polaroid):
@@ -115,9 +128,37 @@ class Cloudwatch(Polaroid):
             connection_pool=connection_pool, global_keyprefix=global_keyprefix
         )
 
+    def _oldest_message_age(self, queue: str) -> int | None:
+        # Kombu uses LPUSH on publish and BRPOP on consume, so the oldest unconsumed
+        # message is at the tail of the list (index -1).
+        raw = self.redis_client.lindex(queue, -1)
+        if raw is None:
+            return None
+        try:
+            msg = json.loads(raw)
+            ts = msg.get("headers", {}).get("enqueued_at")
+            if not ts:
+                return None
+            # Clamp at 0; the publisher's clock may be ahead of the camera host.
+            return max(0, int((utc_now() - datetime.fromisoformat(ts)).total_seconds()))
+        except (ValueError, AttributeError, TypeError):
+            # ValueError: malformed JSON or non-ISO timestamp string.
+            # AttributeError: json envelope isn't a dict (.get fails).
+            # TypeError: enqueued_at is set to a non-string — fromisoformat raises.
+            self.logger.exception(
+                "Failed to parse oldest message in queue %r for age metric.",
+                queue,
+                extra={"palace_raw_message": raw},
+            )
+            return None
+
     def get_queue_stats(self) -> dict[str, QueueStats]:
         return {
-            queue: QueueStats(self.redis_client.llen(queue)) for queue in self.queues
+            queue: QueueStats(
+                queued=self.redis_client.llen(queue),
+                oldest_age_seconds=self._oldest_message_age(queue),
+            )
+            for queue in self.queues
         }
 
     def on_shutter(self, state: State) -> None:

--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -2,9 +2,26 @@ from enum import StrEnum, auto
 from typing import Any
 
 from celery.schedules import crontab
+from celery.signals import before_task_publish
 from kombu import Exchange, Queue
 
+from palace.util.datetime_helpers import utc_now
+
 from palace.manager.celery.celery import Celery
+
+
+@before_task_publish.connect
+def add_enqueued_at_header(headers: dict[str, Any], **kwargs: Any) -> None:
+    """Stamp outgoing task messages with the time they were first enqueued.
+
+    Used by the CloudWatch queue-statistics camera so we can report the age of
+    the oldest message still waiting in the queue.
+
+    ``setdefault`` preserves the original timestamp across ``replace()`` calls,
+    retries, and chained-task re-publishes, so the metric reflects how long the
+    work has actually been waiting rather than restarting on each republish.
+    """
+    headers.setdefault("enqueued_at", utc_now().isoformat())
 
 
 class QueueNames(StrEnum):

--- a/tests/manager/celery/test_monitoring.py
+++ b/tests/manager/celery/test_monitoring.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock, call, create_autospec, patch
 
 import pytest
@@ -66,7 +67,7 @@ def cloudwatch_camera():
 
 
 class TestQueueStats:
-    def test_metrics(self):
+    def test_metrics_without_age(self):
         stats = QueueStats(queued=2)
         timestamp = MagicMock()
         dimensions = {"key": "value", "key2": "value2"}
@@ -79,6 +80,24 @@ class TestQueueStats:
         assert metric["Timestamp"] == timestamp.isoformat()
         assert metric["Dimensions"] == expected_dimensions
         assert metric["Unit"] == "Count"
+
+    def test_metrics_with_age(self):
+        stats = QueueStats(queued=2, oldest_age_seconds=42)
+        timestamp = MagicMock()
+        dimensions = {"key": "value"}
+        expected_dimensions = [{"Name": "key", "Value": "value"}]
+
+        [waiting, oldest] = stats.metrics(timestamp, dimensions)
+
+        assert waiting["MetricName"] == "QueueWaiting"
+        assert waiting["Value"] == 2
+        assert waiting["Unit"] == "Count"
+
+        assert oldest["MetricName"] == "QueueOldestAge"
+        assert oldest["Value"] == 42
+        assert oldest["Timestamp"] == timestamp.isoformat()
+        assert oldest["Dimensions"] == expected_dimensions
+        assert oldest["Unit"] == "Seconds"
 
 
 class TestCloudwatch:
@@ -119,6 +138,7 @@ class TestCloudwatch:
         mock_publish = create_autospec(cloudwatch.publish)
         cloudwatch.publish = mock_publish
         cloudwatch_camera.mock_get_redis.return_value.llen.return_value = 10
+        cloudwatch_camera.mock_get_redis.return_value.lindex.return_value = None
         with freeze_time("2021-01-01"):
             cloudwatch.on_shutter(MagicMock())
         assert cloudwatch_camera.mock_get_redis.return_value.llen.call_count == 2
@@ -129,10 +149,93 @@ class TestCloudwatch:
         [queues, time] = mock_publish.call_args.args
 
         assert queues == {
-            "queue1": QueueStats(queued=10),
-            "queue2": QueueStats(queued=10),
+            "queue1": QueueStats(queued=10, oldest_age_seconds=None),
+            "queue2": QueueStats(queued=10, oldest_age_seconds=None),
         }
         assert time.isoformat() == "2021-01-01T00:00:00+00:00"
+
+    def test__oldest_message_age_happy_path(
+        self, cloudwatch_camera: CloudwatchCameraFixture
+    ):
+        cloudwatch = cloudwatch_camera.create_cloudwatch()
+        envelope = {"headers": {"enqueued_at": "2026-05-13T11:59:00+00:00"}}
+        cloudwatch_camera.mock_get_redis.return_value.lindex.return_value = json.dumps(
+            envelope
+        )
+        with freeze_time("2026-05-13T12:00:30+00:00"):
+            age = cloudwatch._oldest_message_age("queue1")
+        cloudwatch_camera.mock_get_redis.return_value.lindex.assert_called_once_with(
+            "queue1", -1
+        )
+        assert age == 90
+        assert isinstance(age, int)
+
+    def test__oldest_message_age_empty_queue(
+        self, cloudwatch_camera: CloudwatchCameraFixture
+    ):
+        cloudwatch = cloudwatch_camera.create_cloudwatch()
+        cloudwatch_camera.mock_get_redis.return_value.lindex.return_value = None
+        assert cloudwatch._oldest_message_age("queue1") is None
+
+    def test__oldest_message_age_future_timestamp_clamped(
+        self, cloudwatch_camera: CloudwatchCameraFixture
+    ):
+        # Future-dated enqueued_at (publisher clock ahead of camera) clamps to 0.
+        cloudwatch = cloudwatch_camera.create_cloudwatch()
+        envelope = {"headers": {"enqueued_at": "2026-05-13T12:01:00+00:00"}}
+        cloudwatch_camera.mock_get_redis.return_value.lindex.return_value = json.dumps(
+            envelope
+        )
+        with freeze_time("2026-05-13T12:00:00+00:00"):
+            age = cloudwatch._oldest_message_age("queue1")
+        assert age == 0
+
+    def test__oldest_message_age_missing_header(
+        self, cloudwatch_camera: CloudwatchCameraFixture
+    ):
+        # External publisher or pre-rollout message without our header — no signal, not an error.
+        cloudwatch = cloudwatch_camera.create_cloudwatch()
+        cloudwatch_camera.mock_get_redis.return_value.lindex.return_value = json.dumps(
+            {"headers": {}}
+        )
+        assert cloudwatch._oldest_message_age("queue1") is None
+
+        cloudwatch_camera.mock_get_redis.return_value.lindex.return_value = json.dumps(
+            {}
+        )
+        assert cloudwatch._oldest_message_age("queue1") is None
+
+    def test__oldest_message_age_malformed(
+        self,
+        cloudwatch_camera: CloudwatchCameraFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        caplog.set_level(LogLevel.error)
+        cloudwatch = cloudwatch_camera.create_cloudwatch()
+        cloudwatch_camera.mock_get_redis.return_value.lindex.return_value = (
+            "not valid json"
+        )
+        assert cloudwatch._oldest_message_age("queue1") is None
+        assert "Failed to parse oldest message in queue 'queue1'" in caplog.text
+        # The raw redis value rides along under the palace_ prefix so it lands in
+        # structured logs and we can debug whatever weird thing was on the queue.
+        assert getattr(caplog.records[-1], "palace_raw_message") == "not valid json"
+
+        caplog.clear()
+        cloudwatch_camera.mock_get_redis.return_value.lindex.return_value = json.dumps(
+            {"headers": {"enqueued_at": "not-a-timestamp"}}
+        )
+        assert cloudwatch._oldest_message_age("queue1") is None
+        assert "Failed to parse oldest message in queue 'queue1'" in caplog.text
+
+        # `enqueued_at` is a non-string (e.g., an int) —
+        # fromisoformat raises TypeError. Still logged, still returns None.
+        caplog.clear()
+        cloudwatch_camera.mock_get_redis.return_value.lindex.return_value = json.dumps(
+            {"headers": {"enqueued_at": 1234567890}}
+        )
+        assert cloudwatch._oldest_message_age("queue1") is None
+        assert "Failed to parse oldest message in queue 'queue1'" in caplog.text
 
     def test_publish(
         self,

--- a/tests/manager/service/celery/test_celery.py
+++ b/tests/manager/service/celery/test_celery.py
@@ -1,0 +1,18 @@
+from freezegun import freeze_time
+
+from palace.manager.service.celery.celery import add_enqueued_at_header
+
+
+class TestAddEnqueuedAtHeader:
+    def test_sets_iso_timestamp_when_missing(self):
+        headers: dict = {}
+        with freeze_time("2026-05-13T12:00:00+00:00"):
+            add_enqueued_at_header(headers)
+        assert headers["enqueued_at"] == "2026-05-13T12:00:00+00:00"
+
+    def test_preserves_existing_value(self):
+        # Idempotent across retries / chained re-publishes: keep the original enqueue time.
+        headers: dict = {"enqueued_at": "2026-01-01T00:00:00+00:00"}
+        with freeze_time("2026-05-13T12:00:00+00:00"):
+            add_enqueued_at_header(headers)
+        assert headers["enqueued_at"] == "2026-01-01T00:00:00+00:00"


### PR DESCRIPTION
## Description

Emit a new per-queue, per-manager `QueueOldestAge` CloudWatch metric (in seconds) measuring how long the oldest unconsumed task has been waiting. To compute it, outgoing task messages are stamped with an `enqueued_at` ISO-8601 header via a `before_task_publish` Celery signal handler in `src/palace/manager/service/celery/celery.py`. The `Cloudwatch` polaroid camera reads the tail of each redis queue (`LINDEX <queue> -1` — kombu LPUSH-on-publish / BRPOP-on-consume puts the oldest message there), parses the header, and emits the age alongside the existing `QueueWaiting` count.

Other notes:
- `setdefault` keeps the original timestamp across retries and chained re-publishes, so the metric reflects how long the work has actually been waiting rather than restarting on each republish.
- Messages without the header (pre-rollout, or published by an external system) return `None` silently — no metric emitted, no error logged.
- JSON-parse / shape-validation failures log at ERROR with a traceback so we know if something on the broker ever goes off the rails.
- `service.celery.*` was added to the existing `palace.manager.celery.*` mypy override block since both wrap untyped Celery features.

## Motivation and Context

Queue depth alone is a load-dependent signal — a 1M-item queue draining in 60s is fine, but 3 items waiting 6h is not. The user-impact signal is the **age** of the oldest waiting task. CloudWatch alarms on `RATE(min QueueWaiting) > 0` had been firing ~57 times per 2 weeks across four managers on noise; tuning that threshold was the short-term fix in the infra repo, but the durable signal needs to be age-based. Celery itself doesn't emit it and no broker header carries enqueue time (verified against a prod redis dump), so we inject it ourselves.

## How Has This Been Tested?

- `tox -e py312-docker -- --no-cov tests/manager/celery/test_monitoring.py tests/manager/service/celery/test_celery.py` — 13 tests pass.
- `mypy` clean across 1137 source files.
- Pre-commit clean.
- **Local smoke**: ran the webapp and Celery beat against a local redis, confirmed every message in `palacedefault` (33 beat-scheduled tasks + 1 webapp-queued task) had `headers.enqueued_at` set. Verified `LINDEX palacedefault -1` returns the oldest message (the 4-minute-older webapp task), not the freshly-published beat batch.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.