### PR TITLE
Remove deprecated PALACE_SEARCH_TIMEOUT setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,7 @@ To let the application know which OpenSearch instance to use, you can set the fo
 - `PALACE_SEARCH_INDEX_PREFIX`: The prefix to use for the OpenSearch indices. The default is `circulation-works`.
     This is useful if you want to use the same OpenSearch instance for multiple Circulation Manager instances (optional).
 - `PALACE_SEARCH_WRITE_TIMEOUT`: The timeout in seconds to use for indexing and admin operations against the OpenSearch
-  instance. The default is `20` (optional). Replaces the deprecated `PALACE_SEARCH_TIMEOUT`, which is still honored for
-  backwards compatibility.
+  instance. The default is `20` (optional).
 - `PALACE_SEARCH_READ_TIMEOUT`: The timeout in seconds to use for the user-facing read/search path. The default is `10`
   (optional).
 - `PALACE_SEARCH_READ_RETRY_ON_TIMEOUT`: Whether a timed-out read should be retried. Must be `true` for

--- a/src/palace/manager/service/search/configuration.py
+++ b/src/palace/manager/service/search/configuration.py
@@ -1,35 +1,17 @@
-from __future__ import annotations
-
-import os
-
-from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import SettingsConfigDict
-
-from palace.util.log import LoggerMixin
 
 from palace.manager.service.configuration.service_configuration import (
     ServiceConfiguration,
 )
 from palace.manager.util.pydantic import HttpUrl
 
-# Deprecated environment variable name for ``write_timeout``, still honored for
-# backwards compatibility. Remove once deployments have migrated.
-_DEPRECATED_WRITE_TIMEOUT_ENV = "PALACE_SEARCH_TIMEOUT"
-_WRITE_TIMEOUT_ENV = "PALACE_SEARCH_WRITE_TIMEOUT"
 
-
-class SearchConfiguration(ServiceConfiguration, LoggerMixin):
+class SearchConfiguration(ServiceConfiguration):
     url: HttpUrl
     index_prefix: str = "circulation-works"
-    # Timeout (seconds) for indexing and admin operations.
-    # ``PALACE_SEARCH_TIMEOUT`` is the deprecated name for this setting and is
-    # still accepted; prefer ``PALACE_SEARCH_WRITE_TIMEOUT``.
-    write_timeout: int = Field(
-        default=20,
-        validation_alias=AliasChoices(
-            _WRITE_TIMEOUT_ENV, _DEPRECATED_WRITE_TIMEOUT_ENV
-        ),
-    )
+    # Timeout (seconds) for indexing and admin operations, which legitimately
+    # run longer.
+    write_timeout: int = 20
     # Timeout (seconds) for the user-facing read path.
     read_timeout: int = 10
     # Read-path request retries, applied only to the read client.
@@ -37,18 +19,3 @@ class SearchConfiguration(ServiceConfiguration, LoggerMixin):
     read_retry_on_timeout: bool = False
     maxsize: int = 25
     model_config = SettingsConfigDict(env_prefix="PALACE_SEARCH_")
-
-    @model_validator(mode="after")
-    def _warn_deprecated_write_timeout_env(self) -> SearchConfiguration:
-        # AliasChoices accepts the deprecated env var, but we want operators to
-        # migrate, so emit a warning when only the deprecated name is set.
-        if (
-            _DEPRECATED_WRITE_TIMEOUT_ENV in os.environ
-            and _WRITE_TIMEOUT_ENV not in os.environ
-        ):
-            self.log.warning(
-                "%s is deprecated; use %s instead.",
-                _DEPRECATED_WRITE_TIMEOUT_ENV,
-                _WRITE_TIMEOUT_ENV,
-            )
-        return self

--- a/tests/manager/service/search/test_configuration.py
+++ b/tests/manager/service/search/test_configuration.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 
 from palace.manager.service.search.configuration import SearchConfiguration
@@ -17,24 +15,3 @@ class TestSearchConfiguration:
         monkeypatch.setenv("PALACE_SEARCH_WRITE_TIMEOUT", "11")
         config = SearchConfiguration(url="http://localhost:9200")
         assert config.write_timeout == 11
-
-    def test_write_timeout_deprecated_env_still_honored(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ):
-        """The deprecated PALACE_SEARCH_TIMEOUT is still accepted, with a warning."""
-        monkeypatch.setenv("PALACE_SEARCH_TIMEOUT", "22")
-        with caplog.at_level(logging.WARNING):
-            config = SearchConfiguration(url="http://localhost:9200")
-        assert config.write_timeout == 22
-        assert "PALACE_SEARCH_TIMEOUT is deprecated" in caplog.text
-
-    def test_write_timeout_new_env_takes_precedence(
-        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-    ):
-        """When both names are set the new one wins and no warning is emitted."""
-        monkeypatch.setenv("PALACE_SEARCH_TIMEOUT", "22")
-        monkeypatch.setenv("PALACE_SEARCH_WRITE_TIMEOUT", "33")
-        with caplog.at_level(logging.WARNING):
-            config = SearchConfiguration(url="http://localhost:9200")
-        assert config.write_timeout == 33
-        assert "deprecated" not in caplog.text


### PR DESCRIPTION
## Description

Removes the backwards-compatibility alias for the search write timeout that #3412 added for the deprecation period:

- Drops the `PALACE_SEARCH_TIMEOUT` env var alias from `write_timeout` (only `PALACE_SEARCH_WRITE_TIMEOUT` remains).
- Removes the deprecation warning and its `model_validator`, along with the now-unused imports.
- Removes the corresponding deprecation tests and the README note.

## Motivation and Context

#3412 renamed `PALACE_SEARCH_TIMEOUT` to `PALACE_SEARCH_WRITE_TIMEOUT` and kept the old name working as a deprecated alias so deployments could migrate without a flag day. This PR completes that deprecation by removing the alias once the migration is done.

## How Has This Been Tested?

- `mypy` clean.
- `tests/manager/service/search/test_configuration.py` updated to drop the deprecated-env cases; the remaining defaults and `PALACE_SEARCH_WRITE_TIMEOUT` env tests pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
