### PR TITLE
Return 404 when work has no presentation_edition

### DIFF
--- a/src/palace/manager/api/controller/work.py
+++ b/src/palace/manager/api/controller/work.py
@@ -161,6 +161,9 @@ class WorkController(CirculationManagerController):
         if isinstance(work, ProblemDetail):
             return work
 
+        if work.presentation_edition is None:
+            return NOT_FOUND_ON_REMOTE
+
         search_engine = self.search_engine
         if isinstance(search_engine, ProblemDetail):
             return search_engine
@@ -215,6 +218,9 @@ class WorkController(CirculationManagerController):
         work = self.load_work(library, identifier_type, identifier)
         if isinstance(work, ProblemDetail):
             return work
+
+        if work.presentation_edition is None:
+            return NOT_FOUND_ON_REMOTE
 
         search_engine = self.search_engine
         if isinstance(search_engine, ProblemDetail):

--- a/tests/manager/api/controller/test_work.py
+++ b/tests/manager/api/controller/test_work.py
@@ -889,6 +889,34 @@ class TestWorkController:
             )
         assert result == NOT_FOUND_ON_REMOTE
 
+    def test_related_no_presentation_edition(self, work_fixture: WorkFixture):
+        """A work without a presentation_edition is treated as not found."""
+        db = work_fixture.db
+        work: Work = db.work(with_license_pool=True)
+        identifier = work.presentation_edition.primary_identifier
+        work.presentation_edition = None
+        db.session.commit()
+
+        with work_fixture.request_context_with_library("/"):
+            result = work_fixture.manager.work_controller.related(
+                identifier.type, identifier.identifier
+            )
+        assert result == NOT_FOUND_ON_REMOTE
+
+    def test_recommendations_no_presentation_edition(self, work_fixture: WorkFixture):
+        """A work without a presentation_edition is treated as not found."""
+        db = work_fixture.db
+        work: Work = db.work(with_license_pool=True)
+        identifier = work.presentation_edition.primary_identifier
+        work.presentation_edition = None
+        db.session.commit()
+
+        with work_fixture.request_context_with_library("/"):
+            result = work_fixture.manager.work_controller.recommendations(
+                identifier.type, identifier.identifier
+            )
+        assert result == NOT_FOUND_ON_REMOTE
+
     def test_series(self, work_fixture: WorkFixture):
         # Test the ability of the series() method to generate an OPDS
         # feed representing all the books in a given series, subject


### PR DESCRIPTION
## Description

When the `/related_books` and `/recommendations` endpoints are called for a work whose `presentation_edition` is `None`, return `NOT_FOUND_ON_REMOTE` instead of crashing.

## Motivation and Context

A Facebook crawler hit `/CA0017/works/Overdrive ID/<uuid>/related_books` for a work whose `presentation_edition` was unset, and we returned a 500:

```
AttributeError: 'NoneType' object has no attribute 'language'
  File ".../feed/worklist/dynamic.py", line 24, in __init__
    self.source_language = self.edition.language
```

`Work.presentation_edition` is typed `Edition | None`, and most accessors on `Work` already defend against it being `None`. `WorkBasedLane.__init__` did not. Both endpoints that construct `WorkBasedLane` subclasses (`related` and `recommendations`) now treat a missing presentation edition the same way they already treat a work whose license pool has no work attached — return `NOT_FOUND_ON_REMOTE`.

Example in production: 
https://lyrasis.slack.com/archives/C049AA32E3S/p1779988337477759

## How Has This Been Tested?

Added `test_related_no_presentation_edition` and `test_recommendations_no_presentation_edition` mirroring the existing `test_related_no_works`. The full `tests/manager/api/controller/test_work.py` suite (22 tests) passes, and mypy is clean.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.