### PR TITLE
Exclude trashed items from Google Drive folder lookup (PP-4435)

### DIFF
--- a/src/palace/manager/service/google_drive/google_drive.py
+++ b/src/palace/manager/service/google_drive/google_drive.py
@@ -17,8 +17,19 @@ class GoogleDriveService(LoggerMixin):
         self.api_client = api_client
 
     def get_file(self, name: str, parent_folder_id: str | None = None) -> File | None:
+        """
+        Return the first non-trashed file or folder with the given name.
 
-        query = f"name = '{name}'"
+        :param name: The exact name to search for.
+        :param parent_folder_id: If provided, restrict the search to items
+            whose parent is this folder/drive ID.
+        :return: The first matching, non-trashed ``File`` object, or ``None``
+            if no match is found.
+        """
+        # Explicitly exclude trashed items so that a folder moved to the
+        # Drive trash is not mistaken for a live folder, which would cause
+        # uploads to land inside a trashed (invisible) directory.
+        query = f"name = '{name}' and trashed = false"
 
         if parent_folder_id:
             query += f" and '{parent_folder_id}' in parents"

--- a/tests/manager/service/google_drive/test_google_drive.py
+++ b/tests/manager/service/google_drive/test_google_drive.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from io import BytesIO
 from typing import TYPE_CHECKING
+from urllib.parse import unquote_plus
 
 import pytest
 from googleapiclient.discovery import build
@@ -113,6 +114,45 @@ class TestGoogleDriveService:
         assert '{"name": "' + file_name + '", "parents": []}' in body
         assert "Hello world" in body
         assert f"Content-Type: {mime_type}" in body
+
+    def test_get_file_excludes_trashed_items(self):
+        """get_file must include 'trashed = false' in its Drive query.
+
+        If a folder has been moved to the Drive trash, it must not be treated
+        as a live folder — doing so would cause uploads to land inside the
+        trash, making them invisible to users.
+        """
+        file_name = "some-folder"
+        file_id = "folder-id"
+        http_mock_sequence = HttpMockSequence(
+            [
+                (
+                    {"status": "200"},
+                    json.dumps(
+                        {
+                            "files": [
+                                {
+                                    "kind": "drive#file",
+                                    "id": file_id,
+                                    "name": file_name,
+                                    "mimeType": "application/vnd.google-apps.folder",
+                                }
+                            ]
+                        }
+                    ),
+                ),
+            ]
+        )
+        service = drive_service(http=http_mock_sequence)
+
+        result = service.get_file(name=file_name, parent_folder_id="parent-id")
+
+        assert result is not None
+        assert result["id"] == file_id
+
+        # Verify the query sent to the Drive API contains the trashed filter.
+        request_uri = unquote_plus(http_mock_sequence.request_sequence[0][0])
+        assert "trashed = false" in request_uri
 
     def test_create_existing_file_fails(self):
         file_name = "file.txt"

--- a/tests/manager/service/google_drive/test_google_drive.py
+++ b/tests/manager/service/google_drive/test_google_drive.py
@@ -116,12 +116,7 @@ class TestGoogleDriveService:
         assert f"Content-Type: {mime_type}" in body
 
     def test_get_file_excludes_trashed_items(self):
-        """get_file must include 'trashed = false' in its Drive query.
-
-        If a folder has been moved to the Drive trash, it must not be treated
-        as a live folder — doing so would cause uploads to land inside the
-        trash, making them invisible to users.
-        """
+        """get_file must include 'trashed = false' in its Drive query."""
         file_name = "some-folder"
         file_id = "folder-id"
         http_mock_sequence = HttpMockSequence(


### PR DESCRIPTION
## Description

Adds `trashed = false` to the `get_file` query in `GoogleDriveService` so that folders moved to the Drive trash are excluded from lookup results.

## Motivation and Context

Without this filter, a trashed folder named e.g. "Blackstone Unlimited" would be returned by `get_file` as though it were a live folder. `create_nested_folders_if_not_exist` would then use the trashed folder's ID as the parent for nested folders and the final file upload — causing all uploaded reports to land inside a trashed (invisible) directory.
JIRA: https://ebce-lyrasis.atlassian.net/browse/PP-4435
## How Has This Been Tested?

- Added `test_get_file_excludes_trashed_items` which verifies `trashed = false` appears in the decoded Drive API request URI.
- All existing Google Drive service tests continue to pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
