### PR TITLE
Fix QueueOldestAge metric reading unprefixed Redis queue keys (PP-4336)

### DIFF
--- a/src/palace/manager/celery/monitoring.py
+++ b/src/palace/manager/celery/monitoring.py
@@ -81,6 +81,21 @@ class QueueStats:
         return metric_data
 
 
+class _PrefixedRedis(PrefixedStrictRedis):
+    """A ``PrefixedStrictRedis`` that also prefixes ``LINDEX``.
+
+    kombu's ``PrefixedStrictRedis`` only prefixes the Redis commands it needs
+    for its own broker operations, and ``LINDEX`` is not one of them. The
+    Cloudwatch camera uses ``LINDEX`` to read the oldest message in a queue, so
+    without this it would query an unprefixed key and always get ``None`` back.
+    """
+
+    PREFIXED_SIMPLE_COMMANDS = [
+        *PrefixedStrictRedis.PREFIXED_SIMPLE_COMMANDS,
+        "LINDEX",
+    ]
+
+
 class Cloudwatch(Polaroid):
     """
     Implements a Celery custom camera that sends queue statistics to Cloudwatch.
@@ -122,9 +137,9 @@ class Cloudwatch(Polaroid):
     @classmethod
     def get_redis_client(
         cls, broker_url: str, global_keyprefix: str | None
-    ) -> PrefixedStrictRedis:
+    ) -> _PrefixedRedis:
         connection_pool = ConnectionPool.from_url(broker_url)
-        return PrefixedStrictRedis(
+        return _PrefixedRedis(
             connection_pool=connection_pool, global_keyprefix=global_keyprefix
         )
 

--- a/tests/manager/celery/test_monitoring.py
+++ b/tests/manager/celery/test_monitoring.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import MagicMock, call, create_autospec, patch
 
 import pytest
+import redis
 from boto3.exceptions import Boto3Error
 from freezegun import freeze_time
 
@@ -129,6 +130,20 @@ class TestCloudwatch:
         cloudwatch_camera.configure_app(dry_run=True)
         cloudwatch = cloudwatch_camera.create_cloudwatch()
         assert cloudwatch.cloudwatch_client is None
+
+    def test_get_redis_client_prefixes_lindex(self):
+        # kombu's PrefixedStrictRedis does not include LINDEX in its prefixed-command list,
+        # so we need to patch it to make sure we can read the timestamp on the oldest message.
+        client = Cloudwatch.get_redis_client("redis://localhost", "prefix")
+        with patch.object(redis.Redis, "execute_command") as mock_execute:
+            client.lindex("apply", -1)
+            client.llen("apply")
+        # Check positional args only; redis-py also passes a `keys=` routing
+        # kwarg whose contents are version-specific and not what we care about.
+        assert [c.args for c in mock_execute.call_args_list] == [
+            ("LINDEX", "prefixapply", -1),
+            ("LLEN", "prefixapply"),
+        ]
 
     def test_on_shutter(
         self,


### PR DESCRIPTION
## Description

The Cloudwatch queue-statistics camera reads the oldest queued message with `redis_client.lindex(queue, -1)`, relying on kombu's `PrefixedStrictRedis` to apply the broker's `global_keyprefix`. But `LINDEX` is not in kombu's `PREFIXED_SIMPLE_COMMANDS` / `PREFIXED_COMPLEX_COMMANDS`, so the call ran against the bare queue name (e.g. `default` instead of `minotaurdefault`) and always returned `None`. `QueueWaiting` was unaffected because `LLEN` *is* in kombu's prefixed-command list — so `QueueOldestAge` was silently never emitted while `QueueWaiting` looked healthy.

This adds a small `_PrefixedRedis` subclass that includes `LINDEX` in the prefixed-command list, and uses it in `Cloudwatch.get_redis_client`.

## Motivation and Context

`QueueOldestAge` (added in #3343) never produced data points. I found this while testing PP-4336 — the metric was missing from CloudWatch even with a deliberately backed-up queue, because every `LINDEX` lookup hit an unprefixed key that doesn't exist.

## How Has This Been Tested?

- `tox -e py312-docker -- --no-cov tests/manager/celery/test_monitoring.py` — 13 tests pass, including a new regression test asserting `LINDEX` reaches Redis with the `global_keyprefix` applied.
- `mypy` clean on the changed files.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.