### PR TITLE
Fix works with stale Adult audience after FBJUV BISAC reclassification

### DIFF
--- a/alembic/versions/20260512_d856ff4dbefb_reset_audience_for_works_with_mis_.py
+++ b/alembic/versions/20260512_d856ff4dbefb_reset_audience_for_works_with_mis_.py
@@ -1,0 +1,61 @@
+"""Reset audience for works with mis-classified FB BISAC subjects
+
+Works linked to BISAC subjects whose identifier begins with "FB" (e.g. FBJUV*, FBYA*)
+were incorrectly assigned audience="Adult" before the scrubber fix landed. The
+classify_unchecked_subjects repair task reclassified the subjects correctly, but a
+structural side-effect in that task meant some works were never re-presented. This
+migration resets work.audience to NULL for those works so the startup task can
+re-run calculate_presentation() on them.
+
+Revision ID: d856ff4dbefb
+Revises: 05a95c828149
+Create Date: 2026-05-12 22:11:05.399881+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from palace.manager.util.migration.helpers import migration_logger
+
+# revision identifiers, used by Alembic.
+revision = "d856ff4dbefb"
+down_revision = "05a95c828149"
+branch_labels = None
+depends_on = None
+
+log = migration_logger(revision)
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    result = conn.execute(
+        sa.text(
+            """
+            UPDATE works
+            SET audience = NULL
+            WHERE audience = 'Adult'
+              AND id IN (
+                  SELECT DISTINCT lp.work_id
+                  FROM licensepools lp
+                  JOIN identifiers i ON i.id = lp.identifier_id
+                  JOIN classifications c ON c.identifier_id = i.id
+                  JOIN subjects s ON s.id = c.subject_id
+                  WHERE s.type = 'BISAC'
+                    AND s.identifier LIKE 'FB%'
+                    AND s.audience IN ('Children', 'Young Adult')
+              )
+            RETURNING id
+            """
+        )
+    )
+    rows = list(result)
+    log.info(
+        f"Reset audience=NULL for {len(rows)} works with mis-classified FB BISAC subjects"
+    )
+
+
+def downgrade() -> None:
+    # Cannot reliably restore the original audience values; intentionally a no-op.
+    pass

--- a/src/palace/manager/celery/tasks/work.py
+++ b/src/palace/manager/celery/tasks/work.py
@@ -16,6 +16,29 @@ from palace.manager.sqlalchemy.model.work import Work
 
 
 @shared_task(queue=QueueNames.default, bind=True)
+def reclassify_null_audience_works(task: Task) -> None:
+    """Reclassify all works whose audience was reset to NULL by a repair migration.
+
+    Iterates works with audience IS NULL in ascending id order and calls
+    calculate_presentation() on each, committing after every work so that
+    progress is preserved if the task is interrupted.
+    """
+    with task.session() as session:
+        policy = PresentationCalculationPolicy.recalculate_classification()
+        last_id: int | None = None
+        while True:
+            qu = session.query(Work).filter(Work.audience.is_(None)).order_by(Work.id)
+            if last_id is not None:
+                qu = qu.filter(Work.id > last_id)
+            work = qu.first()
+            if not work:
+                break
+            last_id = work.id
+            work.calculate_presentation(policy=policy)
+            session.commit()
+
+
+@shared_task(queue=QueueNames.default, bind=True)
 def classify_unchecked_subjects(task: Task) -> None:
     """Reclassify all Works whose current classifications appear to
     depend on Subjects in the 'unchecked' state.

--- a/src/palace/manager/celery/tasks/work.py
+++ b/src/palace/manager/celery/tasks/work.py
@@ -19,6 +19,10 @@ def reclassify_null_audience_works(task: Task) -> None:
     Iterates works with audience IS NULL in ascending id order and calls
     calculate_presentation() on each, committing after every work so that
     progress is preserved if the task is interrupted.
+
+    TODO: Remove this task and its startup task
+    (startup_tasks/2026_05_12_reclassify_fb_misclassified_works.py) once the
+    startup task has been run on all deployments.
     """
     with task.session() as session:
         policy = PresentationCalculationPolicy.recalculate_classification()

--- a/src/palace/manager/celery/tasks/work.py
+++ b/src/palace/manager/celery/tasks/work.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Generator
-
 from celery import shared_task
-from sqlalchemy import tuple_
-from sqlalchemy.orm import Session, defer
+from sqlalchemy.orm import Session
 
 from palace.manager.celery.task import Task
 from palace.manager.data_layer.policy.presentation import PresentationCalculationPolicy
@@ -47,111 +44,31 @@ def classify_unchecked_subjects(task: Task) -> None:
     Subjects because the rules for processing them changed.
     """
     with task.session() as session:
-        paged_query = _paginate_query(session, 1000)
-
+        # Snapshot all affected work IDs before processing begins.
+        # calculate_presentation() calls assign_to_genre() which marks subjects
+        # checked=True as a side effect; a live query would silently skip works
+        # that share those subjects with an already-processed work.
+        work_ids = _work_ids_with_unchecked_subjects(session)
         policy = PresentationCalculationPolicy.recalculate_classification()
-        while True:
-            works = next(paged_query, [])
-            if not works:
-                break
-            for work in works:
-                work.calculate_presentation(policy=policy)
-                session.commit()
+        for work_id in work_ids:
+            work = session.get(Work, work_id)
+            if work is None:
+                continue
+            work.calculate_presentation(policy=policy)
+            session.commit()
 
 
-def _unchecked_subjects(_db: Session) -> Generator[Subject]:
-    """Yield one unchecked subject at a time"""
-    query = _db.query(Subject).filter(Subject.checked == False).order_by(Subject.id)
-    last_id = None
-    while True:
-        qu = query
-        if last_id:
-            qu = qu.filter(Subject.id > last_id)
-        subject = qu.first()
-
-        if not subject:
-            return
-
-        last_id = subject.id
-        yield subject
-
-
-def _paginate_query(_db: Session, batch_size: int) -> Generator[list[Work]]:
-    """Page this query using the row-wise comparison
-    technique unique to this job. We have already ensured
-    the ordering of the rows follows all the joined tables"""
-
-    for subject in _unchecked_subjects(_db):
-        last_work: Work | None = None  # Last work object of the previous page
-        # IDs of the last work, for paging
-        work_id, license_id, iden_id, classn_id = (
-            None,
-            None,
-            None,
-            None,
-        )
-
-        query = (
-            _db.query(Work, LicensePool.id, Identifier.id, Classification.id)
-            .join(Work.license_pools)
-            .join(LicensePool.identifier)
-            .join(Identifier.classifications)
-            .join(Classification.subject)
-        )
-
-        while True:
-
-            # Must order by all joined attributes
-            query = (
-                query.order_by(None)
-                .order_by(
-                    Subject.id,
-                    Work.id,
-                    LicensePool.id,
-                    Identifier.id,
-                    Classification.id,
-                )
-                .options(
-                    defer(Work.summary_text),
-                )
-            )
-            # We are a "per subject" filter, this is the MOST efficient method
-            qu = query.filter(Subject.id == subject.id)
-            # # Add the columns we need to page with explicitly in the query
-            # qu: Query[Tuple[Work, int, int, int]] = qu.add_columns(LicensePool.id, Identifier.id, Classification.id)
-            # We're not on the first page, add the row-wise comparison
-            if last_work is not None:
-                qu = qu.filter(
-                    tuple_(
-                        Work.id,
-                        LicensePool.id,
-                        Identifier.id,
-                        Classification.id,
-                    )
-                    > (work_id, license_id, iden_id, classn_id)
-                )
-
-            qu2 = qu.limit(batch_size)
-            works = qu2.all()
-            if not len(works):
-                break
-
-            last_work_row = works[-1]
-            last_work = last_work_row[0]
-            # set comprehension ensures we get unique works per loop
-            # Works will get duplicated in the query because of the addition
-            # of the ID columns in the select, it is possible and expected
-            # that works will get duplicated across loops. It is not a desired
-            # outcome to duplicate works across loops, but the alternative is to maintain
-            # the IDs in memory and add a NOT IN operator in the query
-            # which would grow quite large, quite fast
-            only_works = list({w[0] for w in works})
-
-            yield only_works
-
-            work_id, license_id, iden_id, classn_id = (
-                last_work_row[0].id,
-                last_work_row[1],
-                last_work_row[2],
-                last_work_row[3],
-            )
+def _work_ids_with_unchecked_subjects(session: Session) -> list[int]:
+    """Return IDs of all works linked to at least one unchecked subject, ordered by id."""
+    rows = (
+        session.query(Work.id)
+        .join(Work.license_pools)
+        .join(LicensePool.identifier)
+        .join(Identifier.classifications)
+        .join(Classification.subject)
+        .filter(Subject.checked == False)
+        .distinct()
+        .order_by(Work.id)
+        .all()
+    )
+    return [row[0] for row in rows]

--- a/startup_tasks/2026_05_12_reclassify_fb_misclassified_works.py
+++ b/startup_tasks/2026_05_12_reclassify_fb_misclassified_works.py
@@ -1,0 +1,20 @@
+"""Reclassify works whose audience was reset by the FB BISAC mis-classification repair.
+
+The migration d856ff4dbefb set audience=NULL for works that had audience='Adult' but
+were linked to FB-prefixed BISAC subjects now correctly classified as Children/Young
+Adult. This task dispatches the one-time Celery job that re-runs calculate_presentation()
+on those works."""
+
+from __future__ import annotations
+
+import logging
+
+from celery.canvas import Signature
+from sqlalchemy.orm import Session
+
+from palace.manager.celery.tasks.work import reclassify_null_audience_works
+from palace.manager.service.container import Services
+
+
+def run(services: Services, session: Session, log: logging.Logger) -> Signature | None:
+    return reclassify_null_audience_works.s()

--- a/tests/manager/celery/tasks/test_work.py
+++ b/tests/manager/celery/tasks/test_work.py
@@ -88,3 +88,33 @@ def test_subject_checked(
     with patch.object(Work, "calculate_presentation") as calc_pres:
         work_tasks.classify_unchecked_subjects.delay().wait()
     assert calc_pres.call_count == 0
+
+
+def test_reclassify_null_audience_works(
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+):
+    """reclassify_null_audience_works calls calculate_presentation for works with NULL audience
+    and leaves works with a non-NULL audience untouched."""
+    null_works = []
+    for _ in range(3):
+        work: Work = db.work(with_license_pool=True)
+        work.audience = None
+        null_works.append(work)
+
+    adult_work: Work = db.work(with_license_pool=True)
+    # audience defaults to "Adult" in db.work()
+
+    db.session.commit()
+
+    with patch.object(Work, "calculate_presentation") as calc_pres:
+        work_tasks.reclassify_null_audience_works.delay().wait()
+
+    # Only the three null-audience works should trigger calculate_presentation.
+    assert calc_pres.call_count == 3
+
+    # Verify the recalculate_classification policy is used for each call.
+    for call_obj in calc_pres.call_args_list:
+        policy = call_obj[1]["policy"]
+        assert policy.classify is True
+        assert policy.choose_edition is False

--- a/tests/manager/celery/tasks/test_work.py
+++ b/tests/manager/celery/tasks/test_work.py
@@ -7,50 +7,51 @@ from tests.fixtures.celery import CeleryFixture
 from tests.fixtures.database import DatabaseTransactionFixture
 
 
-def test_paginate(db: DatabaseTransactionFixture):
-    """Pagination is changed to be row-wise comparison
-    Ensure we are paginating correctly within the same Subject page"""
-    subject = db.subject(Subject.AXIS_360_AUDIENCE, "Any")
-    works = []
-    for i in range(20):
-        work: Work = db.work(with_license_pool=True)
+def test_work_ids_with_unchecked_subjects(db: DatabaseTransactionFixture):
+    """_work_ids_with_unchecked_subjects returns IDs for works linked to at
+    least one unchecked subject, deduplicates, and excludes works whose
+    subjects are all checked."""
+    unchecked = db.subject(Subject.BISAC, "FBJUV000000")
+    checked = db.subject(Subject.BISAC, "FIC000000")
+    checked.checked = True
+
+    # Work with one unchecked subject — should appear.
+    work_a: Work = db.work(with_license_pool=True)
+    db.classification(
+        work_a.presentation_edition.primary_identifier,
+        unchecked,
+        work_a.license_pools[0].data_source,
+    )
+
+    # Work with both an unchecked and a checked subject — should appear once.
+    work_b: Work = db.work(with_license_pool=True)
+    for subject in [unchecked, checked]:
         db.classification(
-            work.presentation_edition.primary_identifier,
+            work_b.presentation_edition.primary_identifier,
             subject,
-            work.license_pools[0].data_source,
+            work_b.license_pools[0].data_source,
         )
-        works.append(work)
 
-    for ix, [work] in enumerate(work_tasks._paginate_query(db.session, batch_size=1)):
-        # We are coming in via "id" order
-        assert work == works[ix]
-
-    assert ix == 19
-
-    other_subject = db.subject(Subject.BISAC, "Any")
-    last_work = works[-1]
+    # Work with only a checked subject — should not appear.
+    work_c: Work = db.work(with_license_pool=True)
     db.classification(
-        last_work.presentation_edition.primary_identifier,
-        other_subject,
-        last_work.license_pools[0].data_source,
+        work_c.presentation_edition.primary_identifier,
+        checked,
+        work_c.license_pools[0].data_source,
     )
-    next_works = next(work_tasks._paginate_query(db.session, batch_size=100))
-    # Works are only iterated over ONCE per loop
-    assert len(next_works) == 20
 
-    # A checked subjects work is not included
-    not_work = db.work(with_license_pool=True)
-    another_subject = db.subject(Subject.DDC, "Any")
-    db.classification(
-        not_work.presentation_edition.primary_identifier,
-        another_subject,
-        not_work.license_pools[0].data_source,
-    )
-    another_subject.checked = True
+    # Work with no classifications — should not appear.
+    work_d: Work = db.work(with_license_pool=True)
+
     db.session.commit()
-    next_works = next(work_tasks._paginate_query(db.session, batch_size=100))
-    assert len(next_works) == 20
-    assert not_work not in next_works
+
+    result = work_tasks._work_ids_with_unchecked_subjects(db.session)
+
+    assert sorted(result) == sorted([work_a.id, work_b.id])
+    assert work_c.id not in result
+    assert work_d.id not in result
+    # Each work appears exactly once even when linked to multiple unchecked subjects.
+    assert len(result) == len(set(result))
 
 
 def test_subject_checked(


### PR DESCRIPTION
## Description

Works from Palace Marketplace with FBJUV* BISAC subjects were incorrectly assigned `audience='Adult'` before the scrubber fix landed. Prior migrations reset `subjects.checked=False` and `classify_unchecked_subjects` re-ran, correctly updating subject records to `audience='Children'`. However, some `works.audience` values remained stale as `'Adult'`.

## Motivation and Context

https://ebce-lyrasis.atlassian.net/browse/PP-4204

Books that are clearly children's titles (e.g. `typicalAgeRange=3-12`, FBJUV classifications) were still surfacing as Adult in the Palace catalog. The problem only affects works that *share* a BISAC subject with another work.

## Root cause

`classify_unchecked_subjects` used a live generator over unchecked subjects. When Work A is processed, `calculate_presentation()` calls `assign_to_genre()` on all of Work A's unchecked subjects — including any shared with Work B — and marks them `checked=True`. The generator then skips those subjects, so Work B is never queued for `calculate_presentation()` and its `work.audience` stays stale.

## Changes

This PR has two distinct parts:

### 1. Repair already-affected works (commit 1)

Because the affected works already have their subjects marked `checked=True` (correctly classified as Children), the structural fix below won't touch them — `classify_unchecked_subjects` only processes works with *unchecked* subjects. A one-time repair is required:

- **Migration `d856ff4dbefb`** — resets `work.audience = NULL` for works with `audience='Adult'` linked to a BISAC subject matching `identifier LIKE 'FB%'` whose audience is now `'Children'` or `'Young Adult'`. Using `FB%` rather than `FBJUV%` catches all Palace Marketplace-prefixed codes (including any `FBYA*`) that fell through to the adult catch-all; the `audience IN ('Children', 'Young Adult')` filter ensures legitimately-Adult works are not reset.

- **`reclassify_null_audience_works` Celery task** — iterates all works with `audience IS NULL` in `id` order, calling `calculate_presentation(policy=recalculate_classification())` on each, committing after every work so progress survives interruption.

- **Startup task `2026_05_12_reclassify_fb_misclassified_works.py`** — dispatches `reclassify_null_audience_works` once at the next deploy. The `startup_tasks` table prevents re-execution on subsequent restarts.

### 2. Fix the root cause in `classify_unchecked_subjects` (commit 2)

Replace the live-generator approach with an upfront snapshot of all work IDs linked to unchecked subjects, taken before any `calculate_presentation()` calls begin. Side effects from `assign_to_genre()` cannot corrupt a snapshot that has already been captured.

The old `_unchecked_subjects` / `_paginate_query` machinery is removed and replaced with `_work_ids_with_unchecked_subjects`, a single query using `DISTINCT` that also eliminates the old code's possibility of processing the same work more than once.

## Design decisions

**Why a snapshot rather than a cursor?**
Any live query filtering by `Subject.checked == False` reintroduces the bug: when Work A's processing marks shared subjects checked, a subsequent page query misses Work B for the same reason as before. The snapshot must be taken before processing starts.

**Memory concern at scale?**
Loading all work IDs upfront is a reasonable tradeoff for the targeted use case this task is designed for (migrations that reset a specific class of subjects). Even a large affected set is just integers — a million IDs is ~8 MB. If a broad "reset all subjects" migration were ever needed, a different approach (e.g. persisting the snapshot in Redis and using the self-replacement pattern) would be warranted, but that scenario hasn't arisen and would be a deliberate architectural decision at that point.

**Why not use the self-replacement pattern used by other long-running tasks?**
Self-replacement requires querying for "what's next" in each invocation. Any such live query reintroduces the side-effect bug unless the snapshot is persisted across invocations (e.g. in Redis). That complexity isn't justified for the targeted use cases `classify_unchecked_subjects` handles. The task runs nightly with a 30-minute limit; if it can't finish in one run, progress is durable (committed works have `checked=True` subjects) and the next night's run picks up the remainder.

## Follow on tasks: 

Once this fix has been deployed across production,  we can work this follow up task to remove obsolete code associated with the one time startup fix: https://ebce-lyrasis.atlassian.net/browse/PP-4330

## How Has This Been Tested?

- `test_work_ids_with_unchecked_subjects` — verifies the snapshot query returns only works with at least one unchecked subject, deduplicates correctly, and excludes works with only checked subjects or no subjects.
- `test_subject_checked` — existing test; verifies `classify_unchecked_subjects` calls `calculate_presentation` for all works linked to an unchecked subject and skips works when the subject is checked.
- `test_reclassify_null_audience_works` — verifies the new repair task calls `calculate_presentation` only for works with `audience IS NULL`, using the `recalculate_classification` policy.

NOTE: This issue only exists in production.   Previous PRs addressed the problem to the extent that we were no longer seein git on minotaur.   So once this goes to production we will be able to confirm the fix.   I will verify that the migration and startup task works on minotaur and we don't have any regressions.



## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.