### PR TITLE
BuildError on loans feed when Work language is null (PP-4368)

### DIFF
--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -963,6 +963,14 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             return None
 
         languages, audiences = self.language_and_audience_key_from_work(entry.work)
+        # Werkzeug treats an explicit `None` kwarg as "present" and won't fall
+        # back to the route variant whose `defaults` cover the missing values,
+        # so we drop the keys entirely when either is missing.
+        extra_kwargs: dict[str, str] = {}
+        if languages and audiences:
+            extra_kwargs["languages"] = languages
+            extra_kwargs["audiences"] = audiences
+
         for author_entry in entry.computed.authors:
             if not (name := author_entry.name):
                 continue
@@ -974,10 +982,9 @@ class LibraryAnnotator(CirculationManagerAnnotator):
                 href=self.url_for(
                     "contributor",
                     contributor_name=name,
-                    languages=languages,
-                    audiences=audiences,
                     library_short_name=self.library.short_name,
                     _external=True,
+                    **extra_kwargs,
                 ),
             )
 
@@ -1002,13 +1009,18 @@ class LibraryAnnotator(CirculationManagerAnnotator):
 
         series_name = work.series
         languages, audiences = self.language_and_audience_key_from_work(work)
+        # See add_author_links for why we omit these keys rather than passing None.
+        extra_kwargs: dict[str, str] = {}
+        if languages and audiences:
+            extra_kwargs["languages"] = languages
+            extra_kwargs["audiences"] = audiences
+
         href = self.url_for(
             "series",
             series_name=series_name,
-            languages=languages,
-            audiences=audiences,
             library_short_name=self.library.short_name,
             _external=True,
+            **extra_kwargs,
         )
         series_entry.link = Link(
             rel="series",

--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -965,11 +965,14 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         languages, audiences = self.language_and_audience_key_from_work(entry.work)
         # Werkzeug treats an explicit `None` kwarg as "present" and won't fall
         # back to the route variant whose `defaults` cover the missing values,
-        # so we drop the keys entirely when either is missing.
+        # so we drop the keys entirely when missing. The routes are hierarchical
+        # (`<name>`, `<name>/<languages>`, `<name>/<languages>/<audiences>`) so
+        # `audiences` is only meaningful when `languages` is also set.
         extra_kwargs: dict[str, str] = {}
-        if languages and audiences:
+        if languages is not None:
             extra_kwargs["languages"] = languages
-            extra_kwargs["audiences"] = audiences
+            if audiences is not None:
+                extra_kwargs["audiences"] = audiences
 
         for author_entry in entry.computed.authors:
             if not (name := author_entry.name):
@@ -1011,9 +1014,10 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         languages, audiences = self.language_and_audience_key_from_work(work)
         # See add_author_links for why we omit these keys rather than passing None.
         extra_kwargs: dict[str, str] = {}
-        if languages and audiences:
+        if languages is not None:
             extra_kwargs["languages"] = languages
-            extra_kwargs["audiences"] = audiences
+            if audiences is not None:
+                extra_kwargs["audiences"] = audiences
 
         href = self.url_for(
             "series",

--- a/tests/manager/feed/test_library_annotator.py
+++ b/tests/manager/feed/test_library_annotator.py
@@ -14,6 +14,7 @@ from palace.util.datetime_helpers import utc_now
 from palace.util.exceptions import BasePalaceException
 
 from palace.manager.api.adobe_vendor_id import AuthdataUtility
+from palace.manager.api.app import app
 from palace.manager.api.circulation.base import BaseCirculationAPI
 from palace.manager.api.circulation.dispatcher import CirculationApiDispatcher
 from palace.manager.api.circulation.fulfillment import RedirectFulfillment
@@ -791,6 +792,11 @@ class TestLibraryAnnotator:
         result = annotator_fixture.annotator.language_and_audience_key_from_work(work)
         assert ("eng", "All+Ages,Children") == result
 
+        work = annotator_fixture.db.work(audience=Classifier.AUDIENCE_ADULT)
+        work.presentation_edition.language = None
+        result = annotator_fixture.annotator.language_and_audience_key_from_work(work)
+        assert (None, "Adult,Adults+Only,All+Ages,Children,Young+Adult") == result
+
     def test_work_entry_includes_contributor_links(
         self, annotator_fixture: LibraryAnnotatorFixture
     ):
@@ -834,6 +840,29 @@ class TestLibraryAnnotator:
         [entry] = self.get_parsed_feed(annotator_fixture, [work]).entries
         assert [] == [l.link for l in entry.computed.authors if l.link]
 
+    def test_add_author_links_when_language_is_none(
+        self, annotator_fixture: LibraryAnnotatorFixture
+    ):
+        # Regression: when work.language is None, language_and_audience_key_from_work
+        # returns (None, ...). Passing those Nones to Werkzeug's url_for raises
+        # BuildError because no route variant matches a None path kwarg.
+        # Verified against the real Flask routes via test_request_context.
+        work = annotator_fixture.db.work(with_open_access_download=True)
+        work.presentation_edition.language = None
+
+        with app.test_request_context("/"):
+            feed = self.get_parsed_feed(annotator_fixture, [work])
+            [entry] = feed.entries
+
+        [contributor_link] = [
+            l.link for l in entry.computed.authors if hasattr(l, "link") and l.link
+        ]
+        assert contributor_link.type == LinkContentType.OPDS_FEED
+        # The unfiltered route is `/works/contributor/<contributor_name>` with no
+        # trailing language/audience segments.
+        path = contributor_link.href.split("/works/contributor/", 1)[1].rstrip("/")
+        assert "/" not in path
+
     def test_work_entry_includes_series_link(
         self, annotator_fixture: LibraryAnnotatorFixture
     ):
@@ -855,6 +884,25 @@ class TestLibraryAnnotator:
         feed = self.get_parsed_feed(annotator_fixture, [work])
         [entry] = feed.entries
         assert None == entry.computed.series
+
+    def test_add_series_link_when_language_is_none(
+        self, annotator_fixture: LibraryAnnotatorFixture
+    ):
+        # Regression: same null-language case as test_add_author_links_when_language_is_none,
+        # but for the series link path.
+        work = annotator_fixture.db.work(
+            with_open_access_download=True, series="Serious Cereals Series"
+        )
+        work.presentation_edition.language = None
+
+        with app.test_request_context("/"):
+            feed = self.get_parsed_feed(annotator_fixture, [work])
+            [entry] = feed.entries
+
+        series_link = entry.computed.series.link
+        assert series_link.type == LinkContentType.OPDS_FEED
+        path = series_link.href.split("/works/series/", 1)[1].rstrip("/")
+        assert "/" not in path
 
     def test_work_entry_includes_recommendations_link(
         self, annotator_fixture: LibraryAnnotatorFixture

--- a/tests/manager/feed/test_library_annotator.py
+++ b/tests/manager/feed/test_library_annotator.py
@@ -863,6 +863,30 @@ class TestLibraryAnnotator:
         path = contributor_link.href.split("/works/contributor/", 1)[1].rstrip("/")
         assert "/" not in path
 
+    def test_add_author_links_when_audience_key_is_none(
+        self, annotator_fixture: LibraryAnnotatorFixture
+    ):
+        # The route hierarchy supports a language-only variant
+        # (`/works/contributor/<name>/<languages>` with audiences defaulted).
+        # When the work has a language but no recognized audience category
+        # (the `else: audiences = []` branch in language_and_audience_key_from_work),
+        # we should still emit the language-filtered URL rather than falling
+        # back to the fully unfiltered route.
+        work = annotator_fixture.db.work(with_open_access_download=True, language="eng")
+        work.audience = None
+
+        with app.test_request_context("/"):
+            feed = self.get_parsed_feed(annotator_fixture, [work])
+            [entry] = feed.entries
+
+        [contributor_link] = [
+            l.link for l in entry.computed.authors if hasattr(l, "link") and l.link
+        ]
+        path = contributor_link.href.split("/works/contributor/", 1)[1].rstrip("/")
+        # `<name>/<languages>` — one slash, with the language segment present.
+        name, languages = path.split("/")
+        assert languages == "eng"
+
     def test_work_entry_includes_series_link(
         self, annotator_fixture: LibraryAnnotatorFixture
     ):
@@ -903,6 +927,27 @@ class TestLibraryAnnotator:
         assert series_link.type == LinkContentType.OPDS_FEED
         path = series_link.href.split("/works/series/", 1)[1].rstrip("/")
         assert "/" not in path
+
+    def test_add_series_link_when_audience_key_is_none(
+        self, annotator_fixture: LibraryAnnotatorFixture
+    ):
+        # Mirrors test_add_author_links_when_audience_key_is_none for the
+        # series route, which has the same hierarchical variants.
+        work = annotator_fixture.db.work(
+            with_open_access_download=True,
+            language="eng",
+            series="Serious Cereals Series",
+        )
+        work.audience = None
+
+        with app.test_request_context("/"):
+            feed = self.get_parsed_feed(annotator_fixture, [work])
+            [entry] = feed.entries
+
+        series_link = entry.computed.series.link
+        path = series_link.href.split("/works/series/", 1)[1].rstrip("/")
+        series_segment, languages = path.split("/")
+        assert languages == "eng"
 
     def test_work_entry_includes_recommendations_link(
         self, annotator_fixture: LibraryAnnotatorFixture


### PR DESCRIPTION
## Description

`CirculationAnnotator.add_author_links` and `add_series_link` (in `src/palace/manager/feed/annotator/circulation.py`) now build the `url_for` call without the `languages` / `audiences` kwargs when either is `None`, so Werkzeug selects the no-filter route variant (`/works/contributor/<contributor_name>` or `/works/series/<series_name>`) instead of trying — and failing — to fill `<languages>` with `None`.

## Motivation and Context

`/<library>/loans/` was returning a 500 for any patron whose loans included a `Work` with `language IS NULL`. The traceback ended in:

```
werkzeug.routing.exceptions.BuildError: Could not build url for endpoint 'contributor' with values ['audiences', 'contributor_name', 'library_short_name']. Did you forget to specify values ['languages']?
```

The root cause: `language_and_audience_key_from_work` returns `work.language` verbatim, which is `None` for affected Works. The annotator then passed `languages=None, audiences=None` to `url_for("contributor", ...)`. Werkzeug treats an explicit `None` kwarg as "present," so it never falls back to the rule whose `defaults=dict(languages=None, audiences=None)` would have covered the missing values — it iterates the longer-path rules instead, none of which accept a `None` path variable, and raises `BuildError`. The series link path (`add_series_link`) had the same shape and would have hit the same error.

Observed in production for patron `external_identifier=1526824` at `CA0081` (Oakland Public Library) — three failures in two minutes from the iOS app; the loans page was completely broken for that patron until the offending Work was fixed.

Found via CloudWatch alerts, looks like this was happening enough to occasionally push the 500 errors rate up enough to cause an error.

## How Has This Been Tested?

- Added `test_add_author_links_when_language_is_none` and `test_add_series_link_when_language_is_none` in `tests/manager/feed/test_library_annotator.py`. Both run inside `app.test_request_context("/")` so the real Flask routing is exercised (the default `_patched_url_for` test fixture short-circuits route matching, so a request context is required to catch this kind of bug).
- Extended `test_language_and_audience_key_from_work` with a `language=None` case to lock in the `(None, <audience_key>)` return shape.
- Verified regression coverage by reverting the source change locally — both new tests fail with `BuildError`, confirming they would have caught this in CI.
- `tox -e py312-docker -- --no-cov tests/manager/feed/test_library_annotator.py` — 41 passed.
- `mypy` — clean.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.