### PR TITLE
Migrate OIDC validator from authlib.jose to joserfc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ authors = [{name = "The Palace Project", email = "info@thepalaceproject.org"}]
 dependencies = [
     "alembic[tz]>=1.18.4,<2",
     "annotated-types>=0.7.0,<0.8",
-    "authlib>=1.7.2,<2",
     "aws-xray-sdk>=2.15,<2.16",
     "bcrypt>=5.0.0,<6",
     "bidict>=0.23.1,<0.24",
@@ -65,6 +64,7 @@ dependencies = [
     "httpx[http2]>=0.28.1,<0.29",
     "isbnlib>=3.10.14,<4",
     "itsdangerous>=2.1.2,<3",
+    "joserfc>=1.6.4,<2",
     "jsonschema>=4.22.0,<5",
     "jwcrypto>=1.4.2,<2",
     "levenshtein>=0.27,<0.28",
@@ -334,8 +334,6 @@ module = [
 # list periodically and remove modules that have since added type hints.
 ignore_missing_imports = true
 module = [
-    "authlib.jose",
-    "authlib.jose.errors",
     "aws_xray_sdk.ext.*",
     "celery.*",
     "expiringdict",

--- a/src/palace/manager/integration/patron_auth/oidc/validator.py
+++ b/src/palace/manager/integration/patron_auth/oidc/validator.py
@@ -12,8 +12,9 @@ import time
 from re import Pattern
 from typing import Any, cast
 
-from authlib.jose import JsonWebKey, JsonWebToken
-from authlib.jose.errors import JoseError
+from joserfc import jwt
+from joserfc.errors import JoseError
+from joserfc.jwk import KeySet, KeySetSerialization
 
 from palace.util.exceptions import BasePalaceException
 from palace.util.log import LoggerMixin
@@ -41,9 +42,8 @@ class OIDCTokenValidator(LoggerMixin):
     # Clock skew tolerance (seconds) - allows for time differences between servers
     CLOCK_SKEW_TOLERANCE = 300  # 5 minutes
 
-    def __init__(self) -> None:
-        """Initialize OIDC token validator."""
-        self._jwt = JsonWebToken(algorithms=["RS256", "RS384", "RS512", "HS256"])
+    # Signing algorithms accepted when verifying ID token signatures
+    ALLOWED_ALGORITHMS = ("RS256", "RS384", "RS512", "HS256")
 
     def validate_signature(self, id_token: str, jwks: dict[str, Any]) -> dict[str, Any]:
         """Validate ID token signature using JWKS.
@@ -54,26 +54,23 @@ class OIDCTokenValidator(LoggerMixin):
         :return: Decoded token claims
         """
         try:
-            # Create JWK from JWKS
-            jwk_set = JsonWebKey.import_key_set(jwks)
+            # Create key set from JWKS. The JWKS is arbitrary JSON fetched from
+            # the provider, so cast it to the structured type joserfc expects.
+            key_set = KeySet.import_key_set(cast(KeySetSerialization, jwks))
 
-            # Decode and verify signature
-            # authlib's decode will automatically:
-            # 1. Find the correct key from the set using 'kid' header
-            # 2. Verify the signature
-            # 3. Return the payload claims
-            claims = cast(
-                dict[str, Any],
-                self._jwt.decode(
-                    id_token,
-                    jwk_set,
-                    # We'll validate claims separately for better error messages
-                    claims_options={"iss": {"essential": False}},
-                ),
+            # Decode and verify signature. joserfc's decode will automatically:
+            # 1. Find the correct key from the set using the 'kid' header
+            # 2. Verify the signature using one of the allowed algorithms
+            # 3. Return a token whose 'claims' is the decoded payload
+            # We validate the claims separately for better error messages.
+            token = jwt.decode(
+                id_token,
+                key_set,
+                algorithms=list(self.ALLOWED_ALGORITHMS),
             )
 
             self.log.debug("ID token signature validated successfully")
-            return claims
+            return token.claims
 
         except JoseError as e:
             self.log.exception("ID token signature validation failed")

--- a/src/palace/manager/integration/patron_auth/oidc/validator.py
+++ b/src/palace/manager/integration/patron_auth/oidc/validator.py
@@ -68,7 +68,7 @@ class OIDCTokenValidator(LoggerMixin):
                 key_set,
                 # This type ignore can go away if / when upstream merges
                 # https://github.com/authlib/joserfc/pull/98
-                algorithms=self.ALLOWED_ALGORITHMS,  # type: ignore
+                algorithms=self.ALLOWED_ALGORITHMS,  # type: ignore[arg-type]
             )
 
             self.log.debug("ID token signature validated successfully")

--- a/src/palace/manager/integration/patron_auth/oidc/validator.py
+++ b/src/palace/manager/integration/patron_auth/oidc/validator.py
@@ -43,7 +43,7 @@ class OIDCTokenValidator(LoggerMixin):
     CLOCK_SKEW_TOLERANCE = 300  # 5 minutes
 
     # Signing algorithms accepted when verifying ID token signatures
-    ALLOWED_ALGORITHMS = ("RS256", "RS384", "RS512", "HS256")
+    ALLOWED_ALGORITHMS = frozenset(("RS256", "RS384", "RS512", "HS256"))
 
     def validate_signature(self, id_token: str, jwks: dict[str, Any]) -> dict[str, Any]:
         """Validate ID token signature using JWKS.
@@ -66,7 +66,9 @@ class OIDCTokenValidator(LoggerMixin):
             token = jwt.decode(
                 id_token,
                 key_set,
-                algorithms=list(self.ALLOWED_ALGORITHMS),
+                # This type ignore can go away if / when upstream merges
+                # https://github.com/authlib/joserfc/pull/98
+                algorithms=self.ALLOWED_ALGORITHMS,  # type: ignore
             )
 
             self.log.debug("ID token signature validated successfully")

--- a/uv.lock
+++ b/uv.lock
@@ -116,19 +116,6 @@ wheels = [
 ]
 
 [[package]]
-name = "authlib"
-version = "1.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "joserfc" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
-]
-
-[[package]]
 name = "aws-xray-sdk"
 version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2067,7 +2054,6 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic", extra = ["tz"] },
     { name = "annotated-types" },
-    { name = "authlib" },
     { name = "aws-xray-sdk" },
     { name = "bcrypt" },
     { name = "bidict" },
@@ -2091,6 +2077,7 @@ dependencies = [
     { name = "httpx", extra = ["http2"] },
     { name = "isbnlib" },
     { name = "itsdangerous" },
+    { name = "joserfc" },
     { name = "jsonschema" },
     { name = "jwcrypto" },
     { name = "levenshtein" },
@@ -2175,7 +2162,6 @@ dev = [
 requires-dist = [
     { name = "alembic", extras = ["tz"], specifier = ">=1.18.4,<2" },
     { name = "annotated-types", specifier = ">=0.7.0,<0.8" },
-    { name = "authlib", specifier = ">=1.7.2,<2" },
     { name = "aws-xray-sdk", specifier = ">=2.15,<2.16" },
     { name = "bcrypt", specifier = ">=5.0.0,<6" },
     { name = "bidict", specifier = ">=0.23.1,<0.24" },
@@ -2199,6 +2185,7 @@ requires-dist = [
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1,<0.29" },
     { name = "isbnlib", specifier = ">=3.10.14,<4" },
     { name = "itsdangerous", specifier = ">=2.1.2,<3" },
+    { name = "joserfc", specifier = ">=1.6.4,<2" },
     { name = "jsonschema", specifier = ">=4.22.0,<5" },
     { name = "jwcrypto", specifier = ">=1.4.2,<2" },
     { name = "levenshtein", specifier = ">=0.27,<0.28" },


### PR DESCRIPTION
## Description

Migrates the OIDC ID token validator off the deprecated `authlib.jose` module and onto `joserfc`, the library the Authlib maintainers now recommend (and which Authlib already depended on internally). `authlib` is dropped as a direct dependency and replaced by `joserfc`; the `authlib.jose` / `authlib.jose.errors` entries in the mypy `ignore_missing_imports` list are removed because `joserfc` ships type hints (`py.typed`).

Mapping of the changes in `validator.py`:

- `from authlib.jose import JsonWebKey, JsonWebToken` / `from authlib.jose.errors import JoseError` → `from joserfc import jwt`, `from joserfc.errors import JoseError`, `from joserfc.jwk import KeySet, KeySetSerialization`. `JoseError` keeps the same name, so the existing error handling is unchanged.
- The `JsonWebToken(algorithms=[...])` instance is replaced by an `ALLOWED_ALGORITHMS` class constant passed to `jwt.decode(...)`, so the `__init__` is no longer needed.
- `JsonWebKey.import_key_set(jwks)` → `KeySet.import_key_set(...)`, and the decoded payload is read from `token.claims`.

Claims validation is done by the validator's own `validate_claims` method (not Authlib's `claims_options`), so that behavior is untouched.

## Motivation and Context

Running the test suite emitted an `AuthlibDeprecationWarning: authlib.jose module is deprecated, please use joserfc instead.` The validator was the only consumer of `authlib` in the codebase, so migrating it removes the warning and the now-unnecessary direct dependency.

## How Has This Been Tested?

- `tox -e py312-docker -- --no-cov tests/manager/integration/patron_auth/oidc/` — 371 passed.
- `mypy` clean on the validator.
- Confirmed importing the module under `-W error::DeprecationWarning` no longer raises.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.