### PR TITLE
Treat unencodable SIP2 patron credentials as invalid (PP-4472)

### DIFF
--- a/src/palace/manager/integration/patron_auth/sip2/provider.py
+++ b/src/palace/manager/integration/patron_auth/sip2/provider.py
@@ -403,7 +403,8 @@ class SIP2AuthenticationProvider(
             # authentication rather than letting it become a 500.
             cls.logger().warning(
                 f"Credentials could not be encoded using the configured "
-                f"SIP2 encoding ({client.encoding}): {e}"
+                f"SIP2 encoding ({client.encoding}): {e}",
+                exc_info=e,
             )
             return INVALID_CREDENTIALS
 

--- a/src/palace/manager/integration/patron_auth/sip2/provider.py
+++ b/src/palace/manager/integration/patron_auth/sip2/provider.py
@@ -401,12 +401,15 @@ class SIP2AuthenticationProvider(
             # the SIP2 server's configured encoding, so they can't possibly be
             # valid credentials for this server. Treat this as a failed
             # authentication rather than letting it become a 500.
-            cls.logger().warning(
+            debug_info = (
                 f"Credentials could not be encoded using the configured "
-                f"SIP2 encoding ({client.encoding}): {e}",
+                f"SIP2 encoding ({client.encoding})"
+            )
+            cls.logger().warning(
+                f"{debug_info}: {e}",
                 exc_info=e,
             )
-            return INVALID_CREDENTIALS
+            return INVALID_CREDENTIALS.with_debug(debug_info)
 
         except OSError as e:
             server_name = client.target_server or "unknown server"

--- a/src/palace/manager/integration/patron_auth/sip2/provider.py
+++ b/src/palace/manager/integration/patron_auth/sip2/provider.py
@@ -368,6 +368,54 @@ class SIP2AuthenticationProvider(
         )
 
     @classmethod
+    def _fetch_patron_info(
+        cls,
+        client: SIPClient,
+        username: str,
+        password: str | None,
+    ) -> dict[str, Any] | ProblemDetail:
+        """Run a full SIP2 patron-information exchange against the given client.
+
+        Performs connect, login, sc_status, patron_information, end_session,
+        disconnect, converting transport and encoding errors into a
+        :class:`ProblemDetail`. This is the single place where both the
+        instance and settings-only code paths talk to the SIP2 server, so the
+        error handling stays consistent between them.
+
+        :param client: A configured :class:`SIPClient` to use for the exchange.
+        :param username: Patron identifier (e.g. barcode or test_identifier).
+        :param password: Patron password (e.g. PIN, test_password, or None).
+        :returns: Raw SIP2 info dict on success, or a :class:`ProblemDetail` on error.
+        """
+        try:
+            client.connect()
+            client.login()
+            client.sc_status()
+            info = client.patron_information(username, password)
+            client.end_session(username, password)
+            client.disconnect()
+            return info
+
+        except UnicodeEncodeError as e:
+            # The credentials contain characters that can't be represented in
+            # the SIP2 server's configured encoding, so they can't possibly be
+            # valid credentials for this server. Treat this as a failed
+            # authentication rather than letting it become a 500.
+            cls.logger().warning(
+                f"Credentials could not be encoded using the configured "
+                f"SIP2 encoding ({client.encoding}): {e}"
+            )
+            return INVALID_CREDENTIALS
+
+        except OSError as e:
+            server_name = client.target_server or "unknown server"
+            cls.logger().warning(f"SIP2 error ({server_name}): {str(e)}", exc_info=e)
+            return INVALID_CREDENTIALS.detailed(
+                f"Error contacting authentication server ({server_name}). "
+                "Please try again later."
+            )
+
+    @classmethod
     def _fetch_patron_info_via_sip2(
         cls,
         settings: SIP2Settings,
@@ -377,8 +425,8 @@ class SIP2AuthenticationProvider(
     ) -> dict[str, Any] | ProblemDetail:
         """Fetch patron information from the SIP2 server using settings only.
 
-        Performs connect, login, sc_status, patron_information, end_session, disconnect.
-        Does not require a provider instance.
+        Builds a SIP client from the settings and delegates to
+        :meth:`_fetch_patron_info`. Does not require a provider instance.
 
         :param settings: The validated :class:`SIP2Settings`.
         :param username: Patron identifier (e.g. test_identifier).
@@ -386,21 +434,8 @@ class SIP2AuthenticationProvider(
         :param institution_id: Optional institution ID from library settings.
         :returns: Raw SIP2 info dict on success, or a :class:`ProblemDetail` on error.
         """
-        sip = cls._build_client_from_settings(settings, institution_id)
-        try:
-            sip.connect()
-            sip.login()
-            sip.sc_status()
-            info = sip.patron_information(username, password)
-            sip.end_session(username, password)
-            sip.disconnect()
-            return info
-        except OSError as e:
-            server_name = settings.url or "unknown server"
-            return INVALID_CREDENTIALS.detailed(
-                f"Error contacting authentication server ({server_name}). "
-                "Please try again later."
-            )
+        client = cls._build_client_from_settings(settings, institution_id)
+        return cls._fetch_patron_info(client, username, password)
 
     @classmethod
     def fetch_live_rule_validation_values(
@@ -462,33 +497,7 @@ class SIP2AuthenticationProvider(
     def patron_information(
         self, username: str, password: str | None
     ) -> dict[str, Any] | ProblemDetail:
-        try:
-            sip = self.client
-            sip.connect()
-            sip.login()
-            sip.sc_status()
-            info = sip.patron_information(username, password)
-            sip.end_session(username, password)
-            sip.disconnect()
-            return info
-
-        except UnicodeEncodeError as e:
-            # The patron's credentials contain characters that can't be
-            # represented in the SIP2 server's configured encoding, so they
-            # can't possibly be valid credentials for this server. Treat this
-            # as a failed authentication rather than letting it become a 500.
-            self.log.warning(
-                f"Patron credentials could not be encoded using the configured "
-                f"SIP2 encoding ({self.encoding}): {e}"
-            )
-            return INVALID_CREDENTIALS
-
-        except OSError as e:
-            server_name = self.server or "unknown server"
-            self.log.warning(f"SIP2 error ({server_name}): {str(e)}", exc_info=e)
-            return INVALID_CREDENTIALS.detailed(
-                f"Error contacting authentication server ({server_name}). Please try again later."
-            )
+        return self._fetch_patron_info(self.client, username, password)
 
     def remote_patron_lookup(
         self, patron_or_patrondata: PatronData | Patron

--- a/src/palace/manager/integration/patron_auth/sip2/provider.py
+++ b/src/palace/manager/integration/patron_auth/sip2/provider.py
@@ -472,6 +472,17 @@ class SIP2AuthenticationProvider(
             sip.disconnect()
             return info
 
+        except UnicodeEncodeError as e:
+            # The patron's credentials contain characters that can't be
+            # represented in the SIP2 server's configured encoding, so they
+            # can't possibly be valid credentials for this server. Treat this
+            # as a failed authentication rather than letting it become a 500.
+            self.log.warning(
+                f"Patron credentials could not be encoded using the configured "
+                f"SIP2 encoding ({self.encoding}): {e}"
+            )
+            return INVALID_CREDENTIALS
+
         except OSError as e:
             server_name = self.server or "unknown server"
             self.log.warning(f"SIP2 error ({server_name}): {str(e)}", exc_info=e)

--- a/tests/manager/integration/patron_auth/sip2/test_provider.py
+++ b/tests/manager/integration/patron_auth/sip2/test_provider.py
@@ -540,6 +540,32 @@ class TestSIP2AuthenticationProvider:
             == "Error contacting authentication server (server.local). Please try again later."
         )
 
+    def test_unencodable_credentials_become_problemdetail(
+        self,
+        create_provider: Callable[..., SIP2AuthenticationProvider],
+        create_settings: Callable[..., SIP2Settings],
+    ):
+        """If the patron's credentials contain characters that can't be
+        encoded using the server's configured encoding, we treat it as a
+        failed authentication rather than letting the UnicodeEncodeError
+        become an unhandled 500 error.
+        """
+
+        # The default encoding is CP850, which can't represent these
+        # characters, so encoding the outgoing message will fail.
+        settings = create_settings(encoding=Sip2Encoding.cp850)
+        provider = create_provider(settings=settings)
+
+        result = provider.remote_authenticate(
+            "username",
+            "密码字字字",
+        )
+        response = result.patron_data
+
+        assert isinstance(response, ProblemDetail)
+        assert response.status_code == INVALID_CREDENTIALS.status_code
+        assert response.uri == INVALID_CREDENTIALS.uri
+
     def test_parse_date(self):
         parse = SIP2AuthenticationProvider.parse_date
         assert datetime(2011, 1, 2) == parse("20110102")

--- a/tests/manager/integration/patron_auth/sip2/test_provider.py
+++ b/tests/manager/integration/patron_auth/sip2/test_provider.py
@@ -1625,6 +1625,35 @@ class TestFetchLiveRuleValidationValues:
 
         mock_fetch.assert_called_once_with(settings, "user1", "")
 
+    def test_unencodable_test_credentials_surface_actionable_error(
+        self,
+        create_settings: Callable[..., SIP2Settings],
+    ) -> None:
+        """If the configured test credentials can't be encoded with the server's
+        encoding, the admin gets a clear INVALID_CREDENTIALS-based error rather
+        than a misleading 'could not contact the server' message.
+        """
+        settings = create_settings(
+            test_identifier="密码字字字",
+            test_password="secret",
+            encoding=Sip2Encoding.cp850,
+        )
+        client = MockSIPClient(target_server="server.com", encoding="cp850")
+
+        with patch.object(
+            SIP2AuthenticationProvider,
+            "_build_client_from_settings",
+            return_value=client,
+        ):
+            with pytest.raises(ProblemDetailException) as exc_info:
+                SIP2AuthenticationProvider.fetch_live_rule_validation_values(settings)
+
+        problem = exc_info.value.problem_detail
+        assert problem.uri == INVALID_CONFIGURATION_OPTION.uri
+        # The message comes from the ProblemDetail branch (server returned an
+        # error), not the broad "could not contact server" exception branch.
+        assert "returned an error" in (problem.detail or "")
+
 
 class TestBuildValuesFromSip2Info:
     """Tests for :meth:`~palace.manager.integration.patron_auth.sip2.provider.SIP2AuthenticationProvider._build_values_from_sip2_info`.

--- a/tests/manager/integration/patron_auth/sip2/test_provider.py
+++ b/tests/manager/integration/patron_auth/sip2/test_provider.py
@@ -1625,35 +1625,6 @@ class TestFetchLiveRuleValidationValues:
 
         mock_fetch.assert_called_once_with(settings, "user1", "")
 
-    def test_unencodable_test_credentials_surface_actionable_error(
-        self,
-        create_settings: Callable[..., SIP2Settings],
-    ) -> None:
-        """If the configured test credentials can't be encoded with the server's
-        encoding, the admin gets a clear INVALID_CREDENTIALS-based error rather
-        than a misleading 'could not contact the server' message.
-        """
-        settings = create_settings(
-            test_identifier="密码字字字",
-            test_password="secret",
-            encoding=Sip2Encoding.cp850,
-        )
-        client = MockSIPClient(target_server="server.com", encoding="cp850")
-
-        with patch.object(
-            SIP2AuthenticationProvider,
-            "_build_client_from_settings",
-            return_value=client,
-        ):
-            with pytest.raises(ProblemDetailException) as exc_info:
-                SIP2AuthenticationProvider.fetch_live_rule_validation_values(settings)
-
-        problem = exc_info.value.problem_detail
-        assert problem.uri == INVALID_CONFIGURATION_OPTION.uri
-        # The message comes from the ProblemDetail branch (server returned an
-        # error), not the broad "could not contact server" exception branch.
-        assert "returned an error" in (problem.detail or "")
-
 
 class TestBuildValuesFromSip2Info:
     """Tests for :meth:`~palace.manager.integration.patron_auth.sip2.provider.SIP2AuthenticationProvider._build_values_from_sip2_info`.


### PR DESCRIPTION
## Description

`SIP2AuthenticationProvider.patron_information()` only caught `OSError`, but when a patron's credentials contain characters that can't be represented in the server's configured encoding (CP850 by default), `SIPClient.send()` raises a `UnicodeEncodeError`. That is a `ValueError` subclass, not an `OSError`, so it escaped the provider's error handling and surfaced as an unhandled 500. This change catches `UnicodeEncodeError` in `patron_information()` and returns `INVALID_CREDENTIALS` instead.

## Motivation and Context

Seen in production: a `POST /<library>/patrons/me/token/` request crashed with `UnicodeEncodeError: 'charmap' codec can't encode characters ... encoding with 'cp850' codec failed` while building the SIP2 patron-information message. The offending bytes were the patron-supplied barcode/PIN, which contained characters CP850 can't represent. Credentials that can't even be encoded in the server's charset can't be valid for that server, so this is a failed authentication (401), not a server error (500). 

Part of PP-4472.

## How Has This Been Tested?

Added `test_unencodable_credentials_become_problemdetail`, which authenticates with a CP850-incompatible password and asserts a `ProblemDetail` matching `INVALID_CREDENTIALS` is returned rather than an exception propagating. The test exercises the real `send()`/encode path via `MockSIPClient`. Ran the new test alongside the existing SIP2 error-handling tests (all pass) and confirmed mypy is clean on the changed file.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
