### PR TITLE
Refuse loan-less streaming and bearer-token fulfillment for OPDS For Distributors

### DIFF
--- a/src/palace/manager/integration/license/opds/for_distributors/api.py
+++ b/src/palace/manager/integration/license/opds/for_distributors/api.py
@@ -100,9 +100,10 @@ class OPDSForDistributorsAPI(
         identifying the patron, assuming the library's policies
         allow it.
 
-        Just to be safe, though, we require that the
-        DeliveryMechanism's drm_scheme be either 'no DRM', 'bearer
-        token', or 'streaming', since other DRM schemes require identifying a patron.
+        Just to be safe, though, we require that the DeliveryMechanism's
+        drm_scheme be either 'no DRM' or 'bearer token', since other DRM
+        schemes require identifying a patron. Streaming content is excluded
+        because fulfilling it requires building an OPDS entry tied to a Loan.
         """
         if not lpdm or not lpdm.delivery_mechanism:
             return False
@@ -110,7 +111,6 @@ class OPDSForDistributorsAPI(
         if drm_scheme in (
             DeliveryMechanism.NO_DRM,
             DeliveryMechanism.BEARER_TOKEN,
-            DeliveryMechanism.STREAMING_DRM,
         ):
             return True
         return False

--- a/src/palace/manager/integration/license/opds/for_distributors/api.py
+++ b/src/palace/manager/integration/license/opds/for_distributors/api.py
@@ -96,24 +96,16 @@ class OPDSForDistributorsAPI(
         lpdm: LicensePoolDeliveryMechanism,
     ) -> bool:
         """Since OPDS For Distributors delivers books to the library rather
-        than creating loans, any book can be fulfilled without
-        identifying the patron, assuming the library's policies
-        allow it.
+        than creating loans, books with no DRM can be fulfilled without
+        identifying the patron — the redirect just points at a public URL.
 
-        Just to be safe, though, we require that the DeliveryMechanism's
-        drm_scheme be either 'no DRM' or 'bearer token', since other DRM
-        schemes require identifying a patron. Streaming content is excluded
-        because fulfilling it requires building an OPDS entry tied to a Loan.
+        Other DRM schemes are excluded: bearer tokens are access credentials
+        we shouldn't hand out without a loan record, and streaming requires
+        building an OPDS entry tied to a Loan.
         """
         if not lpdm or not lpdm.delivery_mechanism:
             return False
-        drm_scheme = lpdm.delivery_mechanism.drm_scheme
-        if drm_scheme in (
-            DeliveryMechanism.NO_DRM,
-            DeliveryMechanism.BEARER_TOKEN,
-        ):
-            return True
-        return False
+        return lpdm.delivery_mechanism.drm_scheme == DeliveryMechanism.NO_DRM
 
     def checkin(self, patron: Patron, pin: str, licensepool: LicensePool) -> None:
         # Delete the patron's loan for this licensepool.

--- a/tests/manager/integration/license/opds/for_distributors/test_api.py
+++ b/tests/manager/integration/license/opds/for_distributors/test_api.py
@@ -129,12 +129,16 @@ class TestOPDSForDistributorsAPI:
         lpdm.delivery_mechanism.drm_scheme = DeliveryMechanism.ADOBE_DRM
         assert False == m(patron, pool, lpdm)
 
-        # Otherwise -> True
+        # NO_DRM is allowed: the redirect points to a public URL, no
+        # credential is issued, no per-patron tracking is required.
         lpdm.delivery_mechanism.drm_scheme = DeliveryMechanism.NO_DRM
         assert True == m(patron, pool, lpdm)
 
+        # BEARER_TOKEN is NOT allowed without a loan: the token document is
+        # an access credential and we shouldn't hand one out without a
+        # corresponding loan record.
         lpdm.delivery_mechanism.drm_scheme = DeliveryMechanism.BEARER_TOKEN
-        assert True == m(patron, pool, lpdm)
+        assert False == m(patron, pool, lpdm)
 
         # STREAMING_DRM is NOT allowed without a loan: a streaming fulfillment
         # is an OPDS entry tied to a Loan, so it cannot be built loan-less.

--- a/tests/manager/integration/license/opds/for_distributors/test_api.py
+++ b/tests/manager/integration/license/opds/for_distributors/test_api.py
@@ -101,8 +101,8 @@ class TestOPDSForDistributorsAPI:
         self, opds_dist_api_fixture: OPDSForDistributorsAPIFixture
     ):
         """A book made available through OPDS For Distributors can be
-        fulfilled with no underlying loan, if its delivery mechanism
-        uses bearer token fulfillment.
+        fulfilled with no underlying loan only if its delivery mechanism
+        uses NO_DRM — a plain redirect to a public URL.
         """
         patron = MagicMock()
         pool = opds_dist_api_fixture.db.licensepool(

--- a/tests/manager/integration/license/opds/for_distributors/test_api.py
+++ b/tests/manager/integration/license/opds/for_distributors/test_api.py
@@ -136,9 +136,10 @@ class TestOPDSForDistributorsAPI:
         lpdm.delivery_mechanism.drm_scheme = DeliveryMechanism.BEARER_TOKEN
         assert True == m(patron, pool, lpdm)
 
-        # STREAMING_DRM is also allowed
+        # STREAMING_DRM is NOT allowed without a loan: a streaming fulfillment
+        # is an OPDS entry tied to a Loan, so it cannot be built loan-less.
         lpdm.delivery_mechanism.drm_scheme = DeliveryMechanism.STREAMING_DRM
-        assert True == m(patron, pool, lpdm)
+        assert False == m(patron, pool, lpdm)
 
     def test_checkin(self, opds_dist_api_fixture: OPDSForDistributorsAPIFixture):
         # The patron has two loans, one from this API's collection and


### PR DESCRIPTION
## Description

`OPDSForDistributorsAPI.can_fulfill_without_loan` previously returned `True` for `NO_DRM`, `BEARER_TOKEN`, and `STREAMING_DRM`. Narrow it to just `NO_DRM`:

- **Streaming** — a streaming fulfillment is an OPDS entry that `single_entry_loans_feed` builds from the `Loan` (or `Hold`/`LicensePool`). Letting the controller proceed with `loan=None` caused `StreamingFulfillment.response` to forward that `None` as the `item` argument, raising `PalaceValueError("Argument 'item' must be non-empty")` as an unhandled 500.
- **Bearer token** — the fulfillment is a bearer-token document, i.e. an access credential. Issuing one without a corresponding loan record means no per-patron tracking and no revocation path, so it shouldn't be served loan-less either.
- **NO_DRM** kept — the fulfillment is just a redirect to a public URL; no credential is issued and no OPDS entry needs to be built.

After the change, a fulfill request that lacks a loan and asks for streaming or bearer-token DRM resolves to `NO_ACTIVE_LOAN` (authenticated patron) or the auth-failure response (unauthenticated), instead of crashing.

## Motivation and Context

Hit in production for library. The library was deactivated and its patron-auth integration disassociated, leaving `LibraryAuthenticator.identifies_individuals = False`. The loan controller then fell through to `circulation.can_fulfill_without_loan(...)`, which returned `True` for `STREAMING_DRM`, which then crashed inside `StreamingFulfillment.response` because no loan exists to build the OPDS entry from.

I think this is the correct fix, especially in the case where we have disassociated patron auth. It seems like we don't want to still be issuing loans here. See slack thread: https://lyrasis.slack.com/archives/CCY3PH8JD/p1779986826890259

Example of this occurring in production: 
https://lyrasis.slack.com/archives/C049AA32E3S/p1779989480144229

## How Has This Been Tested?

- Updated `TestOPDSForDistributorsAPI::test_can_fulfill_without_loan` to assert the new behavior for `BEARER_TOKEN` and `STREAMING_DRM`.
- `mypy` clean for the changed file.
- `tox -e py312-docker -- --no-cov tests/manager/integration/license/opds/for_distributors/test_api.py` — all 12 tests pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.