### PR TITLE
500 on /search/ from Accept-Language header (PP-4368)

### DIFF
--- a/src/palace/manager/util/accept_language.py
+++ b/src/palace/manager/util/accept_language.py
@@ -54,15 +54,41 @@ def parse_accept_language(
         return []
 
     if len(accept_language_str) > MAX_HEADER_LEN:
-        raise ValueError("Accept-Language too long, max length is 8192")
+        # Reject pathological input rather than spending CPU on it. We log
+        # the size + a prefix so we can see what's hitting us in metrics,
+        # but callers get an empty list — a malformed header from an
+        # external client should not break the request.
+        logger.warning(
+            "parse_accept_language: header exceeds max length %d (got %d); "
+            "returning no languages. Prefix: %r",
+            MAX_HEADER_LEN,
+            len(accept_language_str),
+            accept_language_str[:200],
+        )
+        return []
 
     parsed_langs = []
     for accept_lang_segment in accept_language_str.split(","):
         quality_value = default_quality or DEFAULT_QUALITY_VALUE
-        lang_code = accept_lang_segment.strip()
-        if ";" in accept_lang_segment:
-            lang_code, quality_value_string = accept_lang_segment.split(";")
-            quality_value = float(QUALITY_VAL_SUB_REGEX.sub("", quality_value_string))
+        # Scan all ';'-separated parameters for the q-value. The strict
+        # Accept-Language grammar (RFC 7231) only allows `q=` after the
+        # language code, but real-world clients send extra accept-params
+        # before or after q (e.g. `en;q=0.8;something`), so we don't
+        # assume q is first.
+        segment_parts = accept_lang_segment.split(";")
+        lang_code = segment_parts[0].strip()
+        for param in segment_parts[1:]:
+            if not QUALITY_VAL_SUB_REGEX.match(param.strip()):
+                continue
+            try:
+                quality_value = float(QUALITY_VAL_SUB_REGEX.sub("", param.strip()))
+            except ValueError:
+                logger.warning(
+                    "parse_accept_language: invalid quality value in "
+                    "segment %r; falling back to default quality",
+                    accept_lang_segment,
+                )
+            break
 
         lang_code_components = re.split("-|_", lang_code)
 

--- a/tests/manager/util/test_accept_language.py
+++ b/tests/manager/util/test_accept_language.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from palace.manager.util.accept_language import (
+    MAX_HEADER_LEN,
+    Lang,
+    parse_accept_language,
+)
+
+
+class TestParseAcceptLanguage:
+    def test_empty_header_returns_empty_list(self) -> None:
+        assert parse_accept_language("") == []
+
+    def test_docstring_example(self) -> None:
+        result = parse_accept_language("en-US,el;q=0.8")
+        assert result == [
+            Lang(language="en", locale="en_US", quality=1.0),
+            Lang(language="el", locale=None, quality=0.8),
+        ]
+
+    def test_sorts_by_quality_descending(self) -> None:
+        result = parse_accept_language("el;q=0.3,en;q=0.9,fr;q=0.6")
+        assert [lang.language for lang in result] == ["en", "fr", "el"]
+
+    def test_default_quality_argument(self) -> None:
+        # When no q-value is specified, the default_quality argument applies.
+        result = parse_accept_language("en,fr;q=0.5", default_quality=0.7)
+        assert result == [
+            Lang(language="en", locale=None, quality=0.7),
+            Lang(language="fr", locale=None, quality=0.5),
+        ]
+
+    def test_segment_with_extra_param_after_q(self) -> None:
+        # Regression: a Facebook crawler sent something like
+        # `en;q=0.8;something`, which used to raise ValueError
+        # ("too many values to unpack") and bubble up to a 500 on /search/.
+        # We parse the q-value and ignore the trailing extra.
+        result = parse_accept_language("en;q=0.8;something,fr;q=0.5")
+        assert result == [
+            Lang(language="en", locale=None, quality=0.8),
+            Lang(language="fr", locale=None, quality=0.5),
+        ]
+
+    def test_segment_with_extra_param_before_q(self) -> None:
+        # Some non-conformant clients put extras before the q-value. The
+        # parser scans all ';'-separated params for `q=` rather than
+        # assuming it comes first.
+        result = parse_accept_language("en;something;q=0.8")
+        assert result == [Lang(language="en", locale=None, quality=0.8)]
+
+    def test_segment_with_non_q_param_only(self) -> None:
+        # If no `q=` param is present, we use the default quality and
+        # still emit the language.
+        result = parse_accept_language("en;something")
+        assert result == [Lang(language="en", locale=None, quality=1.0)]
+
+    def test_empty_segments_are_skipped(self) -> None:
+        # Trailing/duplicate commas should not crash; the empty segments
+        # fail the language-code regex and are skipped silently.
+        result = parse_accept_language("en,,fr,")
+        assert [lang.language for lang in result] == ["en", "fr"]
+
+    def test_invalid_quality_value_falls_back_to_default(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # When `q=` is present but unparseable, we keep the language code
+        # at default quality and log a warning. Dropping a usable language
+        # because of a garbage parameter would be too aggressive.
+        caplog.set_level(logging.WARNING)
+        result = parse_accept_language("en;q=,fr;q=abc,de;q=0.4")
+        assert result == [
+            Lang(language="en", locale=None, quality=1.0),
+            Lang(language="fr", locale=None, quality=1.0),
+            Lang(language="de", locale=None, quality=0.4),
+        ]
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("en;q=" in m for m in warnings)
+        assert any("fr;q=abc" in m for m in warnings)
+
+    def test_invalid_language_code_is_skipped(self) -> None:
+        # Digits and other non-alpha characters in the language code fail
+        # the validation regex and are silently dropped.
+        result = parse_accept_language("en,123,fr")
+        assert [lang.language for lang in result] == ["en", "fr"]
+
+    def test_header_too_long_returns_empty_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # An over-length header is rejected as a sanity guard, but we
+        # return [] rather than raising — every caller wants the same
+        # empty-list fallback, and a malformed external header should
+        # never break the request.
+        caplog.set_level(logging.WARNING)
+        oversized = "en," * (MAX_HEADER_LEN // 3 + 1)
+        assert len(oversized) > MAX_HEADER_LEN
+        assert parse_accept_language(oversized) == []
+        assert any(
+            "exceeds max length" in record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        )
+
+    def test_whitespace_in_segments(self) -> None:
+        # Browsers commonly send `en-US, en;q=0.9` with a space after the
+        # comma. Existing behavior strips whitespace.
+        result = parse_accept_language("en-US, en;q=0.9")
+        assert result == [
+            Lang(language="en", locale="en_US", quality=1.0),
+            Lang(language="en", locale=None, quality=0.9),
+        ]


### PR DESCRIPTION
## Description

`parse_accept_language` in `src/palace/manager/util/accept_language.py` called `accept_lang_segment.split(";")` with no `maxsplit`, so any segment with more than one `;` (e.g. `en-US;q=0.8;something`) raised `ValueError: too many values to unpack`. The exception bubbled up from `SearchFacets.from_request` and returned **500** on `/<library>/search/<lane_id>` endpoints.

The parser is now lenient with malformed input rather than relying on the caller to catch exceptions:

- Scan all `;`-separated params for `q=` instead of assuming it's the first param. Real-world clients send extras before or after `q` (the RFC technically forbids it, but `meta-externalagent/1.1` and others ignore that).
- Invalid q-values (`q=`, `q=abc`) log a warning and fall back to the default quality, keeping the language code. Dropping a usable language because one param is garbage would be too aggressive.
- Over-length headers (>8192 chars) log a warning and return `[]` instead of raising. Every caller wanted the empty-list fallback anyway.

## Motivation and Context

I'm looking into alerts from over the weekend and it looks like `meta-externalagent/1.1` (Facebook crawler) hit `/FL0249/search/915`, `/VT0014/search/60583`, and other lane-search endpoints with a multi-`;` `Accept-Language` header, generating 500s. It crawled enough of them for us to get an alert on 500s coming from production.

Jira ticket: PP-4368.

## How Has This Been Tested?

- New test file `tests/manager/util/test_accept_language.py` with 11 cases covering: docstring example, sort ordering, `default_quality` argument, extras after `q`, extras before `q`, segments with no `q=` at all, empty segments, invalid q-values (`q=`, `q=abc`), invalid language codes, over-length header returning `[]` with a warning, and whitespace handling.
- Existing `tests/manager/feed/facets/test_search.py` (8 tests) continues to pass — no behavior change for the happy path.
- `mypy` clean on the changed files.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.