### PR TITLE
Cap search query length to protect OpenSearch heap (PP-4472)

### DIFF
--- a/src/palace/manager/search/query.py
+++ b/src/palace/manager/search/query.py
@@ -22,6 +22,7 @@ from opensearchpy.helpers.query import (
 from spellchecker import SpellChecker
 
 from palace.util.exceptions import BasePalaceException
+from palace.util.log import LoggerMixin
 
 from palace.manager.core.classifier.age import AgeClassifier, GradeLevelClassifier
 from palace.manager.core.classifier.keyword import KeywordBasedClassifier
@@ -41,7 +42,7 @@ from palace.manager.util.personal_names import display_name_to_sort_name
 from palace.manager.util.stopwords import ENGLISH_STOPWORDS
 
 
-class Query:
+class Query(LoggerMixin):
     """An attempt to find something in the search index."""
 
     # This dictionary establishes the relative importance of the
@@ -169,6 +170,10 @@ class Query:
         # a pasted block of text from exhausting OpenSearch search heap.
         self.words = self.query_string.split()
         if len(self.words) > self.MAX_QUERY_WORDS:
+            self.log.warning(
+                f"Truncating search query from {len(self.words)} to "
+                f"{self.MAX_QUERY_WORDS} words to protect OpenSearch heap."
+            )
             self.words = self.words[: self.MAX_QUERY_WORDS]
             self.query_string = " ".join(self.words)
 

--- a/src/palace/manager/search/query.py
+++ b/src/palace/manager/search/query.py
@@ -133,6 +133,15 @@ class Query:
     # in a query string are _important_.
     STOPWORD_FIELDS = ["title", "subtitle", "series"]
 
+    # The maximum number of words we'll consider from a query string.
+    # Real catalog searches (a title, an author, a few qualifiers) are
+    # well under this. Longer strings are almost always a patron pasting
+    # a block of text into the search box; the extra words add no search
+    # value but multiply the cost of the fuzzy/multi-match hypotheses
+    # below -- enough to exhaust OpenSearch's per-request search heap and
+    # get the whole query cancelled. We truncate to this many words.
+    MAX_QUERY_WORDS = 32
+
     # SpellChecker is expensive to initialize, so keep around
     # a class-level instance.
     SPELLCHECKER = SpellChecker()
@@ -155,15 +164,19 @@ class Query:
         self.filter = filter
         self.use_query_parser = use_query_parser
 
+        # Cap the query at a sane number of words (see MAX_QUERY_WORDS).
+        # This bounds the cost of every hypothesis built below and keeps
+        # a pasted block of text from exhausting OpenSearch search heap.
+        self.words = self.query_string.split()
+        if len(self.words) > self.MAX_QUERY_WORDS:
+            self.words = self.words[: self.MAX_QUERY_WORDS]
+            self.query_string = " ".join(self.words)
+
         # Pre-calculate some values that will be checked frequently
         # when generating the opensearch-dsl query.
 
         # Check if the string contains English stopwords.
-        if query_string:
-            self.words = query_string.split()
-        else:
-            self.words = []
-        self.contains_stopwords = query_string and any(
+        self.contains_stopwords = bool(self.words) and any(
             word in ENGLISH_STOPWORDS for word in self.words
         )
 

--- a/tests/manager/search/test_query.py
+++ b/tests/manager/search/test_query.py
@@ -62,8 +62,23 @@ class TestQuery:
         # Try again with a query that contains no query string.
         # The fuzzy hypotheses will not be run at all.
         query = Query(None)
-        assert None == query.contains_stopwords
+        assert False == query.contains_stopwords
         assert 0 == query.fuzzy_coefficient
+
+    def test_constructor_caps_query_length(self):
+        # A pathologically long query string (e.g. a patron pasting a
+        # block of text into the search box) is truncated to
+        # MAX_QUERY_WORDS so it can't exhaust OpenSearch search heap.
+        long_query = " ".join(f"word{i}" for i in range(Query.MAX_QUERY_WORDS * 3))
+        query = Query(long_query)
+        assert Query.MAX_QUERY_WORDS == len(query.words)
+        assert Query.MAX_QUERY_WORDS == len(query.query_string.split())
+
+        # A query at or below the limit is left untouched.
+        short_query = " ".join(f"word{i}" for i in range(Query.MAX_QUERY_WORDS))
+        query = Query(short_query)
+        assert short_query == query.query_string
+        assert Query.MAX_QUERY_WORDS == len(query.words)
 
     def test_build(self, db: DatabaseTransactionFixture):
         # Verify that the build() method combines the 'query' part of

--- a/tests/manager/search/test_query.py
+++ b/tests/manager/search/test_query.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import uuid
 from collections.abc import Callable
 from datetime import datetime
@@ -65,7 +66,9 @@ class TestQuery:
         assert False == query.contains_stopwords
         assert 0 == query.fuzzy_coefficient
 
-    def test_constructor_caps_query_length(self):
+    def test_constructor_caps_query_length(self, caplog: pytest.LogCaptureFixture):
+        caplog.set_level(logging.WARNING)
+
         # A pathologically long query string (e.g. a patron pasting a
         # block of text into the search box) is truncated to
         # MAX_QUERY_WORDS so it can't exhaust OpenSearch search heap.
@@ -74,11 +77,19 @@ class TestQuery:
         assert Query.MAX_QUERY_WORDS == len(query.words)
         assert Query.MAX_QUERY_WORDS == len(query.query_string.split())
 
-        # A query at or below the limit is left untouched.
+        # Truncation is logged so it's visible in production.
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == "WARNING"
+        assert "Truncating search query" in caplog.records[0].message
+
+        # A query at or below the limit is left untouched, and nothing
+        # is logged.
+        caplog.clear()
         short_query = " ".join(f"word{i}" for i in range(Query.MAX_QUERY_WORDS))
         query = Query(short_query)
         assert short_query == query.query_string
         assert Query.MAX_QUERY_WORDS == len(query.words)
+        assert len(caplog.records) == 0
 
     def test_build(self, db: DatabaseTransactionFixture):
         # Verify that the build() method combines the 'query' part of


### PR DESCRIPTION
## Description

Truncate a search query to `Query.MAX_QUERY_WORDS` (32) words in the `Query` constructor, before any hypotheses are built. This bounds the cost of every hypothesis (fuzzy automata, multi-match, parsed query) so a pathologically long query string can't exhaust an OpenSearch node's per-request search heap.

## Motivation and Context

Production OpenSearch logs show search-backpressure cancelling queries with `cancelled task with reason: heap usage exceeded [...]`. The stack trace is always the fuzzy-query rewrite (`FuzzyTermsEnum` /
`TopTermsRewrite`) building Levenshtein automata over every term in the query. Two incidents in 30 days, both driven by query *length*, not the cluster being unhealthy:

- **kappa, 05-27:** a patron pasted a 656-word job description into `/GA0008/search/`. One search task hit 787MB, OpenSearch cancelled it (`All shards failed`), and the search came back as `search_phase_execution_exception` (handled as an empty result set).
- **theta, 05-22:** `/IL9993/search/` (a QA library) sent a 60-115 word type-ahead query that grew one word per keystroke, triggering a burst of fetch-phase cancellations. Recovered transparently via replica.

Both build expensive fuzzy automata over many terms. Capping the query length addresses both at the source.

JIRA: PP-4472

### Why 32 words

Validated against 30 days of production search traffic (~2.0M searches):

| percentile | words |
|---|---|
| p50 | 2 |
| p90 | 5 |
| p99 | 15 |
| p99.9 | 26 |

Exact count of searches that exceed the cap, across all ~2.0M:

| cap | over cap | % of all | ~/day |
|---|---|---|---|
| 24 words | 1,793 | 0.090% | ~59 |
| **32 words** | **1,119** | **0.056%** | **~37** |
| 48 words | 531 | 0.027% | ~17 |

32 leaves 99.94% of searches untouched and sits above the legitimate p99.9 of 26 words, so no real catalog search is affected -- only the pathological long queries are clipped (and a clipped query still searches on its first 32 words).

## How Has This Been Tested?

- `mypy` clean on `query.py`.
- New `test_constructor_caps_query_length`; updated `test_constructor`
  (`Query(None).contains_stopwords` is now `False` rather than `None` --
  both falsy, downstream only checks truthiness).

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
