### PR TITLE
Fail over on OpenSearch read timeouts (PP-4472)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,11 @@ To let the application know which OpenSearch instance to use, you can set the fo
 - `PALACE_SEARCH_URL`: The URL of the OpenSearch instance (**required**).
 - `PALACE_SEARCH_INDEX_PREFIX`: The prefix to use for the OpenSearch indices. The default is `circulation-works`.
     This is useful if you want to use the same OpenSearch instance for multiple Circulation Manager instances (optional).
-- `PALACE_SEARCH_TIMEOUT`: The timeout in seconds to use when connecting to the OpenSearch instance. The default is `20`
-  (optional).
+- `PALACE_SEARCH_WRITE_TIMEOUT`: The timeout in seconds to use for indexing and admin operations against the OpenSearch
+  instance. The default is `20` (optional). Replaces the deprecated `PALACE_SEARCH_TIMEOUT`, which is still honored for
+  backwards compatibility.
+- `PALACE_SEARCH_READ_TIMEOUT`: The timeout in seconds to use for the user-facing read/search path. Kept short so a node
+  that briefly stalls during OpenSearch maintenance fails over quickly. The default is `4` (optional).
 - `PALACE_SEARCH_MAXSIZE`: The maximum size of the connection pool to use when connecting to the OpenSearch instance
   (optional).
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ To let the application know which OpenSearch instance to use, you can set the fo
   backwards compatibility.
 - `PALACE_SEARCH_READ_TIMEOUT`: The timeout in seconds to use for the user-facing read/search path. Kept short so a node
   that briefly stalls during OpenSearch maintenance fails over quickly. The default is `4` (optional).
+- `PALACE_SEARCH_READ_RETRY_ON_TIMEOUT`: Whether a timed-out read should be retried against another node. The default is
+  `true` (optional).
+- `PALACE_SEARCH_READ_MAX_RETRIES`: The maximum number of retries for a timed-out read before the error is propagated.
+  The default is `2` (optional).
 - `PALACE_SEARCH_MAXSIZE`: The maximum size of the connection pool to use when connecting to the OpenSearch instance
   (optional).
 

--- a/src/palace/manager/search/service.py
+++ b/src/palace/manager/search/service.py
@@ -165,11 +165,14 @@ class SearchService(ABC):
 class SearchServiceOpensearch1(SearchService, LoggerMixin):
     """The real Opensearch 1.x service."""
 
-    def __init__(self, client: OpenSearch, base_revision_name: str):
+    def __init__(
+        self, client: OpenSearch, base_revision_name: str, search_timeout: int = 4
+    ):
         self._client = client
         self._search = Search(using=self._client)
         self._base_revision_name = base_revision_name
         self._multi_search = MultiSearch(using=self._client)
+        self._search_timeout = search_timeout
 
         # Documents are not allowed to automatically create indexes.
         # AWS OpenSearch only accepts the "flat" format
@@ -319,12 +322,16 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
         return self._get_pointer(self.read_pointer_name())
 
     def read_search_client(self) -> Search:
-        return self._search.index(self.read_pointer_name())  # type: ignore[no-any-return]
-        # opensearchpy Search.index() is not properly typed
+        # opensearchpy Search.index()/params() are not properly typed
+        return self._search.index(self.read_pointer_name()).params(  # type: ignore[no-any-return]
+            request_timeout=self._search_timeout
+        )
 
     def read_search_multi_client(self) -> MultiSearch:
-        return self._multi_search.index(self.read_pointer_name())  # type: ignore[no-any-return]
-        # opensearchpy MultiSearch.index() is not properly typed
+        # opensearchpy MultiSearch.index()/params() are not properly typed
+        return self._multi_search.index(self.read_pointer_name()).params(  # type: ignore[no-any-return]
+            request_timeout=self._search_timeout
+        )
 
     def read_pointer_name(self) -> str:
         return f"{self.base_revision_name}-search-read"

--- a/src/palace/manager/search/service.py
+++ b/src/palace/manager/search/service.py
@@ -322,12 +322,18 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
         return self._get_pointer(self.read_pointer_name())
 
     def read_search_client(self) -> Search:
-        # opensearchpy Search.index()/params() are not properly typed
-        return self._search.index(self.read_pointer_name()).params(  # type: ignore[no-any-return]
-            request_timeout=self._search_timeout
-        )
+        # NOTE: request_timeout is intentionally NOT set here. Every read goes
+        # through the MultiSearch in read_search_multi_client(), and a Search's
+        # params are serialized into the msearch metadata header line, where
+        # OpenSearch rejects request_timeout ("not supported in the metadata
+        # section"). The timeout is applied on the MultiSearch instead.
+        return self._search.index(self.read_pointer_name())  # type: ignore[no-any-return]
+        # opensearchpy Search.index() is not properly typed
 
     def read_search_multi_client(self) -> MultiSearch:
+        # request_timeout here is passed through to client.msearch() as a
+        # transport parameter (not into the request body), so it governs the
+        # read path without tripping the metadata-section validation.
         # opensearchpy MultiSearch.index()/params() are not properly typed
         return self._multi_search.index(self.read_pointer_name()).params(  # type: ignore[no-any-return]
             request_timeout=self._search_timeout

--- a/src/palace/manager/search/service.py
+++ b/src/palace/manager/search/service.py
@@ -166,17 +166,27 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
     """The real Opensearch 1.x service."""
 
     def __init__(
-        self, client: OpenSearch, base_revision_name: str, search_timeout: int = 4
+        self,
+        write_client: OpenSearch,
+        read_client: OpenSearch,
+        base_revision_name: str,
     ):
-        self._client = client
-        self._search = Search(using=self._client)
+        # Indexing and admin operations use the write client, which keeps the
+        # longer client-wide timeout because they legitimately run longer.
+        self._write_client = write_client
+        # The user-facing read path uses a dedicated client configured with a
+        # short timeout (and timeout retries) so a node that briefly stalls
+        # during OpenSearch maintenance fails over fast. The timeout is a
+        # transport property of the client, so every Search/MultiSearch built
+        # with it inherits it without per-request overrides.
+        self._read_client = read_client
+        self._search = Search(using=self._read_client)
+        self._multi_search = MultiSearch(using=self._read_client)
         self._base_revision_name = base_revision_name
-        self._multi_search = MultiSearch(using=self._client)
-        self._search_timeout = search_timeout
 
         # Documents are not allowed to automatically create indexes.
         # AWS OpenSearch only accepts the "flat" format
-        self._client.cluster.put_settings(
+        self._write_client.cluster.put_settings(
             body={"persistent": {"action.auto_create_index": "false"}}
         )
 
@@ -186,7 +196,7 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
 
     def _get_pointer(self, name: str) -> SearchPointer | None:
         try:
-            result = self._client.indices.get_alias(name=name)
+            result = self._write_client.indices.get_alias(name=name)
             if len(result) != 1:
                 # This should never happen, based on my understanding of the API.
                 self.log.error(
@@ -215,13 +225,13 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
             ]
         }
         self.log.debug(f"setting read pointer {alias_name} to index {target_index}")
-        self._client.indices.update_aliases(body=action)
+        self._write_client.indices.update_aliases(body=action)
 
     def index_create(self, revision: SearchSchemaRevision) -> None:
         try:
             index_name = revision.name_for_index(self.base_revision_name)
             self.log.info(f"creating index {index_name}")
-            self._client.indices.create(
+            self._write_client.indices.create(
                 index=index_name,
                 body=revision.mapping_document().serialize(),
             )
@@ -234,7 +244,7 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
         data = {"properties": revision.mapping_document().serialize_properties()}
         index_name = revision.name_for_index(self.base_revision_name)
         self.log.debug(f"setting mappings for index {index_name}")
-        self._client.indices.put_mapping(index=index_name, body=data)
+        self._write_client.indices.put_mapping(index=index_name, body=data)
         self._ensure_scripts(revision)
 
     def _ensure_scripts(self, revision: SearchSchemaRevision) -> None:
@@ -242,13 +252,13 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
             script = dict(script=dict(lang="painless", source=body))
             if not name.startswith("simplified"):
                 name = revision.script_name(name)
-            self._client.put_script(id=name, body=script)
+            self._write_client.put_script(id=name, body=script)
 
     def index_submit_document(
         self, document: dict[str, Any], refresh: bool = False
     ) -> None:
         _id = document.pop("_id")
-        self._client.index(
+        self._write_client.index(
             id=_id,
             index=self.write_pointer_name(),
             body=document,
@@ -276,7 +286,7 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
         # and a list of documents that failed. Unfortunately, the type checker disagrees and the documentation
         # gives no hint as to what an "int" might mean for errors.
         (success_count, errors) = opensearchpy.helpers.bulk(
-            client=self._client,
+            client=self._write_client,
             actions=documents,
             raise_on_error=False,
             max_retries=3,
@@ -296,7 +306,7 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
         return error_results
 
     def index_clear_documents(self) -> None:
-        self._client.delete_by_query(
+        self._write_client.delete_by_query(
             index=self.write_pointer_name(),
             body={"query": {"match_all": {}}},
             wait_for_completion=True,
@@ -304,7 +314,7 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
 
     def refresh(self) -> None:
         self.log.debug(f"waiting for indexes to become ready")
-        self._client.indices.refresh()
+        self._write_client.indices.refresh()
 
     def write_pointer_set(self, revision: SearchSchemaRevision) -> None:
         alias_name = self.write_pointer_name()
@@ -316,28 +326,20 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
             ]
         }
         self.log.debug(f"setting write pointer {alias_name} to {target_index}")
-        self._client.indices.update_aliases(body=action)
+        self._write_client.indices.update_aliases(body=action)
 
     def read_pointer(self) -> SearchPointer | None:
         return self._get_pointer(self.read_pointer_name())
 
     def read_search_client(self) -> Search:
-        # NOTE: request_timeout is intentionally NOT set here. Every read goes
-        # through the MultiSearch in read_search_multi_client(), and a Search's
-        # params are serialized into the msearch metadata header line, where
-        # OpenSearch rejects request_timeout ("not supported in the metadata
-        # section"). The timeout is applied on the MultiSearch instead.
+        # The read timeout comes from the dedicated read client (see __init__),
+        # so no per-request override is needed here.
         return self._search.index(self.read_pointer_name())  # type: ignore[no-any-return]
         # opensearchpy Search.index() is not properly typed
 
     def read_search_multi_client(self) -> MultiSearch:
-        # request_timeout here is passed through to client.msearch() as a
-        # transport parameter (not into the request body), so it governs the
-        # read path without tripping the metadata-section validation.
-        # opensearchpy MultiSearch.index()/params() are not properly typed
-        return self._multi_search.index(self.read_pointer_name()).params(  # type: ignore[no-any-return]
-            request_timeout=self._search_timeout
-        )
+        return self._multi_search.index(self.read_pointer_name())  # type: ignore[no-any-return]
+        # opensearchpy MultiSearch.index() is not properly typed
 
     def read_pointer_name(self) -> str:
         return f"{self.base_revision_name}-search-read"
@@ -346,4 +348,4 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
         return f"{self.base_revision_name}-search-write"
 
     def index_remove_document(self, doc_id: int) -> None:
-        self._client.delete(index=self.write_pointer_name(), id=doc_id)
+        self._write_client.delete(index=self.write_pointer_name(), id=doc_id)

--- a/src/palace/manager/service/search/configuration.py
+++ b/src/palace/manager/service/search/configuration.py
@@ -1,3 +1,9 @@
+from __future__ import annotations
+
+import logging
+import os
+
+from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import SettingsConfigDict
 
 from palace.manager.service.configuration.service_configuration import (
@@ -5,19 +11,49 @@ from palace.manager.service.configuration.service_configuration import (
 )
 from palace.manager.util.pydantic import HttpUrl
 
+# Deprecated environment variable name for ``write_timeout``, still honored for
+# backwards compatibility. Remove once deployments have migrated.
+_DEPRECATED_WRITE_TIMEOUT_ENV = "PALACE_SEARCH_TIMEOUT"
+_WRITE_TIMEOUT_ENV = "PALACE_SEARCH_WRITE_TIMEOUT"
+
 
 class SearchConfiguration(ServiceConfiguration):
     url: HttpUrl
     index_prefix: str = "circulation-works"
-    timeout: int = 20
-    # Per-request timeout (seconds) for the user-facing read/search path. Kept
-    # well below ``timeout`` (which still applies to indexing/admin calls) so a
-    # node that goes briefly unresponsive during OpenSearch maintenance fails
-    # over quickly instead of stalling a web worker for the full ``timeout``.
-    search_timeout: int = 4
-    # Retry timed-out requests against another node. With two nodes per domain
+    # Timeout (seconds) for indexing and admin operations, which legitimately
+    # run longer. ``PALACE_SEARCH_TIMEOUT`` is the deprecated name for this
+    # setting and is still accepted; prefer ``PALACE_SEARCH_WRITE_TIMEOUT``.
+    write_timeout: int = Field(
+        default=20,
+        validation_alias=AliasChoices(
+            _WRITE_TIMEOUT_ENV, _DEPRECATED_WRITE_TIMEOUT_ENV
+        ),
+    )
+    # Timeout (seconds) for the user-facing read path. Kept well below
+    # ``write_timeout`` so a node that goes briefly unresponsive during
+    # OpenSearch maintenance fails over quickly instead of stalling a web
+    # worker for the full write timeout.
+    read_timeout: int = 4
+    # Retry timed-out reads against another node. With two nodes per domain
     # this lets a read survive a single node bouncing during maintenance.
     max_retries: int = 2
     retry_on_timeout: bool = True
     maxsize: int = 25
-    model_config = SettingsConfigDict(env_prefix="PALACE_SEARCH_")
+    model_config = SettingsConfigDict(
+        env_prefix="PALACE_SEARCH_", populate_by_name=True
+    )
+
+    @model_validator(mode="after")
+    def _warn_deprecated_write_timeout_env(self) -> SearchConfiguration:
+        # AliasChoices accepts the deprecated env var, but we want operators to
+        # migrate, so emit a warning when only the deprecated name is set.
+        if (
+            _DEPRECATED_WRITE_TIMEOUT_ENV in os.environ
+            and _WRITE_TIMEOUT_ENV not in os.environ
+        ):
+            logging.getLogger(__name__).warning(
+                "%s is deprecated; use %s instead.",
+                _DEPRECATED_WRITE_TIMEOUT_ENV,
+                _WRITE_TIMEOUT_ENV,
+            )
+        return self

--- a/src/palace/manager/service/search/configuration.py
+++ b/src/palace/manager/service/search/configuration.py
@@ -10,5 +10,14 @@ class SearchConfiguration(ServiceConfiguration):
     url: HttpUrl
     index_prefix: str = "circulation-works"
     timeout: int = 20
+    # Per-request timeout (seconds) for the user-facing read/search path. Kept
+    # well below ``timeout`` (which still applies to indexing/admin calls) so a
+    # node that goes briefly unresponsive during OpenSearch maintenance fails
+    # over quickly instead of stalling a web worker for the full ``timeout``.
+    search_timeout: int = 4
+    # Retry timed-out requests against another node. With two nodes per domain
+    # this lets a read survive a single node bouncing during maintenance.
+    max_retries: int = 2
+    retry_on_timeout: bool = True
     maxsize: int = 25
     model_config = SettingsConfigDict(env_prefix="PALACE_SEARCH_")

--- a/src/palace/manager/service/search/configuration.py
+++ b/src/palace/manager/service/search/configuration.py
@@ -40,9 +40,7 @@ class SearchConfiguration(ServiceConfiguration, LoggerMixin):
     max_retries: int = 2
     retry_on_timeout: bool = True
     maxsize: int = 25
-    model_config = SettingsConfigDict(
-        env_prefix="PALACE_SEARCH_", populate_by_name=True
-    )
+    model_config = SettingsConfigDict(env_prefix="PALACE_SEARCH_")
 
     @model_validator(mode="after")
     def _warn_deprecated_write_timeout_env(self) -> SearchConfiguration:

--- a/src/palace/manager/service/search/configuration.py
+++ b/src/palace/manager/service/search/configuration.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-import logging
 import os
 
 from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import SettingsConfigDict
+
+from palace.util.log import LoggerMixin
 
 from palace.manager.service.configuration.service_configuration import (
     ServiceConfiguration,
@@ -17,7 +18,7 @@ _DEPRECATED_WRITE_TIMEOUT_ENV = "PALACE_SEARCH_TIMEOUT"
 _WRITE_TIMEOUT_ENV = "PALACE_SEARCH_WRITE_TIMEOUT"
 
 
-class SearchConfiguration(ServiceConfiguration):
+class SearchConfiguration(ServiceConfiguration, LoggerMixin):
     url: HttpUrl
     index_prefix: str = "circulation-works"
     # Timeout (seconds) for indexing and admin operations, which legitimately
@@ -51,7 +52,7 @@ class SearchConfiguration(ServiceConfiguration):
             _DEPRECATED_WRITE_TIMEOUT_ENV in os.environ
             and _WRITE_TIMEOUT_ENV not in os.environ
         ):
-            logging.getLogger(__name__).warning(
+            self.log.warning(
                 "%s is deprecated; use %s instead.",
                 _DEPRECATED_WRITE_TIMEOUT_ENV,
                 _WRITE_TIMEOUT_ENV,

--- a/src/palace/manager/service/search/configuration.py
+++ b/src/palace/manager/service/search/configuration.py
@@ -36,9 +36,10 @@ class SearchConfiguration(ServiceConfiguration, LoggerMixin):
     # worker for the full write timeout.
     read_timeout: int = 4
     # Retry timed-out reads against another node. With two nodes per domain
-    # this lets a read survive a single node bouncing during maintenance.
-    max_retries: int = 2
-    retry_on_timeout: bool = True
+    # this lets a read survive a single node bouncing during maintenance. These
+    # apply only to the read path; indexing/admin calls are not retried.
+    read_max_retries: int = 2
+    read_retry_on_timeout: bool = True
     maxsize: int = 25
     model_config = SettingsConfigDict(env_prefix="PALACE_SEARCH_")
 

--- a/src/palace/manager/service/search/container.py
+++ b/src/palace/manager/service/search/container.py
@@ -29,8 +29,8 @@ class Search(DeclarativeContainer):
         hosts=config.url,
         timeout=config.read_timeout,
         maxsize=config.maxsize,
-        max_retries=config.max_retries,
-        retry_on_timeout=config.retry_on_timeout,
+        max_retries=config.read_max_retries,
+        retry_on_timeout=config.read_retry_on_timeout,
     )
 
     service: Provider[SearchServiceOpensearch1] = providers.Singleton(

--- a/src/palace/manager/service/search/container.py
+++ b/src/palace/manager/service/search/container.py
@@ -16,12 +16,15 @@ class Search(DeclarativeContainer):
         hosts=config.url,
         timeout=config.timeout,
         maxsize=config.maxsize,
+        max_retries=config.max_retries,
+        retry_on_timeout=config.retry_on_timeout,
     )
 
     service: Provider[SearchServiceOpensearch1] = providers.Singleton(
         SearchServiceOpensearch1,
         client=client,
         base_revision_name=config.index_prefix,
+        search_timeout=config.search_timeout,
     )
 
     revision_directory: Provider[SearchRevisionDirectory] = providers.Singleton(

--- a/src/palace/manager/service/search/container.py
+++ b/src/palace/manager/service/search/container.py
@@ -11,10 +11,23 @@ from palace.manager.search.service import SearchServiceOpensearch1
 class Search(DeclarativeContainer):
     config = providers.Configuration()
 
-    client: Provider[OpenSearch] = providers.Singleton(
+    # Used for indexing and admin operations, which legitimately run longer and
+    # keep the full client-wide timeout. No timeout retries here, so indexing
+    # and admin behavior is unchanged.
+    write_client: Provider[OpenSearch] = providers.Singleton(
         OpenSearch,
         hosts=config.url,
         timeout=config.timeout,
+        maxsize=config.maxsize,
+    )
+
+    # Used for the user-facing read path. The shorter ``search_timeout`` plus
+    # timeout retries let a read fail over quickly to the domain's other node
+    # when one briefly stalls during OpenSearch maintenance.
+    read_client: Provider[OpenSearch] = providers.Singleton(
+        OpenSearch,
+        hosts=config.url,
+        timeout=config.search_timeout,
         maxsize=config.maxsize,
         max_retries=config.max_retries,
         retry_on_timeout=config.retry_on_timeout,
@@ -22,9 +35,9 @@ class Search(DeclarativeContainer):
 
     service: Provider[SearchServiceOpensearch1] = providers.Singleton(
         SearchServiceOpensearch1,
-        client=client,
+        write_client=write_client,
+        read_client=read_client,
         base_revision_name=config.index_prefix,
-        search_timeout=config.search_timeout,
     )
 
     revision_directory: Provider[SearchRevisionDirectory] = providers.Singleton(

--- a/src/palace/manager/service/search/container.py
+++ b/src/palace/manager/service/search/container.py
@@ -17,17 +17,17 @@ class Search(DeclarativeContainer):
     write_client: Provider[OpenSearch] = providers.Singleton(
         OpenSearch,
         hosts=config.url,
-        timeout=config.timeout,
+        timeout=config.write_timeout,
         maxsize=config.maxsize,
     )
 
-    # Used for the user-facing read path. The shorter ``search_timeout`` plus
+    # Used for the user-facing read path. The shorter ``read_timeout`` plus
     # timeout retries let a read fail over quickly to the domain's other node
     # when one briefly stalls during OpenSearch maintenance.
     read_client: Provider[OpenSearch] = providers.Singleton(
         OpenSearch,
         hosts=config.url,
-        timeout=config.search_timeout,
+        timeout=config.read_timeout,
         maxsize=config.maxsize,
         max_retries=config.max_retries,
         retry_on_timeout=config.retry_on_timeout,

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -28,6 +28,9 @@ from tests.mocks.search import SearchServiceFake
 class SearchTestConfiguration(FixtureTestUrlConfiguration):
     url: HttpUrl
     timeout: int = 20
+    search_timeout: int = 4
+    max_retries: int = 2
+    retry_on_timeout: bool = True
     maxsize: int = 25
     model_config = SettingsConfigDict(env_prefix="PALACE_TEST_SEARCH_")
 

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -58,7 +58,7 @@ class ExternalSearchFixture(LoggerMixin):
         services.search.override(self.search_container)
 
         self.db = db
-        self.client: OpenSearch = services.search().client()
+        self.client: OpenSearch = services.search().write_client()
         self.service: SearchServiceOpensearch1 = services.search().service()
         self.index: ExternalSearchIndex = services.search().index()
         self.revision: SearchSchemaRevision = (

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -58,7 +58,7 @@ class ExternalSearchFixture(LoggerMixin):
         services.search.override(self.search_container)
 
         self.db = db
-        self.client: OpenSearch = services.search().write_client()
+        self.write_client: OpenSearch = services.search().write_client()
         self.service: SearchServiceOpensearch1 = services.search().service()
         self.index: ExternalSearchIndex = services.search().index()
         self.revision: SearchSchemaRevision = (
@@ -67,7 +67,7 @@ class ExternalSearchFixture(LoggerMixin):
 
     def close(self):
         # Delete our index prefix
-        self.client.indices.delete(index=f"{self.index_prefix}*")
+        self.write_client.indices.delete(index=f"{self.index_prefix}*")
         return None
 
     def default_work(self, *args, **kwargs):
@@ -128,7 +128,7 @@ class EndToEndSearchFixture:
         # Add all the works created in the setup to the search index.
         documents = get_work_search_documents(self.db.session, 1000, 0)
         self.external_search_index.add_documents(documents)
-        self.external_search.client.indices.refresh()
+        self.external_search.write_client.indices.refresh()
 
     @staticmethod
     def assert_works(description, expect, actual, should_be_ordered=True):

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -29,8 +29,8 @@ class SearchTestConfiguration(FixtureTestUrlConfiguration):
     url: HttpUrl
     write_timeout: int = 20
     read_timeout: int = 4
-    max_retries: int = 2
-    retry_on_timeout: bool = True
+    read_max_retries: int = 2
+    read_retry_on_timeout: bool = True
     maxsize: int = 25
     model_config = SettingsConfigDict(env_prefix="PALACE_TEST_SEARCH_")
 

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -27,8 +27,8 @@ from tests.mocks.search import SearchServiceFake
 
 class SearchTestConfiguration(FixtureTestUrlConfiguration):
     url: HttpUrl
-    timeout: int = 20
-    search_timeout: int = 4
+    write_timeout: int = 20
+    read_timeout: int = 4
     max_retries: int = 2
     retry_on_timeout: bool = True
     maxsize: int = 25

--- a/tests/fixtures/services.py
+++ b/tests/fixtures/services.py
@@ -79,7 +79,8 @@ class ServicesFixture:
 
         # Mock out search
         search_container = self.services.search()
-        search_container.client.override(self.search_client)
+        search_container.write_client.override(self.search_client)
+        search_container.read_client.override(self.search_client)
         search_container.service.override(self.search_service)
         search_container.revision_directory.override(self.search_revision_directory)
         search_container.index.override(self.search_index)

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -71,7 +71,7 @@ def test_search_reindex(
     search_reindex_task_lock_fixture: SearchReindexTaskLockFixture,
     end_to_end_search_fixture: EndToEndSearchFixture,
 ) -> None:
-    client = end_to_end_search_fixture.external_search.client
+    client = end_to_end_search_fixture.external_search.write_client
     index = end_to_end_search_fixture.external_search_index
 
     work1 = db.work(with_open_access_download=True)
@@ -271,7 +271,7 @@ def test_update_read_pointer(
     celery_fixture: CeleryFixture,
     end_to_end_search_fixture: EndToEndSearchFixture,
 ):
-    client = end_to_end_search_fixture.external_search.client
+    client = end_to_end_search_fixture.external_search.write_client
     service = end_to_end_search_fixture.external_search.service
 
     # Remove the read pointer
@@ -322,7 +322,7 @@ def test_get_migrate_search_chain(
 ):
     container = end_to_end_search_fixture.external_search.search_container
 
-    client = container.client()
+    client = container.write_client()
     service = container.service()
     revision_directory = container.revision_directory()
     revision = revision_directory.highest()
@@ -460,7 +460,7 @@ def test_index_works(
     celery_fixture: CeleryFixture,
     end_to_end_search_fixture: EndToEndSearchFixture,
 ):
-    client = end_to_end_search_fixture.external_search.client
+    client = end_to_end_search_fixture.external_search.write_client
     index = end_to_end_search_fixture.external_search_index
 
     work1_id = db.work(with_open_access_download=True).id

--- a/tests/manager/scripts/test_initialization.py
+++ b/tests/manager/scripts/test_initialization.py
@@ -193,7 +193,7 @@ class TestInstanceInitializationScript:
     ):
         service = external_search_fixture.service
         index = external_search_fixture.index
-        client = external_search_fixture.client
+        client = external_search_fixture.write_client
         revision = external_search_fixture.revision
         base_name = service.base_revision_name
 

--- a/tests/manager/search/test_external_search.py
+++ b/tests/manager/search/test_external_search.py
@@ -100,7 +100,7 @@ class TestExternalSearch:
             title="Moby's life as a Duck", with_open_access_download=True
         )
         moby_dick = db.work(title="Moby Dick", with_open_access_download=True)
-        client = end_to_end_search_fixture.external_search.client
+        client = end_to_end_search_fixture.external_search.write_client
         index = end_to_end_search_fixture.external_search_index
         end_to_end_search_fixture.populate_search_index()
 
@@ -120,7 +120,7 @@ class TestExternalSearch:
         end_to_end_search_fixture: EndToEndSearchFixture,
         db: DatabaseTransactionFixture,
     ):
-        client = end_to_end_search_fixture.external_search.client
+        client = end_to_end_search_fixture.external_search.write_client
         index = end_to_end_search_fixture.external_search_index
 
         butterfly = db.work(
@@ -137,7 +137,7 @@ class TestExternalSearch:
         end_to_end_search_fixture: EndToEndSearchFixture,
         db: DatabaseTransactionFixture,
     ):
-        client = end_to_end_search_fixture.external_search.client
+        client = end_to_end_search_fixture.external_search.write_client
         index = end_to_end_search_fixture.external_search_index
 
         butterfly = db.work(
@@ -155,7 +155,7 @@ class TestExternalSearch:
         end_to_end_search_fixture: EndToEndSearchFixture,
         db: DatabaseTransactionFixture,
     ):
-        client = end_to_end_search_fixture.external_search.client
+        client = end_to_end_search_fixture.external_search.write_client
         index = end_to_end_search_fixture.external_search_index
 
         work = db.work(with_open_access_download=True)

--- a/tests/manager/search/test_service.py
+++ b/tests/manager/search/test_service.py
@@ -168,13 +168,23 @@ class TestService:
             "properties": mappings.serialize_properties()
         }
 
-    def test_read_search_client_applies_timeout(self):
-        """The read search client applies search_timeout as request_timeout."""
+    def test_read_search_client_omits_request_timeout(self):
+        """The read search client must NOT set request_timeout.
+
+        Searches built from read_search_client() are added to the MultiSearch
+        and their params are serialized into the msearch metadata header line,
+        which OpenSearch rejects if it contains request_timeout. The timeout is
+        applied on the MultiSearch instead.
+        """
         service = SearchServiceOpensearch1(MagicMock(), "base", search_timeout=7)
-        assert service.read_search_client()._params.get("request_timeout") == 7
+        assert "request_timeout" not in service.read_search_client()._params
 
     def test_read_search_multi_client_applies_timeout(self):
-        """The read multi-search client applies search_timeout as request_timeout."""
+        """The read multi-search client applies search_timeout as request_timeout.
+
+        These params are passed to client.msearch() as a transport parameter,
+        so they govern the read path without ending up in the request body.
+        """
         service = SearchServiceOpensearch1(MagicMock(), "base", search_timeout=7)
         assert service.read_search_multi_client()._params.get("request_timeout") == 7
 

--- a/tests/manager/search/test_service.py
+++ b/tests/manager/search/test_service.py
@@ -24,7 +24,7 @@ class TestSearchPointer:
         ],
     )
     def test_from_index(self, base: str, index: str, expected_version: int):
-        service = SearchServiceOpensearch1(MagicMock(), base)
+        service = SearchServiceOpensearch1(MagicMock(), MagicMock(), base)
 
         write_pointer = SearchPointer.from_index(
             base, service.write_pointer_name(), index
@@ -54,7 +54,7 @@ class TestSearchPointer:
         ],
     )
     def test_from_index_errors(self, base: str, index: str):
-        service = SearchServiceOpensearch1(MagicMock(), base)
+        service = SearchServiceOpensearch1(MagicMock(), MagicMock(), base)
 
         assert (
             SearchPointer.from_index(base, service.write_pointer_name(), index) is None
@@ -168,25 +168,20 @@ class TestService:
             "properties": mappings.serialize_properties()
         }
 
-    def test_read_search_client_omits_request_timeout(self):
-        """The read search client must NOT set request_timeout.
+    def test_read_clients_use_dedicated_read_client(self):
+        """The read search/multi-search clients are built on the read client.
 
-        Searches built from read_search_client() are added to the MultiSearch
-        and their params are serialized into the msearch metadata header line,
-        which OpenSearch rejects if it contains request_timeout. The timeout is
-        applied on the MultiSearch instead.
+        The read timeout is a transport property of the dedicated read client,
+        so reads inherit it without any per-request override (which would be
+        rejected in the msearch metadata header). Indexing/admin operations use
+        the write client instead.
         """
-        service = SearchServiceOpensearch1(MagicMock(), "base", search_timeout=7)
-        assert "request_timeout" not in service.read_search_client()._params
+        write_client = MagicMock()
+        read_client = MagicMock()
+        service = SearchServiceOpensearch1(write_client, read_client, "base")
 
-    def test_read_search_multi_client_applies_timeout(self):
-        """The read multi-search client applies search_timeout as request_timeout.
-
-        These params are passed to client.msearch() as a transport parameter,
-        so they govern the read path without ending up in the request body.
-        """
-        service = SearchServiceOpensearch1(MagicMock(), "base", search_timeout=7)
-        assert service.read_search_multi_client()._params.get("request_timeout") == 7
+        assert service.read_search_client()._using is read_client
+        assert service.read_search_multi_client()._using is read_client
 
     def test__get_pointer(self):
         """Getting a pointer works."""
@@ -194,7 +189,7 @@ class TestService:
         mock_client.indices.get_alias.return_value = {
             "base-v23": {"aliases": {"base-search-read": {}}}
         }
-        service = SearchServiceOpensearch1(mock_client, "base")
+        service = SearchServiceOpensearch1(mock_client, MagicMock(), "base")
 
         pointer = service._get_pointer("base-search-read")
         assert pointer is not None

--- a/tests/manager/search/test_service.py
+++ b/tests/manager/search/test_service.py
@@ -78,7 +78,7 @@ class TestService:
         service.index_create(revision)
         service.index_create(revision)
 
-        indices = external_search_fixture.client.indices.client.indices
+        indices = external_search_fixture.write_client.indices.client.indices
         assert indices is not None
         assert indices.exists(
             index=revision.name_for_index(external_search_fixture.index_prefix)
@@ -157,7 +157,7 @@ class TestService:
         service.index_submit_documents(documents)
         service.index_submit_documents(documents)
 
-        indices = external_search_fixture.client.indices.client.indices
+        indices = external_search_fixture.write_client.indices.client.indices
         assert indices is not None
         assert indices.exists(
             index=revision.name_for_index(external_search_fixture.index_prefix)

--- a/tests/manager/search/test_service.py
+++ b/tests/manager/search/test_service.py
@@ -168,6 +168,16 @@ class TestService:
             "properties": mappings.serialize_properties()
         }
 
+    def test_read_search_client_applies_timeout(self):
+        """The read search client applies search_timeout as request_timeout."""
+        service = SearchServiceOpensearch1(MagicMock(), "base", search_timeout=7)
+        assert service.read_search_client()._params.get("request_timeout") == 7
+
+    def test_read_search_multi_client_applies_timeout(self):
+        """The read multi-search client applies search_timeout as request_timeout."""
+        service = SearchServiceOpensearch1(MagicMock(), "base", search_timeout=7)
+        assert service.read_search_multi_client()._params.get("request_timeout") == 7
+
     def test__get_pointer(self):
         """Getting a pointer works."""
         mock_client = MagicMock()

--- a/tests/manager/service/search/test_configuration.py
+++ b/tests/manager/service/search/test_configuration.py
@@ -1,0 +1,38 @@
+import logging
+
+import pytest
+
+from palace.manager.service.search.configuration import SearchConfiguration
+
+
+class TestSearchConfiguration:
+    def test_defaults(self):
+        config = SearchConfiguration(url="http://localhost:9200")
+        assert config.write_timeout == 20
+        assert config.read_timeout == 4
+
+    def test_write_timeout_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("PALACE_SEARCH_WRITE_TIMEOUT", "11")
+        config = SearchConfiguration(url="http://localhost:9200")
+        assert config.write_timeout == 11
+
+    def test_write_timeout_deprecated_env_still_honored(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """The deprecated PALACE_SEARCH_TIMEOUT is still accepted, with a warning."""
+        monkeypatch.setenv("PALACE_SEARCH_TIMEOUT", "22")
+        with caplog.at_level(logging.WARNING):
+            config = SearchConfiguration(url="http://localhost:9200")
+        assert config.write_timeout == 22
+        assert "PALACE_SEARCH_TIMEOUT is deprecated" in caplog.text
+
+    def test_write_timeout_new_env_takes_precedence(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """When both names are set the new one wins and no warning is emitted."""
+        monkeypatch.setenv("PALACE_SEARCH_TIMEOUT", "22")
+        monkeypatch.setenv("PALACE_SEARCH_WRITE_TIMEOUT", "33")
+        with caplog.at_level(logging.WARNING):
+            config = SearchConfiguration(url="http://localhost:9200")
+        assert config.write_timeout == 33
+        assert "deprecated" not in caplog.text


### PR DESCRIPTION
## Description

Make the user-facing OpenSearch read path resilient to transient node unavailability by giving reads their own client with a short timeout and timeout retries, while leaving indexing/admin behavior unchanged.

`SearchServiceOpensearch1` now takes an explicit `write_client` and `read_client`:

- **`write_client`** — indexing and admin operations. Keeps the full client-wide timeout (`write_timeout`, default **20s**) because these legitimately run longer, and has no timeout retries, so its behavior is unchanged.
- **`read_client`** — the user-facing read/search path. Configured with a short `read_timeout` (default **4s**) plus `retry_on_timeout` / `max_retries=2`, so a read that stalls against a bouncing node fails over fast to the domain's healthy node.

The settings were renamed to describe what they govern, matching the client split:

- `read_timeout` — read path timeout (`PALACE_SEARCH_READ_TIMEOUT`, default 4).
- `write_timeout` — indexing/admin timeout (`PALACE_SEARCH_WRITE_TIMEOUT`, default 20). The old `PALACE_SEARCH_TIMEOUT` is still honored as a deprecated alias and logs a warning when it is the only one set.
- `read_max_retries` / `read_retry_on_timeout` — read-path retry behavior (`PALACE_SEARCH_READ_MAX_RETRIES`, `PALACE_SEARCH_READ_RETRY_ON_TIMEOUT`).

## Motivation and Context

Production was emitting user-facing `500`s on the groups/search endpoints every night, sharply concentrated in the **04:00–07:00 UTC** window (5-day peak: 240 errors at 05:00 UTC). The errors were `opensearchpy.ConnectionTimeout` (`read timeout=20`) from `query_works_multi`.

JIRA: PP-4472

Investigation (tpp-prod):

- The errors span **all four prod ES shards**, not one cluster — a shared event, not a sick node.
- **05:00 UTC is exactly the configured OpenSearch off-peak maintenance window** (`auto_software_update_enabled = true`), and the ES application log confirms shard recovery / node bounces in that window (e.g. kappa `failed recovery … recovery was cancelled` at 05:11 UTC).
- The clusters are **healthy throughout** — 7-day SearchLatency p99.9 ≤ 41 ms (max 218 ms), no node loss, no yellow/red. So a 20 s timeout is a connection-level stall against a bouncing node, **not** a slow query.

The client did not retry on timeout, so a single stalled connection failed the whole request. With two nodes per domain, retrying against the other node recovers transparently.

Latency budget: the read path worst case becomes `4s × (1 + 2 retries) = 12s`, comfortably inside the **60 s ALB idle timeout**, while a single node bounce now recovers in ~4 s instead of failing at 20 s. The 4 s per-attempt value sits ~25× above the observed msearch server-side cost, leaving margin for the degraded (single-node) maintenance window.

## How Has This Been Tested?

- `mypy` clean.
- New `tests/manager/service/search/test_configuration.py` covers the defaults, the new `PALACE_SEARCH_WRITE_TIMEOUT` env var, the deprecated `PALACE_SEARCH_TIMEOUT` fallback (value honored + warning logged), and new-over-deprecated precedence.
- Updated `tests/manager/search/test_service.py` to assert the read search / multi-search clients are built on the dedicated read client.
- Full `tests/manager/search/` suite passes, including `test_filter.py` and `test_external_search.py`, which execute against a live test cluster via msearch and would surface the metadata-header rejection.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
