### PR TITLE
Fix a very slow test

### DIFF
--- a/tests/manager/api/test_authenticator.py
+++ b/tests/manager/api/test_authenticator.py
@@ -1333,8 +1333,26 @@ class TestLibraryAuthenticator:
         providers = list(authenticator.providers)
         assert oidc_provider in providers
 
+        # Stub the discovery HTTP call so no real network request is made.
+        # Omitting end_session_endpoint/revocation_endpoint keeps supports_logout()
+        # False, so only the authenticate link appears.
+        mock_discovery = {
+            "issuer": "https://idp.example.com",
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://idp.example.com/token",
+            "jwks_uri": "https://idp.example.com/.well-known/jwks.json",
+        }
+        mock_http_response = MagicMock()
+        mock_http_response.json.return_value = mock_discovery
+
         # Verify provider appears in authentication document
-        with app.test_request_context("/"):
+        with (
+            patch(
+                "palace.manager.integration.patron_auth.oidc.util.HTTP.get_with_timeout",
+                return_value=mock_http_response,
+            ),
+            app.test_request_context("/"),
+        ):
             doc = json.loads(authenticator.create_authentication_document())
             authenticators = doc["authentication"]
 


### PR DESCRIPTION
## Description

Patches `palace.manager.integration.patron_auth.oidc.util.HTTP.get_with_timeout` in  `tests/manager/api/test_authenticator.py::TestLibraryAuthenticator::test_register_oidc_provider` to return a minimal discovery document rather than making a real HTTP call.

## Motivation and Context

Improves specific and overall test performance by avoiding the wait for the fetch to timeout, which took a couple of minutes.

## How Has This Been Tested?

- All tests continue to pass locally.
- CI tests pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.