### PR TITLE
Add missing Any import to OIDC provider

### DIFF
--- a/src/palace/manager/integration/patron_auth/oidc/provider.py
+++ b/src/palace/manager/integration/patron_auth/oidc/provider.py
@@ -6,7 +6,7 @@ This module provides the OIDC authentication provider implementation for patron 
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from flask import url_for
 from flask_babel import lazy_gettext as _


### PR DESCRIPTION
## Description

Adds the missing `Any` import to `src/palace/manager/integration/patron_auth/oidc/provider.py`. 

## Motivation and Context

mypy is currently failing on `main` with `Name "Any" is not defined`. The `_filter_claims` method (and its `dict[str, Any]` annotation) was added in #3408, while #3394 also edited the import block of this file. Each PR passed type checking on its own branch, but merging the two together dropped the `Any` import, leaving the annotation referencing an undefined name.

See the failing run: https://github.com/ThePalaceProject/circulation/actions/runs/26762787265/job/78899186998

## How Has This Been Tested?

Ran `mypy` locally — `Success: no issues found in 1141 source files`.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.