### PR TITLE
Skip fresh titles in the Overdrive reaper

### DIFF
--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 from celery import chain, chord, group, shared_task
 from celery.exceptions import Ignore
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from palace.util.datetime_helpers import utc_now
 
@@ -34,6 +34,13 @@ from palace.manager.util.http.exception import (
 )
 
 IMPORT_SKIPPED: str = "import_skipped"
+
+# Reaper skips titles whose availability was refreshed more recently than this
+# (typically by the incremental import). Stale titles are checked against Overdrive,
+# which both refreshes their availability and detects collection removals via 404.
+# This caps removal-detection latency for any one title at roughly STALE_THRESHOLD
+# plus the reap interval.
+REAP_STALE_THRESHOLD: datetime.timedelta = datetime.timedelta(hours=24)
 
 
 class ImportSkippedPayload(TypedDict):
@@ -526,9 +533,15 @@ def reap_collection(
     """
     Check for books that are in the local collection but have left our Overdrive collection.
 
+    Only identifiers whose LicensePool.last_checked is older than REAP_STALE_THRESHOLD
+    (or unset) are checked against Overdrive — titles with circulation activity since the
+    threshold have already been refreshed by the incremental import. For each checked
+    identifier, ``api.update_licensepool`` refreshes availability and detects removals
+    (Overdrive returns 404 for titles no longer in the collection).
+
     Processes identifiers in batches, re-queuing itself via task.replace() until all
-    identifiers have been checked. A Redis workflow lock prevents overlapping runs for
-    the same collection; the lock auto-expires after 2 hours if the process dies.
+    stale identifiers have been checked. A Redis workflow lock prevents overlapping runs
+    for the same collection; the lock auto-expires after 2 hours if the process dies.
 
     :param collection_id: The ID of the Overdrive collection to reap.
     :param offset: The last Identifier.id processed; used to resume across batches.
@@ -568,6 +581,7 @@ def reap_collection(
             collection = load_from_id(session, Collection, collection_id)
             collection_name = collection.name
 
+            stale_cutoff = utc_now() - REAP_STALE_THRESHOLD
             identifiers = (
                 session.execute(
                     select(Identifier)
@@ -575,6 +589,10 @@ def reap_collection(
                     .where(
                         LicensePool.collection_id == collection_id,
                         Identifier.id > offset,
+                        or_(
+                            LicensePool.last_checked.is_(None),
+                            LicensePool.last_checked < stale_cutoff,
+                        ),
                     )
                     .order_by(Identifier.id)
                     .limit(batch_size)

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import datetime
 from unittest.mock import MagicMock, Mock, call, patch
 from uuid import uuid4
 
 import pytest
 from celery.result import AsyncResult
 
-from palace.util.datetime_helpers import datetime_utc
+from palace.util.datetime_helpers import datetime_utc, utc_now
 from palace.util.log import LogLevel
 
 from palace.manager.celery.importer import import_workflow_lock, reap_workflow_lock
@@ -1318,6 +1319,40 @@ class TestOverdriveReaper:
         }
         assert pool1.identifier.identifier in identifiers_called
         assert pool2.identifier.identifier in identifiers_called
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_skips_fresh_titles(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+    ):
+        """Only LicensePools with last_checked older than REAP_STALE_THRESHOLD
+        (or unset) are checked against Overdrive."""
+        collection = overdrive_api_fixture.collection
+        fresh_pool = db.licensepool(db.edition(), collection=collection)
+        stale_pool = db.licensepool(db.edition(), collection=collection)
+        never_checked_pool = db.licensepool(db.edition(), collection=collection)
+
+        now = utc_now()
+        fresh_pool.last_checked = now
+        stale_pool.last_checked = (
+            now - overdrive.REAP_STALE_THRESHOLD - datetime.timedelta(minutes=1)
+        )
+        # never_checked_pool.last_checked stays None
+        db.session.flush()
+
+        overdrive.reap_collection.delay(collection.id).wait()
+
+        mock_api = mock_api_class.return_value
+        identifiers_called = {
+            c.args[0] for c in mock_api.update_licensepool.call_args_list
+        }
+        assert fresh_pool.identifier.identifier not in identifiers_called
+        assert stale_pool.identifier.identifier in identifiers_called
+        assert never_checked_pool.identifier.identifier in identifiers_called
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_replaces_when_full_batch(


### PR DESCRIPTION
## Description

Add a `last_checked` predicate to the `overdrive.reap_collection` batch query so the reaper only issues per-title Overdrive availability calls for `LicensePool`s that haven't been refreshed within `REAP_STALE_THRESHOLD` (24h). Titles with recent circulation activity have already been refreshed by the incremental import — re-asking Overdrive about them every hour is wasted work.

Removal detection still works: when a title's circulation activity stops (the case where it has been removed from the Overdrive collection), its `last_checked` ages past the threshold and the next reap cycle picks it up. Overdrive's per-title availability endpoint returns 404 for removed titles, which is how the existing reaper detects them. Removal-detection latency for any single title is bounded by `REAP_STALE_THRESHOLD + reap_interval`.

## Motivation and Context

While investigating `LockNotAcquired` errors raised by `opds_odl.import_collection` (the work that produced #3340), CloudWatch worker-time accounting revealed that the `default` Celery queue is dominated by Overdrive work — and that the largest single consumer is the reaper, not the importer.

The headline number: `overdrive.reap_collection` ran **134,306** times fleet-wide over 12 hours (5,284 succeeded + 129,022 mid-chain `task.replace` invocations that log as `ignored`, which my earlier accounting under-counted by ~25×). Each successful batch did ~50 sequential synchronous availability HTTP calls to Overdrive (one per Identifier). At ~22s of HTTP per batch, that's hundreds of worker-hours/day fleet-wide spent re-checking titles that the incremental import had just refreshed.

The reaper's only unique job is detecting titles that have *left* the Overdrive collection — i.e. titles whose `last_checked` has gone stale precisely because they no longer appear in the circulation-changes feed. So the filter is the right shape: we only need to issue Overdrive calls for titles whose freshness has lapsed.

### What this PR does not do

- It does not change the reaper's beat cadence. Hourly is fine once each cycle's work shrinks to "just the stale titles."
- It does not restructure the reaper to walk the full Overdrive product feed for removal detection (the more efficient structural answer). That's a larger change that can be considered separately once we see the impact of this one.
- It does not touch the importer's per-title metadata fetch (the `fetch_metadata=True` waste on the incremental path is a related but separate optimization).

## How Has This Been Tested?

- New unit test `test_reap_collection_skips_fresh_titles` exercises three pools (recent `last_checked`, stale `last_checked`, and `last_checked is None`) and asserts that `update_licensepool` is called only for the stale and never-checked pools.
- Existing reaper tests still pass — they create pools without setting `last_checked`, so `last_checked IS NULL` keeps them included in the batch as before.

```
tox -e py312-docker -- --no-cov tests/manager/celery/tasks/test_overdrive.py::TestOverdriveReaper
9 passed
```

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.