### PR TITLE
Add basic JSON UI form field support (PP-4438)

### DIFF
--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -140,7 +140,7 @@ class FormMetadata(LoggerMixin):
 
         if default is not None and default is not PydanticUndefined:
             if self.type == FormFieldType.JSON:
-                form_entry["default"] = json.dumps(default)
+                form_entry["default"] = json.dumps(default, ensure_ascii=False)
             else:
                 form_entry["default"] = self.get_form_value(default)
         if self.type.value is not None:

--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -205,9 +205,7 @@ class BaseSettings(BaseModel, LoggerMixin):
             if isinstance(value, str) and value.strip() == "":
                 values[key] = None
 
-        # For FormFieldType.JSON fields, the admin interface sends the textarea
-        # content as a string. Parse it as JSON so downstream validators and
-        # callers receive the actual Python value.
+        # The admin interface submits JSON field values as raw strings.
         for name, field_info in cls.model_fields.items():
             fm = _get_form_metadata(field_info)
             if fm is None or fm.type != FormFieldType.JSON:

--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import typing
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -52,6 +53,7 @@ class FormFieldType(Enum):
     ANNOUNCEMENTS = "announcements"
     COLOR = "color-picker"
     IMAGE = "image"
+    JSON = "json"
 
 
 FormOptionsType = Mapping[Enum | str | bool | None, str | LazyString]
@@ -137,7 +139,10 @@ class FormMetadata(LoggerMixin):
             )
 
         if default is not None and default is not PydanticUndefined:
-            form_entry["default"] = self.get_form_value(default)
+            if self.type == FormFieldType.JSON:
+                form_entry["default"] = json.dumps(default)
+            else:
+                form_entry["default"] = self.get_form_value(default)
         if self.type.value is not None:
             form_entry["type"] = self.type.value
         if self.description is not None:
@@ -199,6 +204,31 @@ class BaseSettings(BaseModel, LoggerMixin):
         for key, value in values.items():
             if isinstance(value, str) and value.strip() == "":
                 values[key] = None
+
+        # For FormFieldType.JSON fields, the admin interface sends the textarea
+        # content as a string. Parse it as JSON so downstream validators and
+        # callers receive the actual Python value.
+        for name, field_info in cls.model_fields.items():
+            fm = _get_form_metadata(field_info)
+            if fm is None or fm.type != FormFieldType.JSON:
+                continue
+            key = (
+                field_info.alias
+                if field_info.alias is not None and field_info.alias in values
+                else name
+            )
+            if key not in values:
+                continue
+            v = values[key]
+            if isinstance(v, str):
+                try:
+                    values[key] = json.loads(v)
+                except json.JSONDecodeError as exc:
+                    raise SettingsValidationError(
+                        problem_detail=INVALID_CONFIGURATION_OPTION.detailed(
+                            f"'{fm.label}' must be valid JSON: {exc}"
+                        )
+                    )
 
         return values
 

--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -140,7 +140,7 @@ class FormMetadata(LoggerMixin):
 
         if default is not None and default is not PydanticUndefined:
             if self.type == FormFieldType.JSON:
-                form_entry["default"] = json.dumps(default, ensure_ascii=False)
+                form_entry["default"] = default
             else:
                 form_entry["default"] = self.get_form_value(default)
         if self.type.value is not None:

--- a/tests/manager/integration/test_settings.py
+++ b/tests/manager/integration/test_settings.py
@@ -181,6 +181,10 @@ class TestBaseSettings:
         settings = JsonMockSettings(data=input_val)
         assert settings.data == expected_val
 
+    def test_json_field_omitted_uses_default_without_raising(self) -> None:
+        settings = JsonMockSettings()
+        assert settings.data is None
+
     def test_json_field_invalid_raises_error(self) -> None:
         with raises_problem_detail() as info:
             JsonMockSettings(data="not json")

--- a/tests/manager/integration/test_settings.py
+++ b/tests/manager/integration/test_settings.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import Annotated, Self
+from typing import Annotated, Any, Self
 from unittest.mock import MagicMock
 
 import pytest
@@ -62,6 +62,13 @@ class MockSettings(BaseSettings):
         float,
         FormMetadata(label="With Alias", description="With Alias description"),
     ] = Field(default=-1.1, alias="foo")
+
+
+class JsonMockSettings(BaseSettings):
+    data: Annotated[
+        dict | list | str | int | float | bool | None,
+        FormMetadata(label="Data", type=FormFieldType.JSON),
+    ] = None
 
 
 class BaseSettingsFixture:
@@ -131,6 +138,10 @@ class TestBaseSettings:
         settings = base_settings_fixture.settings(test=" foo ")
         assert settings.model_dump() == {"test": "foo", "number": 1}
 
+        # Empty string is normalized to None for all fields, including JSON fields.
+        settings = JsonMockSettings(data="")
+        assert settings.data is None
+
     def test_whitespace_only_required_field_treated_as_missing(self) -> None:
         # A whitespace-only string submitted for a required field should be
         # treated the same as an empty string (i.e. missing), because the admin
@@ -144,6 +155,72 @@ class TestBaseSettings:
 
         with raises_problem_detail(detail="Required field 'Username' is missing."):
             RequiredStrSettings(username=" ")
+
+    @pytest.mark.parametrize(
+        "input_val, expected_val",
+        [
+            ('{"a": 1}', {"a": 1}),
+            ("[1, 2, 3]", [1, 2, 3]),
+            ("42", 42),
+            ("true", True),
+            ({"a": 1}, {"a": 1}),
+            ("null", None),
+            (None, None),
+        ],
+        ids=[
+            "dict-string",
+            "list-string",
+            "int-string",
+            "bool-string",
+            "already-parsed-dict",
+            "json-null-string",
+            "none-passthrough",
+        ],
+    )
+    def test_json_field_parsing(self, input_val: Any, expected_val: Any) -> None:
+        settings = JsonMockSettings(data=input_val)
+        assert settings.data == expected_val
+
+    def test_json_field_invalid_raises_error(self) -> None:
+        with raises_problem_detail() as info:
+            JsonMockSettings(data="not json")
+        assert (
+            info.value.detail is not None
+            and "'Data' must be valid JSON:" in info.value.detail
+        )
+
+    def test_json_field_alias_parsing(self) -> None:
+        class AliasedJsonSettings(BaseSettings):
+            data: Annotated[
+                dict | None,
+                FormMetadata(label="Data", type=FormFieldType.JSON),
+            ] = Field(default=None, alias="cfg")
+
+        settings = AliasedJsonSettings(**{"cfg": '{"x": 1}'})
+        assert settings.data == {"x": 1}
+
+    @pytest.mark.parametrize(
+        "default_val, expected_json",
+        [
+            ({"key": "value"}, '{"key": "value"}'),
+            ([1, 2, 3], "[1, 2, 3]"),
+            ("hello", '"hello"'),
+            (42, "42"),
+            (True, "true"),
+        ],
+        ids=["dict", "list", "str", "int", "bool"],
+    )
+    def test_json_field_default_serialized_in_form(
+        self, default_val: Any, expected_json: str
+    ) -> None:
+        class DefaultJsonSettings(BaseSettings):
+            data: Annotated[
+                Any,
+                FormMetadata(label="Data", type=FormFieldType.JSON),
+            ] = default_val
+
+        form = DefaultJsonSettings.configuration_form(MagicMock())
+        assert form[0]["default"] == expected_json
 
     def test_field_validator_return_pd_exception(
         self, base_settings_fixture: BaseSettingsFixture

--- a/tests/manager/integration/test_settings.py
+++ b/tests/manager/integration/test_settings.py
@@ -204,19 +204,17 @@ class TestBaseSettings:
         assert settings.data == {"x": 1}
 
     @pytest.mark.parametrize(
-        "default_val, expected_json",
+        "default_val",
         [
-            ({"key": "value"}, '{"key": "value"}'),
-            ([1, 2, 3], "[1, 2, 3]"),
-            ("hello", '"hello"'),
-            (42, "42"),
-            (True, "true"),
+            {"key": "value"},
+            [1, 2, 3],
+            "hello",
+            42,
+            True,
         ],
         ids=["dict", "list", "str", "int", "bool"],
     )
-    def test_json_field_default_serialized_in_form(
-        self, default_val: Any, expected_json: str
-    ) -> None:
+    def test_json_field_default_passed_through_in_form(self, default_val: Any) -> None:
         class DefaultJsonSettings(BaseSettings):
             data: Annotated[
                 Any,
@@ -224,7 +222,7 @@ class TestBaseSettings:
             ] = default_val
 
         form = DefaultJsonSettings.configuration_form(MagicMock())
-        assert form[0]["default"] == expected_json
+        assert form[0]["default"] == default_val
 
     def test_field_validator_return_pd_exception(
         self, base_settings_fixture: BaseSettingsFixture


### PR DESCRIPTION
## Description

Adds a `json` form field type for integration settings. Fields annotated with `FormFieldType.JSON` display a textarea in the admin UI that accepts a JSON value. Two-way handling is wired up automatically:
- **Form rendering**: the field's default value is serialized to a JSON string so the UI displays it correctly.
- **Form submission**: the incoming string is parsed back to a Python value before Pydantic validation runs, with a clear error message if the input is not valid JSON.

**Note**: The ability to edit this field type depends on new support introduced on [circulation-admin PR #224](https://github.com/ThePalaceProject/circulation-admin/pull/224).

## Motivation and Context

Integration settings that need to store structured data (objects, arrays) previously had no native form type. This adds a first-class JSON field type that makes the round-trip between the admin UI and the settings model transparent.

[Jira PP-4438]

## How Has This Been Tested?

- Manual testing in local development environment admin UI.
- New/updated tests for the new functionality.
- All tests and checks pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/26350026007) and checks pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.

