### PR TITLE
Add OIDC integration- and library-level patron filtering (PP-4387)

### DIFF
--- a/src/palace/manager/integration/patron_auth/oidc/configuration/model.py
+++ b/src/palace/manager/integration/patron_auth/oidc/configuration/model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from re import Pattern
-from typing import Annotated
+from typing import Annotated, Any
 
 from flask_babel import lazy_gettext as _
 from pydantic import (
@@ -27,10 +27,13 @@ from palace.manager.api.authentication.base import (
     AuthProviderSettings,
 )
 from palace.manager.integration.settings import (
+    BaseSettings,
     FormFieldType,
     FormMetadata,
     SettingsValidationError,
 )
+from palace.manager.util.filter import FilterExpression, FilterExpressionError
+from palace.manager.util.problem_detail import ProblemDetail as pd
 
 PRODUCTION_AUTH_ADAPTER: TypeAdapter[
     Annotated[HttpUrl, UrlConstraints(allowed_schemes=["https"])]
@@ -38,6 +41,33 @@ PRODUCTION_AUTH_ADAPTER: TypeAdapter[
 TEST_MODE_AUTH_ADAPTER: TypeAdapter[
     Annotated[HttpUrl, UrlConstraints(allowed_schemes=["https", "http"])]
 ] = TypeAdapter(Annotated[HttpUrl, UrlConstraints(allowed_schemes=["https", "http"])])
+
+OIDC_INCORRECT_FILTER_EXPRESSION = pd(
+    "http://palaceproject.io/terms/problem/auth/unrecoverable/oidc/incorrect-filter-expression-format",
+    status_code=400,
+    title=_("Invalid filter expression."),
+    detail=_("OIDC filter expression has an incorrect format."),
+)
+
+
+def _validate_filter_expression(cls: type[BaseSettings], v: str | None) -> str | None:
+    """Shared validator for OIDC filter expression fields on settings models.
+
+    :raises SettingsValidationError: if the expression is syntactically invalid.
+    """
+    if v is not None:
+        try:
+            FilterExpression(v).check_syntax()
+        except FilterExpressionError as exception:
+            cls.logger().warning(
+                f"Validation of the filter expression failed: {exception}"
+            )
+            raise SettingsValidationError(
+                problem_detail=OIDC_INCORRECT_FILTER_EXPRESSION.detailed(
+                    f"OIDC filter expression has an incorrect format: {exception}"
+                )
+            )
+    return v
 
 
 class OIDCAuthSettings(AuthProviderSettings, LoggerMixin):
@@ -218,6 +248,7 @@ class OIDCAuthSettings(AuthProviderSettings, LoggerMixin):
                 "Comma-separated list."
             ),
             type=FormFieldType.LIST,
+            patron_auth_filter_context=True,
         ),
     ] = ["openid", "profile", "email"]
 
@@ -231,6 +262,7 @@ class OIDCAuthSettings(AuthProviderSettings, LoggerMixin):
                 "'preferred_username', 'eduPersonPrincipalName'. "
                 "Default: 'sub'"
             ),
+            patron_auth_filter_context=True,
         ),
     ] = "sub"
 
@@ -259,6 +291,49 @@ class OIDCAuthSettings(AuthProviderSettings, LoggerMixin):
                 "Note: This only affects the Circulation Manager's session. "
                 "Protected content access is still governed by the OIDC provider's tokens."
             ),
+            patron_auth_filter_context=True,
+        ),
+    ] = None
+
+    filter_expression: Annotated[
+        str | None,
+        FormMetadata(
+            label="Filter Expression",
+            description=(
+                "A Python expression that may restrict a patron's access based on their"
+                " ID token claims and other settings."
+                " When present, it must evaluate to True in order for the patron to gain access."
+                " If a per-library Filter Expression is also configured, both must evaluate to True."
+                "<br>"
+                "<br>"
+                "The expression has access to: 'claims' (dict of ID token claims),"
+                " 'integration' (selected integration settings),"
+                " and 'library' (id, name, short_name)."
+                "<br>"
+                "<br>"
+                "Example — restrict to a specific email domain:"
+                "<br>"
+                "<pre>claims['email'].endswith('@example.edu')</pre>"
+            ),
+            type=FormFieldType.TEXTAREA,
+        ),
+    ] = None
+
+    # Note: the key-ordering caveat in the description below is a JSONB storage
+    # side effect — PostgreSQL sorts all object keys when storing/retrieving JSONB.
+    extra_data: Annotated[
+        dict[str, Any] | list[Any] | int | float | bool | str | None,
+        FormMetadata(
+            label="Extra Data",
+            description=(
+                "Extra data available to patron filter expressions via the"
+                " 'integration.extra_data' context variable."
+                " Accepts any JSON value (object, array, string, number, boolean, or null)."
+                "<br>"
+                "Note: Dictionary/object key order may not be preserved after saving."
+            ),
+            type=FormFieldType.JSON,
+            patron_auth_filter_context=True,
         ),
     ] = None
 
@@ -471,6 +546,11 @@ class OIDCAuthSettings(AuthProviderSettings, LoggerMixin):
             )
         return v
 
+    @field_validator("filter_expression")
+    @classmethod
+    def validate_filter_expression(cls, v: str | None) -> str | None:
+        return _validate_filter_expression(cls, v)
+
     @field_validator("patron_id_regular_expression")
     @classmethod
     def validate_patron_id_regex(cls, v: Pattern[str] | None) -> Pattern[str] | None:
@@ -487,11 +567,27 @@ class OIDCAuthSettings(AuthProviderSettings, LoggerMixin):
 
 
 class OIDCAuthLibrarySettings(AuthProviderLibrarySettings):
-    """OIDC Authentication Library-Level Settings.
+    """Per-library OIDC authentication settings."""
 
-    Currently empty (like SAML). Future enhancements may include:
-    - Library-specific scope overrides
-    - Custom claim mappings
-    """
+    filter_expression: Annotated[
+        str | None,
+        FormMetadata(
+            label="Filter Expression",
+            description=(
+                "A Python expression that may restrict a patron's access to this library"
+                " based on their ID token claims and other settings."
+                " When present, it must evaluate to True in order for the patron to gain"
+                " access to this library."
+                "<br>"
+                "<br>"
+                "Refer to the integration-level Filter Expression setting for expression"
+                " syntax and available context variables."
+            ),
+            type=FormFieldType.TEXTAREA,
+        ),
+    ] = None
 
-    ...
+    @field_validator("filter_expression")
+    @classmethod
+    def validate_filter_expression(cls, v: str | None) -> str | None:
+        return _validate_filter_expression(cls, v)

--- a/src/palace/manager/integration/patron_auth/oidc/provider.py
+++ b/src/palace/manager/integration/patron_auth/oidc/provider.py
@@ -32,6 +32,7 @@ from palace.manager.integration.patron_auth.oidc.util import (
 from palace.manager.service.analytics.analytics import Analytics
 from palace.manager.sqlalchemy.model.credential import Credential
 from palace.manager.sqlalchemy.model.patron import Patron
+from palace.manager.util.filter import FilterExpression, FilterExpressionError
 from palace.manager.util.problem_detail import (
     ProblemDetail as pd,
     ProblemDetailException,
@@ -57,6 +58,27 @@ OIDC_TOKEN_EXPIRED = pd(
     detail=_(
         "Your OIDC session has expired. Please reauthenticate via your identity provider."
     ),
+)
+
+OIDC_NO_ACCESS_ERROR = pd(
+    "http://palaceproject.io/terms/problem/auth/unrecoverable/oidc/no-access",
+    status_code=401,
+    title=_("No access."),
+    detail=_("Patron does not have access based on their ID token claims."),
+)
+
+OIDC_LIBRARY_NOT_FOUND = pd(
+    "http://palaceproject.io/terms/problem/auth/unrecoverable/oidc/library-not-found",
+    status_code=500,
+    title=_("Library not found."),
+    detail=_("The library associated with this OIDC integration could not be found."),
+)
+
+OIDC_FILTER_EVALUATION_ERROR = pd(
+    "http://palaceproject.io/terms/problem/auth/unrecoverable/oidc/filter-evaluation-error",
+    status_code=500,
+    title=_("Filter expression error."),
+    detail=_("OIDC patron filter expression could not be evaluated."),
 )
 
 
@@ -87,6 +109,7 @@ class OIDCAuthenticationProvider(
 
         self._credential_manager = OIDCCredentialManager()
         self._settings = settings
+        self._library_settings = library_settings
         self._auth_manager: OIDCAuthenticationManager | None = None
 
     @classmethod
@@ -316,6 +339,54 @@ class OIDCAuthenticationProvider(
         """
         raise PatronLookupNotSupported()
 
+    def _filter_claims(self, db: Session, id_token_claims: dict[str, Any]) -> None:
+        """Apply the configured filter expression as an authorization check.
+
+        The integration-level expression is evaluated first, then the library-level
+        expression. Both must evaluate to True for access to be granted. The
+        evaluation context exposes ``claims`` (ID token claims dict),
+        ``integration`` (fields from the integration settings marked with
+        ``patron_auth_filter_context=True``, including ``extra_data``),
+        and ``library`` (``id``, ``name``, ``short_name``).
+
+        :param db: Database session
+        :param id_token_claims: Validated ID token claims from the OIDC provider
+        :raises ProblemDetailException: if the patron is denied access or an expression errors
+        """
+        expressions = [
+            e
+            for e in (
+                self._settings.filter_expression,
+                self._library_settings.filter_expression,
+            )
+            if e is not None
+        ]
+        if not expressions:
+            return
+
+        library = self.library(db)
+        if library is None:
+            raise ProblemDetailException(problem_detail=OIDC_LIBRARY_NOT_FOUND)
+        context = {
+            "claims": id_token_claims,
+            "integration": self._settings.filter_context_dump(),
+            "library": {
+                "short_name": library.short_name,
+                "name": library.name,
+                "id": library.id,
+            },
+        }
+
+        for expression in expressions:
+            try:
+                result = FilterExpression(expression).evaluate(context)
+            except FilterExpressionError as exc:
+                raise ProblemDetailException(
+                    problem_detail=OIDC_FILTER_EVALUATION_ERROR.detailed(str(exc))
+                ) from exc
+            if not result:
+                raise ProblemDetailException(problem_detail=OIDC_NO_ACCESS_ERROR)
+
     def oidc_callback(
         self,
         db: Session,
@@ -335,6 +406,8 @@ class OIDCAuthenticationProvider(
         :param id_token: Raw ID token JWT (stored for use as id_token_hint on logout)
         :return: 3-tuple (Credential, Patron, PatronData)
         """
+        self._filter_claims(db, id_token_claims)
+
         patron_data = self.remote_patron_lookup_from_oidc_claims(id_token_claims)
 
         patron, is_new = patron_data.get_or_create_patron(

--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -331,9 +331,9 @@ class BaseSettings(BaseModel, LoggerMixin):
     def filter_context_dump(self) -> dict[str, Any]:
         """Return a dict of fields eligible for patron-auth filter expression context.
 
-        Only fields whose `FormMetadata` has `patron_auth_filter_context=True`
+        Only fields whose :class:`FormMetadata` has ``patron_auth_filter_context=True``
         are included. All fields are included at their current value regardless of
-        whether they match their default (i.e. `exclude_defaults=False`).
+        whether they match their default (i.e. ``exclude_defaults=False``).
         """
         return self.model_dump(
             include=_filter_context_fields(type(self)), exclude_defaults=False

--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import json
 import typing
 from collections.abc import Callable, Mapping
@@ -38,6 +39,21 @@ def _get_form_metadata(field_info: FieldInfo) -> FormMetadata | None:
         if isinstance(item, FormMetadata):
             return item
     return None
+
+
+@functools.cache
+def _filter_context_fields(cls: type[BaseSettings]) -> frozenset[str]:
+    """Return the set of field names with `patron_auth_filter_context=True`.
+
+    Cached per class — field metadata is set at class-definition time and never
+    changes at runtime, so no invalidation is required.
+    """
+    return frozenset(
+        name
+        for name, field_info in cls.model_fields.items()
+        if (fm := _get_form_metadata(field_info)) is not None
+        and fm.patron_auth_filter_context
+    )
 
 
 class FormFieldType(Enum):
@@ -315,17 +331,13 @@ class BaseSettings(BaseModel, LoggerMixin):
     def filter_context_dump(self) -> dict[str, Any]:
         """Return a dict of fields eligible for patron-auth filter expression context.
 
-        Only fields whose :class:`FormMetadata` has ``patron_auth_filter_context=True``
+        Only fields whose `FormMetadata` has `patron_auth_filter_context=True`
         are included. All fields are included at their current value regardless of
-        whether they match their default (i.e. ``exclude_defaults=False``).
+        whether they match their default (i.e. `exclude_defaults=False`).
         """
-        include = {
-            name
-            for name, field_info in type(self).model_fields.items()
-            if (fm := _get_form_metadata(field_info)) is not None
-            and fm.patron_auth_filter_context
-        }
-        return self.model_dump(include=include, exclude_defaults=False)
+        return self.model_dump(
+            include=_filter_context_fields(type(self)), exclude_defaults=False
+        )
 
     @classmethod
     def get_form_field_label(cls, field_name: str) -> str:

--- a/tests/manager/integration/patron_auth/oidc/configuration/test_model.py
+++ b/tests/manager/integration/patron_auth/oidc/configuration/test_model.py
@@ -9,7 +9,9 @@ from typing import Any
 import pytest
 from pydantic import HttpUrl
 
-from palace.manager.api.admin.problem_details import INVALID_CONFIGURATION_OPTION
+from palace.manager.api.admin.problem_details import (
+    INVALID_CONFIGURATION_OPTION,
+)
 from palace.manager.integration.patron_auth.oidc.configuration.model import (
     OIDCAuthLibrarySettings,
     OIDCAuthSettings,
@@ -550,6 +552,57 @@ class TestOIDCAuthSettings:
         settings = OIDCAuthSettings(**kwargs)
         assert settings.patron_id_claim == expected
 
+    @pytest.mark.parametrize(
+        "value, expected_python",
+        [
+            pytest.param(None, None, id="none-becomes-none"),
+            pytest.param("", None, id="empty-string-becomes-none"),
+            pytest.param({}, {}, id="dict-passthrough"),
+            pytest.param('{"key": "value"}', {"key": "value"}, id="json-object-string"),
+            pytest.param("[1, 2, 3]", [1, 2, 3], id="json-array-string"),
+            pytest.param("42", 42, id="json-number-string"),
+            pytest.param('"hello"', "hello", id="json-string-string"),
+            pytest.param("true", True, id="json-bool-string"),
+            pytest.param("null", None, id="json-null-string"),
+            pytest.param(
+                '{"nested": {"a": [1, 2]}}',
+                {"nested": {"a": [1, 2]}},
+                id="nested-json",
+            ),
+        ],
+    )
+    def test_extra_data_valid(self, value: object, expected_python: object) -> None:
+        settings = OIDCAuthSettings(
+            issuer_url="https://idp.example.com",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            extra_data=value,
+        )
+        assert settings.extra_data == expected_python
+        assert settings.filter_context_dump()["extra_data"] == expected_python
+
+    def test_extra_data_default(self) -> None:
+        settings = OIDCAuthSettings(
+            issuer_url="https://idp.example.com",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+        )
+        assert settings.extra_data is None
+        assert settings.filter_context_dump()["extra_data"] is None
+
+    def test_extra_data_invalid_json(self) -> None:
+        with pytest.raises(ProblemDetailException) as exc_info:
+            OIDCAuthSettings(
+                issuer_url="https://idp.example.com",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+                extra_data="{not valid json}",
+            )
+        assert exc_info.value.problem_detail.uri == INVALID_CONFIGURATION_OPTION.uri
+        assert "'Extra Data' must be valid JSON" in (
+            exc_info.value.problem_detail.detail or ""
+        )
+
 
 class TestOIDCAuthLibrarySettings:
     """Tests for OIDCAuthLibrarySettings."""
@@ -561,14 +614,8 @@ class TestOIDCAuthLibrarySettings:
         assert settings is not None
         assert isinstance(settings, OIDCAuthLibrarySettings)
 
-    def test_library_settings_is_empty(self):
-        """Test that OIDCAuthLibrarySettings has no required fields."""
-        # Should not raise any errors
+    def test_library_settings_defaults(self):
+        """Test that OIDCAuthLibrarySettings fields default to None."""
         settings = OIDCAuthLibrarySettings()
-
-        # Convert to dict to check it's empty (only has inherited fields if any)
-        settings_dict = settings.model_dump()
-        # Should be empty or only contain inherited base fields
-        assert len(settings_dict) == 0 or all(
-            k.startswith("_") for k in settings_dict.keys()
-        )
+        assert settings.filter_expression is None
+        assert settings.model_dump() == {}

--- a/tests/manager/integration/patron_auth/oidc/configuration/test_validator.py
+++ b/tests/manager/integration/patron_auth/oidc/configuration/test_validator.py
@@ -1,0 +1,101 @@
+"""Tests for OIDC settings field validators."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+
+import pytest
+
+from palace.manager.integration.patron_auth.oidc.configuration.model import (
+    OIDC_INCORRECT_FILTER_EXPRESSION,
+    OIDCAuthLibrarySettings,
+    OIDCAuthSettings,
+)
+from palace.manager.util.problem_detail import ProblemDetailException
+
+
+class TestOIDCSettingsValidator:
+    @pytest.mark.parametrize(
+        "filter_expression, expect_raises",
+        [
+            pytest.param(
+                'claims["edu_person_entitlement"][0 == "eresources"',
+                True,
+                id="syntax-error",
+            ),
+            pytest.param(
+                'claims["email"].endswith("@example.edu")',
+                False,
+                id="valid-endswith",
+            ),
+            pytest.param(
+                '"staff" in claims.get("groups", [])',
+                False,
+                id="valid-in-expression",
+            ),
+            pytest.param(
+                'claims["sub"] == "admin"',
+                False,
+                id="valid-equality",
+            ),
+            pytest.param(
+                # Syntax check is parse-only; names used in the expression are
+                # not verified — undefined names fail only at evaluation time.
+                'undefined_var == "value"',
+                False,
+                id="valid-no-claims-reference",
+            ),
+        ],
+    )
+    def test_validate_filter_expression(
+        self,
+        filter_expression: str,
+        expect_raises: bool,
+    ) -> None:
+        context_manager = (
+            pytest.raises(ProblemDetailException) if expect_raises else nullcontext()
+        )
+        with context_manager as exc_info:
+            OIDCAuthSettings(
+                issuer_url="https://idp.example.com",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+                filter_expression=filter_expression,
+            )
+
+        if expect_raises:
+            assert (
+                exc_info.value.problem_detail.uri
+                == OIDC_INCORRECT_FILTER_EXPRESSION.uri
+            )
+
+    @pytest.mark.parametrize(
+        "filter_expression, expect_raises",
+        [
+            pytest.param(None, False, id="none-passes"),
+            pytest.param(
+                'claims["email"].endswith("@example.edu")',
+                False,
+                id="valid-expression",
+            ),
+            pytest.param(
+                'claims["edu_person_entitlement"][0 == "eresources"',
+                True,
+                id="syntax-error",
+            ),
+        ],
+    )
+    def test_validate_filter_expression_library_settings(
+        self, filter_expression: str | None, expect_raises: bool
+    ) -> None:
+        context_manager = (
+            pytest.raises(ProblemDetailException) if expect_raises else nullcontext()
+        )
+        with context_manager as exc_info:
+            OIDCAuthLibrarySettings(filter_expression=filter_expression)
+
+        if expect_raises:
+            assert (
+                exc_info.value.problem_detail.uri
+                == OIDC_INCORRECT_FILTER_EXPRESSION.uri
+            )

--- a/tests/manager/integration/patron_auth/oidc/conftest.py
+++ b/tests/manager/integration/patron_auth/oidc/conftest.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from functools import partial
 from unittest.mock import patch
 
 import pytest
 from pydantic import HttpUrl
 
+from palace.manager.integration.goals import Goals
 from palace.manager.integration.patron_auth.oidc.auth import OIDCAuthenticationManager
 from palace.manager.integration.patron_auth.oidc.configuration.model import (
     OIDCAuthLibrarySettings,
@@ -48,6 +51,37 @@ def oidc_provider(db: DatabaseTransactionFixture) -> OIDCAuthenticationProvider:
     ):
         provider.get_authentication_manager()
     return provider
+
+
+@pytest.fixture
+def create_oidc_settings() -> Callable[..., OIDCAuthSettings]:
+    """Factory fixture that creates OIDCAuthSettings with minimal required fields."""
+    return partial(
+        OIDCAuthSettings,
+        issuer_url="https://idp.example.com",
+        client_id="test-client-id",
+        client_secret="test-client-secret",
+    )
+
+
+@pytest.fixture
+def create_oidc_provider(
+    db: DatabaseTransactionFixture,
+    create_oidc_settings: Callable[..., OIDCAuthSettings],
+) -> Callable[..., OIDCAuthenticationProvider]:
+    """Factory fixture that creates OIDCAuthenticationProvider instances."""
+    library = db.default_library()
+    assert library.id is not None
+    integration = db.integration_configuration(
+        protocol="oidc", goal=Goals.PATRON_AUTH_GOAL
+    )
+    return partial(
+        OIDCAuthenticationProvider,
+        library_id=library.id,
+        integration_id=integration.id,
+        settings=create_oidc_settings(),
+        library_settings=OIDCAuthLibrarySettings(),
+    )
 
 
 @pytest.fixture

--- a/tests/manager/integration/patron_auth/oidc/test_provider.py
+++ b/tests/manager/integration/patron_auth/oidc/test_provider.py
@@ -22,6 +22,7 @@ from palace.manager.integration.patron_auth.oidc.configuration.model import (
 )
 from palace.manager.integration.patron_auth.oidc.provider import (
     OIDC_CANNOT_DETERMINE_PATRON,
+    OIDC_FILTER_EVALUATION_ERROR,
     OIDC_LIBRARY_NOT_FOUND,
     OIDC_NO_ACCESS_ERROR,
     OIDC_TOKEN_EXPIRED,
@@ -678,6 +679,29 @@ class TestOIDCAuthenticationProvider:
         assert isinstance(credential, Credential)
         assert isinstance(patron, Patron)
         assert isinstance(patron_data, PatronData)
+
+    def test_oidc_callback_filter_evaluation_error(
+        self,
+        db: DatabaseTransactionFixture,
+        create_oidc_settings: Callable[..., OIDCAuthSettings],
+        create_oidc_provider: Callable[..., OIDCAuthenticationProvider],
+    ) -> None:
+        """oidc_callback raises OIDC_FILTER_EVALUATION_ERROR when the filter expression errors at evaluation."""
+        configuration = create_oidc_settings(
+            # Syntactically valid, so the model validator accepts it;
+            # claims.nonexistent raises AttributeDoesNotExist at evaluation time.
+            filter_expression="claims.nonexistent == 'value'"
+        )
+        provider = create_oidc_provider(settings=configuration)
+
+        with pytest.raises(ProblemDetailException) as exc_info:
+            provider.oidc_callback(
+                db.session,
+                self._FILTER_CLAIMS,
+                "test-access-token",
+            )
+
+        assert exc_info.value.problem_detail.uri == OIDC_FILTER_EVALUATION_ERROR.uri
 
     def test_filter_claims_library_not_found(
         self,

--- a/tests/manager/integration/patron_auth/oidc/test_provider.py
+++ b/tests/manager/integration/patron_auth/oidc/test_provider.py
@@ -2,6 +2,9 @@
 
 import logging
 import re
+from collections.abc import Callable
+from contextlib import nullcontext
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,13 +22,17 @@ from palace.manager.integration.patron_auth.oidc.configuration.model import (
 )
 from palace.manager.integration.patron_auth.oidc.provider import (
     OIDC_CANNOT_DETERMINE_PATRON,
+    OIDC_LIBRARY_NOT_FOUND,
+    OIDC_NO_ACCESS_ERROR,
     OIDC_TOKEN_EXPIRED,
     OIDCAuthenticationProvider,
 )
 from palace.manager.integration.patron_auth.oidc.util import (
     OIDCDiscoveryError,
 )
+from palace.manager.sqlalchemy.model.credential import Credential
 from palace.manager.sqlalchemy.model.datasource import DataSource
+from palace.manager.sqlalchemy.model.patron import Patron
 from palace.manager.util.problem_detail import ProblemDetailException
 from tests.fixtures.database import DatabaseTransactionFixture
 
@@ -572,3 +579,257 @@ class TestOIDCAuthenticationProvider:
             MockNewManager.return_value = new_mock_manager
 
             assert new_provider.get_authentication_manager() is not manager
+
+    # Shared ID token claims for filter tests.
+    _FILTER_CLAIMS: dict[str, Any] = {
+        "sub": "user-123",
+        "email": "user@example.edu",
+        "iss": "https://idp.example.com",
+        "aud": "test-client-id",
+    }
+
+    @pytest.mark.parametrize(
+        "filter_expression, expect_raises, expected_uri",
+        [
+            pytest.param(None, False, None, id="no-filter-passes"),
+            pytest.param(
+                "claims['email'].endswith('@example.edu')",
+                False,
+                None,
+                id="filter-passes",
+            ),
+            pytest.param(
+                "claims['email'].endswith('@other.com')",
+                True,
+                "http://palaceproject.io/terms/problem/auth/unrecoverable/oidc/no-access",
+                id="filter-rejects",
+            ),
+            pytest.param(
+                # Syntactically valid so the model validator accepts it;
+                # claims.nonexistent raises at evaluation time.
+                "claims.nonexistent == 'value'",
+                True,
+                "http://palaceproject.io/terms/problem/auth/unrecoverable/oidc/filter-evaluation-error",
+                id="filter-error",
+            ),
+        ],
+    )
+    def test_filter_claims(
+        self,
+        db: DatabaseTransactionFixture,
+        create_oidc_settings: Callable[..., OIDCAuthSettings],
+        create_oidc_provider: Callable[..., OIDCAuthenticationProvider],
+        filter_expression: str | None,
+        expect_raises: bool,
+        expected_uri: str | None,
+    ) -> None:
+        configuration = create_oidc_settings(filter_expression=filter_expression)
+        provider = create_oidc_provider(settings=configuration)
+
+        context_manager = (
+            pytest.raises(ProblemDetailException) if expect_raises else nullcontext()
+        )
+        with context_manager as exc_info:
+            provider._filter_claims(db.session, self._FILTER_CLAIMS)
+
+        if expect_raises:
+            assert exc_info.value.problem_detail.uri == expected_uri
+
+    def test_oidc_callback_filter_rejects(
+        self,
+        db: DatabaseTransactionFixture,
+        create_oidc_settings: Callable[..., OIDCAuthSettings],
+        create_oidc_provider: Callable[..., OIDCAuthenticationProvider],
+    ) -> None:
+        """oidc_callback raises OIDC_NO_ACCESS_ERROR when the filter rejects the patron."""
+        configuration = create_oidc_settings(
+            filter_expression="claims['email'].endswith('@other.com')"
+        )
+        provider = create_oidc_provider(settings=configuration)
+
+        with pytest.raises(ProblemDetailException) as exc_info:
+            provider.oidc_callback(
+                db.session,
+                self._FILTER_CLAIMS,
+                "test-access-token",
+            )
+
+        assert exc_info.value.problem_detail.uri == OIDC_NO_ACCESS_ERROR.uri
+
+    def test_oidc_callback_filter_passes(
+        self,
+        db: DatabaseTransactionFixture,
+        create_oidc_settings: Callable[..., OIDCAuthSettings],
+        create_oidc_provider: Callable[..., OIDCAuthenticationProvider],
+    ) -> None:
+        """oidc_callback succeeds and returns (Credential, Patron, PatronData) when the filter passes."""
+        DataSource.lookup(db.session, "OIDC", autocreate=True)
+        configuration = create_oidc_settings(
+            filter_expression="claims['email'].endswith('@example.edu')"
+        )
+        provider = create_oidc_provider(settings=configuration)
+
+        credential, patron, patron_data = provider.oidc_callback(
+            db.session,
+            self._FILTER_CLAIMS,
+            "test-access-token",
+        )
+
+        assert isinstance(credential, Credential)
+        assert isinstance(patron, Patron)
+        assert isinstance(patron_data, PatronData)
+
+    def test_filter_claims_library_not_found(
+        self,
+        db: DatabaseTransactionFixture,
+        create_oidc_settings: Callable[..., OIDCAuthSettings],
+        create_oidc_provider: Callable[..., OIDCAuthenticationProvider],
+    ) -> None:
+        """_filter_claims raises OIDC_LIBRARY_NOT_FOUND when the library cannot be resolved."""
+        configuration = create_oidc_settings(filter_expression="1 == 1")
+        provider = create_oidc_provider(settings=configuration)
+
+        with patch.object(provider, "library", return_value=None):
+            with pytest.raises(ProblemDetailException) as exc_info:
+                provider._filter_claims(db.session, self._FILTER_CLAIMS)
+
+        assert exc_info.value.problem_detail.uri == OIDC_LIBRARY_NOT_FOUND.uri
+
+    @pytest.mark.parametrize(
+        "session_lifetime, extra_data, filter_expression, expect_no_access",
+        [
+            pytest.param(
+                7,
+                None,
+                "integration.session_lifetime == 7",
+                False,
+                id="integration-field-matches",
+            ),
+            pytest.param(
+                None,
+                None,
+                "integration.session_lifetime == 7",
+                True,
+                id="integration-field-no-match",
+            ),
+            pytest.param(
+                None,
+                None,
+                "library.id > 0",
+                False,
+                id="library-field-matches",
+            ),
+            pytest.param(
+                None,
+                None,
+                "library.id == 0",
+                True,
+                id="library-field-no-match",
+            ),
+            pytest.param(
+                None,
+                {"role": "staff"},
+                'integration.extra_data["role"] == "staff"',
+                False,
+                id="extra-data-dict-matches",
+            ),
+            pytest.param(
+                None,
+                {"role": "guest"},
+                'integration.extra_data["role"] == "staff"',
+                True,
+                id="extra-data-dict-no-match",
+            ),
+            pytest.param(
+                None,
+                None,
+                "integration.extra_data is None",
+                False,
+                id="extra-data-none",
+            ),
+        ],
+    )
+    def test_filter_claims_context_variables(
+        self,
+        db: DatabaseTransactionFixture,
+        create_oidc_settings: Callable[..., OIDCAuthSettings],
+        create_oidc_provider: Callable[..., OIDCAuthenticationProvider],
+        session_lifetime: int | None,
+        extra_data: object,
+        filter_expression: str,
+        expect_no_access: bool,
+    ) -> None:
+        """_filter_claims passes integration and library dicts into the expression context."""
+        configuration = create_oidc_settings(
+            filter_expression=filter_expression,
+            session_lifetime=session_lifetime,
+            extra_data=extra_data,
+        )
+        provider = create_oidc_provider(settings=configuration)
+
+        context_manager = (
+            pytest.raises(ProblemDetailException) if expect_no_access else nullcontext()
+        )
+        with context_manager as exc_info:
+            provider._filter_claims(db.session, self._FILTER_CLAIMS)
+
+        if expect_no_access:
+            assert exc_info.value.problem_detail.uri == OIDC_NO_ACCESS_ERROR.uri
+
+    @pytest.mark.parametrize(
+        "integration_expression, library_expression, extra_data, expect_no_access",
+        [
+            pytest.param("1 == 1", "1 == 1", None, False, id="both-pass"),
+            pytest.param("1 == 2", "1 == 1", None, True, id="integration-rejects"),
+            pytest.param("1 == 1", "1 == 2", None, True, id="library-rejects"),
+            pytest.param("1 == 2", "1 == 2", None, True, id="both-reject"),
+            pytest.param(None, "1 == 1", None, False, id="only-library-passes"),
+            pytest.param(None, "1 == 2", None, True, id="only-library-rejects"),
+            pytest.param("1 == 1", None, None, False, id="only-integration-passes"),
+            pytest.param("1 == 2", None, None, True, id="only-integration-rejects"),
+            pytest.param(
+                None,
+                'integration.extra_data["role"] == "staff"',
+                {"role": "staff"},
+                False,
+                id="library-reads-extra-data-passes",
+            ),
+            pytest.param(
+                None,
+                'integration.extra_data["role"] == "staff"',
+                {"role": "guest"},
+                True,
+                id="library-reads-extra-data-rejects",
+            ),
+        ],
+    )
+    def test_filter_claims_and_behavior(
+        self,
+        db: DatabaseTransactionFixture,
+        create_oidc_settings: Callable[..., OIDCAuthSettings],
+        create_oidc_provider: Callable[..., OIDCAuthenticationProvider],
+        integration_expression: str | None,
+        library_expression: str | None,
+        extra_data: object,
+        expect_no_access: bool,
+    ) -> None:
+        """Integration and library filter expressions are ANDed; both must pass."""
+        configuration = create_oidc_settings(
+            filter_expression=integration_expression,
+            extra_data=extra_data,
+        )
+        provider = create_oidc_provider(
+            settings=configuration,
+            library_settings=OIDCAuthLibrarySettings(
+                filter_expression=library_expression
+            ),
+        )
+
+        context_manager = (
+            pytest.raises(ProblemDetailException) if expect_no_access else nullcontext()
+        )
+        with context_manager as exc_info:
+            provider._filter_claims(db.session, self._FILTER_CLAIMS)
+
+        if expect_no_access:
+            assert exc_info.value.problem_detail.uri == OIDC_NO_ACCESS_ERROR.uri


### PR DESCRIPTION
## Description

Adds patron filter expressions to the OIDC authentication provider, matching the capability just added for SAML in #3400. Two filter levels are supported:

- **Integration-level** (`filter_expression` on `OIDCAuthSettings`): applies to all libraries using this OIDC integration.
- **Library-level** (`filter_expression` on `OIDCAuthLibrarySettings`): applies only to a specific library.

Either or both expressions -- when provided -- must evaluate to `True` for a patron to be granted access. Expressions are evaluated during the OIDC callback (before any patron record is created or updated) using the existing sandboxed `FilterExpression` evaluator.

A new `extra_data` field (accepts any JSON value) is also added to `OIDCAuthSettings` to allow admins to supply arbitrary data accessible to filter expressions via `integration.extra_data`.

The evaluation context available to expressions includes:
- `claims` — ID token claims dict from the OIDC provider
- `integration` — selected integration settings (scopes, patron ID claim, session lifetime, extra data)
- `library` — id, name, short_name

## Motivation and Context

Libraries need to restrict OIDC-authenticated patron access based on claims returned in the ID token — for example, limiting access to patrons from a specific email domain or with a particular group membership. The per-library filter allows a single OIDC integration to serve multiple libraries with different access rules.

[Jira PP-4387]

## How Has This Been Tested?

- Manual testing in local development environment.
- New and updated tests for the new functionality.
- All tests and checks pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/26605010934) and checks pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
