### PR TITLE
Return 404 instead of 500 for invalid identifiers on the work permalink route

### DIFF
--- a/src/palace/manager/api/controller/circulation_manager.py
+++ b/src/palace/manager/api/controller/circulation_manager.py
@@ -191,9 +191,23 @@ class CirculationManagerController(BaseCirculationManagerController):
             to look up an Identifier.
         """
         _db = Session.object_session(library)
-        identifier_obj, ignore = Identifier.for_foreign_id(
-            _db, identifier_type, identifier, autocreate=False
-        )
+        try:
+            identifier_obj, ignore = Identifier.for_foreign_id(
+                _db, identifier_type, identifier, autocreate=False
+            )
+        except ValueError:
+            # The identifier isn't valid for its type (e.g. a Bibliotheca ID
+            # with an embedded slash, which happens when a malformed request
+            # path is captured by the greedy <path:identifier> route). Such an
+            # identifier can't exist in any collection, so report it as a
+            # missing item rather than letting the ValueError escape as a 500.
+            self.log.info(
+                "Invalid identifier requested: %s/%s", identifier_type, identifier
+            )
+            return NO_LICENSES.detailed(
+                _("The item you're asking about (%s/%s) isn't in this collection.")
+                % (identifier_type, identifier)
+            )
         pools = (
             _db.scalars(
                 select(LicensePool)

--- a/tests/manager/api/controller/test_base.py
+++ b/tests/manager/api/controller/test_base.py
@@ -400,6 +400,24 @@ class TestBaseController:
         assert isinstance(problem_detail, ProblemDetail)
         assert NO_LICENSES.uri == problem_detail.uri
 
+        # Try an identifier that is invalid for its type. A Bibliotheca ID
+        # may not contain a slash, which is what happens when a malformed
+        # request path (e.g. ".../axv8gvz9/open_book") is captured by the
+        # greedy <path:identifier> route. This must be reported as a missing
+        # item rather than raising a ValueError that escapes as a 500.
+        problem_detail = circulation_fixture.controller.load_licensepools(
+            circulation_fixture.db.default_library(),
+            Identifier.BIBLIOTHECA_ID,
+            "axv8gvz9/open_book",
+        )
+        assert isinstance(problem_detail, ProblemDetail)
+        assert NO_LICENSES.uri == problem_detail.uri
+        expect = (
+            "The item you're asking about (%s/axv8gvz9/open_book) isn't in this collection."
+            % Identifier.BIBLIOTHECA_ID
+        )
+        assert expect == problem_detail.detail
+
     def test_load_work(self, circulation_fixture: CirculationControllerFixture):
         # Create a Work with two LicensePools.
         work = circulation_fixture.db.work(with_license_pool=True)


### PR DESCRIPTION
## Description

Catch the `ValueError` raised by `Identifier.for_foreign_id` when an identifier is invalid for its type, in `CirculationManagerController.load_licensepools`, and return the `NO_LICENSES` (404) problem detail instead of letting it escape as a 500.

## Motivation and Context

We've been seeing 500s in production like `"axv8gvz9/open_book" is not a valid Bibliotheca ID.` from `GET /<library>/works/Bibliotheca ID/axv8gvz9/open_book`.

The request that triggers this is a misrouted analytics event: `open_book` is a `CirculationEvent` whose valid endpoint is `/<library>/analytics/<identifier_type>/<path:identifier>/<event_type>` (`track_analytics_event`). The Palace iOS app (v476) is instead posting it to the work permalink path (`/works/...`), where the greedy `<path:identifier>` converter swallows `axv8gvz9/open_book` as the identifier. `Identifier.for_foreign_id` then rejects the embedded slash (slashes are forbidden in Bibliotheca IDs) by raising a bare `ValueError`. The permalink route's `@returns_problem_detail` only catches `ProblemError`, so the `ValueError` propagates to the error handler and becomes a 500.

This PR is a server-hardening fix: an identifier that's invalid for its type can't exist in any collection, so we now report it as a missing item (404) rather than crashing. It does **not** address the root cause — the app posting open-book events to the wrong path — which is a separate client-side issue and means those analytics events are still being lost.

Note: `annotation.py` and `playtime_entries.py` also call `Identifier.for_foreign_id` on raw user-supplied identifiers and share this failure mode; they are left out of scope for this targeted bugfix.

## How Has This Been Tested?

- Added a case to `test_load_licensepools` asserting that `Bibliotheca ID` + `"axv8gvz9/open_book"` returns the `NO_LICENSES` problem detail rather than raising.
- Ran `tox -e py312-docker -- --no-cov tests/manager/api/controller/test_base.py -k test_load_licensepools` (passes).
- `mypy` clean on the changed file.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
