### PR TITLE
Add signature_with helper to re-queue Celery tasks without re-listing args

### DIFF
--- a/src/palace/manager/celery/tasks/bibliotheca.py
+++ b/src/palace/manager/celery/tasks/bibliotheca.py
@@ -20,7 +20,7 @@ from palace.util.datetime_helpers import utc_now
 
 from palace.manager.celery.importer import import_workflow_lock
 from palace.manager.celery.task import Task
-from palace.manager.celery.utils import load_from_id
+from palace.manager.celery.utils import load_from_id, signature_with
 from palace.manager.integration.license.bibliotheca import BibliothecaAPI
 from palace.manager.integration.license.bibliotheca_importer import (
     EVENT_IMPORT_OVERLAP,
@@ -146,9 +146,11 @@ def import_collection(
 
         if result.slice_end < cutoff:
             raise task.replace(
-                task.s(
-                    collection_id=collection_id,
+                signature_with(
+                    task,
                     start=result.slice_end,
+                    # lock_value is resolved from None on the first slice, so it
+                    # must be carried forward explicitly rather than refilled.
                     lock_value=lock_value,
                 )
             )

--- a/src/palace/manager/celery/tasks/boundless.py
+++ b/src/palace/manager/celery/tasks/boundless.py
@@ -11,7 +11,7 @@ from palace.manager.celery.importer import (
 )
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import apply
-from palace.manager.celery.utils import load_from_id
+from palace.manager.celery.utils import load_from_id, signature_with
 from palace.manager.integration.license.boundless.api import BoundlessApi
 from palace.manager.integration.license.boundless.importer import BoundlessImporter
 from palace.manager.service.celery.celery import QueueNames
@@ -141,10 +141,12 @@ def import_collection(
             f"Boundless import re-queueing: '{collection_name}' Next page: {result.next_page}."
         )
         raise task.replace(
-            task.s(
-                collection_id=collection_id,
-                import_all=import_all,
+            signature_with(
+                task,
                 page=result.next_page,
+                # modified_since and start_time are resolved from None on the
+                # first page, so they must be carried forward explicitly rather
+                # than refilled from the original arguments.
                 modified_since=modified_since,
                 start_time=start_time,
             )

--- a/src/palace/manager/celery/tasks/collection_delete.py
+++ b/src/palace/manager/celery/tasks/collection_delete.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from celery import shared_task
 
 from palace.manager.celery.task import Task
+from palace.manager.celery.utils import signature_with
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.sqlalchemy.model.collection import Collection
 
@@ -34,4 +35,4 @@ def collection_delete(task: Task, collection_id: int, batch_size: int = 1000) ->
             f"Collection {collection_id} has more license pools to delete. "
             f"Re-queueing."
         )
-        raise task.replace(collection_delete.s(collection_id, batch_size=batch_size))
+        raise task.replace(signature_with(task))

--- a/src/palace/manager/celery/tasks/marc.py
+++ b/src/palace/manager/celery/tasks/marc.py
@@ -7,6 +7,7 @@ from celery import shared_task
 from palace.util.datetime_helpers import utc_now
 
 from palace.manager.celery.task import Task
+from palace.manager.celery.utils import signature_with
 from palace.manager.integration.catalog.marc.exporter import LibraryInfo, MarcExporter
 from palace.manager.integration.catalog.marc.uploader import (
     MarcUploadManager,
@@ -236,11 +237,8 @@ def marc_export_collection(
     # This task is complete, but there are more works waiting to be exported. So we requeue ourselves
     # to process the next batch.
     raise task.replace(
-        marc_export_collection.s(
-            collection_id=collection_id,
-            collection_name=collection_name,
-            start_time=start_time,
-            libraries=libraries,
+        signature_with(
+            task,
             # We pass context as a list of tuples instead of a dict, because the json serializer
             # converts all dict keys to strings, so we lose the integer keys. We convert it back
             # to a dict on the other side.
@@ -249,9 +247,8 @@ def marc_export_collection(
                 (library.library_id, upload.context)
                 for library, upload in uploads.items()
             ],
+            # last_work_id advances each batch, so carry the updated value forward.
             last_work_id=last_work_id,
-            batch_size=batch_size,
-            delta=delta,
         )
     )
 

--- a/src/palace/manager/celery/tasks/notifications.py
+++ b/src/palace/manager/celery/tasks/notifications.py
@@ -14,7 +14,7 @@ from palace.util.exceptions import PalaceValueError
 from palace.util.log import LoggerMixin
 
 from palace.manager.celery.task import Task
-from palace.manager.celery.utils import load_from_id
+from palace.manager.celery.utils import load_from_id, signature_with
 from palace.manager.data_layer.base.frozen import BaseFrozenData
 from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.service.celery.celery import QueueNames
@@ -396,9 +396,9 @@ def loan_expiration(
     if len(loans) == batch_size:
         # We have more loans to process, requeue the task
         raise task.replace(
-            loan_expiration.s(
-                loan_expiration_days=loan_expiration_days, batch_size=batch_size
-            )
+            # loan_expiration_days is resolved to a default when empty, so carry
+            # the resolved value forward rather than refilling the original.
+            signature_with(task, loan_expiration_days=loan_expiration_days)
         )
 
     task.log.info(f"Loan notifications complete")
@@ -442,6 +442,6 @@ def hold_available(
 
     if len(holds) == batch_size:
         # We have more holds to process, requeue the task
-        raise task.replace(hold_available.s(batch_size=batch_size))
+        raise task.replace(signature_with(task))
 
     task.log.info(f"Hold available notifications complete")

--- a/src/palace/manager/celery/tasks/opds_odl.py
+++ b/src/palace/manager/celery/tasks/opds_odl.py
@@ -13,7 +13,7 @@ from palace.manager.celery import importer
 from palace.manager.celery.importer import import_workflow_lock
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import apply
-from palace.manager.celery.utils import load_from_id
+from palace.manager.celery.utils import load_from_id, signature_with
 from palace.manager.integration.license.opds.odl.api import OPDS2WithODLApi
 from palace.manager.integration.license.opds.odl.importer import (
     importer_from_collection,
@@ -291,11 +291,7 @@ def recalculate_hold_queue_collection(
 
     if len(license_pool_ids) == batch_size:
         # We are done this batch, but there is probably more work to do, we queue up the next batch.
-        raise task.replace(
-            recalculate_hold_queue_collection.s(
-                collection_id, batch_size, license_pool_ids[-1]
-            )
-        )
+        raise task.replace(signature_with(task, after_id=license_pool_ids[-1]))
 
     task.log.info(
         f"Finished recalculating hold queue for collection {collection_name} ({collection_id})."
@@ -405,12 +401,7 @@ def import_collection(
             # This page is complete, but there are more pages to import, so we requeue ourselves with the
             # next page URL, forwarding lock_value so the workflow lock is held across the page boundary.
             raise task.replace(
-                task.s(
-                    collection_id=collection_id,
-                    url=next_link,
-                    force=force,
-                    lock_value=lock_value,
-                )
+                signature_with(task, url=next_link, lock_value=lock_value)
             )
 
         task.log.info(

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -16,7 +16,7 @@ from palace.manager.celery.importer import (
 )
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import apply
-from palace.manager.celery.utils import load_from_id
+from palace.manager.celery.utils import load_from_id, signature_with
 from palace.manager.integration.license.overdrive.api import (
     BookInfoEndpoint,
     OverdriveAPI,
@@ -215,12 +215,13 @@ def import_collection(
                 parent_identifier_set.__json__() if parent_identifier_set else None
             )
             raise task.replace(
-                task.s(
-                    collection_id=collection_id,
-                    import_all=import_all,
+                signature_with(
+                    task,
                     parent_identifiers=serialized_parent_identifiers,
-                    return_identifiers=return_identifiers,
                     page=result.next_page.url,
+                    # modified_since, start_time, and lock_value are resolved from
+                    # None on the first page, so they must be carried forward
+                    # explicitly rather than refilled from the original arguments.
                     modified_since=modified_since,
                     start_time=start_time,
                     lock_value=lock_value,
@@ -604,10 +605,11 @@ def reap_collection(
 
         if processed_count == batch_size:
             raise task.replace(
-                task.s(
-                    collection_id=collection_id,
+                signature_with(
+                    task,
                     offset=new_offset,
-                    batch_size=batch_size,
+                    # lock_value is resolved from None on the first batch, so it
+                    # must be carried forward explicitly rather than refilled.
                     lock_value=lock_value,
                 )
             )

--- a/src/palace/manager/celery/tasks/reaper.py
+++ b/src/palace/manager/celery/tasks/reaper.py
@@ -19,6 +19,7 @@ from palace.manager.celery.tasks.notifications import (
     RemovedItemNotificationData,
     send_item_removed_notification,
 )
+from palace.manager.celery.utils import signature_with
 from palace.manager.service.analytics.eventdata import AnalyticsEventData
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
@@ -112,7 +113,7 @@ def work_reaper(task: Task, batch_size: int = 1000) -> None:
     )
     if len(works) == batch_size:
         task.log.info("There may be more Works to delete. Re-queueing the reaper.")
-        raise task.replace(work_reaper.s(batch_size=batch_size))
+        raise task.replace(signature_with(task))
 
 
 @shared_task(queue=QueueNames.default, bind=True)
@@ -220,7 +221,7 @@ def hold_reaper(task: Task, batch_size: int = 100) -> None:
 
     if count == batch_size:
         task.log.info("There may be more holds to delete. Re-queueing the reaper.")
-        raise task.replace(hold_reaper.s(batch_size=batch_size))
+        raise task.replace(signature_with(task))
 
 
 @shared_task(queue=QueueNames.default, bind=True)
@@ -354,9 +355,7 @@ def removed_license_pool_hold_loan_reaper(task: Task, batch_size: int = 100) -> 
         task.log.info(
             "Batch size reached. There may be more items to delete. Re-queueing the reaper."
         )
-        raise task.replace(
-            removed_license_pool_hold_loan_reaper.s(batch_size=batch_size)
-        )
+        raise task.replace(signature_with(task))
 
 
 @shared_task(queue=QueueNames.default, bind=True)

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -14,6 +14,7 @@ from palace.util.exceptions import BasePalaceException
 from palace.util.log import elapsed_time_logging
 
 from palace.manager.celery.task import Task
+from palace.manager.celery.utils import signature_with
 from palace.manager.search.external_search import ExternalSearchIndex
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.redis.models.lock import TaskLock
@@ -96,9 +97,7 @@ def search_reindex(task: Task, offset: int = 0, batch_size: int = 500) -> None:
             # when this task is running in parallel on multiple workers.
             delay = random.uniform(5, 15)
             raise task.replace(
-                search_reindex.s(offset=offset + batch_size, batch_size=batch_size).set(
-                    countdown=delay
-                )
+                signature_with(task, offset=offset + batch_size).set(countdown=delay)
             )
 
     task.log.info("Finished search reindex.")
@@ -144,7 +143,7 @@ def search_indexing(task: Task, batch_size: int = 500) -> None:
     if len(works) == batch_size:
         # This task is complete, but there are more works waiting to be indexed. Requeue ourselves
         # to process the next batch.
-        raise task.replace(search_indexing.s(batch_size=batch_size))
+        raise task.replace(signature_with(task))
 
     task.log.info(f"Finished queuing indexing tasks.")
     return

--- a/src/palace/manager/celery/utils.py
+++ b/src/palace/manager/celery/utils.py
@@ -2,6 +2,11 @@
 Helper functions for use in Celery tasks
 """
 
+import inspect
+from typing import Any
+
+import celery
+from celery import Signature
 from sqlalchemy.orm import Session
 
 from palace.util.exceptions import PalaceTypeError, PalaceValueError
@@ -44,3 +49,43 @@ def validate_not_none[T](value: T | None, message: str) -> T:
     if value is None:
         raise PalaceTypeError(message)
     return value
+
+
+def signature_with(task: celery.Task, **overrides: Any) -> Signature:
+    """
+    Build a signature to re-queue the currently-running task, reusing its
+    original arguments and applying only the given overrides.
+
+    Tasks that paginate or batch their work re-queue themselves via
+    ``task.replace(...)``. Rather than re-listing every parameter in the new
+    signature (and risking silently dropping one when the signature gains a
+    parameter), this fills the unchanged parameters from the current invocation
+    (``task.request.args`` / ``task.request.kwargs``) and overrides only what
+    the caller passes.
+
+    Positional arguments are normalized to keyword arguments using the task's
+    own signature, so an override applies to the correct parameter regardless of
+    whether it was originally passed positionally or by keyword. The returned
+    signature is therefore always keyword-only.
+
+    This requires a bound task (``bind=True``), so that ``task`` is the running
+    task instance and exposes its request.
+
+    :param task: The bound, currently-running task (the ``task`` parameter of a
+        ``bind=True`` task).
+    :param overrides: Parameters whose values should change for the next run.
+    :return: A signature re-queuing the same task with the merged arguments.
+    """
+    # For a bound task, ``task.run`` is a bound method, so its signature already
+    # omits the bound ``task`` parameter and begins at the first real argument.
+    # These positional-capable names therefore map one-to-one onto request.args.
+    positional_names = [
+        name
+        for name, parameter in inspect.signature(task.run).parameters.items()
+        if parameter.kind
+        in (parameter.POSITIONAL_ONLY, parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    merged: dict[str, Any] = dict(zip(positional_names, task.request.args))
+    merged.update(task.request.kwargs)
+    merged.update(overrides)
+    return task.s(**merged)

--- a/tests/manager/celery/test_utils.py
+++ b/tests/manager/celery/test_utils.py
@@ -1,14 +1,50 @@
+from collections.abc import Generator
+from contextlib import contextmanager
+
 import pytest
+from celery import Celery
 
 from palace.util.exceptions import PalaceTypeError
 
+from palace.manager.celery.task import Task
 from palace.manager.celery.utils import (
     ModelNotFoundError,
     load_from_id,
+    signature_with,
     validate_not_none,
 )
 from palace.manager.sqlalchemy.model.collection import Collection
 from tests.fixtures.database import DatabaseTransactionFixture
+
+# A standalone Celery app and bound tasks used only to exercise
+# ``signature_with``. Using a local app (rather than the worker fixture)
+# keeps these tests fast and isolated: we just need registered bound tasks and a
+# simulated request, which we provide via ``push_request`` below.
+_signature_app = Celery("test_signature_with", task_cls=Task)
+
+
+@_signature_app.task(bind=True)
+def _sample_task(
+    task: Task, collection_id: int, batch_size: int = 100, after_id: int | None = None
+) -> None:
+    """A task whose parameters are all positional-or-keyword."""
+
+
+@_signature_app.task(bind=True)
+def _keyword_only_task(
+    task: Task, collection_id: int, *, offset: int = 0, batch_size: int = 50
+) -> None:
+    """A task with keyword-only parameters following ``*``."""
+
+
+@contextmanager
+def _running(task: Task, *args: object, **kwargs: object) -> Generator[None]:
+    """Simulate ``task`` running with the given args/kwargs in its request."""
+    task.push_request(args=args, kwargs=kwargs)
+    try:
+        yield
+    finally:
+        task.pop_request()
 
 
 class TestLoadFromId:
@@ -36,3 +72,72 @@ class TestValidateNotNone:
 
         with pytest.raises(PalaceTypeError, match="Should not be None"):
             validate_not_none(None, "Should not be None")
+
+
+class TestSignatureWith:
+    def test_keyword_args_with_override(self) -> None:
+        # Originally invoked with all arguments as keywords; overriding one
+        # leaves the rest intact.
+        with _running(_sample_task, collection_id=42, batch_size=100, after_id=7):
+            signature = signature_with(_sample_task, after_id=1234)
+
+        assert signature.task == _sample_task.name
+        assert signature.args == ()
+        assert signature.kwargs == {
+            "collection_id": 42,
+            "batch_size": 100,
+            "after_id": 1234,
+        }
+
+    def test_positional_args_with_override(self) -> None:
+        # Originally invoked positionally (as ``recalculate_hold_queue_collection``
+        # does). The override must update the right parameter by name and must not
+        # produce a duplicate positional + keyword for that parameter.
+        with _running(_sample_task, 42, 100, 999):
+            signature = signature_with(_sample_task, after_id=1234)
+
+        assert signature.args == ()
+        assert signature.kwargs == {
+            "collection_id": 42,
+            "batch_size": 100,
+            "after_id": 1234,
+        }
+
+    def test_mixed_positional_and_keyword_args(self) -> None:
+        with _running(_sample_task, 42, batch_size=50):
+            signature = signature_with(_sample_task, after_id=1234)
+
+        assert signature.args == ()
+        assert signature.kwargs == {
+            "collection_id": 42,
+            "batch_size": 50,
+            "after_id": 1234,
+        }
+
+    def test_no_overrides_reproduces_original_arguments(self) -> None:
+        with _running(_sample_task, 42, after_id=7):
+            signature = signature_with(_sample_task)
+
+        assert signature.args == ()
+        assert signature.kwargs == {"collection_id": 42, "after_id": 7}
+
+    def test_override_parameter_that_used_its_default(self) -> None:
+        # ``after_id`` was not supplied originally (it relied on its default);
+        # an override for it still lands in the signature.
+        with _running(_sample_task, collection_id=42):
+            signature = signature_with(_sample_task, after_id=1234)
+
+        assert signature.kwargs == {"collection_id": 42, "after_id": 1234}
+
+    def test_keyword_only_parameters(self) -> None:
+        # Keyword-only parameters never arrive via request.args, so they are
+        # carried through request.kwargs and remain overridable by name.
+        with _running(_keyword_only_task, 42, offset=10, batch_size=50):
+            signature = signature_with(_keyword_only_task, offset=20)
+
+        assert signature.args == ()
+        assert signature.kwargs == {
+            "collection_id": 42,
+            "offset": 20,
+            "batch_size": 50,
+        }


### PR DESCRIPTION
## Description

Adds `signature_with(task, **overrides)` to `celery/utils.py` — a helper that builds a signature for the currently-running Celery task by reusing its live invocation arguments (`request.args` / `request.kwargs`) and applying only the given overrides. Positional arguments are normalized to keyword arguments using the task's own signature, so an override applies to the correct parameter regardless of how it was originally passed, and the resulting signature never mixes a positional and keyword value for the same parameter.

The self-replacing tasks across `overdrive`, `bibliotheca`, `boundless`, `opds_odl`, `search`, `marc`, `notifications`, `reaper`, and `collection_delete` are migrated to call it, so each site now passes only the values that actually change. Values that are reassigned in the task body (e.g. `start_time`/`lock_value`/`modified_since` resolved from `None`, `last_work_id` advancing in a loop) are kept as explicit overrides, since they genuinely differ from the received arguments.

`marc_export_cleanup` is intentionally left unchanged: its no-arg `.s()` deliberately resets `batch_size` to the default, which the helper would instead preserve, and it has no pass-through arguments to forget.

## Motivation and Context

Self-replacing tasks paginate/batch by calling `task.replace(task.s(...))`, where `task.s(...)` had to re-list **every** parameter the task accepts so the next run received the full set. This is fragile: when a parameter is added to a task, every self-replace site must be updated to thread it through, and forgetting one silently drops the value (it reverts to its default on the next run). This helper removes the need to re-list pass-through parameters at all.

## How Has This Been Tested?

- New `TestSignatureWith` unit tests in `tests/manager/celery/test_utils.py` cover kwargs / positional / mixed originals, no-override, overriding a parameter that used its default, and keyword-only parameters.
- `mypy` passes.
- Full Celery task suite (`tox -e py312-docker -- tests/manager/celery/test_utils.py tests/manager/celery/tasks`) passes (325 tests), exercising the re-queue paths of every migrated task (reaper batching, multi-page import integration, overdrive reaper batching, etc.).

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
