### PR TITLE
AttributeError on top-level lane requests (PP-4368)

### DIFF
--- a/src/palace/manager/api/circulation_manager.py
+++ b/src/palace/manager/api/circulation_manager.py
@@ -37,7 +37,6 @@ from palace.manager.api.controller.playtime_entries import PlaytimeEntriesContro
 from palace.manager.api.controller.profile import ProfileController
 from palace.manager.api.controller.urn_lookup import URNLookupController
 from palace.manager.api.controller.work import WorkController
-from palace.manager.api.lanes import load_lanes
 from palace.manager.api.problem_details import NO_SUCH_LANE
 from palace.manager.api.util.flask import get_request_library
 from palace.manager.core.app_server import (
@@ -311,20 +310,8 @@ class CirculationManager(LoggerMixin):
 
         self.auth = Authenticator(self._db, libraries, self.analytics)
 
-        # Track the Lane configuration for each library by mapping its
-        # short name to the top-level lane.
-        new_top_level_lanes = {}
         # Create a CirculationAPI for each library.
         new_circulation_apis = {}
-
-        with elapsed_time_logging(
-            log_method=self.log.debug,
-            message_prefix="load_settings - per-library lanes",
-        ):
-            for library in libraries:
-                new_top_level_lanes[library.id] = load_lanes(
-                    self._db, library, [c.id for c in libraries_collections[library.id]]
-                )
 
         with elapsed_time_logging(
             log_method=self.log.debug,
@@ -342,7 +329,6 @@ class CirculationManager(LoggerMixin):
                     )
                 )
 
-        self.top_level_lanes = new_top_level_lanes
         self.circulation_apis = new_circulation_apis
 
         self.patron_web_domains = self.get_patron_web_domains()

--- a/src/palace/manager/api/controller/circulation_manager.py
+++ b/src/palace/manager/api/controller/circulation_manager.py
@@ -107,16 +107,16 @@ class CirculationManagerController(BaseCirculationManagerController):
 
     def load_lane(self, lane_identifier: int | None) -> Lane | WorkList | ProblemDetail:
         """Turn user input into a Lane object."""
-        library_id = get_request_library().id
+        library = get_request_library()
+        library_id = library.id
 
         lane = None
         if lane_identifier is None:
-            # Return the top-level lane.
-            lane = self.manager.top_level_lanes[library_id]
-            if isinstance(lane, Lane):
-                lane = self._db.merge(lane)
-            elif isinstance(lane, WorkList):
-                lane.children = [self._db.merge(child) for child in lane.children]
+            lane = WorkList.top_level_for_library(
+                self._db,
+                library,
+                collection_ids=[c.id for c in library.active_collections],
+            )
         else:
             try:
                 lane_identifier = int(lane_identifier)

--- a/src/palace/manager/api/controller/urn_lookup.py
+++ b/src/palace/manager/api/controller/urn_lookup.py
@@ -5,6 +5,7 @@ from palace.manager.core.app_server import (
     URNLookupController as CoreURNLookupController,
 )
 from palace.manager.feed.annotator.circulation import CirculationManagerAnnotator
+from palace.manager.feed.worklist.base import WorkList
 
 
 class URNLookupController(CoreURNLookupController):
@@ -21,6 +22,10 @@ class URNLookupController(CoreURNLookupController):
         (filtered_audiences and filtered_genres).
         """
         library = get_request_library()
-        top_level_worklist = self.manager.top_level_lanes[library.id]
+        top_level_worklist = WorkList.top_level_for_library(
+            self._db,
+            library,
+            collection_ids=[c.id for c in library.active_collections],
+        )
         annotator = CirculationManagerAnnotator(top_level_worklist)
         return super().work_lookup(annotator, route_name, library=library)

--- a/src/palace/manager/api/lanes.py
+++ b/src/palace/manager/api/lanes.py
@@ -17,7 +17,6 @@ from palace.manager.core.classifier import (
     nonfiction_genres,
 )
 from palace.manager.core.config import CannotLoadConfiguration
-from palace.manager.feed.worklist.base import WorkList
 from palace.manager.integration.metadata.nyt import NYTBestSellerAPI
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.edition import Edition
@@ -39,41 +38,6 @@ def _genre_name(genre: GenreInput) -> str:
     if isinstance(genre, Mapping):
         return cast(str, genre.get("name"))
     return genre
-
-
-def load_lanes(
-    _db: Session, library: Library, collection_ids: Sequence[int] | None
-) -> WorkList | Lane:
-    """Return a WorkList that reflects the current lane structure of the
-    Library.
-
-    If no top-level visible lanes are configured, the WorkList will be
-    configured to show every book in the collection.
-
-    If a single top-level Lane is configured, it will returned as the
-    WorkList.
-
-    Otherwise, a WorkList containing the visible top-level lanes is
-    returned.
-    """
-    top_level = cast(
-        WorkList | Lane,
-        WorkList.top_level_for_library(_db, library, collection_ids=collection_ids),
-    )
-
-    # It's likely this WorkList will be used across sessions, so
-    # expunge any data model objects from the database session.
-    #
-    # TODO: This is the cause of a lot of problems in the cached OPDS
-    # feed generator. There, these Lanes are used in a normal database
-    # session and we end up needing hacks to merge them back into the
-    # session.
-    if isinstance(top_level, Lane):
-        to_expunge = [top_level]
-    else:
-        to_expunge = [x for x in top_level.children if isinstance(x, Lane)]
-    list(map(_db.expunge, to_expunge))
-    return top_level
 
 
 def _lane_configuration_from_collection_sizes(

--- a/tests/fixtures/api_controller.py
+++ b/tests/fixtures/api_controller.py
@@ -19,7 +19,6 @@ from palace.manager.api.controller.circulation_manager import (
 from palace.manager.api.lanes import create_default_lanes
 from palace.manager.api.util.flask import PalaceFlask
 from palace.manager.core.entrypoint import AudiobooksEntryPoint, EbooksEntryPoint
-from palace.manager.feed.worklist.base import WorkList
 from palace.manager.integration.configuration.library import LibrarySettings
 from palace.manager.integration.goals import Goals
 from palace.manager.integration.patron_auth.simple_authentication import (
@@ -163,14 +162,8 @@ class ControllerFixture:
         # Create mock CM instance
         self.manager = MockCirculationManager(session, self.services_fixture.services)
 
-        # Set CirculationAPI and top-level lane for the default
-        # library, for convenience in tests.
+        # Set CirculationAPI for the default library, for convenience in tests.
         self.manager.d_circulation = self.manager.circulation_apis[self.library.id]
-        self.manager.d_top_level_lane = WorkList.top_level_for_library(
-            session,
-            self.library,
-            collection_ids=[c.id for c in self.library.active_collections],
-        )
         self.controller = CirculationManagerController(self.manager)
 
         # Set a convenient default lane.

--- a/tests/fixtures/api_controller.py
+++ b/tests/fixtures/api_controller.py
@@ -19,6 +19,7 @@ from palace.manager.api.controller.circulation_manager import (
 from palace.manager.api.lanes import create_default_lanes
 from palace.manager.api.util.flask import PalaceFlask
 from palace.manager.core.entrypoint import AudiobooksEntryPoint, EbooksEntryPoint
+from palace.manager.feed.worklist.base import WorkList
 from palace.manager.integration.configuration.library import LibrarySettings
 from palace.manager.integration.goals import Goals
 from palace.manager.integration.patron_auth.simple_authentication import (
@@ -165,7 +166,11 @@ class ControllerFixture:
         # Set CirculationAPI and top-level lane for the default
         # library, for convenience in tests.
         self.manager.d_circulation = self.manager.circulation_apis[self.library.id]
-        self.manager.d_top_level_lane = self.manager.top_level_lanes[self.library.id]  # type: ignore
+        self.manager.d_top_level_lane = WorkList.top_level_for_library(
+            session,
+            self.library,
+            collection_ids=[c.id for c in self.library.active_collections],
+        )
         self.controller = CirculationManagerController(self.manager)
 
         # Set a convenient default lane.

--- a/tests/manager/api/controller/test_base.py
+++ b/tests/manager/api/controller/test_base.py
@@ -21,6 +21,8 @@ from palace.manager.api.problem_details import (
     REMOTE_INTEGRATION_FAILED,
 )
 from palace.manager.core.classifier import Classifier
+from palace.manager.feed.worklist.base import WorkList
+from palace.manager.feed.worklist.top_level import TopLevelWorkList
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.lane import Lane
@@ -630,23 +632,22 @@ class TestBaseController:
         # Verify that requests for specific lanes are mapped to
         # the appropriate lane.
 
-        # TODO: The case where the top-level lane is a WorkList rather
-        # than a Lane is not tested.
-
-        lanes = circulation_fixture.db.default_library().lanes
+        library = circulation_fixture.db.default_library()
+        lanes = library.lanes
 
         with circulation_fixture.request_context_with_library("/"):
             top_level = circulation_fixture.controller.load_lane(None)
-            expect = circulation_fixture.controller.manager.top_level_lanes[
-                circulation_fixture.db.default_library().id
-            ]
+            expect = WorkList.top_level_for_library(
+                circulation_fixture.db.session,
+                library,
+                collection_ids=[c.id for c in library.active_collections],
+            )
 
-            # expect and top_level are different ORM objects
-            # representing the same lane. (They're different objects
-            # because the lane stored across requests inside the
-            # CirculationManager object was merged into the request's
-            # database session.)
+            # The default library has a single top-level Lane, so
+            # load_lane returns that Lane directly, attached to the
+            # request session.
             assert isinstance(top_level, Lane)
+            assert isinstance(expect, Lane)
             assert expect.id == top_level.id
 
             # A lane can be looked up by ID.
@@ -689,3 +690,18 @@ class TestBaseController:
             lane.accessible_to.assert_called_once_with(
                 circulation_fixture.default_patron
             )
+
+    def test_load_lane_top_level_worklist(
+        self, circulation_fixture: CirculationControllerFixture
+    ):
+        # When a library has multiple top-level visible lanes,
+        # load_lane(None) returns a TopLevelWorkList wrapping them.
+        library = circulation_fixture.db.default_library()
+        extra = circulation_fixture.db.lane(library=library, display_name="Extra")
+
+        with circulation_fixture.request_context_with_library("/", library=library):
+            result = circulation_fixture.controller.load_lane(None)
+            assert isinstance(result, TopLevelWorkList)
+            child_ids = {c.id for c in result.children}
+            assert extra.id in child_ids
+            assert len(child_ids) >= 2

--- a/tests/manager/api/controller/test_opds_feed.py
+++ b/tests/manager/api/controller/test_opds_feed.py
@@ -12,6 +12,7 @@ from palace.manager.feed.facets.feed import Facets, FeaturedFacets
 from palace.manager.feed.facets.search import SearchFacets
 from palace.manager.feed.navigation import NavigationFeed
 from palace.manager.feed.opds import NavigationFacets
+from palace.manager.feed.worklist.base import WorkList
 from palace.manager.search.pagination import SortKeyPagination
 from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.util.flask_util import Response
@@ -243,7 +244,7 @@ class TestOPDSFeedController:
         settings.minimum_featured_quality = 0.15
         settings.featured_lane_size = 2
 
-        # Patron with root lane -> redirect to root lane
+        # Patron with root lane -> redirect to root lane.
         lane = circulation_fixture.db.lane()
         lane.root_for_patron_type = ["1"]
         circulation_fixture.default_patron.external_type = "1"
@@ -259,6 +260,11 @@ class TestOPDSFeedController:
                 _external=True,
             )
             assert response.headers["Location"] == expect_url
+
+        # Clean up the patron-root lane so subsequent blocks see only
+        # the "World Languages" top-level lane.
+        circulation_fixture.db.session.delete(lane)
+        circulation_fixture.db.session.flush()
 
         # Bad lane -> Problem detail
         with circulation_fixture.request_context_with_library("/"):
@@ -408,10 +414,12 @@ class TestOPDSFeedController:
         circulation_fixture.add_works(self._EXTRA_BOOKS)
 
         library = circulation_fixture.db.default_library()
-        lane = circulation_fixture.manager.top_level_lanes[library.id]
         session = circulation_fixture.db.session
-        lane = session.merge(lane)
-        session.expire_all()
+        lane = WorkList.top_level_for_library(
+            session,
+            library,
+            collection_ids=[c.id for c in library.active_collections],
+        )
 
         # Mock NavigationFeed.navigation so we can see the arguments going
         # into it.
@@ -452,10 +460,12 @@ class TestOPDSFeedController:
         circulation_fixture.add_works(self._EXTRA_BOOKS)
 
         library = circulation_fixture.db.default_library()
-        lane = circulation_fixture.manager.top_level_lanes[library.id]
         session = circulation_fixture.db.session
-        lane = session.merge(lane)
-        session.expire_all()
+        lane = WorkList.top_level_for_library(
+            session,
+            library,
+            collection_ids=[c.id for c in library.active_collections],
+        )
 
         helper = OPDSSerializationTestHelper(accept_header, expected_content_type)
         headers = helper.merge_accept_header({})

--- a/tests/manager/api/test_controller_cm.py
+++ b/tests/manager/api/test_controller_cm.py
@@ -71,9 +71,8 @@ class TestCirculationManager:
         # But some fields are _not_ about to be reloaded
         index_controller = manager.index_controller
 
-        # The CirculationManager has a top-level lane and a CirculationAPI,
-        # for the default library, but no others.
-        assert 1 == len(manager.top_level_lanes)
+        # The CirculationManager has a CirculationAPI for the default
+        # library, but no others.
         assert 1 == len(manager.circulation_apis)
 
         # Now let's create a brand new library, never before seen.
@@ -99,10 +98,7 @@ class TestCirculationManager:
         # Then reload the CirculationManager...
         circulation_fixture.manager.load_settings()
 
-        # Now the new library has a top-level lane.
-        assert library.id in manager.top_level_lanes
-
-        # And a circulation API.
+        # Now the new library has a circulation API.
         assert library.id in manager.circulation_apis
 
         # The Authenticator has been reloaded with information about

--- a/tests/mocks/circulation.py
+++ b/tests/mocks/circulation.py
@@ -15,11 +15,13 @@ from palace.manager.api.circulation.data import HoldInfo, LoanInfo
 from palace.manager.api.circulation.dispatcher import CirculationApiDispatcher
 from palace.manager.api.circulation.fulfillment import Fulfillment
 from palace.manager.api.circulation_manager import CirculationManager
+from palace.manager.feed.worklist.base import WorkList
 from palace.manager.integration.settings import BaseSettings
 from palace.manager.service.analytics.analytics import Analytics
 from palace.manager.service.container import Services
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.datasource import DataSource
+from palace.manager.sqlalchemy.model.lane import Lane
 from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.model.licensing import (
     LicensePool,
@@ -232,6 +234,7 @@ class MockPatronActivityCirculationAPI(
 
 class MockCirculationManager(CirculationManager):
     d_circulation: MockCirculationApiDispatcher
+    d_top_level_lane: Lane | WorkList
 
     def __init__(self, db: Session, services: Services):
         super().__init__(db, services=services)

--- a/tests/mocks/circulation.py
+++ b/tests/mocks/circulation.py
@@ -15,13 +15,11 @@ from palace.manager.api.circulation.data import HoldInfo, LoanInfo
 from palace.manager.api.circulation.dispatcher import CirculationApiDispatcher
 from palace.manager.api.circulation.fulfillment import Fulfillment
 from palace.manager.api.circulation_manager import CirculationManager
-from palace.manager.feed.worklist.base import WorkList
 from palace.manager.integration.settings import BaseSettings
 from palace.manager.service.analytics.analytics import Analytics
 from palace.manager.service.container import Services
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.datasource import DataSource
-from palace.manager.sqlalchemy.model.lane import Lane
 from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.model.licensing import (
     LicensePool,
@@ -234,7 +232,6 @@ class MockPatronActivityCirculationAPI(
 
 class MockCirculationManager(CirculationManager):
     d_circulation: MockCirculationApiDispatcher
-    d_top_level_lane: Lane | WorkList
 
     def __init__(self, db: Session, services: Services):
         super().__init__(db, services=services)


### PR DESCRIPTION
## Description

`CirculationManager.top_level_lanes` cached SQLAlchemy-mapped `Lane` objects across requests, expunging them from the session at boot time. The detached `Lane` objects still held `InstrumentedList` collections backed by weakrefs to the populating session; once that session closed and the underlying collection data was GC'd, the next request's `_db.merge(child)` in `CirculationManagerController.load_lane` crashed deep inside SQLAlchemy's relationship traversal with `AttributeError: 'NoneType' object has no attribute '_sa_iterator'`.

The fragility was called out in a long-standing TODO at `api/lanes.py:67-70`.

This PR drops the cache entirely. `load_lane` and `URNLookupController.work_lookup` now build the top-level WorkList per request via `WorkList.top_level_for_library`, with no cross-session object sharing.

## Motivation and Context

Top-level OPDS endpoints (`/<library>/groups/`, `/<library>/search/`, `/<library>/`, `/<library>/navigation/`, `/<library>/urn/...`) intermittently 500'd on this `AttributeError` — observed ~10–20/hr per library during incidents. The crash rate correlated with GC pressure, fitting the weakref-collection hypothesis.

The cache itself was introduced in 2017 (commit `67f22847b`) for multi-library structural support, not performance. A 2016 commit (`d3780e7`) had already once removed an expunge call with the rationale "we no longer rely on storing objects across database sessions" — the same conclusion this PR reaches.

A local benchmark measured the per-request rebuild at ~0.8 ms/call against the test DB in Docker. 

A latent test-pollution bug in `test_groups` that the stale cache had been hiding is also fixed — the test was implicitly relying on the cache being out-of-date.

## How Has This Been Tested?

- Full test suite (`tox -e py312-docker -- --no-cov`): 5704 passed.
- `mypy`: clean.
- New test `test_load_lane_top_level_worklist` exercises the multi-top-level-lane WorkList path that the existing test suite did not cover (the previous test had a `TODO` flagging this gap).
- Local micro-benchmark of `WorkList.top_level_for_library` to confirm per-request cost is acceptable.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.