### PR TITLE
Re-run imports on retry in workflow-lock importers, extract workflow_lock_guard (PP-4472)

### DIFF
--- a/src/palace/manager/celery/importer.py
+++ b/src/palace/manager/celery/importer.py
@@ -1,9 +1,13 @@
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from datetime import timedelta
 
 from celery.canvas import Signature
+from celery.exceptions import Ignore
 
 from palace.util.log import LoggerType, pluralize
 
+from palace.manager.celery.task import Task
 from palace.manager.service.redis.models.lock import RedisLock
 from palace.manager.service.redis.redis import Redis
 from palace.manager.sqlalchemy.model.collection import Collection
@@ -104,3 +108,50 @@ def reap_workflow_lock(
         random_value=random_value,
         lock_timeout=timedelta(hours=2),
     )
+
+
+@contextmanager
+def workflow_lock_guard(
+    task: Task,
+    collection_id: int,
+    *,
+    label: str,
+    lock_factory: Callable[[Redis, int, str], RedisLock] = import_workflow_lock,
+) -> Generator[bool, None, None]:
+    """
+    Acquire a paginated workflow's per-collection lock and decide whether to run.
+
+    Centralises the locking policy shared by every paginated importer/reaper task. The
+    lock is keyed on ``task.request.id``, which Celery preserves across both
+    ``task.replace()`` page/batch hand-offs and ``autoretry_for`` retries. A run
+    therefore re-acquires its own lock for free on every page and retry, while a
+    concurrent run (a different task id) is locked out until the holder finishes or the
+    lock's timeout expires. ``Ignore`` (raised by ``task.replace()``) and the task's
+    ``autoretry_for`` exceptions do not release the lock, so it stays held across page
+    boundaries and retry backoff windows.
+
+    :param task: The bound task instance (``self``).
+    :param collection_id: The collection being processed.
+    :param label: Human-readable task description for log messages, e.g.
+        ``"OverDrive import"``.
+    :param lock_factory: Builds the lock; defaults to :func:`import_workflow_lock`. Pass
+        :func:`reap_workflow_lock` for reaper tasks.
+    :returns: Yields ``proceed`` — ``True`` when the caller should run its body, ``False``
+        when another run already holds the lock and the caller should skip.
+    """
+    redis = task.services.redis().client()
+    with lock_factory(redis, collection_id, task.request.id).lock(
+        raise_when_not_acquired=False,
+        # Hold the lock for exactly the exceptions the task retries on, plus Ignore
+        # (task.replace hand-off), so it is not released when they propagate out and the
+        # retry/next page re-acquires the same lock under its stable task id.
+        ignored_exceptions=(Ignore, *getattr(task, "autoretry_for", ())),
+    ) as acquired:
+        if acquired:
+            yield True
+        else:
+            task.log.warning(
+                f"{label} skipped for collection {collection_id}: "
+                "another run is already in progress."
+            )
+            yield False

--- a/src/palace/manager/celery/tasks/bibliotheca.py
+++ b/src/palace/manager/celery/tasks/bibliotheca.py
@@ -17,14 +17,12 @@ Four tasks handle near-real-time event import and historical purchase record imp
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from uuid import uuid4
 
 from celery import shared_task
-from celery.exceptions import Ignore
 
 from palace.util.datetime_helpers import utc_now
 
-from palace.manager.celery.importer import import_workflow_lock
+from palace.manager.celery.importer import workflow_lock_guard
 from palace.manager.celery.task import Task
 from palace.manager.celery.utils import ModelNotFoundError, load_from_id, signature_with
 from palace.manager.integration.license.bibliotheca import BibliothecaAPI
@@ -81,7 +79,6 @@ def import_collection(
     collection_id: int,
     *,
     start: datetime | None = None,
-    lock_value: str | None = None,
 ) -> None:
     """Process one time slice of Bibliotheca circulation events.
 
@@ -90,42 +87,19 @@ def import_collection(
     slice via ``task.replace()`` until the collection is caught up to
     ``now - EVENT_IMPORT_OVERLAP``.
 
-    A Redis workflow lock keyed to ``collection_id`` ensures at most one chain
-    runs per collection at a time.  The lock is held across both ``task.replace()``
-    calls and Celery retries (``BadResponseException``, ``RequestTimedOut``) so that
-    a transient API failure does not open a window for a second concurrent run.
+    Concurrency is governed by
+    :func:`~palace.manager.celery.importer.workflow_lock_guard`, which holds a
+    per-collection Redis lock across both ``task.replace()`` calls and Celery retries.
 
     :param collection_id: Database ID of the Bibliotheca collection.
     :param start: Start of the slice to process.  ``None`` on the first
         invocation — the start is derived from the stored ``Timestamp``.
-    :param lock_value: UUID identifying this workflow.  Generated on the first
-        invocation and forwarded unchanged to every subsequent slice so the
-        lock is held across ``task.replace()`` calls.
     """
-    redis = task.services.redis().client()
-
-    is_first_slice = lock_value is None
-    if lock_value is None:
-        lock_value = str(uuid4())
-
-    workflow_lock = import_workflow_lock(redis, collection_id, lock_value)
-
-    with workflow_lock.lock(
-        raise_when_not_acquired=False,
-        # Hold the lock across task.replace() (Ignore), and across Celery retries
-        # (BadResponseException, RequestTimedOut) so a transient API failure doesn't
-        # open a window for a concurrent run to start on the same collection.
-        ignored_exceptions=(Ignore, BadResponseException, RequestTimedOut),
-    ) as workflow_lock_acquired:
-        if not workflow_lock_acquired and is_first_slice:
-            task.log.warning(
-                f"Bibliotheca event import skipped for collection {collection_id}: another run is already in progress."
-            )
+    with workflow_lock_guard(
+        task, collection_id, label="Bibliotheca event import"
+    ) as proceed:
+        if not proceed:
             return
-        if not workflow_lock_acquired and not is_first_slice:
-            task.log.warning(
-                f"Bibliotheca event import for collection {collection_id}: workflow lock expired between slices; continuing (another run may be active)."
-            )
 
         cutoff = utc_now() - EVENT_IMPORT_OVERLAP
         result = None
@@ -161,9 +135,6 @@ def import_collection(
                 signature_with(
                     task,
                     start=result.slice_end,
-                    # lock_value is resolved from None on the first slice, so it
-                    # must be carried forward explicitly rather than refilled.
-                    lock_value=lock_value,
                 )
             )
 
@@ -228,7 +199,6 @@ def import_purchase_records_by_collection(
     *,
     current_day: datetime | None = None,
     offset: int = 1,
-    lock_value: str | None = None,
     reset_timestamp: bool = False,
 ) -> None:
     """Process one page of Bibliotheca MARC purchase records.
@@ -245,11 +215,11 @@ def import_purchase_records_by_collection(
 
     This continues until the collection is caught up to ``utc_now()``.
 
-    A Redis workflow lock keyed to ``collection_id`` (prefix
-    ``PurchaseRecordCollectionWorkflow``) ensures at most one purchase-record-import
-    chain runs per collection at a time.  The lock is held across ``task.replace()``
-    calls and Celery retries so that a transient API failure does not open a
-    window for a second concurrent run.
+    Concurrency is governed by
+    :func:`~palace.manager.celery.importer.workflow_lock_guard` using a dedicated
+    :func:`_purchase_record_workflow_lock` (prefix ``PurchaseRecordCollectionWorkflow``),
+    which holds a per-collection Redis lock across both ``task.replace()`` calls and
+    Celery retries so at most one purchase-record-import chain runs per collection.
 
     :param collection_id: Database ID of the Bibliotheca collection.
     :param current_day: Start of the day to process.  ``None`` on the first
@@ -257,9 +227,6 @@ def import_purchase_records_by_collection(
         (defaulting to 2014-01-01 when no timestamp exists).
     :param offset: 1-based record offset within the current day's result set.
         Defaults to ``1`` (the first page).
-    :param lock_value: UUID identifying this workflow.  Generated on the first
-        invocation and forwarded unchanged to every subsequent page/day so the
-        lock is held across ``task.replace()`` calls.
     :param reset_timestamp: When ``True`` on the **first** invocation, clears
         ``Timestamp.finish`` within the transaction so that ``get_start()``
         returns :data:`DEFAULT_PURCHASE_RECORD_START_TIME` rather than the stale
@@ -267,30 +234,14 @@ def import_purchase_records_by_collection(
         since ``get_start()`` is not called in that case.  Not forwarded to
         replacement tasks.
     """
-    redis = task.services.redis().client()
-
-    is_first_invocation = lock_value is None
-    if lock_value is None:
-        lock_value = str(uuid4())
-
-    workflow_lock = _purchase_record_workflow_lock(redis, collection_id, lock_value)
-
-    with workflow_lock.lock(
-        raise_when_not_acquired=False,
-        # Hold the lock across task.replace() (Ignore) and Celery retries
-        # (BadResponseException, RequestTimedOut) so a transient API failure
-        # does not open a window for a concurrent run on the same collection.
-        ignored_exceptions=(Ignore, BadResponseException, RequestTimedOut),
-    ) as workflow_lock_acquired:
-        if not workflow_lock_acquired and is_first_invocation:
-            task.log.warning(
-                f"Bibliotheca purchase record import skipped for collection {collection_id}: another run is already in progress."
-            )
+    with workflow_lock_guard(
+        task,
+        collection_id,
+        label="Bibliotheca purchase record import",
+        lock_factory=_purchase_record_workflow_lock,
+    ) as proceed:
+        if not proceed:
             return
-        if not workflow_lock_acquired and not is_first_invocation:
-            task.log.warning(
-                f"Bibliotheca purchase record import for collection {collection_id}: workflow lock expired between invocations; continuing (another run may be active)."
-            )
 
         cutoff = utc_now()
         result: DayImportResult
@@ -319,8 +270,9 @@ def import_purchase_records_by_collection(
             # On a force-reimport's first invocation, clear Timestamp.finish so
             # that a crash before the first record is processed causes the next
             # scheduled run to fall back to DEFAULT_PURCHASE_RECORD_START_TIME
-            # rather than the stale pre-reimport finish date.
-            if is_first_invocation and reset_timestamp:
+            # rather than the stale pre-reimport finish date. reset_timestamp is
+            # only ever True on the first invocation (replacements force it False).
+            if reset_timestamp:
                 ts = Timestamp.lookup(
                     session,
                     PURCHASE_RECORD_SERVICE_NAME,
@@ -357,9 +309,6 @@ def import_purchase_records_by_collection(
                     # (via get_start()), so it must be carried forward explicitly.
                     current_day=current_day,
                     offset=result.next_offset,
-                    # lock_value is resolved from None on the first invocation, so it
-                    # must be carried forward explicitly rather than refilled.
-                    lock_value=lock_value,
                     # reset_timestamp applies only to the first invocation.
                     reset_timestamp=False,
                 )
@@ -372,9 +321,6 @@ def import_purchase_records_by_collection(
                     task,
                     current_day=result.day_end,
                     offset=1,
-                    # lock_value is resolved from None on the first invocation, so it
-                    # must be carried forward explicitly rather than refilled.
-                    lock_value=lock_value,
                     # reset_timestamp applies only to the first invocation.
                     reset_timestamp=False,
                 )

--- a/src/palace/manager/celery/tasks/opds_odl.py
+++ b/src/palace/manager/celery/tasks/opds_odl.py
@@ -1,16 +1,16 @@
 import datetime
-from uuid import uuid4
 
 from celery import shared_task
-from celery.exceptions import Ignore
 from sqlalchemy import delete, select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session
 
 from palace.util.datetime_helpers import utc_now
 
-from palace.manager.celery import importer
-from palace.manager.celery.importer import import_workflow_lock
+from palace.manager.celery.importer import (
+    import_all as create_import_tasks,
+    workflow_lock_guard,
+)
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import apply
 from palace.manager.celery.utils import load_from_id, signature_with
@@ -308,7 +308,7 @@ def import_all(task: Task, force: bool = False) -> None:
         collection_query = Collection.select_by_protocol(
             OPDS2WithODLApi, registry=registry
         )
-        importer.import_all(
+        create_import_tasks(
             session.scalars(collection_query).all(),
             import_collection.s(
                 force=force,
@@ -331,51 +331,23 @@ def import_collection(
     url: str | None = None,
     *,
     force: bool = False,
-    lock_value: str | None = None,
 ) -> None:
     """
     Run an OPDS2+ODL import for the given collection.
 
-    A Redis workflow lock keyed to ``collection_id`` ensures at most one import
-    runs per collection at a time. The lock is held across ``task.replace()``
-    page boundaries and across Celery retries (``BadResponseException``,
-    ``RequestTimedOut``) so a transient failure does not open a window for a
-    second concurrent run to start on the same collection.
+    Concurrency is governed by
+    :func:`~palace.manager.celery.importer.workflow_lock_guard`, which holds a
+    per-collection Redis lock across ``task.replace()`` page boundaries and
+    ``autoretry_for`` retries.
 
     :param collection_id: Database ID of the collection to import.
     :param url: The next page URL to import. ``None`` on the first page — the
         import starts from the beginning of the feed.
     :param force: If True, import even if the feed is unchanged.
-    :param lock_value: UUID identifying this import workflow. Generated on the
-        first page and forwarded unchanged to every subsequent page so the lock
-        is held across ``task.replace()`` calls.
     """
-    redis = task.services.redis().client()
-
-    is_first_page = lock_value is None
-    if lock_value is None:
-        lock_value = str(uuid4())
-
-    workflow_lock = import_workflow_lock(redis, collection_id, lock_value)
-
-    with workflow_lock.lock(
-        raise_when_not_acquired=False,
-        # Hold the lock across task.replace() (Ignore) and across Celery retries
-        # (BadResponseException, RequestTimedOut) so a transient failure doesn't
-        # open a window for a concurrent run to start on the same collection.
-        ignored_exceptions=(Ignore, BadResponseException, RequestTimedOut),
-    ) as workflow_lock_acquired:
-        if not workflow_lock_acquired and is_first_page:
-            task.log.warning(
-                f"Import skipped for collection {collection_id}: "
-                "another import is already in progress."
-            )
+    with workflow_lock_guard(task, collection_id, label="OPDS2+ODL import") as proceed:
+        if not proceed:
             return
-        if not workflow_lock_acquired and not is_first_page:
-            task.log.warning(
-                f"Import for collection {collection_id}: workflow lock expired "
-                "between pages; continuing (another import may be running)."
-            )
 
         with task.session() as session:
             collection = load_from_id(session, Collection, collection_id)
@@ -398,11 +370,10 @@ def import_collection(
 
         next_link = import_result.next_url
         if next_link is not None:
-            # This page is complete, but there are more pages to import, so we requeue ourselves with the
-            # next page URL, forwarding lock_value so the workflow lock is held across the page boundary.
-            raise task.replace(
-                signature_with(task, url=next_link, lock_value=lock_value)
-            )
+            # This page is complete, but there are more pages to import, so we requeue
+            # ourselves with the next page URL. The workflow lock is keyed on the task id,
+            # which task.replace() preserves, so the next page re-acquires the same lock.
+            raise task.replace(signature_with(task, url=next_link))
 
         task.log.info(
             f"Import complete for collection '{collection_name}' (id={collection_id})."

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -3,7 +3,6 @@ from typing import Any, Literal, TypedDict, TypeGuard
 from uuid import uuid4
 
 from celery import chain, chord, group, shared_task
-from celery.exceptions import Ignore
 from sqlalchemy import select
 
 from palace.util.datetime_helpers import utc_now
@@ -13,6 +12,7 @@ from palace.manager.celery.importer import (
     import_key,
     import_workflow_lock,
     reap_workflow_lock,
+    workflow_lock_guard,
 )
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import apply
@@ -67,7 +67,6 @@ def import_collection(
     start_time: datetime.datetime | None = None,
     return_identifiers: bool = True,
     parent_identifiers: dict[str, Any] | None = None,
-    lock_value: str | None = None,
 ) -> IdentifierSet | ImportSkippedPayload | None:
     """
     Run an import for a single Overdrive collection.
@@ -94,8 +93,6 @@ def import_collection(
     :param parent_identifiers: A running set of parent identifiers (if not a parent collection)
         that were processed before this run started. This value is a serialized representation of the
         parent_identifier IdentifierSet.
-    :param lock_value: UUID identifying this import workflow. Passed between pages to hold the workflow lock
-        across page boundaries. Generated on the first page when None.
     :return: IdentifierSet when import completes and return_identifiers is True; None when
         return_identifiers is False or collection is marked for deletion; {IMPORT_SKIPPED: True}
         when the workflow lock is held and another import is already in progress.
@@ -106,32 +103,9 @@ def import_collection(
     if start_time is None:
         start_time = utc_now()
 
-    # Both page and lock_value are None only on the first page of a fresh import.
-    # They are always set together when task.replace() chains to the next page.
-    is_first_page = page is None and lock_value is None
-    if lock_value is None:
-        lock_value = str(uuid4())
-
-    workflow_lock = import_workflow_lock(redis, collection_id, lock_value)
-
-    # Ignore is raised by task.replace() and Retry is raised by autoretry_for exceptions.
-    # Neither should release the workflow lock: replace() hands it to the next page task,
-    # and retries should continue holding the lock across the backoff window.
-    with workflow_lock.lock(
-        raise_when_not_acquired=False,
-        ignored_exceptions=(Ignore, BadResponseException, RequestTimedOut),
-    ) as workflow_lock_acquired:
-        if not workflow_lock_acquired and is_first_page:
-            task.log.warning(
-                f"OverDrive import skipped for collection {collection_id}: "
-                "another import is already in progress."
-            )
+    with workflow_lock_guard(task, collection_id, label="OverDrive import") as proceed:
+        if not proceed:
             return _import_skipped_payload()
-        if not workflow_lock_acquired and not is_first_page:
-            task.log.warning(
-                f"OverDrive import for collection {collection_id}: workflow lock expired "
-                "between pages; continuing (another import may be running)."
-            )
 
         with task.transaction() as session:
             collection = load_from_id(session, Collection, collection_id)
@@ -219,12 +193,11 @@ def import_collection(
                     task,
                     parent_identifiers=serialized_parent_identifiers,
                     page=result.next_page.url,
-                    # modified_since, start_time, and lock_value are resolved from
-                    # None on the first page, so they must be carried forward
-                    # explicitly rather than refilled from the original arguments.
+                    # modified_since and start_time are resolved from None on the first
+                    # page, so they must be carried forward explicitly rather than
+                    # refilled from the original arguments.
                     modified_since=modified_since,
                     start_time=start_time,
-                    lock_value=lock_value,
                 )
             )
         else:
@@ -522,44 +495,26 @@ def reap_collection(
     *,
     offset: int = 0,
     batch_size: int = 50,
-    lock_value: str | None = None,
 ) -> None:
     """
     Check for books that are in the local collection but have left our Overdrive collection.
 
     Processes identifiers in batches, re-queuing itself via task.replace() until all
-    identifiers have been checked. A Redis workflow lock prevents overlapping runs for
-    the same collection; the lock auto-expires after 2 hours if the process dies.
+    identifiers have been checked. Concurrency is governed by
+    :func:`~palace.manager.celery.importer.workflow_lock_guard`.
 
     :param collection_id: The ID of the Overdrive collection to reap.
     :param offset: The last Identifier.id processed; used to resume across batches.
     :param batch_size: Number of identifiers to process per batch.
-    :param lock_value: UUID identifying this reap workflow. Generated on the first batch
-        when None, then passed to each subsequent batch to hold the lock across replacements.
     """
-    redis = task.services.redis().client()
-
-    is_first_batch = lock_value is None
-    if lock_value is None:
-        lock_value = str(uuid4())
-
-    workflow_lock = reap_workflow_lock(redis, collection_id, lock_value)
-
-    with workflow_lock.lock(
-        raise_when_not_acquired=False,
-        ignored_exceptions=(Ignore, BadResponseException, RequestTimedOut),
-    ) as workflow_lock_acquired:
-        if not workflow_lock_acquired and is_first_batch:
-            task.log.warning(
-                f"Overdrive reaper skipped for collection {collection_id}: "
-                "another reap is already in progress."
-            )
+    with workflow_lock_guard(
+        task,
+        collection_id,
+        label="Overdrive reaper",
+        lock_factory=reap_workflow_lock,
+    ) as proceed:
+        if not proceed:
             return
-        if not workflow_lock_acquired and not is_first_batch:
-            task.log.warning(
-                f"Overdrive reaper for collection {collection_id}: workflow lock expired "
-                "between batches; continuing (another reap may be running)."
-            )
 
         new_offset = 0
         processed_count = 0
@@ -608,8 +563,5 @@ def reap_collection(
                 signature_with(
                     task,
                     offset=new_offset,
-                    # lock_value is resolved from None on the first batch, so it
-                    # must be carried forward explicitly rather than refilled.
-                    lock_value=lock_value,
                 )
             )

--- a/tests/manager/celery/tasks/test_bibliotheca.py
+++ b/tests/manager/celery/tasks/test_bibliotheca.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, call, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 
@@ -183,7 +183,6 @@ class TestBibliothecaImportCollection:
         collection = bibliotheca_task_fixture.collection
 
         explicit_start = utc_now() - timedelta(hours=2)
-        lock_value = str(uuid4())
 
         with patch.object(bibliotheca.import_collection, "replace") as mock_replace:
             mock_replace.side_effect = Exception("replaced")
@@ -191,7 +190,6 @@ class TestBibliothecaImportCollection:
                 bibliotheca.import_collection.delay(
                     collection_id=collection.id,
                     start=explicit_start,
-                    lock_value=lock_value,
                 ).wait()
 
         slice_start, _ = mock_api.get_events_between.call_args.args
@@ -225,7 +223,7 @@ class TestBibliothecaImportCollection:
         redis_fixture: RedisFixture,
     ) -> None:
         """When start is more than one slice behind cutoff, task.replace() is raised
-        with the next slice's start and the same lock_value."""
+        with the next slice's start."""
         mock_api_cls.return_value.get_events_between.return_value = iter([])
         collection = bibliotheca_task_fixture.collection
 
@@ -234,17 +232,14 @@ class TestBibliothecaImportCollection:
             finish=utc_now() - timedelta(hours=1)
         )
 
-        lock_value = str(uuid4())
         with patch.object(bibliotheca.import_collection, "replace") as mock_replace:
             mock_replace.side_effect = Exception("replaced")
             with pytest.raises(Exception, match="replaced"):
                 bibliotheca.import_collection.delay(
                     collection_id=collection.id,
-                    lock_value=lock_value,
                 ).wait()
 
         replace_sig = mock_replace.call_args[0][0]
-        assert replace_sig.kwargs["lock_value"] == lock_value
         # The next start should be approximately 5 minutes after the slice started.
         assert replace_sig.kwargs["start"] is not None
 
@@ -270,34 +265,6 @@ class TestBibliothecaImportCollection:
 
         mock_replace.assert_not_called()
         mock_api_cls.return_value.get_events_between.assert_called_once()
-
-    @patch("palace.manager.integration.license.bibliotheca_importer.BibliothecaAPI")
-    def test_lock_value_passed_through_on_replace(
-        self,
-        mock_api_cls: MagicMock,
-        bibliotheca_task_fixture: BibliothecaTaskFixture,
-        celery_fixture: CeleryFixture,
-        redis_fixture: RedisFixture,
-    ) -> None:
-        """The lock_value generated on the first slice is forwarded unchanged to the
-        next slice so the workflow lock remains held across task.replace() calls."""
-        mock_api_cls.return_value.get_events_between.return_value = iter([])
-        collection = bibliotheca_task_fixture.collection
-
-        bibliotheca_task_fixture.stamp_event_import(
-            finish=utc_now() - timedelta(hours=1)
-        )
-
-        with patch.object(bibliotheca.import_collection, "replace") as mock_replace:
-            mock_replace.side_effect = Exception("replaced")
-            with pytest.raises(Exception, match="replaced"):
-                # First invocation: no lock_value (will be generated internally).
-                bibliotheca.import_collection.delay(collection_id=collection.id).wait()
-
-        replace_sig = mock_replace.call_args[0][0]
-        lock_value = replace_sig.kwargs["lock_value"]
-        assert lock_value is not None
-        UUID(lock_value)  # raises ValueError if not a valid UUID
 
     def test_skips_when_lock_held(
         self,
@@ -329,57 +296,19 @@ class TestBibliothecaImportCollection:
 
         workflow_lock.release()
 
-    def test_continues_with_warning_when_lock_expires_mid_chain(
-        self,
-        bibliotheca_task_fixture: BibliothecaTaskFixture,
-        celery_fixture: CeleryFixture,
-        redis_fixture: RedisFixture,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """When the workflow lock expires between slices (is_first_slice=False and lock
-        not acquired), the task logs a warning but still processes the slice rather than
-        silently returning."""
-        collection = bibliotheca_task_fixture.collection
-        bibliotheca_task_fixture.stamp_event_import(
-            finish=utc_now() - timedelta(minutes=3)
-        )
-
-        # Simulate the lock having expired and been re-acquired by a competing run.
-        # A free lock would be acquired successfully; we need another holder so that our
-        # task's lock_value (a different UUID) fails to acquire.
-        competing_lock = import_workflow_lock(
-            redis_fixture.client, collection.id, str(uuid4())
-        )
-        competing_lock.acquire()
-
-        caplog.set_level(LogLevel.warning)
-
-        with patch(
-            "palace.manager.integration.license.bibliotheca_importer.BibliothecaAPI"
-        ) as mock_api_cls:
-            mock_api_cls.return_value.get_events_between.return_value = iter([])
-            # Pass a lock_value that does not match the competing lock so acquire fails,
-            # but is_first_slice is False (lock_value is not None).
-            bibliotheca.import_collection.delay(
-                collection_id=collection.id,
-                lock_value=str(uuid4()),
-            ).wait()
-            # Despite the lock not being acquired, the slice was still processed.
-            mock_api_cls.return_value.get_events_between.assert_called_once()
-
-        assert "workflow lock expired between slices" in caplog.text
-
-        competing_lock.release()
-
     def test_lock_not_released_on_autoretry(
         self,
         bibliotheca_task_fixture: BibliothecaTaskFixture,
         celery_fixture: CeleryFixture,
         redis_fixture: RedisFixture,
     ) -> None:
-        """When a retryable exception is raised the workflow lock is held so that
-        a concurrent run cannot start on the same collection while retries are
-        in progress."""
+        """A retryable failure holds the workflow lock and each retry re-runs the import.
+
+        The workflow lock is keyed on ``task.request.id``, which Celery preserves across
+        retries, so every retry re-acquires the same lock and re-runs the slice rather
+        than skipping as if another run were in progress. The lock stays held so no
+        concurrent run can start.
+        """
         collection = bibliotheca_task_fixture.collection
         bibliotheca_task_fixture.stamp_event_import(
             finish=utc_now() - timedelta(minutes=10)
@@ -398,6 +327,10 @@ class TestBibliothecaImportCollection:
                 bibliotheca.import_collection.delay(collection_id=collection.id).get(
                     propagate=False
                 )
+
+            # The slice was re-run on every retry (1 initial attempt + max_retries=4),
+            # not skipped as an "already in progress" run.
+            assert mock_api_cls.return_value.get_events_between.call_count == 5
 
         # Lock should still be held after retries exhaust — it will expire via
         # the 2-hour Redis TTL, preventing a concurrent run from starting.
@@ -472,13 +405,11 @@ class TestBibliothecaImportCollection:
         one_hour_ago = utc_now() - timedelta(hours=1)
         bibliotheca_task_fixture.stamp_event_import(finish=one_hour_ago)
 
-        lock_value = str(uuid4())
         with patch.object(bibliotheca.import_collection, "replace") as mock_replace:
             mock_replace.side_effect = Exception("replaced")
             with pytest.raises(Exception, match="replaced"):
                 bibliotheca.import_collection.delay(
                     collection_id=collection.id,
-                    lock_value=lock_value,
                 ).wait()
 
         # After processing one slice the timestamp finish should have advanced
@@ -743,7 +674,7 @@ class TestImportPurchaseRecordsByCollection:
         redis_fixture: RedisFixture,
     ) -> None:
         """When current_day + 1 day is still behind cutoff, task.replace() is raised
-        with the next day and the same lock_value."""
+        with the next day."""
         mock_api_cls.return_value.marc_request.return_value = iter([])
         collection = bibliotheca_purchase_record_task_fixture.collection
 
@@ -753,7 +684,6 @@ class TestImportPurchaseRecordsByCollection:
             finish=stored_finish
         )
 
-        lock_value = str(uuid4())
         with patch.object(
             bibliotheca.import_purchase_records_by_collection, "replace"
         ) as mock_replace:
@@ -761,11 +691,9 @@ class TestImportPurchaseRecordsByCollection:
             with pytest.raises(Exception, match="replaced"):
                 bibliotheca.import_purchase_records_by_collection.delay(
                     collection_id=collection.id,
-                    lock_value=lock_value,
                 ).wait()
 
         replace_sig = mock_replace.call_args[0][0]
-        assert replace_sig.kwargs["lock_value"] == lock_value
         expected_next_day = stored_finish + timedelta(days=1)
         assert (
             abs((replace_sig.kwargs["current_day"] - expected_next_day).total_seconds())
@@ -801,7 +729,6 @@ class TestImportPurchaseRecordsByCollection:
             next_offset=1 + _MARC_PAGE_SIZE,
         )
 
-        lock_value = str(uuid4())
         with patch.object(
             bibliotheca.import_purchase_records_by_collection, "replace"
         ) as mock_replace:
@@ -810,7 +737,6 @@ class TestImportPurchaseRecordsByCollection:
                 bibliotheca.import_purchase_records_by_collection.delay(
                     collection_id=collection.id,
                     offset=1,
-                    lock_value=lock_value,
                 ).wait()
 
         replace_sig = mock_replace.call_args[0][0]
@@ -819,7 +745,6 @@ class TestImportPurchaseRecordsByCollection:
             abs((replace_sig.kwargs["current_day"] - stored_finish).total_seconds()) < 5
         )
         assert replace_sig.kwargs["offset"] == 1 + _MARC_PAGE_SIZE
-        assert replace_sig.kwargs["lock_value"] == lock_value
 
     @patch(
         "palace.manager.integration.license.bibliotheca_purchase_record_importer.BibliothecaAPI"
@@ -848,39 +773,6 @@ class TestImportPurchaseRecordsByCollection:
             ).wait()
 
         mock_replace.assert_not_called()
-
-    @patch(
-        "palace.manager.integration.license.bibliotheca_purchase_record_importer.BibliothecaAPI"
-    )
-    def test_lock_value_passed_through_on_replace(
-        self,
-        mock_api_cls: MagicMock,
-        bibliotheca_purchase_record_task_fixture: BibliothecaPurchaseRecordTaskFixture,
-        celery_fixture: CeleryFixture,
-        redis_fixture: RedisFixture,
-    ) -> None:
-        """The lock_value generated on the first day is forwarded unchanged to the
-        next day so the workflow lock remains held across task.replace() calls."""
-        mock_api_cls.return_value.marc_request.return_value = iter([])
-        collection = bibliotheca_purchase_record_task_fixture.collection
-
-        bibliotheca_purchase_record_task_fixture.stamp_purchase_record(
-            finish=utc_now() - timedelta(days=5)
-        )
-
-        with patch.object(
-            bibliotheca.import_purchase_records_by_collection, "replace"
-        ) as mock_replace:
-            mock_replace.side_effect = Exception("replaced")
-            with pytest.raises(Exception, match="replaced"):
-                bibliotheca.import_purchase_records_by_collection.delay(
-                    collection_id=collection.id
-                ).wait()
-
-        replace_sig = mock_replace.call_args[0][0]
-        lock_value = replace_sig.kwargs["lock_value"]
-        assert lock_value is not None
-        UUID(lock_value)  # raises ValueError if not a valid UUID
 
     def test_skips_when_lock_held(
         self,
@@ -913,50 +805,19 @@ class TestImportPurchaseRecordsByCollection:
 
         existing_lock.release()
 
-    def test_continues_with_warning_when_lock_expires_mid_chain(
-        self,
-        bibliotheca_purchase_record_task_fixture: BibliothecaPurchaseRecordTaskFixture,
-        celery_fixture: CeleryFixture,
-        redis_fixture: RedisFixture,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """When the purchase record workflow lock expires mid-chain (is_first_invocation=False
-        and lock not acquired), the task logs a warning but still processes the day."""
-        collection = bibliotheca_purchase_record_task_fixture.collection
-        bibliotheca_purchase_record_task_fixture.stamp_purchase_record(
-            finish=utc_now() - timedelta(hours=3)
-        )
-
-        competing_lock = _purchase_record_workflow_lock(
-            redis_fixture.client, collection.id, str(uuid4())
-        )
-        competing_lock.acquire()
-
-        caplog.set_level(LogLevel.warning)
-
-        with patch(
-            "palace.manager.integration.license.bibliotheca_purchase_record_importer.BibliothecaAPI"
-        ) as mock_api_cls:
-            mock_api_cls.return_value.marc_request.return_value = iter([])
-            bibliotheca.import_purchase_records_by_collection.delay(
-                collection_id=collection.id,
-                lock_value=str(uuid4()),
-            ).wait()
-            mock_api_cls.return_value.marc_request.assert_called_once()
-
-        assert "workflow lock expired between invocations" in caplog.text
-
-        competing_lock.release()
-
     def test_lock_not_released_on_autoretry(
         self,
         bibliotheca_purchase_record_task_fixture: BibliothecaPurchaseRecordTaskFixture,
         celery_fixture: CeleryFixture,
         redis_fixture: RedisFixture,
     ) -> None:
-        """When a retryable exception is raised the purchase record workflow lock is held so
-        that a concurrent run cannot start on the same collection while retries are
-        in progress."""
+        """A retryable failure holds the workflow lock and each retry re-runs the import.
+
+        The workflow lock is keyed on ``task.request.id``, which Celery preserves across
+        retries, so every retry re-acquires the same lock and re-runs the day rather than
+        skipping as if another run were in progress. The lock stays held so no concurrent
+        run can start.
+        """
         collection = bibliotheca_purchase_record_task_fixture.collection
         bibliotheca_purchase_record_task_fixture.stamp_purchase_record(
             finish=utc_now() - timedelta(days=5)
@@ -976,6 +837,12 @@ class TestImportPurchaseRecordsByCollection:
                     collection_id=collection.id
                 ).get(propagate=False)
 
+            # The day was re-run on every retry (1 initial attempt + max_retries=4),
+            # not skipped as an "already in progress" run.
+            assert mock_api_cls.return_value.marc_request.call_count == 5
+
+        # Lock should still be held after retries exhaust — it will expire via
+        # the 2-hour Redis TTL, preventing a concurrent run from starting.
         workflow_lock = _purchase_record_workflow_lock(
             redis_fixture.client, collection.id, random_value="any"
         )
@@ -1001,7 +868,6 @@ class TestImportPurchaseRecordsByCollection:
             finish=stored_finish
         )
 
-        lock_value = str(uuid4())
         with patch.object(
             bibliotheca.import_purchase_records_by_collection, "replace"
         ) as mock_replace:
@@ -1009,7 +875,6 @@ class TestImportPurchaseRecordsByCollection:
             with pytest.raises(Exception, match="replaced"):
                 bibliotheca.import_purchase_records_by_collection.delay(
                     collection_id=collection.id,
-                    lock_value=lock_value,
                 ).wait()
 
         ts = bibliotheca_purchase_record_task_fixture.get_purchase_record_timestamp()
@@ -1171,10 +1036,8 @@ class TestImportPurchaseRecordsByCollection:
 
         caplog.set_level(LogLevel.warning)
 
-        # Pass a non-None lock_value to simulate a mid-chain invocation (not first).
         bibliotheca.import_purchase_records_by_collection.delay(
             collection_id=collection_id,
-            lock_value=str(uuid4()),
         ).wait()
 
         assert "not found" in caplog.text
@@ -1200,7 +1063,6 @@ class TestImportPurchaseRecordsByCollection:
         ) as mock_api_cls:
             bibliotheca.import_purchase_records_by_collection.delay(
                 collection_id=collection.id,
-                lock_value=str(uuid4()),
             ).wait()
             mock_api_cls.return_value.marc_request.assert_not_called()
 

--- a/tests/manager/celery/tasks/test_opds_odl.py
+++ b/tests/manager/celery/tasks/test_opds_odl.py
@@ -750,66 +750,20 @@ class TestImportCollection:
 
         workflow_lock.release()
 
-    def test_continues_with_warning_when_lock_expires_mid_chain(
-        self,
-        db: DatabaseTransactionFixture,
-        celery_fixture: CeleryFixture,
-        redis_fixture: RedisFixture,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
-        """When the workflow lock expires between pages (is_first_page is False and
-        the lock cannot be acquired), the task logs a warning but still processes the
-        page rather than silently returning."""
-        collection = db.collection(
-            protocol=OPDS2WithODLApi,
-            settings=db.opds2_odl_settings(external_account_id="http://feed.com"),
-        )
-
-        # Simulate the lock having been re-acquired by a competing run. A free lock
-        # would be acquired successfully; we need another holder so that our task's
-        # lock_value (a different UUID) fails to acquire.
-        competing_lock = import_workflow_lock(
-            redis_fixture.client, collection.id, str(uuid.uuid4())
-        )
-        competing_lock.acquire()
-
-        caplog.set_level(LogLevel.warning)
-
-        mock_importer = create_autospec(OpdsImporter)
-        mock_importer.import_feed.return_value = FeedImportResult(
-            next_url=None,
-            feed=MagicMock(),
-            results={},
-            failures=[],
-            identifier_set=None,
-        )
-        with patch.object(
-            opds_odl,
-            "importer_from_collection",
-            autospec=True,
-            return_value=mock_importer,
-        ):
-            # Pass a lock_value that does not match the competing lock so acquire
-            # fails, but is_first_page is False (lock_value is not None).
-            opds_odl.import_collection.delay(
-                collection.id, lock_value=str(uuid.uuid4())
-            ).wait()
-
-        # Despite the lock not being acquired, the page was still processed.
-        mock_importer.import_feed.assert_called_once()
-        assert "workflow lock expired between pages" in caplog.text
-
-        competing_lock.release()
-
-    def test_lock_not_released_on_autoretry(
+    def test_autoretry_holds_lock_and_re_runs_import(
         self,
         db: DatabaseTransactionFixture,
         celery_fixture: CeleryFixture,
         redis_fixture: RedisFixture,
     ) -> None:
-        """When a retryable exception is raised the workflow lock is held so that a
-        concurrent run cannot start on the same collection while retries are in
-        progress."""
+        """A retryable failure holds the workflow lock and each retry actually re-runs
+        the import.
+
+        The workflow lock is keyed on ``task.request.id``, which Celery preserves across
+        retries, so every retry re-acquires the *same* workflow lock and re-runs
+        import_feed, rather than skipping as if another run held the lock. The lock is
+        also held the whole time so no concurrent run can start.
+        """
         collection = db.collection(
             protocol=OPDS2WithODLApi,
             settings=db.opds2_odl_settings(external_account_id="http://feed.com"),
@@ -828,6 +782,10 @@ class TestImportCollection:
         ):
             with celery_fixture.patch_retry_backoff():
                 opds_odl.import_collection.delay(collection.id).get(propagate=False)
+
+        # The import was re-run on every retry (1 initial attempt + max_retries=5),
+        # not skipped as an "already in progress" run.
+        assert mock_importer.import_feed.call_count == 6
 
         # Lock should still be held after retries exhaust — it will expire via the
         # Redis TTL, preventing a concurrent run from starting in the meantime.

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -454,12 +454,14 @@ class TestImportCollection:
         assert not workflow_lock.locked()
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveImporter")
-    def test_workflow_lock_passed_to_next_page(
+    def test_replace_raised_with_next_page(
         self,
         mock_importer_class: MagicMock,
         overdrive_import_fixture: OverdriveImportFixture,
     ):
-        """When replacing task with next page, lock_value is passed to the next task."""
+        """When more pages remain, task.replace() is raised with the next page. The
+        workflow lock is keyed on the task id (which replace preserves), so nothing
+        needs to be threaded through the signature's kwargs."""
         collection = overdrive_import_fixture.collection
 
         next_endpoint = BookInfoEndpoint(url="http://test.com/books/page2")
@@ -475,29 +477,30 @@ class TestImportCollection:
                 overdrive.import_collection.delay(collection.id).wait()
 
             replace_sig = mock_replace.call_args[0][0]
-            assert replace_sig.kwargs["lock_value"] is not None
-            assert isinstance(replace_sig.kwargs["lock_value"], str)
+            assert replace_sig.kwargs["page"] == "http://test.com/books/page2"
+            assert "lock_value" not in replace_sig.kwargs
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveImporter")
-    def test_workflow_lock_subsequent_page_runs_importer(
+    def test_workflow_lock_continuation_reacquires_own_lock(
         self,
         mock_importer_class: MagicMock,
         overdrive_import_fixture: OverdriveImportFixture,
         redis_fixture: RedisFixture,
     ):
-        """When lock_value is passed for a subsequent page, the task runs the importer."""
+        """A continuation page carries the same task id, so it re-acquires the workflow
+        lock it already holds and runs the importer."""
         collection = overdrive_import_fixture.collection
-        lock_value = str(uuid4())
-        workflow_lock = import_workflow_lock(
-            redis_fixture.client, collection.id, lock_value
-        )
-        workflow_lock.acquire()
+        # Simulate the lock still held by this run's own task id from a prior page.
+        task_id = str(uuid4())
+        import_workflow_lock(redis_fixture.client, collection.id, task_id).acquire()
 
         mock_importer, _ = overdrive_import_fixture.create_mock_importer()
         mock_importer_class.return_value = mock_importer
 
-        result = overdrive.import_collection.delay(
-            collection.id, page="http://test.com/page1", lock_value=lock_value
+        result = overdrive.import_collection.apply_async(
+            args=(collection.id,),
+            kwargs={"page": "http://test.com/page1"},
+            task_id=task_id,
         ).wait()
 
         mock_importer_class.assert_called_once()
@@ -511,7 +514,13 @@ class TestImportCollection:
         redis_fixture: RedisFixture,
         celery_fixture: CeleryFixture,
     ):
-        """When an autoretry exception is raised, the workflow lock is not released."""
+        """A retryable failure holds the workflow lock and each retry re-runs the import.
+
+        The workflow lock is keyed on ``task.request.id``, which Celery preserves across
+        retries, so every retry re-acquires the same workflow lock and re-runs the import,
+        rather than skipping as if another run were in progress. The lock stays held the
+        whole time so no concurrent run can start.
+        """
         collection = overdrive_import_fixture.collection
         mock_importer, _ = overdrive_import_fixture.create_mock_importer()
         mock_response = MockRequestsResponse(500, content="Internal Server Error")
@@ -521,49 +530,15 @@ class TestImportCollection:
         mock_importer_class.return_value = mock_importer
 
         with celery_fixture.patch_retry_backoff():
-            result = overdrive.import_collection.delay(collection.id).wait()
+            overdrive.import_collection.delay(collection.id).get(propagate=False)
 
-        # First attempt raises BadResponseException; lock is not released (ignored).
-        # Retry fails to acquire (lock still held), returns skip payload.
-        assert result == overdrive._import_skipped_payload()
+        # The import was re-run on every retry (1 initial attempt + max_retries=4),
+        # not skipped as an "already in progress" run.
+        assert mock_importer.import_collection.call_count == 5
         workflow_lock = import_workflow_lock(
             redis_fixture.client, collection.id, random_value="any"
         )
         assert workflow_lock.locked()
-
-    @patch("palace.manager.celery.tasks.overdrive.OverdriveImporter")
-    def test_workflow_lock_expired_between_pages(
-        self,
-        mock_importer_class: MagicMock,
-        overdrive_import_fixture: OverdriveImportFixture,
-        redis_fixture: RedisFixture,
-        caplog: pytest.LogCaptureFixture,
-    ):
-        """When the workflow lock expired between pages, the task logs a warning and continues."""
-        collection = overdrive_import_fixture.collection
-        lock_value_held = str(uuid4())
-        lock_value_passed = str(uuid4())
-        workflow_lock = import_workflow_lock(
-            redis_fixture.client, collection.id, lock_value_held
-        )
-        workflow_lock.acquire()
-
-        mock_importer, _ = overdrive_import_fixture.create_mock_importer()
-        mock_importer_class.return_value = mock_importer
-
-        caplog.set_level(LogLevel.warning)
-
-        result = overdrive.import_collection.delay(
-            collection.id,
-            page="http://test.com/page1",
-            lock_value=lock_value_passed,
-        ).wait()
-
-        assert "workflow lock expired" in caplog.text
-        assert "between pages" in caplog.text
-        mock_importer_class.assert_called_once()
-        assert result is not None
-        workflow_lock.release()
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveImporter")
     def test_import_collection_marked_for_deletion(
@@ -1328,7 +1303,7 @@ class TestOverdriveReaper:
         overdrive_api_fixture: OverdriveAPIFixture,
         redis_fixture: RedisFixture,
     ):
-        """When a full batch is processed, task.replace is raised with the next offset and same lock_value."""
+        """When a full batch is processed, task.replace is raised with the next offset."""
         collection = overdrive_api_fixture.collection
         # Create exactly batch_size identifiers to trigger replace
         batch_size = 3
@@ -1341,15 +1316,14 @@ class TestOverdriveReaper:
 
         with patch.object(overdrive.reap_collection, "replace") as mock_replace:
             mock_replace.side_effect = Exception("replaced")
-            lock_value = str(uuid4())
             with pytest.raises(Exception, match="replaced"):
                 overdrive.reap_collection.delay(
-                    collection.id, batch_size=batch_size, lock_value=lock_value
+                    collection.id, batch_size=batch_size
                 ).wait()
 
             replace_sig = mock_replace.call_args[0][0]
             assert replace_sig.kwargs["offset"] == last_id
-            assert replace_sig.kwargs["lock_value"] == lock_value
+            assert "lock_value" not in replace_sig.kwargs
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_stops_on_partial_batch(
@@ -1378,10 +1352,12 @@ class TestOverdriveReaper:
         overdrive_api_fixture: OverdriveAPIFixture,
         redis_fixture: RedisFixture,
     ):
-        """When an autoretry exception is raised, the workflow lock is not released.
+        """A retryable failure holds the workflow lock and each retry re-runs the reap.
 
-        On the retry attempt, lock_value is None (fresh call), so a new UUID is generated
-        and fails to acquire the still-held lock, causing the retry to silently skip.
+        The workflow lock is keyed on ``task.request.id``, which Celery preserves across
+        retries, so every retry re-acquires the same workflow lock and re-runs the batch,
+        rather than skipping as if another run were in progress. The lock stays held so no
+        concurrent run can start.
         """
         collection = overdrive_api_fixture.collection
         db.licensepool(db.edition(), collection=collection)
@@ -1397,10 +1373,13 @@ class TestOverdriveReaper:
             )
 
             with celery_fixture.patch_retry_backoff():
-                overdrive.reap_collection.delay(collection.id).wait()
+                overdrive.reap_collection.delay(collection.id).get(propagate=False)
 
-        # Lock is still held: first attempt raised BadResponseException (ignored),
-        # retry generated a new lock_value and skipped rather than releasing.
+            # The reap was re-run on every retry (1 initial attempt + max_retries=4),
+            # not skipped as an "already in progress" run.
+            assert mock_api_class.return_value.update_licensepool.call_count == 5
+
+        # Lock is still held after retries exhaust; it expires via the Redis TTL.
         workflow_lock = reap_workflow_lock(
             redis_fixture.client, collection.id, random_value="any"
         )
@@ -1436,30 +1415,3 @@ class TestOverdriveReaper:
         assert "skipped" in caplog.text
         assert "already in progress" in caplog.text
         workflow_lock.release()
-
-    def test_reap_collection_lock_value_passed_through(
-        self,
-        db: DatabaseTransactionFixture,
-        celery_fixture: CeleryFixture,
-        overdrive_api_fixture: OverdriveAPIFixture,
-        redis_fixture: RedisFixture,
-    ):
-        """The lock_value generated on the first batch is forwarded unchanged to the next batch."""
-        collection = overdrive_api_fixture.collection
-        batch_size = 2
-        for _ in range(batch_size):
-            db.licensepool(db.edition(), collection=collection)
-        db.session.flush()
-
-        with patch("palace.manager.celery.tasks.overdrive.OverdriveAPI"):
-            with patch.object(overdrive.reap_collection, "replace") as mock_replace:
-                mock_replace.side_effect = Exception("replaced")
-                with pytest.raises(Exception, match="replaced"):
-                    overdrive.reap_collection.delay(
-                        collection.id, batch_size=batch_size
-                    ).wait()
-
-                replace_sig = mock_replace.call_args[0][0]
-                lock_value = replace_sig.kwargs["lock_value"]
-                assert lock_value is not None
-                assert isinstance(lock_value, str)

--- a/tests/manager/celery/test_importer.py
+++ b/tests/manager/celery/test_importer.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+from typing import cast
+from unittest.mock import MagicMock
 from uuid import uuid4
 
-from palace.manager.celery.importer import import_workflow_key, import_workflow_lock
+from palace.manager.celery.importer import (
+    import_workflow_key,
+    import_workflow_lock,
+    reap_workflow_lock,
+    workflow_lock_guard,
+)
+from palace.manager.celery.task import Task
 from tests.fixtures.redis import RedisFixture
 
 
@@ -16,6 +24,82 @@ class TestImportWorkflowKey:
 
     def test_different_collection_ids_produce_distinct_keys(self) -> None:
         assert import_workflow_key(1) != import_workflow_key(2)
+
+
+def _guard_task(redis_fixture: RedisFixture, task_id: str = "task-id") -> MagicMock:
+    """A mock bound task wired so the guard's redis client and request.id work.
+
+    The workflow lock is keyed on ``task.request.id``, which Celery keeps stable across
+    ``task.replace()`` hand-offs and retries; the tests vary it to model separate runs.
+    """
+    task = MagicMock()
+    task.services.redis.return_value.client.return_value = redis_fixture.client
+    task.request.id = task_id
+    task.autoretry_for = ()
+    return task
+
+
+class TestWorkflowLockGuard:
+    def test_proceeds_and_releases_when_lock_free(
+        self, redis_fixture: RedisFixture
+    ) -> None:
+        """A free lock: the guard acquires it (keyed on the task id), proceeds, and
+        releases it on exit."""
+        task = _guard_task(redis_fixture, "task-a")
+
+        with workflow_lock_guard(cast(Task, task), 1, label="Test") as proceed:
+            assert proceed is True
+            # The lock is held by this task's id while inside the guard.
+            assert import_workflow_lock(redis_fixture.client, 1, "task-a").locked(
+                by_us=True
+            )
+
+        task.log.warning.assert_not_called()
+        # Released on normal exit.
+        assert not import_workflow_lock(redis_fixture.client, 1, "any").locked()
+
+    def test_skips_when_another_run_holds_lock(
+        self, redis_fixture: RedisFixture
+    ) -> None:
+        """When a different run (a different task id) holds the lock, the guard does not
+        proceed and logs a skip warning."""
+        holder = import_workflow_lock(redis_fixture.client, 2, str(uuid4()))
+        holder.acquire()
+        task = _guard_task(redis_fixture, "task-b")
+
+        with workflow_lock_guard(cast(Task, task), 2, label="Test") as proceed:
+            assert proceed is False
+
+        message = task.log.warning.call_args.args[0]
+        assert "skipped" in message
+        assert "already in progress" in message
+        holder.release()
+
+    def test_continuation_reacquires_own_lock(
+        self, redis_fixture: RedisFixture
+    ) -> None:
+        """A continuation (page/batch hand-off or retry) carries the same task id, so it
+        re-acquires the lock it already holds and proceeds without warning."""
+        task = _guard_task(redis_fixture, "task-c")
+        # Simulate the lock still held by this task's own id from a prior page.
+        import_workflow_lock(redis_fixture.client, 3, "task-c").acquire()
+
+        with workflow_lock_guard(cast(Task, task), 3, label="Test") as proceed:
+            assert proceed is True
+
+        task.log.warning.assert_not_called()
+
+    def test_uses_lock_factory(self, redis_fixture: RedisFixture) -> None:
+        """A custom lock_factory (e.g. reap_workflow_lock) is used for acquisition."""
+        task = _guard_task(redis_fixture, "task-d")
+
+        with workflow_lock_guard(
+            cast(Task, task), 4, label="Test", lock_factory=reap_workflow_lock
+        ) as proceed:
+            assert proceed is True
+            # The reap (not import) workflow lock is the one held.
+            assert reap_workflow_lock(redis_fixture.client, 4, "any").locked()
+            assert not import_workflow_lock(redis_fixture.client, 4, "any").locked()
 
 
 class TestImportWorkflowLock:


### PR DESCRIPTION
## Description

Two changes to the paginated workflow tasks (OPDS2+ODL, Bibliotheca, Overdrive import + reap):

1. **Re-run the import on retry.** These tasks hold a Redis workflow lock across a run and keep it held when a retryable exception (`BadResponseException`, `RequestTimedOut`) is raised, via the lock's `ignored_exceptions`. But the lock's `lock_value` was minted inside the task body, so it was absent from the original request that `autoretry_for` re-sends. Each retry therefore generated a *fresh* `lock_value`, failed to acquire the lock still held by the failed attempt, hit the first-page guard, logged "another run is already in progress", and **returned SUCCESS** — silently swallowing the failure with no real retry until the lock's TTL expired. Fixed by keying the lock on `task.request.id` instead of a minted value: Celery preserves the task id across both `task.replace()` page/batch hand-offs and `autoretry_for` retries, so every retry and every page re-acquires the *same* lock for free (`RedisLock.acquire()` extends a lock already held by the same value), while a concurrent run — which has a different task id — is locked out. This removes the minted `lock_value`, the `task.request.kwargs` injection, the explicit threading through every `task.replace()`, and the `lock_value` parameter on all four tasks.

2. **Extract `workflow_lock_guard`.** The four tasks each repeated the same locking preamble (resolve the Redis client, build the lock, acquire with the shared `ignored_exceptions` policy, branch on the logging). That `ignored_exceptions` tuple was duplicated in four places and could drift. Pulled it all into a single `workflow_lock_guard` context manager that yields `proceed`. The held-exception set is now derived from the task's own `autoretry_for`, so the lock is held for exactly the exceptions the task retries on.

Because the lock is now keyed on the stable task id, the first-vs-continuation distinction is gone: a run always re-acquires its own lock, so the only `proceed=False` case is a genuinely concurrent run already holding the lock. This carries one intentional behavior change — a continuation whose lock expired mid-run *and was taken over by another run* now skips cleanly rather than proceeding best-effort alongside it, which is strictly safer since it avoids two concurrent runs on the same collection.

## Motivation and Context

Found while investigating the `LockNotAcquired` alerts addressed by #3415. In the previous workflow lock pattern an error on the first page generated retries, but each retry minted a different `lock_value`, so recovery was delayed to the next scheduled beat run instead of the intended fast autoretry. Keying the lock on the task id — which Celery already keeps stable across `replace()` and retries — restores real retry behavior across all four importers/reaper, and removes the duplicated locking boilerplate so the policy can't drift between tasks.

## How Has This Been Tested?

- Verified that retries now re-run the import (`import_feed` / `import_collection` call count goes from 1 → `1 + max_retries`) instead of skipping.
- Confirmed against the Celery 5.6.3 source that `task.request.id` is preserved across both `task.replace()` (`sig.freeze(self.request.id)`) and `autoretry_for` retries (`signature_from_request` re-sends `task_id=self.id`).
- Updated the autoretry tests for all four tasks to assert re-run-on-retry; rewrote the `workflow_lock_guard` unit tests around task-id keying (free lock, concurrent-run skip, continuation re-acquiring its own lock, custom `lock_factory`); added a worker-level test that pins `task_id` via `apply_async` to exercise a continuation end-to-end.
- `tox -e py312-docker -- --no-cov` across the four affected suites — 94 passed.
- `mypy` clean.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
