### PR TITLE
Add generate_playtime_report collection setting to gate playtime reports (PP-4346)

### DIFF
--- a/alembic/versions/20260528_a6c85605404c_add_generate_playtime_report_setting_to_.py
+++ b/alembic/versions/20260528_a6c85605404c_add_generate_playtime_report_setting_to_.py
@@ -13,6 +13,7 @@ Create Date: 2026-05-28 19:52:19.605245+00:00
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy import bindparam
 
 from palace.manager.util.json import json_serializer
 from palace.manager.util.migration.helpers import migration_logger
@@ -45,8 +46,8 @@ def upgrade() -> None:
               )
             FOR UPDATE
             """
-        ),
-        {"protocols": _ELIGIBLE_PROTOCOLS},
+        ).bindparams(bindparam("protocols", expanding=True)),
+        {"protocols": list(_ELIGIBLE_PROTOCOLS)},
     )
 
     rows = list(results)
@@ -85,8 +86,8 @@ def downgrade() -> None:
               AND protocol IN :protocols
               AND settings ? 'generate_playtime_report'
             """
-        ),
-        {"protocols": _ELIGIBLE_PROTOCOLS},
+        ).bindparams(bindparam("protocols", expanding=True)),
+        {"protocols": list(_ELIGIBLE_PROTOCOLS)},
     )
     log.info(
         f"Removed generate_playtime_report from {result.rowcount} integration configuration(s)"

--- a/alembic/versions/20260528_a6c85605404c_add_generate_playtime_report_setting_to_.py
+++ b/alembic/versions/20260528_a6c85605404c_add_generate_playtime_report_setting_to_.py
@@ -1,6 +1,6 @@
-"""Add is_generate_playtime_report setting to Blackstone collections
+"""Add generate_playtime_report setting to Blackstone collections
 
-Enable the is_generate_playtime_report flag for all OPDS 2.0 Import and
+Enable the generate_playtime_report flag for all OPDS 2.0 Import and
 OPDS for Distributors collections whose data_source name begins with
 "Blackstone" or "Unlimited". All other collections default to False
 (the Pydantic field default), so no update is required for them.
@@ -52,7 +52,7 @@ def upgrade() -> None:
 
     rows = list(results)
     for integration_id, name, settings_dict in rows:
-        settings_dict["is_generate_playtime_report"] = True
+        settings_dict["generate_playtime_report"] = True
         conn.execute(
             sa.text(
                 """
@@ -67,10 +67,10 @@ def upgrade() -> None:
             },
         )
         log.info(
-            f"Enabled is_generate_playtime_report for integration {name!r} (id={integration_id})"
+            f"Enabled generate_playtime_report for integration {name!r} (id={integration_id})"
         )
 
-    log.info(f"Enabled is_generate_playtime_report on {len(rows)} collection(s)")
+    log.info(f"Enabled generate_playtime_report on {len(rows)} collection(s)")
 
 
 def downgrade() -> None:
@@ -81,14 +81,14 @@ def downgrade() -> None:
         sa.text(
             """
             UPDATE integration_configurations
-            SET settings = settings - 'is_generate_playtime_report'
+            SET settings = settings - 'generate_playtime_report'
             WHERE goal = 'LICENSE_GOAL'
               AND protocol IN :protocols
-              AND settings ? 'is_generate_playtime_report'
+              AND settings ? 'generate_playtime_report'
             """
         ).bindparams(bindparam("protocols", expanding=True)),
         {"protocols": list(_ELIGIBLE_PROTOCOLS)},
     )
     log.info(
-        f"Removed is_generate_playtime_report from {result.rowcount} integration configuration(s)"
+        f"Removed generate_playtime_report from {result.rowcount} integration configuration(s)"
     )

--- a/alembic/versions/20260528_a6c85605404c_add_generate_playtime_report_setting_to_.py
+++ b/alembic/versions/20260528_a6c85605404c_add_generate_playtime_report_setting_to_.py
@@ -1,0 +1,93 @@
+"""Add generate_playtime_report setting to Blackstone collections
+
+Enable the generate_playtime_report flag for all OPDS 2.0 Import and
+OPDS for Distributors collections whose data_source name begins with
+"Blackstone" or "Unlimited". All other collections default to False
+(the Pydantic field default), so no update is required for them.
+
+Revision ID: a6c85605404c
+Revises: d856ff4dbefb
+Create Date: 2026-05-28 19:52:19.605245+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from palace.manager.util.json import json_serializer
+from palace.manager.util.migration.helpers import migration_logger
+
+# revision identifiers, used by Alembic.
+revision = "a6c85605404c"
+down_revision = "d856ff4dbefb"
+branch_labels = None
+depends_on = None
+
+log = migration_logger(revision)
+
+# Protocol strings as registered in LicenseProvidersRegistry.
+_ELIGIBLE_PROTOCOLS = ("OPDS 2.0 Import", "OPDS for Distributors")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    results = conn.execute(
+        sa.text(
+            """
+            SELECT id, name, settings
+            FROM integration_configurations
+            WHERE goal = 'LICENSE_GOAL'
+              AND protocol IN :protocols
+              AND (
+                  settings->>'data_source' LIKE 'Blackstone%'
+                  OR settings->>'data_source' LIKE 'Unlimited%'
+              )
+            FOR UPDATE
+            """
+        ),
+        {"protocols": _ELIGIBLE_PROTOCOLS},
+    )
+
+    rows = list(results)
+    for integration_id, name, settings_dict in rows:
+        settings_dict["generate_playtime_report"] = True
+        conn.execute(
+            sa.text(
+                """
+                UPDATE integration_configurations
+                SET settings = :settings
+                WHERE id = :integration_id
+                """
+            ),
+            {
+                "settings": json_serializer(settings_dict),
+                "integration_id": integration_id,
+            },
+        )
+        log.info(
+            f"Enabled generate_playtime_report for integration {name!r} (id={integration_id})"
+        )
+
+    log.info(f"Enabled generate_playtime_report on {len(rows)} collection(s)")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # Remove the key entirely; absence is equivalent to False for the Pydantic default.
+    result = conn.execute(
+        sa.text(
+            """
+            UPDATE integration_configurations
+            SET settings = settings - 'generate_playtime_report'
+            WHERE goal = 'LICENSE_GOAL'
+              AND protocol IN :protocols
+              AND settings ? 'generate_playtime_report'
+            """
+        ),
+        {"protocols": _ELIGIBLE_PROTOCOLS},
+    )
+    log.info(
+        f"Removed generate_playtime_report from {result.rowcount} integration configuration(s)"
+    )

--- a/alembic/versions/20260528_a6c85605404c_add_generate_playtime_report_setting_to_.py
+++ b/alembic/versions/20260528_a6c85605404c_add_generate_playtime_report_setting_to_.py
@@ -1,6 +1,6 @@
-"""Add generate_playtime_report setting to Blackstone collections
+"""Add is_generate_playtime_report setting to Blackstone collections
 
-Enable the generate_playtime_report flag for all OPDS 2.0 Import and
+Enable the is_generate_playtime_report flag for all OPDS 2.0 Import and
 OPDS for Distributors collections whose data_source name begins with
 "Blackstone" or "Unlimited". All other collections default to False
 (the Pydantic field default), so no update is required for them.
@@ -52,7 +52,7 @@ def upgrade() -> None:
 
     rows = list(results)
     for integration_id, name, settings_dict in rows:
-        settings_dict["generate_playtime_report"] = True
+        settings_dict["is_generate_playtime_report"] = True
         conn.execute(
             sa.text(
                 """
@@ -67,10 +67,10 @@ def upgrade() -> None:
             },
         )
         log.info(
-            f"Enabled generate_playtime_report for integration {name!r} (id={integration_id})"
+            f"Enabled is_generate_playtime_report for integration {name!r} (id={integration_id})"
         )
 
-    log.info(f"Enabled generate_playtime_report on {len(rows)} collection(s)")
+    log.info(f"Enabled is_generate_playtime_report on {len(rows)} collection(s)")
 
 
 def downgrade() -> None:
@@ -81,14 +81,14 @@ def downgrade() -> None:
         sa.text(
             """
             UPDATE integration_configurations
-            SET settings = settings - 'generate_playtime_report'
+            SET settings = settings - 'is_generate_playtime_report'
             WHERE goal = 'LICENSE_GOAL'
               AND protocol IN :protocols
-              AND settings ? 'generate_playtime_report'
+              AND settings ? 'is_generate_playtime_report'
             """
         ).bindparams(bindparam("protocols", expanding=True)),
         {"protocols": list(_ELIGIBLE_PROTOCOLS)},
     )
     log.info(
-        f"Removed generate_playtime_report from {result.rowcount} integration configuration(s)"
+        f"Removed is_generate_playtime_report from {result.rowcount} integration configuration(s)"
     )

--- a/src/palace/manager/celery/tasks/playtime_entries.py
+++ b/src/palace/manager/celery/tasks/playtime_entries.py
@@ -307,7 +307,7 @@ def _fetch_distinct_eligible_data_source_names(
     Fetches a sorted list of distinct data source names for which to produce a playtime report.
 
     Only OPDS 2.0 and OPDS for Distributors collections that have the
-    ``is_generate_playtime_report`` setting explicitly set to ``True`` are included.
+    ``generate_playtime_report`` setting explicitly set to ``True`` are included.
     All other collections are ignored.
 
     :param session: The SQLAlchemy database session.
@@ -333,12 +333,12 @@ def _fetch_distinct_eligible_data_source_names(
     )
     eligible_collections = session.scalars(eligible_collections_query).all()
 
-    # Only include collections that have opted in via the is_generate_playtime_report flag.
+    # Only include collections that have opted in via the generate_playtime_report flag.
     # c.integration_configuration is guaranteed non-null by the query filter above.
     collection_ds_names = {
         c.data_source.name
         for c in eligible_collections
-        if c.integration_configuration.settings_dict.get("is_generate_playtime_report")
+        if c.integration_configuration.settings_dict.get("generate_playtime_report")
         is True
         and c.data_source
         and c.data_source.name is not None

--- a/src/palace/manager/celery/tasks/playtime_entries.py
+++ b/src/palace/manager/celery/tasks/playtime_entries.py
@@ -25,9 +25,6 @@ from palace.manager.integration.license.opds.for_distributors.api import (
     OPDSForDistributorsAPI,
 )
 from palace.manager.integration.license.opds.opds2.api import OPDS2API
-from palace.manager.integration.license.opds.settings.playtime_report import (
-    PLAYTIME_REPORT_FLAG_KEY,
-)
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.integration_registry.license_providers import (
     LicenseProvidersRegistry,
@@ -341,7 +338,7 @@ def _fetch_distinct_eligible_data_source_names(
     collection_ds_names = {
         c.data_source.name
         for c in eligible_collections
-        if c.integration_configuration.settings_dict.get(PLAYTIME_REPORT_FLAG_KEY)
+        if c.integration_configuration.settings_dict.get("is_generate_playtime_report")
         is True
         and c.data_source
         and c.data_source.name is not None

--- a/src/palace/manager/celery/tasks/playtime_entries.py
+++ b/src/palace/manager/celery/tasks/playtime_entries.py
@@ -307,7 +307,7 @@ def _fetch_distinct_eligible_data_source_names(
     Fetches a sorted list of distinct data source names for which to produce a playtime report.
 
     Only OPDS 2.0 and OPDS for Distributors collections that have the
-    ``generate_playtime_report`` setting explicitly set to ``True`` are included.
+    ``is_generate_playtime_report`` setting explicitly set to ``True`` are included.
     All other collections are ignored.
 
     :param session: The SQLAlchemy database session.
@@ -333,12 +333,12 @@ def _fetch_distinct_eligible_data_source_names(
     )
     eligible_collections = session.scalars(eligible_collections_query).all()
 
-    # Only include collections that have opted in via the generate_playtime_report flag.
+    # Only include collections that have opted in via the is_generate_playtime_report flag.
     # c.integration_configuration is guaranteed non-null by the query filter above.
     collection_ds_names = {
         c.data_source.name
         for c in eligible_collections
-        if c.integration_configuration.settings_dict.get("generate_playtime_report")
+        if c.integration_configuration.settings_dict.get("is_generate_playtime_report")
         is True
         and c.data_source
         and c.data_source.name is not None

--- a/src/palace/manager/celery/tasks/playtime_entries.py
+++ b/src/palace/manager/celery/tasks/playtime_entries.py
@@ -304,14 +304,11 @@ def _fetch_distinct_eligible_data_source_names(
     registry: LicenseProvidersRegistry,
 ) -> list[str]:
     """
-    Fetches a sorted list of distinct data source names for which to produce a playback time report.
+    Fetches a sorted list of distinct data source names for which to produce a playtime report.
 
-    We gather data source names from two sources:
-    1. Collections with eligible protocols.
-    2. Data sources that appear in PlaytimeSummary records.
-
-    The names collected from both sources are combined, deduplicated, and then
-    returned as a sorted list.
+    Only OPDS 2.0 and OPDS for Distributors collections that have the
+    ``generate_playtime_report`` setting explicitly set to ``True`` are included.
+    All other collections are ignored.
 
     :param session: The SQLAlchemy database session.
     :param registry: The license providers registry for protocol lookups.
@@ -328,27 +325,26 @@ def _fetch_distinct_eligible_data_source_names(
             for protocol in eligible_protocols
         ]
     )
-    # Query collections with those configuration IDs.
+    # Query collections with those configuration IDs, eagerly loading their configuration.
     eligible_collections_query = (
         select(Collection)
         .where(Collection.integration_configuration_id.in_(eligible_config_ids_query))
         .options(joinedload(Collection.integration_configuration))
     )
     eligible_collections = session.scalars(eligible_collections_query).all()
-    # And get their data source names.
+
+    # Only include collections that have opted in via the generate_playtime_report flag.
     collection_ds_names = {
         c.data_source.name
         for c in eligible_collections
-        if c.data_source and c.data_source.name is not None
+        if c.integration_configuration
+        and c.integration_configuration.settings_dict.get("generate_playtime_report")
+        is True
+        and c.data_source
+        and c.data_source.name is not None
     }
 
-    # Data sources that appear in existing playback time summary records...
-    playtime_summary_query = select(distinct(PlaytimeSummary.data_source_name))
-    playtime_summary_result = session.scalars(playtime_summary_query).all()
-    playtime_summary_ds_names = set(playtime_summary_result)
-
-    all_ds_names = collection_ds_names.union(playtime_summary_ds_names)
-    return sorted(list(all_ds_names))
+    return sorted(collection_ds_names)
 
 
 def _fetch_report_records(

--- a/src/palace/manager/celery/tasks/playtime_entries.py
+++ b/src/palace/manager/celery/tasks/playtime_entries.py
@@ -334,11 +334,11 @@ def _fetch_distinct_eligible_data_source_names(
     eligible_collections = session.scalars(eligible_collections_query).all()
 
     # Only include collections that have opted in via the generate_playtime_report flag.
+    # c.integration_configuration is guaranteed non-null by the query filter above.
     collection_ds_names = {
         c.data_source.name
         for c in eligible_collections
-        if c.integration_configuration
-        and c.integration_configuration.settings_dict.get("generate_playtime_report")
+        if c.integration_configuration.settings_dict.get("generate_playtime_report")
         is True
         and c.data_source
         and c.data_source.name is not None

--- a/src/palace/manager/celery/tasks/playtime_entries.py
+++ b/src/palace/manager/celery/tasks/playtime_entries.py
@@ -25,6 +25,9 @@ from palace.manager.integration.license.opds.for_distributors.api import (
     OPDSForDistributorsAPI,
 )
 from palace.manager.integration.license.opds.opds2.api import OPDS2API
+from palace.manager.integration.license.opds.settings.playtime_report import (
+    PLAYTIME_REPORT_FLAG_KEY,
+)
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.integration_registry.license_providers import (
     LicenseProvidersRegistry,
@@ -338,7 +341,7 @@ def _fetch_distinct_eligible_data_source_names(
     collection_ds_names = {
         c.data_source.name
         for c in eligible_collections
-        if c.integration_configuration.settings_dict.get("is_generate_playtime_report")
+        if c.integration_configuration.settings_dict.get(PLAYTIME_REPORT_FLAG_KEY)
         is True
         and c.data_source
         and c.data_source.name is not None

--- a/src/palace/manager/integration/license/opds/for_distributors/settings.py
+++ b/src/palace/manager/integration/license/opds/for_distributors/settings.py
@@ -5,31 +5,16 @@ from typing import Annotated
 from flask_babel import lazy_gettext as _
 
 from palace.manager.integration.license.opds.opds1.settings import OPDSImporterSettings
+from palace.manager.integration.license.opds.settings.playtime_report import (
+    PlaytimeReportSettings,
+)
 from palace.manager.integration.settings import (
     BaseSettings,
-    FormFieldType,
     FormMetadata,
 )
 
 
-class OPDSForDistributorsSettings(OPDSImporterSettings):
-    generate_playtime_report: Annotated[
-        bool,
-        FormMetadata(
-            label=_("Generate playtime report for audio books"),
-            description=_(
-                "When enabled, this collection will be included in the monthly "
-                "playtime report uploaded to Google Drive. This is a system "
-                "administrator setting."
-            ),
-            type=FormFieldType.SELECT,
-            options={
-                True: "Yes",
-                False: "(Default) No",
-            },
-        ),
-    ] = False
-
+class OPDSForDistributorsSettings(PlaytimeReportSettings, OPDSImporterSettings):
     username: Annotated[
         str,
         FormMetadata(

--- a/src/palace/manager/integration/license/opds/for_distributors/settings.py
+++ b/src/palace/manager/integration/license/opds/for_distributors/settings.py
@@ -7,11 +7,29 @@ from flask_babel import lazy_gettext as _
 from palace.manager.integration.license.opds.opds1.settings import OPDSImporterSettings
 from palace.manager.integration.settings import (
     BaseSettings,
+    FormFieldType,
     FormMetadata,
 )
 
 
 class OPDSForDistributorsSettings(OPDSImporterSettings):
+    generate_playtime_report: Annotated[
+        bool,
+        FormMetadata(
+            label=_("Generate playtime report for audio books"),
+            description=_(
+                "When enabled, this collection will be included in the monthly "
+                "playtime report uploaded to Google Drive. This is a system "
+                "administrator setting."
+            ),
+            type=FormFieldType.SELECT,
+            options={
+                True: "Yes",
+                False: "(Default) No",
+            },
+        ),
+    ] = False
+
     username: Annotated[
         str,
         FormMetadata(

--- a/src/palace/manager/integration/license/opds/opds2/api.py
+++ b/src/palace/manager/integration/license/opds/opds2/api.py
@@ -17,8 +17,8 @@ from palace.manager.api.circulation.exceptions import CannotFulfill
 from palace.manager.api.circulation.fulfillment import RedirectFulfillment
 from palace.manager.integration.license.opds.base.api import BaseOPDSAPI
 from palace.manager.integration.license.opds.opds2.settings import (
+    OPDS2APISettings,
     OPDS2ImporterLibrarySettings,
-    OPDS2ImporterSettings,
 )
 from palace.manager.integration.license.opds.requests import (
     OpdsAuthType,
@@ -50,14 +50,14 @@ SUPPORTED_TEMPLATE_VARIABLES: frozenset[str] = frozenset(TemplateVariable)
 
 
 class OPDS2API(
-    BaseOPDSAPI[OPDS2ImporterSettings, OPDS2ImporterLibrarySettings], SupportsImport
+    BaseOPDSAPI[OPDS2APISettings, OPDS2ImporterLibrarySettings], SupportsImport
 ):
     TOKEN_AUTH_CONFIG_KEY = "token_auth_endpoint"
     LAST_REAP_TIME_KEY = "last_reap_time"
 
     @classmethod
-    def settings_class(cls) -> type[OPDS2ImporterSettings]:
-        return OPDS2ImporterSettings
+    def settings_class(cls) -> type[OPDS2APISettings]:
+        return OPDS2APISettings
 
     @classmethod
     def library_settings_class(cls) -> type[OPDS2ImporterLibrarySettings]:

--- a/src/palace/manager/integration/license/opds/opds2/settings.py
+++ b/src/palace/manager/integration/license/opds/opds2/settings.py
@@ -22,7 +22,7 @@ from palace.manager.integration.settings import (
 from palace.manager.sqlalchemy.constants import IdentifierType
 
 
-class OPDS2ImporterSettings(PlaytimeReportSettings, OPDSImporterSettings):
+class OPDS2ImporterSettings(OPDSImporterSettings):
     custom_accept_header: Annotated[
         str,
         FormMetadata(
@@ -99,3 +99,13 @@ class OPDS2ImporterSettings(PlaytimeReportSettings, OPDSImporterSettings):
 
 class OPDS2ImporterLibrarySettings(OPDSImporterLibrarySettings):
     pass
+
+
+class OPDS2APISettings(PlaytimeReportSettings, OPDS2ImporterSettings):
+    """Settings for OPDS2API.
+
+    Extends :class:`OPDS2ImporterSettings` with the ``generate_playtime_report``
+    opt-in flag.  Kept as a separate subclass so that ``OPDS2WithODLSettings``
+    (which also inherits from ``OPDS2ImporterSettings``) does not inadvertently
+    expose the playtime-report setting on ODL 2.0 collection forms.
+    """

--- a/src/palace/manager/integration/license/opds/opds2/settings.py
+++ b/src/palace/manager/integration/license/opds/opds2/settings.py
@@ -20,6 +20,23 @@ from palace.manager.sqlalchemy.constants import IdentifierType
 
 
 class OPDS2ImporterSettings(OPDSImporterSettings):
+    generate_playtime_report: Annotated[
+        bool,
+        FormMetadata(
+            label=_("Generate playtime report for audio books"),
+            description=_(
+                "When enabled, this collection will be included in the monthly "
+                "playtime report uploaded to Google Drive. This is a system "
+                "administrator setting."
+            ),
+            type=FormFieldType.SELECT,
+            options={
+                True: "Yes",
+                False: "(Default) No",
+            },
+        ),
+    ] = False
+
     custom_accept_header: Annotated[
         str,
         FormMetadata(

--- a/src/palace/manager/integration/license/opds/opds2/settings.py
+++ b/src/palace/manager/integration/license/opds/opds2/settings.py
@@ -12,6 +12,9 @@ from palace.manager.integration.license.opds.opds1.settings import (
     OPDSImporterLibrarySettings,
     OPDSImporterSettings,
 )
+from palace.manager.integration.license.opds.settings.playtime_report import (
+    PlaytimeReportSettings,
+)
 from palace.manager.integration.settings import (
     FormFieldType,
     FormMetadata,
@@ -19,24 +22,7 @@ from palace.manager.integration.settings import (
 from palace.manager.sqlalchemy.constants import IdentifierType
 
 
-class OPDS2ImporterSettings(OPDSImporterSettings):
-    generate_playtime_report: Annotated[
-        bool,
-        FormMetadata(
-            label=_("Generate playtime report for audio books"),
-            description=_(
-                "When enabled, this collection will be included in the monthly "
-                "playtime report uploaded to Google Drive. This is a system "
-                "administrator setting."
-            ),
-            type=FormFieldType.SELECT,
-            options={
-                True: "Yes",
-                False: "(Default) No",
-            },
-        ),
-    ] = False
-
+class OPDS2ImporterSettings(PlaytimeReportSettings, OPDSImporterSettings):
     custom_accept_header: Annotated[
         str,
         FormMetadata(

--- a/src/palace/manager/integration/license/opds/settings/playtime_report.py
+++ b/src/palace/manager/integration/license/opds/settings/playtime_report.py
@@ -35,3 +35,10 @@ class PlaytimeReportSettings(BaseSettings):
             },
         ),
     ] = False
+
+
+# The key as it appears in settings_dict; derived from the model field to avoid bare string literals.
+PLAYTIME_REPORT_FLAG_KEY: str = (
+    PlaytimeReportSettings.model_fields["is_generate_playtime_report"].alias
+    or "is_generate_playtime_report"
+)

--- a/src/palace/manager/integration/license/opds/settings/playtime_report.py
+++ b/src/palace/manager/integration/license/opds/settings/playtime_report.py
@@ -12,14 +12,14 @@ from palace.manager.integration.settings import (
 
 
 class PlaytimeReportSettings(BaseSettings):
-    """Mixin that adds the is_generate_playtime_report opt-in flag.
+    """Mixin that adds the generate_playtime_report opt-in flag.
 
     Intended for OPDS 2.0 and OPDS for Distributors collections only.
     When True the collection's data source is included in the monthly
     playtime report uploaded to Google Drive.
     """
 
-    is_generate_playtime_report: Annotated[
+    generate_playtime_report: Annotated[
         bool,
         FormMetadata(
             label=_("Generate playtime report for audio books"),

--- a/src/palace/manager/integration/license/opds/settings/playtime_report.py
+++ b/src/palace/manager/integration/license/opds/settings/playtime_report.py
@@ -35,10 +35,3 @@ class PlaytimeReportSettings(BaseSettings):
             },
         ),
     ] = False
-
-
-# The key as it appears in settings_dict; derived from the model field to avoid bare string literals.
-PLAYTIME_REPORT_FLAG_KEY: str = (
-    PlaytimeReportSettings.model_fields["is_generate_playtime_report"].alias
-    or "is_generate_playtime_report"
-)

--- a/src/palace/manager/integration/license/opds/settings/playtime_report.py
+++ b/src/palace/manager/integration/license/opds/settings/playtime_report.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from flask_babel import lazy_gettext as _
+
+from palace.manager.integration.settings import (
+    BaseSettings,
+    FormFieldType,
+    FormMetadata,
+)
+
+
+class PlaytimeReportSettings(BaseSettings):
+    """Mixin that adds the is_generate_playtime_report opt-in flag.
+
+    Intended for OPDS 2.0 and OPDS for Distributors collections only.
+    When True the collection's data source is included in the monthly
+    playtime report uploaded to Google Drive.
+    """
+
+    is_generate_playtime_report: Annotated[
+        bool,
+        FormMetadata(
+            label=_("Generate playtime report for audio books"),
+            description=_(
+                "When enabled, this collection will be included in the monthly "
+                "playtime report uploaded to Google Drive. This is a system "
+                "administrator setting."
+            ),
+            type=FormFieldType.SELECT,
+            options={
+                True: "Yes",
+                False: "(Default) No",
+            },
+        ),
+    ] = False

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -66,7 +66,9 @@ from palace.manager.integration.license.opds.odl.settings import OPDS2WithODLSet
 from palace.manager.integration.license.opds.opds1.api import OPDSAPI
 from palace.manager.integration.license.opds.opds1.settings import OPDSImporterSettings
 from palace.manager.integration.license.opds.opds2.api import OPDS2API
-from palace.manager.integration.license.opds.opds2.settings import OPDS2ImporterSettings
+from palace.manager.integration.license.opds.opds2.settings import (
+    OPDS2APISettings,
+)
 from palace.manager.integration.license.overdrive.api import OverdriveAPI
 from palace.manager.integration.license.overdrive.settings import OverdriveSettings
 from palace.manager.integration.patron_auth.simple_authentication import (
@@ -624,7 +626,7 @@ class DatabaseTransactionFixture:
 
     opds2_settings = staticmethod(
         functools.partial(
-            OPDS2ImporterSettings,
+            OPDS2APISettings,
             external_account_id="http://opds.example.com/feed",
             data_source="OPDS",
         )

--- a/tests/manager/celery/tasks/test_playtime_entries.py
+++ b/tests/manager/celery/tasks/test_playtime_entries.py
@@ -576,7 +576,7 @@ class TestGeneratePlaytimeReport:
             "collection b",
             protocol=OPDSForDistributorsAPI,
             settings=db.opds_for_distributors_settings(
-                data_source="ds_b", generate_playtime_report=True
+                data_source="ds_b", is_generate_playtime_report=True
             ),
         )
 
@@ -587,7 +587,7 @@ class TestGeneratePlaytimeReport:
             "collection a",
             protocol=OPDS2API,
             settings=db.opds2_settings(
-                data_source="ds_a", generate_playtime_report=True
+                data_source="ds_a", is_generate_playtime_report=True
             ),
         )
 
@@ -596,7 +596,7 @@ class TestGeneratePlaytimeReport:
             "collection c",
             protocol=OPDS2API,
             settings=db.opds2_settings(
-                data_source="ds_c", generate_playtime_report=True
+                data_source="ds_c", is_generate_playtime_report=True
             ),
         )
 
@@ -607,7 +607,7 @@ class TestGeneratePlaytimeReport:
             "collection d",
             protocol=OPDS2API,
             settings=db.opds2_settings(
-                data_source="ds_d", generate_playtime_report=True
+                data_source="ds_d", is_generate_playtime_report=True
             ),
         )
 
@@ -1086,7 +1086,7 @@ class TestGeneratePlaytimeReport:
         """Test fetching distinct data source names for collections with the playtime flag.
 
         Verifies that:
-        - Only collections with generate_playtime_report=True are included
+        - Only collections with is_generate_playtime_report=True are included
         - Collections without the flag are excluded regardless of protocol
         - Ineligible protocols (Bibliotheca, OPDS2WithODL) are excluded even without the flag
         - Results are sorted alphabetically
@@ -1095,15 +1095,15 @@ class TestGeneratePlaytimeReport:
         for protocol, ds_name in flagged_collections:
             if protocol == OPDS2API:
                 settings = db.opds2_settings(
-                    data_source=ds_name, generate_playtime_report=True
+                    data_source=ds_name, is_generate_playtime_report=True
                 )
             elif protocol == OPDSForDistributorsAPI:
                 settings = db.opds_for_distributors_settings(
-                    data_source=ds_name, generate_playtime_report=True
+                    data_source=ds_name, is_generate_playtime_report=True
                 )
             else:
                 raise ValueError(
-                    f"Protocol {protocol} does not support generate_playtime_report"
+                    f"Protocol {protocol} does not support is_generate_playtime_report"
                 )
             db.collection(
                 name=f"collection_flagged_{ds_name or 'none'}",
@@ -1146,7 +1146,7 @@ class TestGeneratePlaytimeReport:
             name="collection_to_delete",
             protocol=OPDS2API,
             settings=db.opds2_settings(
-                data_source="ds_deleted", generate_playtime_report=True
+                data_source="ds_deleted", is_generate_playtime_report=True
             ),
         )
 

--- a/tests/manager/celery/tasks/test_playtime_entries.py
+++ b/tests/manager/celery/tasks/test_playtime_entries.py
@@ -575,7 +575,9 @@ class TestGeneratePlaytimeReport:
         collection = db.collection(
             "collection b",
             protocol=OPDSForDistributorsAPI,
-            settings=db.opds_for_distributors_settings(data_source="ds_b"),
+            settings=db.opds_for_distributors_settings(
+                data_source="ds_b", generate_playtime_report=True
+            ),
         )
 
         library = db.default_library()
@@ -584,22 +586,29 @@ class TestGeneratePlaytimeReport:
         collection2 = db.collection(
             "collection a",
             protocol=OPDS2API,
-            settings=db.opds2_settings(data_source="ds_a"),
+            settings=db.opds2_settings(
+                data_source="ds_a", generate_playtime_report=True
+            ),
         )
 
         # a data source with no playtime data - we expect an empty report for ds_c
         collection3 = db.collection(
             "collection c",
             protocol=OPDS2API,
-            settings=db.opds2_settings(data_source="ds_c"),
+            settings=db.opds2_settings(
+                data_source="ds_c", generate_playtime_report=True
+            ),
         )
 
-        # A collection and datasource that will be removed after the playtime is recorded, but before the report
-        # is generated.
+        # A collection whose data source will be deleted before the report runs.
+        # Without the PlaytimeSummary fallback, its data source will NOT appear
+        # in the report even though playtime was recorded for it.
         collection4 = db.collection(
             "collection d",
             protocol=OPDS2API,
-            settings=db.opds2_settings(data_source="ds_d"),
+            settings=db.opds2_settings(
+                data_source="ds_d", generate_playtime_report=True
+            ),
         )
 
         library2 = db.library()
@@ -767,19 +776,18 @@ class TestGeneratePlaytimeReport:
         # Act
         generate_playtime_report.delay().wait()
 
-        # Assert
-        assert len(output_data) == 4
+        # Assert: only 3 reports — ds_d's collection is deleted before the task runs,
+        # so it is excluded from the eligible set (no PlaytimeSummary fallback).
+        assert len(output_data) == 3
         [
             (ds_a_filename, ds_a_data),
             (ds_b_filename, ds_b_data),
             (ds_c_filename, ds_c_data),
-            (ds_d_filename, ds_d_data),
         ] = [(k, list(csv.reader(StringIO(v)))) for k, v in output_data.items()]
 
         assert len(ds_a_data) == 6
         assert len(ds_b_data) == 4
         assert len(ds_c_data) == 1
-        assert len(ds_d_data) == 2
 
         cutoff = date1m(0).replace(day=1)
         until = utc_now().date().replace(day=1)
@@ -902,29 +910,10 @@ class TestGeneratePlaytimeReport:
             headers,
         ]
 
-        assert (
-            f"{cutoff.strftime(REPORT_DATE_FORMAT)}-{until.strftime(REPORT_DATE_FORMAT)}-playtime-summary-test_cm-ds_d-"
-            in ds_d_filename
-        )
-
-        assert ds_d_data == [
-            headers,
-            [
-                column1,
-                identifier.urn,
-                strongest_isbn,
-                "collection d",
-                library.name,
-                "",
-                "1",
-                "1",
-            ],
-        ]
-
-        assert mock_google_drive_service.create_file.call_count == 4
+        assert mock_google_drive_service.create_file.call_count == 3
 
         nested_method = mock_google_drive_service.create_nested_folders_if_not_exist
-        assert nested_method.call_count == 4
+        assert nested_method.call_count == 3
         # The year in the folder structure is based on the start of the reporting period.
         expected_year = str(cutoff.year)
         assert nested_method.call_args_list[0].kwargs == {
@@ -956,15 +945,6 @@ class TestGeneratePlaytimeReport:
             ],
         }
 
-        assert nested_method.call_args_list[3].kwargs == {
-            "parent_folder_id": parent_folder_id,
-            "folders": [
-                "ds_d",
-                "Usage Reports",
-                "test cm",
-                expected_year,
-            ],
-        }
 
     def test_generate_playtime_report_folder_lock_contention(
         self,
@@ -982,7 +962,7 @@ class TestGeneratePlaytimeReport:
         collection = db.collection(
             "collection a",
             protocol=OPDS2API,
-            settings=db.opds2_settings(data_source="ds_a"),
+            settings=db.opds2_settings(data_source="ds_a", generate_playtime_report=True),
         )
         library = db.default_library()
         identifier = db.identifier()
@@ -1033,26 +1013,27 @@ class TestGeneratePlaytimeReport:
         # Despite the lock timeout, the task should still have completed and uploaded a file.
         assert mock_google_drive_service.create_file.call_count == 1
 
+
     @pytest.mark.parametrize(
-        "eligible_collections,playtime_summaries,expected_ds_names",
+        "flagged_collections,unflagged_collections,expected_ds_names",
         (
             pytest.param(
                 [],
                 [],
                 [],
-                id="no-collections-no-summaries",
+                id="no-collections",
             ),
             pytest.param(
                 [(OPDS2API, "ds_opds2")],
                 [],
                 ["ds_opds2"],
-                id="eligible-collection-only-opds2",
+                id="opds2-with-flag",
             ),
             pytest.param(
                 [(OPDSForDistributorsAPI, "ds_ofd")],
                 [],
                 ["ds_ofd"],
-                id="eligible-collection-only-opds-for-distributors",
+                id="ofd-with-flag",
             ),
             pytest.param(
                 [
@@ -1061,125 +1042,91 @@ class TestGeneratePlaytimeReport:
                 ],
                 [],
                 ["ds_ofd", "ds_opds2"],
-                id="multiple-eligible-collections",
+                id="multiple-flagged",
             ),
             pytest.param(
+                [],
+                [(OPDS2API, "ds_unflagged")],
+                [],
+                id="opds2-without-flag-excluded",
+            ),
+            pytest.param(
+                [(OPDS2API, "ds_flagged")],
+                [(OPDS2API, "ds_unflagged")],
+                ["ds_flagged"],
+                id="mix-flagged-and-unflagged",
+            ),
+            pytest.param(
+                [],
                 [
                     (BibliothecaAPI, "ds_bibliotheca"),
                     (OPDS2WithODLApi, "ds_opds2odl"),
                 ],
                 [],
-                [],
-                id="ineligible-collections-only",
-            ),
-            pytest.param(
-                [],
-                ["ds_from_summary"],
-                ["ds_from_summary"],
-                id="playtime-summary-only",
-            ),
-            pytest.param(
-                [(OPDS2API, "ds_shared")],
-                ["ds_shared"],
-                ["ds_shared"],
-                id="collection-and-summary-same-ds",
-            ),
-            pytest.param(
-                [(OPDS2API, "ds_collection")],
-                ["ds_summary"],
-                ["ds_collection", "ds_summary"],
-                id="collection-and-summary-different-ds",
-            ),
-            pytest.param(
-                [],
-                ["ds_dup", "ds_dup", "ds_dup"],
-                ["ds_dup"],
-                id="multiple-summaries-same-ds",
+                id="ineligible-protocols-excluded",
             ),
             pytest.param(
                 [
                     (OPDS2API, "ds_z"),
                     (OPDSForDistributorsAPI, "ds_a"),
-                    (BibliothecaAPI, "ds_ineligible"),
                 ],
-                ["ds_m", "ds_b"],
-                ["ds_a", "ds_b", "ds_m", "ds_z"],
-                id="mixed-eligible-ineligible-with-summaries-sorting",
+                [(BibliothecaAPI, "ds_ineligible")],
+                ["ds_a", "ds_z"],
+                id="mixed-eligible-ineligible-sorted",
             ),
         ),
     )
     def test_fetch_distinct_eligible_data_source_names(
         self,
         db: DatabaseTransactionFixture,
-        eligible_collections: list[tuple[type, str | None]],
-        playtime_summaries: list[str],
+        flagged_collections: list[tuple[type, str | None]],
+        unflagged_collections: list[tuple[type, str | None]],
         expected_ds_names: list[str],
     ):
-        """Test fetching distinct eligible data source names from collections and summaries.
+        """Test fetching distinct data source names for collections with the playtime flag.
 
         Verifies that:
-        - Only collections with eligible protocols are included
-        - All PlaytimeSummary data sources are included
-        - Results are deduplicated
+        - Only collections with generate_playtime_report=True are included
+        - Collections without the flag are excluded regardless of protocol
+        - Ineligible protocols (Bibliotheca, OPDS2WithODL) are excluded even without the flag
         - Results are sorted alphabetically
-        - Mixed scenarios with both eligible and ineligible collections work correctly
         """
-        # Create collections with specified protocols and data sources.
-        for protocol, ds_name in eligible_collections:
-            settings: BaseCirculationApiSettings
+        settings: BaseCirculationApiSettings
+        for protocol, ds_name in flagged_collections:
             if protocol == OPDS2API:
-                settings = db.opds2_settings(data_source=ds_name)
-            elif protocol == OPDS2WithODLApi:
-                settings = db.opds2_odl_settings(data_source=ds_name)
+                settings = db.opds2_settings(
+                    data_source=ds_name, generate_playtime_report=True
+                )
             elif protocol == OPDSForDistributorsAPI:
-                settings = db.opds_for_distributors_settings(data_source=ds_name)
-            elif protocol == BibliothecaAPI:
-                settings = db.bibliotheca_settings(data_source=ds_name)
+                settings = db.opds_for_distributors_settings(
+                    data_source=ds_name, generate_playtime_report=True
+                )
             else:
-                raise ValueError(f"Unhandled protocol: {protocol}")
-
+                raise ValueError(
+                    f"Protocol {protocol} does not support generate_playtime_report"
+                )
             db.collection(
-                name=f"collection_{ds_name or 'none'}",
+                name=f"collection_flagged_{ds_name or 'none'}",
                 protocol=protocol,
                 settings=settings,
             )
 
-        if playtime_summaries:
-            identifier = db.identifier()
-            # We'll delete this collection after creating summaries so that
-            # only the summary data sources are counted.
-            temp_collection = db.collection(
-                protocol=OPDS2API,
-                settings=db.opds2_settings(data_source="temp_ds_to_delete"),
+        for protocol, ds_name in unflagged_collections:
+            if protocol == OPDS2API:
+                settings = db.opds2_settings(data_source=ds_name)
+            elif protocol == OPDSForDistributorsAPI:
+                settings = db.opds_for_distributors_settings(data_source=ds_name)
+            elif protocol == BibliothecaAPI:
+                settings = db.bibliotheca_settings(data_source=ds_name)
+            elif protocol == OPDS2WithODLApi:
+                settings = db.opds2_odl_settings(data_source=ds_name)
+            else:
+                raise ValueError(f"Unhandled protocol: {protocol}")
+            db.collection(
+                name=f"collection_unflagged_{ds_name or 'none'}",
+                protocol=protocol,
+                settings=settings,
             )
-            library = db.default_library()
-
-            for idx, ds_name in enumerate(playtime_summaries):
-                # Create summaries and assign data sources.
-                playtime(
-                    db.session,
-                    identifier=identifier,
-                    collection=temp_collection,
-                    library=library,
-                    timestamp=dt1m(3),
-                    total_seconds=10,
-                    loan_identifier=f"loan_{idx}",
-                )
-                summary = (
-                    db.session.query(PlaytimeSummary)
-                    .order_by(PlaytimeSummary.id.desc())
-                    .first()
-                )
-                assert summary is not None
-                summary.data_source_name = ds_name
-
-            db.session.flush()
-
-            # Delete the temporary collection and its data source so they don't affect the result.
-            temp_ds = temp_collection.data_source
-            db.session.delete(temp_collection)
-            db.session.delete(temp_ds)
-            db.session.flush()
 
         registry = LicenseProvidersRegistry()
         result = _fetch_distinct_eligible_data_source_names(db.session, registry)
@@ -1190,26 +1137,20 @@ class TestGeneratePlaytimeReport:
         self,
         db: DatabaseTransactionFixture,
     ):
-        """Test that data sources from deleted collections still appear via PlaytimeSummary."""
+        """Test that deleted collections are excluded even if they had playtime data.
+
+        With the flag-based system there is no PlaytimeSummary fallback. Once a
+        collection is deleted the data source no longer appears in the report.
+        """
         collection = db.collection(
             name="collection_to_delete",
             protocol=OPDS2API,
-            settings=db.opds2_settings(data_source="ds_deleted"),
+            settings=db.opds2_settings(
+                data_source="ds_deleted", generate_playtime_report=True
+            ),
         )
 
-        identifier = db.identifier()
-        library = db.default_library()
-        playtime(
-            db.session,
-            identifier=identifier,
-            collection=collection,
-            library=library,
-            timestamp=dt1m(3),
-            total_seconds=100,
-            loan_identifier="loan_1",
-        )
-
-        # Verify that the data source is returned before the collection is deleted.
+        # Verify that the data source is returned while the collection exists.
         registry = LicenseProvidersRegistry()
         result = _fetch_distinct_eligible_data_source_names(db.session, registry)
         assert result == ["ds_deleted"]
@@ -1220,6 +1161,7 @@ class TestGeneratePlaytimeReport:
         db.session.delete(data_source)
         db.session.flush()
 
-        # Verify that the data source is returned after the collection is deleted.
+        # The data source is no longer returned because no live flagged collection
+        # references it (PlaytimeSummary records are not used as a fallback).
         result = _fetch_distinct_eligible_data_source_names(db.session, registry)
-        assert result == ["ds_deleted"]
+        assert result == []

--- a/tests/manager/celery/tasks/test_playtime_entries.py
+++ b/tests/manager/celery/tasks/test_playtime_entries.py
@@ -576,7 +576,7 @@ class TestGeneratePlaytimeReport:
             "collection b",
             protocol=OPDSForDistributorsAPI,
             settings=db.opds_for_distributors_settings(
-                data_source="ds_b", is_generate_playtime_report=True
+                data_source="ds_b", generate_playtime_report=True
             ),
         )
 
@@ -587,7 +587,7 @@ class TestGeneratePlaytimeReport:
             "collection a",
             protocol=OPDS2API,
             settings=db.opds2_settings(
-                data_source="ds_a", is_generate_playtime_report=True
+                data_source="ds_a", generate_playtime_report=True
             ),
         )
 
@@ -596,7 +596,7 @@ class TestGeneratePlaytimeReport:
             "collection c",
             protocol=OPDS2API,
             settings=db.opds2_settings(
-                data_source="ds_c", is_generate_playtime_report=True
+                data_source="ds_c", generate_playtime_report=True
             ),
         )
 
@@ -607,7 +607,7 @@ class TestGeneratePlaytimeReport:
             "collection d",
             protocol=OPDS2API,
             settings=db.opds2_settings(
-                data_source="ds_d", is_generate_playtime_report=True
+                data_source="ds_d", generate_playtime_report=True
             ),
         )
 
@@ -962,7 +962,7 @@ class TestGeneratePlaytimeReport:
             "collection a",
             protocol=OPDS2API,
             settings=db.opds2_settings(
-                data_source="ds_a", is_generate_playtime_report=True
+                data_source="ds_a", generate_playtime_report=True
             ),
         )
         library = db.default_library()
@@ -1086,7 +1086,7 @@ class TestGeneratePlaytimeReport:
         """Test fetching distinct data source names for collections with the playtime flag.
 
         Verifies that:
-        - Only collections with is_generate_playtime_report=True are included
+        - Only collections with generate_playtime_report=True are included
         - Collections without the flag are excluded regardless of protocol
         - Ineligible protocols (Bibliotheca, OPDS2WithODL) are excluded even without the flag
         - Results are sorted alphabetically
@@ -1095,15 +1095,15 @@ class TestGeneratePlaytimeReport:
         for protocol, ds_name in flagged_collections:
             if protocol == OPDS2API:
                 settings = db.opds2_settings(
-                    data_source=ds_name, is_generate_playtime_report=True
+                    data_source=ds_name, generate_playtime_report=True
                 )
             elif protocol == OPDSForDistributorsAPI:
                 settings = db.opds_for_distributors_settings(
-                    data_source=ds_name, is_generate_playtime_report=True
+                    data_source=ds_name, generate_playtime_report=True
                 )
             else:
                 raise ValueError(
-                    f"Protocol {protocol} does not support is_generate_playtime_report"
+                    f"Protocol {protocol} does not support generate_playtime_report"
                 )
             db.collection(
                 name=f"collection_flagged_{ds_name or 'none'}",
@@ -1146,7 +1146,7 @@ class TestGeneratePlaytimeReport:
             name="collection_to_delete",
             protocol=OPDS2API,
             settings=db.opds2_settings(
-                data_source="ds_deleted", is_generate_playtime_report=True
+                data_source="ds_deleted", generate_playtime_report=True
             ),
         )
 

--- a/tests/manager/celery/tasks/test_playtime_entries.py
+++ b/tests/manager/celery/tasks/test_playtime_entries.py
@@ -945,7 +945,6 @@ class TestGeneratePlaytimeReport:
             ],
         }
 
-
     def test_generate_playtime_report_folder_lock_contention(
         self,
         db: DatabaseTransactionFixture,
@@ -962,7 +961,9 @@ class TestGeneratePlaytimeReport:
         collection = db.collection(
             "collection a",
             protocol=OPDS2API,
-            settings=db.opds2_settings(data_source="ds_a", generate_playtime_report=True),
+            settings=db.opds2_settings(
+                data_source="ds_a", is_generate_playtime_report=True
+            ),
         )
         library = db.default_library()
         identifier = db.identifier()
@@ -1012,7 +1013,6 @@ class TestGeneratePlaytimeReport:
         )
         # Despite the lock timeout, the task should still have completed and uploaded a file.
         assert mock_google_drive_service.create_file.call_count == 1
-
 
     @pytest.mark.parametrize(
         "flagged_collections,unflagged_collections,expected_ds_names",


### PR DESCRIPTION
## Description

Replaces the current behavior of generating reports for every OPDS2 and OPDSForDistributors protocol with an explicit per-collection opt-in flag that controls whether a collection's playtime data is included in the monthly Google Drive report.

### Changes

**New setting: `generate_playtime_report` (bool, default `False`)**

Added via the `PlaytimeReportSettings` mixin to:
- `OPDS2APISettings` — the settings class used exclusively by `OPDS2API` (OPDS 2.0 Import)
- `OPDSForDistributorsSettings` — the settings class used by `OPDSForDistributorsAPI`

The field is **not** present on `OPDS2ImporterSettings` (the shared base class), which means `OPDS2WithODLSettings` (ODL 2.0) does not inherit it and the setting does not appear on ODL 2.0 collection forms. `OPDS2APISettings` is a thin subclass of `OPDS2ImporterSettings` that adds the mixin.

The field is sysadmin-facing and rendered as a SELECT ("Generate playtime report for audio books"). All other protocols are ineligible by design.

**Migration**

Sets `generate_playtime_report = True` for all existing OPDS 2.0 / OPDS for Distributors collections whose `data_source` name begins with `"Blackstone"` or `"Unlimited"`. All other collections default to `False` and require no update. I verified in Redshift that using the aforementioned constraints will match all Blackstone and Unlimited Listens data sources and no others.

Downgrade removes the key entirely (absence is equivalent to the Pydantic default of `False`).

**`_fetch_distinct_eligible_data_source_names`**

Now returns only data source names for collections where `generate_playtime_report` is explicitly `True`. The `PlaytimeSummary` fallback (which was the root cause of folder proliferation — it included every historical data source regardless of intent) has been removed.

> **Behavioral note — deleted collections:** Because eligibility is now determined entirely by a collection's settings, a deleted collection produces no report regardless of how much historical playtime data it accumulated. Without a live collection there are no collection settings, and therefore no `generate_playtime_report` flag to evaluate. This is intentional: report generation should reflect an active, administrator-approved configuration, not the presence of stale summary rows. If we need to go back and find playtime summaries for deleted collections, the data will still be there.

## Motivation and Context

The Partner Success team observed large numbers of Google Drive folders being generated for every data source in the system. The underlying cause was a combination of:

1. `_fetch_distinct_eligible_data_source_names` returning all data sources that ever appeared in `PlaytimeSummary` records, and
2. A prior change expanding the set of eligible protocols beyond the two Blackstone-platform integrations.

The flag-based approach gives sysadmins explicit control, makes the opt-in visible and auditable in the collection settings UI, and removes the unbounded fallback.

JIRA: PP-4346

## How Has This Been Tested?

- `test_fetch_distinct_eligible_data_source_names` (8 parametrised cases): verifies that only flagged OPDS 2.0/OFD collections are included; unflagged collections, ineligible protocols, and mixed scenarios all behave correctly.
- `test_fetch_distinct_eligible_data_source_names_deleted_collection`: verifies the new no-fallback behaviour — a deleted collection is excluded even if it had prior playtime data.
- `test_generate_playtime_reports`: updated to set `generate_playtime_report=True` on active collections and verify that the deleted `collection4` (ds_d) no longer produces a report (3 files instead of 4).
- `test_generate_playtime_report_folder_lock_contention`: verifies that the task completes and logs a warning when the folder-creation lock cannot be acquired (from PR #3377, now included here after rebase).
- All 14 affected tests pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.