### PR TITLE
Add matched route rule to request log data

### DIFF
--- a/src/palace/manager/service/logging/log.py
+++ b/src/palace/manager/service/logging/log.py
@@ -107,10 +107,7 @@ class JSONFormatter(logging.Formatter):
                 "method": flask_request.method,
                 "host": flask_request.host_url,
             }
-            # The matched route rule (e.g. "/<library_short_name>/works/
-            # <identifier_type>/<path:identifier>") -- a stable per-route key for
-            # log aggregation, unlike `path`, which varies per request. None when
-            # no route matched (e.g. a 404).
+            # Stable per-route pattern for log aggregation; omitted when no route matched (e.g. 404).
             if flask_request.url_rule:
                 data["request"]["rule"] = flask_request.url_rule.rule
             if flask_request.query_string:

--- a/src/palace/manager/service/logging/log.py
+++ b/src/palace/manager/service/logging/log.py
@@ -107,6 +107,12 @@ class JSONFormatter(logging.Formatter):
                 "method": flask_request.method,
                 "host": flask_request.host_url,
             }
+            # The matched route rule (e.g. "/<library_short_name>/works/
+            # <identifier_type>/<path:identifier>") -- a stable per-route key for
+            # log aggregation, unlike `path`, which varies per request. None when
+            # no route matched (e.g. a 404).
+            if flask_request.url_rule:
+                data["request"]["rule"] = flask_request.url_rule.rule
             if flask_request.query_string:
                 data["request"]["query"] = flask_request.query_string.decode()
             if user_agent := flask_request.headers.get("User-Agent"):

--- a/tests/manager/service/logging/test_log.py
+++ b/tests/manager/service/logging/test_log.py
@@ -196,9 +196,7 @@ class TestJSONFormatter:
             # No route matched this path, so there is no rule to include.
             assert "rule" not in request
 
-        # When the request matches a registered route, the matched rule pattern is
-        # included in the log -- a stable per-route key for aggregation, unlike
-        # `path`, which varies per request.
+        # When the request matches a registered route, its rule pattern is included.
         flask_app_fixture.app.add_url_rule(
             "/books/<identifier>", "book", lambda identifier: ""
         )

--- a/tests/manager/service/logging/test_log.py
+++ b/tests/manager/service/logging/test_log.py
@@ -193,6 +193,20 @@ class TestJSONFormatter:
             assert "query" not in request
             assert "user_agent" not in request
             assert "forwarded_for" not in request
+            # No route matched this path, so there is no rule to include.
+            assert "rule" not in request
+
+        # When the request matches a registered route, the matched rule pattern is
+        # included in the log -- a stable per-route key for aggregation, unlike
+        # `path`, which varies per request.
+        flask_app_fixture.app.add_url_rule(
+            "/books/<identifier>", "book", lambda identifier: ""
+        )
+        with flask_app_fixture.test_request_context("/books/12345"):
+            data = json.loads(formatter.format(record))
+            request = data["request"]
+            assert request["path"] == "/books/12345"
+            assert request["rule"] == "/books/<identifier>"
 
         with flask_app_fixture.test_request_context(
             "/test?query=string&foo=bar",


### PR DESCRIPTION
## Description

Include the matched Flask route rule in the `request` section of JSON log records. The rule is the route pattern string (e.g. `/<library_short_name>/works/<identifier_type>/<path:identifier>`) rather than the concrete request path.

The field is added under `request.rule` and is guarded: `flask_request.url_rule` is `None` when no route matched (e.g. a 404), in which case the field is omitted.

## Motivation and Context

We want to be able to collapse and aggregate logging information by route, and there wasn't a nice way to do that. The existing `request.path` varies per request (e.g. `/books/12345` vs `/books/67890`), so it can't be used as an aggregation key. The matched route rule is stable per-route, making it a good key for grouping logs.

## How Has This Been Tested?

Extended `test_flask_request` in `tests/manager/service/logging/test_log.py`:
- Asserts `rule` is omitted when no route matched the request path.
- Registers a route (`/books/<identifier>`) and asserts the matched rule pattern is included in the log while `path` reflects the concrete request path.

Ran the affected tests via `tox -e py312-docker`; all pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.