### PR TITLE
Return 404 for permalink of a work with no presentation edition (PP-4472)

### DIFF
--- a/src/palace/manager/api/controller/work.py
+++ b/src/palace/manager/api/controller/work.py
@@ -114,6 +114,13 @@ class WorkController(CirculationManagerController):
         if isinstance(work, ProblemDetail):
             return work
 
+        if work.presentation_edition is None:
+            # The work exists but has no presentation edition, so there's no
+            # usable metadata or identifier to build an entry around. Treat it
+            # as not found rather than letting single_entry raise an unhandled
+            # error. This mirrors the behavior of the `related` endpoint.
+            return NOT_FOUND_ON_REMOTE
+
         patron = get_request_patron(default=None)
 
         if patron:

--- a/src/palace/manager/api/controller/work.py
+++ b/src/palace/manager/api/controller/work.py
@@ -114,13 +114,6 @@ class WorkController(CirculationManagerController):
         if isinstance(work, ProblemDetail):
             return work
 
-        if work.presentation_edition is None:
-            # The work exists but has no presentation edition, so there's no
-            # usable metadata or identifier to build an entry around. Treat it
-            # as not found rather than letting single_entry raise an unhandled
-            # error. This mirrors the behavior of the `related` endpoint.
-            return NOT_FOUND_ON_REMOTE
-
         patron = get_request_patron(default=None)
 
         if patron:
@@ -143,6 +136,15 @@ class WorkController(CirculationManagerController):
                 mime_types=flask.request.accept_mimetypes,
             )
         else:
+            if work.presentation_edition is None:
+                # The work exists but has no presentation edition, so there's
+                # no usable metadata or identifier to build an entry around.
+                # Treat it as not found rather than letting single_entry raise
+                # an unhandled error. The authenticated patron path above builds
+                # its entry from the loan/hold's license pool instead, so this
+                # guard only applies to the unauthenticated path.
+                return NOT_FOUND_ON_REMOTE
+
             annotator = self.manager.annotator(lane=None)
 
             return OPDSAcquisitionFeed.entry_as_response(

--- a/tests/manager/api/controller/test_work.py
+++ b/tests/manager/api/controller/test_work.py
@@ -302,6 +302,25 @@ class TestWorkController:
         assert expect.data == response.get_data()
         assert OPDSFeed.ENTRY_TYPE == response.headers["Content-Type"]
 
+    def test_permalink_work_with_no_presentation_edition(
+        self, work_fixture: WorkFixture
+    ):
+        # A work can be looked up by a valid identifier yet have no
+        # presentation edition (no usable metadata). In that case there is
+        # no identifier to build an entry around, so rather than raising an
+        # unhandled error from single_entry we return a 404.
+        work_fixture.english_1.presentation_edition = None
+
+        with work_fixture.request_context_with_library("/"):
+            assert work_fixture.identifier.type is not None
+            assert work_fixture.identifier.identifier is not None
+            response = work_fixture.manager.work_controller.permalink(
+                work_fixture.identifier.type, work_fixture.identifier.identifier
+            )
+
+        assert isinstance(response, ProblemDetail)
+        assert NOT_FOUND_ON_REMOTE == response
+
     @pytest.mark.parametrize(
         *OPDSSerializationTestHelper.PARAMETRIZED_SINGLE_ENTRY_ACCEPT_HEADERS
     )


### PR DESCRIPTION
## Description

Guard the `permalink` controller against works that have no presentation edition. When such a work is encountered we now return `NOT_FOUND_ON_REMOTE` (404) instead of letting `OPDSAcquisitionFeed.single_entry` raise an unhandled `PalaceValueError`. This mirrors the existing behavior of the sibling `related` endpoint.

## Motivation and Context

We were occasionally seeing unhandled 500s in production from the permalink endpoint, e.g. `Work has no associated identifier: <Work #5968341 "None" (by None) lang=None (1 lp)>`.

The work is looked up via a valid identifier, but `single_entry` re-derives the identifier from the *work's own state* rather than the looked-up identifier. For a degenerate work both derivation paths come up empty: `active_license_pool()` returns `None` (the work's single pool is filtered out because it has no titled edition / owned licenses) and `work.presentation_edition` is also `None`. With no identifier derivable, `single_entry` raises `PalaceValueError`, which surfaces as a 500.

Since a work with no presentation edition has no usable metadata to render, treating it as "not found" is the correct, graceful behavior.

Example of error occuring in production: 
https://lyrasis.slack.com/archives/C049AA32E3S/p1780405014686049

JIRA: PP-4472

## How Has This Been Tested?

Added `test_permalink_work_with_no_presentation_edition`, which clears the work's `presentation_edition` and asserts the endpoint returns `NOT_FOUND_ON_REMOTE`. Ran the full permalink test suite (`tests/manager/api/controller/test_work.py -k permalink`, 10 passed) under the docker tox environment, plus mypy on the changed controller.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.