### PR TITLE
Hold a workflow lock across OPDS2+ODL import pages (PP-4472)

### DIFF
--- a/src/palace/manager/celery/tasks/opds_odl.py
+++ b/src/palace/manager/celery/tasks/opds_odl.py
@@ -1,6 +1,8 @@
 import datetime
+from uuid import uuid4
 
 from celery import shared_task
+from celery.exceptions import Ignore
 from sqlalchemy import delete, select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session
@@ -8,7 +10,7 @@ from sqlalchemy.orm import Session
 from palace.util.datetime_helpers import utc_now
 
 from palace.manager.celery import importer
-from palace.manager.celery.importer import import_lock
+from palace.manager.celery.importer import import_workflow_lock
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import apply
 from palace.manager.celery.utils import load_from_id
@@ -333,41 +335,84 @@ def import_collection(
     url: str | None = None,
     *,
     force: bool = False,
+    lock_value: str | None = None,
 ) -> None:
     """
     Run an OPDS2+ODL import for the given collection.
+
+    A Redis workflow lock keyed to ``collection_id`` ensures at most one import
+    runs per collection at a time. The lock is held across ``task.replace()``
+    page boundaries and across Celery retries (``BadResponseException``,
+    ``RequestTimedOut``) so a transient failure does not open a window for a
+    second concurrent run to start on the same collection.
+
+    :param collection_id: Database ID of the collection to import.
+    :param url: The next page URL to import. ``None`` on the first page — the
+        import starts from the beginning of the feed.
+    :param force: If True, import even if the feed is unchanged.
+    :param lock_value: UUID identifying this import workflow. Generated on the
+        first page and forwarded unchanged to every subsequent page so the lock
+        is held across ``task.replace()`` calls.
     """
     redis = task.services.redis().client()
-    with import_lock(redis, collection_id).lock(), task.session() as session:
-        collection = load_from_id(session, Collection, collection_id)
-        registry = task.services.integration_registry().license_providers()
 
-        import_result = importer_from_collection(collection, registry).import_feed(
-            collection,
-            url,
-            apply_bibliographic=apply.bibliographic_apply.delay,
-            apply_circulation=apply.circulation_apply.delay,
-            import_even_if_unchanged=force,
-        )
+    is_first_page = lock_value is None
+    if lock_value is None:
+        lock_value = str(uuid4())
 
-    if not import_result:
-        task.log.info(
-            f"Import failed, aborting task for collection '{collection.name}' (id={collection_id})."
-        )
-        return
+    workflow_lock = import_workflow_lock(redis, collection_id, lock_value)
 
-    next_link = import_result.next_url
-    if next_link is not None:
-        # This page is complete, but there are more pages to import, so we requeue ourselves with the
-        # next page URL.
-        raise task.replace(
-            task.s(
-                collection_id=collection_id,
-                url=next_link,
-                force=force,
+    with workflow_lock.lock(
+        raise_when_not_acquired=False,
+        # Hold the lock across task.replace() (Ignore) and across Celery retries
+        # (BadResponseException, RequestTimedOut) so a transient failure doesn't
+        # open a window for a concurrent run to start on the same collection.
+        ignored_exceptions=(Ignore, BadResponseException, RequestTimedOut),
+    ) as workflow_lock_acquired:
+        if not workflow_lock_acquired and is_first_page:
+            task.log.warning(
+                f"Import skipped for collection {collection_id}: "
+                "another import is already in progress."
             )
-        )
+            return
+        if not workflow_lock_acquired and not is_first_page:
+            task.log.warning(
+                f"Import for collection {collection_id}: workflow lock expired "
+                "between pages; continuing (another import may be running)."
+            )
 
-    task.log.info(
-        f"Import complete for collection '{collection.name}' (id={collection_id})."
-    )
+        with task.session() as session:
+            collection = load_from_id(session, Collection, collection_id)
+            collection_name = collection.name
+            registry = task.services.integration_registry().license_providers()
+
+            import_result = importer_from_collection(collection, registry).import_feed(
+                collection,
+                url,
+                apply_bibliographic=apply.bibliographic_apply.delay,
+                apply_circulation=apply.circulation_apply.delay,
+                import_even_if_unchanged=force,
+            )
+
+        if not import_result:
+            task.log.info(
+                f"Import failed, aborting task for collection '{collection_name}' (id={collection_id})."
+            )
+            return
+
+        next_link = import_result.next_url
+        if next_link is not None:
+            # This page is complete, but there are more pages to import, so we requeue ourselves with the
+            # next page URL, forwarding lock_value so the workflow lock is held across the page boundary.
+            raise task.replace(
+                task.s(
+                    collection_id=collection_id,
+                    url=next_link,
+                    force=force,
+                    lock_value=lock_value,
+                )
+            )
+
+        task.log.info(
+            f"Import complete for collection '{collection_name}' (id={collection_id})."
+        )

--- a/tests/manager/celery/tasks/test_opds_odl.py
+++ b/tests/manager/celery/tasks/test_opds_odl.py
@@ -18,6 +18,7 @@ from palace.util import datetime_helpers
 from palace.util.datetime_helpers import utc_now
 from palace.util.log import LogLevel
 
+from palace.manager.celery.importer import import_workflow_lock
 from palace.manager.celery.tasks import apply, opds_odl
 from palace.manager.celery.tasks.opds_odl import (
     _licensepool_ids_with_holds,
@@ -61,6 +62,7 @@ from palace.manager.sqlalchemy.model.patron import Hold, Patron
 from palace.manager.sqlalchemy.model.resource import Hyperlink
 from palace.manager.sqlalchemy.model.work import Work
 from palace.manager.sqlalchemy.util import create
+from palace.manager.util.http.exception import RequestTimedOut
 from tests.fixtures.celery import ApplyTaskFixture, CeleryFixture
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.files import OPDS2WithODLFilesFixture
@@ -710,6 +712,129 @@ class TestImportCollection:
                 ),
             ]
         )
+
+    def test_skipped_when_already_running(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """When the workflow lock is already held (another import is in progress),
+        the task logs a warning and returns without importing anything."""
+        collection = db.collection(
+            protocol=OPDS2WithODLApi,
+            settings=db.opds2_odl_settings(external_account_id="http://feed.com"),
+        )
+
+        existing_lock_value = str(uuid.uuid4())
+        workflow_lock = import_workflow_lock(
+            redis_fixture.client, collection.id, existing_lock_value
+        )
+        workflow_lock.acquire()
+
+        caplog.set_level(LogLevel.warning)
+
+        mock_importer = create_autospec(OpdsImporter)
+        with patch.object(
+            opds_odl,
+            "importer_from_collection",
+            autospec=True,
+            return_value=mock_importer,
+        ):
+            opds_odl.import_collection.delay(collection.id).wait()
+
+        mock_importer.import_feed.assert_not_called()
+        assert "skipped" in caplog.text
+        assert "already in progress" in caplog.text
+
+        workflow_lock.release()
+
+    def test_continues_with_warning_when_lock_expires_mid_chain(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """When the workflow lock expires between pages (is_first_page is False and
+        the lock cannot be acquired), the task logs a warning but still processes the
+        page rather than silently returning."""
+        collection = db.collection(
+            protocol=OPDS2WithODLApi,
+            settings=db.opds2_odl_settings(external_account_id="http://feed.com"),
+        )
+
+        # Simulate the lock having been re-acquired by a competing run. A free lock
+        # would be acquired successfully; we need another holder so that our task's
+        # lock_value (a different UUID) fails to acquire.
+        competing_lock = import_workflow_lock(
+            redis_fixture.client, collection.id, str(uuid.uuid4())
+        )
+        competing_lock.acquire()
+
+        caplog.set_level(LogLevel.warning)
+
+        mock_importer = create_autospec(OpdsImporter)
+        mock_importer.import_feed.return_value = FeedImportResult(
+            next_url=None,
+            feed=MagicMock(),
+            results={},
+            failures=[],
+            identifier_set=None,
+        )
+        with patch.object(
+            opds_odl,
+            "importer_from_collection",
+            autospec=True,
+            return_value=mock_importer,
+        ):
+            # Pass a lock_value that does not match the competing lock so acquire
+            # fails, but is_first_page is False (lock_value is not None).
+            opds_odl.import_collection.delay(
+                collection.id, lock_value=str(uuid.uuid4())
+            ).wait()
+
+        # Despite the lock not being acquired, the page was still processed.
+        mock_importer.import_feed.assert_called_once()
+        assert "workflow lock expired between pages" in caplog.text
+
+        competing_lock.release()
+
+    def test_lock_not_released_on_autoretry(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        redis_fixture: RedisFixture,
+    ) -> None:
+        """When a retryable exception is raised the workflow lock is held so that a
+        concurrent run cannot start on the same collection while retries are in
+        progress."""
+        collection = db.collection(
+            protocol=OPDS2WithODLApi,
+            settings=db.opds2_odl_settings(external_account_id="http://feed.com"),
+        )
+
+        mock_importer = create_autospec(OpdsImporter)
+        mock_importer.import_feed.side_effect = RequestTimedOut(
+            "http://feed.com", "Request timed out"
+        )
+
+        with patch.object(
+            opds_odl,
+            "importer_from_collection",
+            autospec=True,
+            return_value=mock_importer,
+        ):
+            with celery_fixture.patch_retry_backoff():
+                opds_odl.import_collection.delay(collection.id).get(propagate=False)
+
+        # Lock should still be held after retries exhaust — it will expire via the
+        # Redis TTL, preventing a concurrent run from starting in the meantime.
+        workflow_lock = import_workflow_lock(
+            redis_fixture.client, collection.id, random_value="any"
+        )
+        assert workflow_lock.locked()
 
     def test_wrong_protocol(
         self,


### PR DESCRIPTION
## Description

The `opds_odl.import_collection` Celery task now holds a single Redis *workflow* lock across an entire import run instead of acquiring a fresh per-page lock. The lock value is a UUID generated on the first page and forwarded through each `task.replace()` so one lock spans every page and is held across Celery retries. When another run already holds the lock, the task logs a warning and returns (first page) or continues with a warning (lock expired mid-chain) rather than crashing.

This adopts the same `import_workflow_lock` pattern already used by the OverDrive and Bibliotheca importers.

## Motivation and Context

We were getting recurring unhandled-exception alerts: `Task opds_odl.import_collection[...] raised unexpected: LockNotAcquired('Lock ...::ImportCollection::Collection::104 could not be acquired')`.

The task acquired a per-page `import_lock` with the default `raise_when_not_acquired=True`, so any collision with a concurrent run raised `LockNotAcquired`. Because that exception is not in `autoretry_for`, it surfaced as an unhandled Celery exception instead of being handled gracefully. The per-page lock was also released and re-acquired between `task.replace()` pages, leaving a race window for the every-3-hours `import_all` beat job to collide with an in-progress multi-page import.

Holding one workflow lock across all pages and retries closes that race, and `raise_when_not_acquired=False` turns contention into a graceful skip-with-warning instead of a crash.

Note: `boundless` and `opds` (OPDS2 non-ODL) still use the old per-page `import_lock` and have the same latent issue. Those are intentionally left out of this PR and can be migrated as a follow-up, after which `import_lock` can be deleted entirely.

## How Has This Been Tested?

- Added three tests to `TestImportCollection` mirroring the Bibliotheca suite: lock already held (skip + warning, no import), lock expired mid-chain (continue + warning), and lock held across an autoretry.
- `tox -e py312-docker -- --no-cov tests/manager/celery/tasks/test_opds_odl.py` — 32 passed.
- `mypy` — clean.
- pre-commit hooks pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.