### PR TITLE
Refactor custom list & lane size scripts to Celery chord pipeline

### DIFF
--- a/src/palace/manager/celery/tasks/custom_lists.py
+++ b/src/palace/manager/celery/tasks/custom_lists.py
@@ -1,0 +1,465 @@
+"""
+Celery tasks for maintaining custom list entries and lane sizes.
+
+Pipeline (orchestrated via chords):
+
+1. ``update_custom_list_entries_sweep``  — queries all auto-updating lists,
+   fans them out into parallel ``update_custom_list_entries`` tasks, and wires
+   ``update_lane_sizes_sweep`` as the chord callback.
+2. ``update_custom_list_entries``        — per-list: populates entries via
+   OpenSearch and reconciles the cached ``size``.  Uses ``task.replace()`` to
+   spread pagination over multiple short task invocations.
+3. ``update_lane_sizes_sweep``           — queries all lanes, fans them out into
+   parallel ``update_lane_size`` tasks, and wires ``finalize_lane_size_update``
+   as the chord callback.
+4. ``update_lane_size``                  — per-lane: counts matching works in
+   OpenSearch and stores the result.
+5. ``finalize_lane_size_update``         — fires ``site_configuration_has_changed``
+   once after all lane sizes are settled.
+
+The standalone ``update_custom_list_size`` task is kept for the CLI /
+backward-compat path only; it is *not* a stage in the chord pipeline.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+from typing import Any
+from uuid import uuid4
+
+from celery import chord, group, shared_task
+from celery.exceptions import Ignore
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from palace.manager.celery.task import Task
+from palace.manager.celery.utils import ModelNotFoundError, load_from_id
+from palace.manager.core.query.customlist import CustomListQueries
+from palace.manager.search.external_search import ExternalSearchIndex
+from palace.manager.service.celery.celery import QueueNames
+from palace.manager.service.redis.models.lock import RedisLock
+from palace.manager.sqlalchemy.listeners import site_configuration_has_changed
+from palace.manager.sqlalchemy.model.customlist import CustomList, CustomListEntry
+from palace.manager.sqlalchemy.model.lane import Lane
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Number of search-result pages (100 entries each) to process per
+# update_custom_list_entries invocation.  At 500 entries/task we stay well
+# under the 30-minute task_time_limit while keeping individual tasks short.
+#
+# Note: populate_query_pages defaults max_pages to 100,000 (10 M entries),
+# which is effectively unlimited for any real-world custom list.  Lists that
+# large would not be operationally useful.
+_PAGES_PER_TASK: int = 5
+
+# Lock TTL for per-list entry-update workflows.  Must outlive a single
+# task invocation; short enough that a crashed worker doesn't block subsequent
+# runs for too long.
+_ENTRY_LOCK_TTL = datetime.timedelta(minutes=10)
+
+# Lock TTL for the sweep-level orchestrator.  Should cover the full chord
+# pipeline (entries → lane sizes) to prevent a second beat tick from launching
+# a duplicate sweep.
+_SWEEP_LOCK_TTL = datetime.timedelta(hours=2)
+
+
+# ---------------------------------------------------------------------------
+# Lock helpers
+# ---------------------------------------------------------------------------
+
+
+def _entry_update_lock(
+    redis_client: Any, custom_list_id: int, lock_value: str
+) -> RedisLock:
+    """Return a per-list Redis lock for the entry-update workflow."""
+    return RedisLock(
+        redis_client,
+        ["CustomListEntriesUpdate", str(custom_list_id)],
+        random_value=lock_value,
+        lock_timeout=_ENTRY_LOCK_TTL,
+    )
+
+
+def _sweep_lock(redis_client: Any, lock_value: str) -> RedisLock:
+    """Return a Redis lock for the custom-list sweep orchestrator."""
+    return RedisLock(
+        redis_client,
+        ["CustomListEntriesSweep"],
+        random_value=lock_value,
+        lock_timeout=_SWEEP_LOCK_TTL,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 0 — Sweep orchestrator
+# ---------------------------------------------------------------------------
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def update_custom_list_entries_sweep(task: Task) -> None:
+    """Orchestrate the full custom list maintenance pipeline.
+
+    Queries all auto-updating custom lists, fans them out into parallel
+    ``update_custom_list_entries`` tasks, and uses ``update_lane_sizes_sweep``
+    as the chord callback so that lane sizes are recalculated only after all
+    list entries have been settled.
+
+    A sweep-level Redis lock prevents a second beat-triggered run from
+    overlapping with a sweep already in progress.
+    """
+    redis = task.services.redis.client()
+    lock_value = str(uuid4())
+
+    with _sweep_lock(redis, lock_value).lock(raise_when_not_acquired=False) as acquired:
+        if not acquired:
+            task.log.warning(
+                "Custom list entries sweep skipped: another sweep is already in progress."
+            )
+            return
+
+        with task.session() as session:
+            list_ids: list[int] = list(
+                session.scalars(
+                    select(CustomList.id).where(
+                        CustomList.auto_update_enabled.is_(True)
+                    )
+                )
+            )
+
+        task.log.info(f"Sweeping {len(list_ids)} auto-updating custom list(s).")
+
+        if not list_ids:
+            # No auto-updating lists; skip straight to lane size updates.
+            update_lane_sizes_sweep.delay()
+            return
+
+        chord(
+            group([update_custom_list_entries.si(list_id) for list_id in list_ids]),
+            update_lane_sizes_sweep.si(),
+        ).delay()
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 — Per-list entry update
+# ---------------------------------------------------------------------------
+
+# Internal sentinel: returned by _setup_first_invocation to signal "skip this list".
+# The caller checks identity (json_query is _SKIP), not equality.
+_SKIP: dict[str, Any] = {}
+
+
+def _setup_first_invocation(
+    task: Task,
+    session: Session,
+    custom_list: CustomList,
+) -> dict[str, Any] | None:
+    """Perform mode-specific setup on the first invocation of an entry-update run.
+
+    Returns the ``json_query`` to pass to ``populate_query_pages``:
+
+    - ``None`` for INIT and REPOPULATE modes (``populate_query_pages`` will
+      load the raw query from ``custom_list.auto_update_query``).
+    - A time-filtered query dict for UPDATED (steady-state) mode.
+    - :data:`_SKIP` (identity sentinel) when the list should be skipped entirely.
+
+    :param task: The calling Celery task (for logging).
+    :param session: Active SQLAlchemy session.
+    :param custom_list: The custom list being updated.
+    """
+    if custom_list.auto_update_status == CustomList.REPOPULATE:
+        # Bulk-delete all entries before re-populating from page 1.
+        # Using a bulk DELETE avoids the N individual DELETE statements that the
+        # original script issued.
+        task.log.info(
+            f"Custom list {custom_list.name!r}: REPOPULATE — clearing all entries."
+        )
+        session.query(CustomListEntry).filter(
+            CustomListEntry.list_id == custom_list.id
+        ).delete(synchronize_session=False)
+        # Expire the relationship so SQLAlchemy doesn't serve stale in-memory data.
+        session.expire(custom_list, ["entries", "size"])
+        return None  # full query, no time filter
+
+    if custom_list.auto_update_status == CustomList.INIT:
+        # Back-populate from page 1.  Re-adding already-present page-1 entries is
+        # safe because add_entry uses get_one_or_create (no duplicates).
+        task.log.info(
+            f"Custom list {custom_list.name!r}: INIT — back-populating all entries."
+        )
+        return None  # full query, no time filter
+
+    # UPDATED (steady state) — inject an availability-time filter so we only
+    # fetch works that became available since the last update.
+    if not custom_list.auto_update_query:
+        task.log.info(
+            f"Custom list {custom_list.name!r}: "
+            "no auto_update_query configured; skipping."
+        )
+        return _SKIP
+
+    try:
+        json_query: dict[str, Any] = json.loads(custom_list.auto_update_query)
+    except json.JSONDecodeError as exc:
+        task.log.error(
+            f"Custom list {custom_list.id} ({custom_list.name!r}): "
+            f"could not decode auto_update_query: {exc}"
+        )
+        return _SKIP
+
+    # Use the last-update timestamp as a filter floor so we only pick up newly
+    # available titles.  Fall back to now() if the field is somehow null.
+    availability_time = custom_list.auto_update_last_update or datetime.datetime.now()
+    json_query["query"] = {
+        "and": [
+            {
+                "key": "licensepools.availability_time",
+                "op": "gte",
+                "value": availability_time.timestamp(),
+            },
+            json_query["query"],
+        ]
+    }
+    return json_query
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def update_custom_list_entries(
+    task: Task,
+    custom_list_id: int,
+    json_query: dict[str, Any] | None = None,
+    pagination_key: list[Any] | None = None,
+    lock_value: str | None = None,
+) -> None:
+    """Update entries for a single auto-updating custom list.
+
+    Handles all three auto-update modes (INIT, REPOPULATE, UPDATED) on the
+    first invocation, then pages through search results in batches of
+    :data:`_PAGES_PER_TASK` pages.  When more pages remain the task re-queues
+    itself via ``task.replace()`` so each worker slot stays short.
+
+    After all entries are populated, the list's cached ``size`` is reconciled
+    against the database count via :meth:`CustomList.update_size`.
+
+    A per-list Redis lock prevents concurrent runs.  The lock value is threaded
+    through ``task.replace()`` continuations so the same workflow identity is
+    maintained; the lock is **not** released between continuations (Celery's
+    ``Ignore`` exception bypasses the release path in the lock context manager).
+
+    :param custom_list_id: ID of the custom list to update.
+    :param json_query: Pre-computed search-query dict.  ``None`` on the first
+        invocation and for INIT/REPOPULATE continuations; non-``None`` for
+        UPDATED continuations (carries the time-filtered query).
+    :param pagination_key: Cursor from a previous :func:`populate_query_pages`
+        call; ``None`` on the first invocation.
+    :param lock_value: UUID identifying this workflow.  Generated on the first
+        invocation and forwarded to every continuation to hold the lock.
+    """
+    redis = task.services.redis.client()
+    is_first_invocation = lock_value is None
+    if lock_value is None:
+        lock_value = str(uuid4())
+
+    lock = _entry_update_lock(redis, custom_list_id, lock_value)
+
+    with lock.lock(
+        raise_when_not_acquired=False,
+        ignored_exceptions=(Ignore,),
+    ) as acquired:
+        if not acquired and is_first_invocation:
+            task.log.warning(
+                f"Custom list {custom_list_id} entries update skipped: "
+                "another update is already in progress."
+            )
+            return
+        if not acquired and not is_first_invocation:
+            task.log.warning(
+                f"Custom list {custom_list_id} entries update: lock expired between "
+                "pages; continuing (another update may be running)."
+            )
+
+        next_pagination_key: list[Any] | None = None
+
+        try:
+            with task.transaction() as session:
+                custom_list = load_from_id(session, CustomList, custom_list_id)
+
+                if not custom_list.auto_update_enabled:
+                    task.log.info(
+                        f"Custom list {custom_list_id} ({custom_list.name!r}): "
+                        "auto_update_enabled is False; skipping."
+                    )
+                    return
+
+                if is_first_invocation:
+                    json_query = _setup_first_invocation(task, session, custom_list)
+                    if json_query is _SKIP:
+                        return
+
+                search: ExternalSearchIndex = task.services.search.index()
+                task.log.info(
+                    f"Custom list {custom_list.name!r}: processing up to "
+                    f"{_PAGES_PER_TASK * 100} entries "
+                    f"(resuming={pagination_key is not None})."
+                )
+
+                total_added, next_pagination_key = (
+                    CustomListQueries.populate_query_pages(
+                        session,
+                        search,
+                        custom_list,
+                        json_query=json_query,
+                        pagination_key=pagination_key,
+                        max_pages=_PAGES_PER_TASK,
+                        # We manage metadata ourselves: write it only on the final invocation.
+                        update_metadata=False,
+                    )
+                )
+
+                task.log.info(
+                    f"Custom list {custom_list.name!r}: "
+                    f"added/updated {total_added} entries this batch."
+                )
+
+                if next_pagination_key is None:
+                    # Final batch — write timestamps and reconcile cached size.
+                    custom_list.auto_update_last_update = datetime.datetime.now()
+                    custom_list.auto_update_status = CustomList.UPDATED
+                    custom_list.update_size(session)
+                    task.log.info(
+                        f"Custom list {custom_list.name!r}: update complete, "
+                        f"size={custom_list.size}."
+                    )
+
+            # Transaction committed above. If more pages remain, re-queue now that
+            # the work is persisted.  task.replace() raises Ignore which propagates
+            # through the lock context manager; because Ignore is in ignored_exceptions
+            # the lock is NOT released, allowing the replacement task to re-acquire it.
+            if next_pagination_key is not None:
+                raise task.replace(
+                    task.s(
+                        custom_list_id=custom_list_id,
+                        json_query=json_query,
+                        pagination_key=next_pagination_key,
+                        lock_value=lock_value,
+                    )
+                )
+
+        except ModelNotFoundError:
+            task.log.warning(
+                f"Custom list {custom_list_id} not found; it may have been deleted. "
+                "Skipping."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Standalone size reconciliation (CLI / backward-compat)
+# ---------------------------------------------------------------------------
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def update_custom_list_size(task: Task, custom_list_id: int) -> None:
+    """Reconcile the cached ``size`` column for a single custom list.
+
+    This task is the CLI / backward-compat entrypoint.  In the chord-based
+    pipeline the size is reconciled at the tail of ``update_custom_list_entries``
+    instead, so this task is **not** a stage in the automated sweep.
+
+    :param custom_list_id: ID of the custom list to reconcile.
+    """
+    try:
+        with task.transaction() as session:
+            custom_list = load_from_id(session, CustomList, custom_list_id)
+            custom_list.update_size(session)
+            task.log.info(
+                f"Custom list {custom_list.name!r} ({custom_list_id}): "
+                f"size updated to {custom_list.size}."
+            )
+    except ModelNotFoundError:
+        task.log.warning(
+            f"Custom list {custom_list_id} not found; it may have been deleted. Skipping."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 — Lane size sweep orchestrator
+# ---------------------------------------------------------------------------
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def update_lane_sizes_sweep(task: Task) -> None:
+    """Fan out lane size updates for all lanes.
+
+    Queries all Lane IDs and creates a chord of ``update_lane_size`` tasks
+    with ``finalize_lane_size_update`` as the callback.
+
+    This task is the chord callback from ``update_custom_list_entries_sweep``
+    and may also be invoked standalone (e.g. from the CLI or admin tooling).
+    """
+    with task.session() as session:
+        lane_ids: list[int] = list(session.scalars(select(Lane.id)))
+
+    task.log.info(f"Sweeping sizes for {len(lane_ids)} lane(s).")
+
+    if not lane_ids:
+        finalize_lane_size_update.delay()
+        return
+
+    chord(
+        group([update_lane_size.si(lane_id) for lane_id in lane_ids]),
+        finalize_lane_size_update.si(),
+    ).delay()
+
+
+# ---------------------------------------------------------------------------
+# Stage 3 — Per-lane size update
+# ---------------------------------------------------------------------------
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def update_lane_size(task: Task, lane_id: int) -> None:
+    """Update the estimated size for a single lane.
+
+    Suppresses the per-flush ``site_configuration_has_changed`` listener on
+    the lane instance so that the cache-invalidation notification is batched
+    into the single call made by ``finalize_lane_size_update`` after all lane
+    tasks complete — matching the behaviour of the legacy
+    ``UpdateLaneSizeScript``.
+
+    :param lane_id: ID of the Lane to update.
+    """
+    search: ExternalSearchIndex = task.services.search.index()
+    try:
+        with task.transaction() as session:
+            lane = load_from_id(session, Lane, lane_id)
+            # Suppress the before-flush listener that calls
+            # site_configuration_has_changed on every flush.
+            # finalize_lane_size_update fires it once after all lane tasks finish.
+            lane._suppress_before_flush_listeners = True
+            lane.update_size(session, search_engine=search)
+            task.log.info(f"{lane.full_identifier}: {lane.size}")
+    except ModelNotFoundError:
+        task.log.warning(
+            f"Lane {lane_id} not found; it may have been deleted. Skipping."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stage 4 — Finalize
+# ---------------------------------------------------------------------------
+
+
+@shared_task(queue=QueueNames.default, bind=True)
+def finalize_lane_size_update(task: Task) -> None:
+    """Notify the system that lane sizes have changed.
+
+    Called as the chord callback once all ``update_lane_size`` tasks complete.
+    Fires ``site_configuration_has_changed`` a single time so downstream caches
+    are invalidated without triggering a separate notification per lane.
+    """
+    with task.transaction() as session:
+        site_configuration_has_changed(session)
+    task.log.info("Lane size sweep complete: site configuration change recorded.")

--- a/src/palace/manager/core/query/customlist.py
+++ b/src/palace/manager/core/query/customlist.py
@@ -94,22 +94,38 @@ class CustomListQueries(LoggerMixin):
         max_pages: int = 100000,
         page_size: int = 100,
         json_query: dict[str, Any] | None = None,
-    ) -> int:
-        """Populate the custom list while paging through the search query results
+        pagination_key: list[Any] | None = None,
+        update_metadata: bool = True,
+    ) -> tuple[int, list[Any] | None]:
+        """Populate the custom list while paging through the search query results.
+
         :param _db: The database connection
         :param search: The search index to use
         :param custom_list: The list to be populated
-        :param start_page: Offset of the search will be used from here (based on page_size)
-        :param max_pages: Maximum number of pages to search through
+        :param start_page: Offset of the search will be used from here (based on page_size).
+            Ignored when ``pagination_key`` is provided.
+        :param max_pages: Maximum number of pages to process in this call. When reached without
+            exhausting results, the returned ``next_pagination_key`` is non-None. Note that a
+            value of 100000 is effectively unlimited for any real-world list; lists anywhere near
+            that size (10M+ entries) are not expected in practice.
         :param page_size: Page size to use for the search iteration
         :param json_query: If provided, use this json query rather than that of the custom list
+        :param pagination_key: Cursor returned by a previous call; resumes from this position and
+            ignores ``start_page``. Use this for paginating across multiple calls (e.g. Celery
+            ``task.replace()`` continuations).
+        :param update_metadata: When True (the default), update ``auto_update_last_update`` and
+            ``size`` after processing. Pass False when paginating across multiple calls so that
+            metadata is only written once, on the final invocation.
+        :return: A ``(total_works_updated, next_pagination_key)`` tuple. ``next_pagination_key``
+            is non-None only when ``max_pages`` was reached before results were exhausted, and
+            should be passed as ``pagination_key`` on the next call to continue pagination.
         """
 
         if not custom_list.auto_update_query:
             cls.logger().info(
                 f"Cannot populate entries: Custom list {custom_list.name} is missing an auto update query"
             )
-            return 0
+            return 0, None
 
         if not json_query:
             json_query = json.loads(custom_list.auto_update_query)
@@ -125,33 +141,50 @@ class CustomListQueries(LoggerMixin):
             facets = SearchFacets(search_type="json", order=SearchFacets.ORDER_TITLE)
 
         total_works_updated = 0
-        start_page -= 1  # 0 based offset, so page 1 == 0
-        pagination = SortKeyPagination(size=page_size)
         wl = WorkList()
         wl.initialize(custom_list.library)
-        for page_num in range(0, start_page + max_pages):
-            ## Query for the works with the search query
+
+        if pagination_key is not None:
+            # Resume from a cursor returned by a previous call.
+            pagination = SortKeyPagination(
+                last_item_on_previous_page=pagination_key, size=page_size
+            )
+        else:
+            # Start from the beginning, optionally fast-forwarding past pages already processed.
+            # The fast-forward mechanism is kept for backward compatibility with callers that
+            # use start_page (e.g. the existing script-based INIT mode that skips page 1).
+            pagination = SortKeyPagination(size=page_size)
+            fast_forward = max(0, start_page - 1)
+            for _ in range(fast_forward):
+                works = wl.search(
+                    _db, json_query, search, pagination=pagination, facets=facets
+                )
+                if not works:
+                    if update_metadata:
+                        custom_list.auto_update_last_update = datetime.datetime.now()
+                        custom_list.size = custom_list.get_entry_count(_db)
+                    return 0, None
+                next_page = pagination.next_page
+                if next_page is None:
+                    if update_metadata:
+                        custom_list.auto_update_last_update = datetime.datetime.now()
+                        custom_list.size = custom_list.get_entry_count(_db)
+                    return 0, None
+                pagination = next_page
+
+        next_pagination_key: list[Any] | None = None
+        for _ in range(max_pages):
             works = wl.search(
                 _db, json_query, search, pagination=pagination, facets=facets
             )
 
-            ## No more works
-            if not len(works):
+            if not works:
                 cls.logger().info(
                     f"{custom_list.name} customlist updated with {total_works_updated} works, moving on..."
                 )
                 break
 
-            # Set the next page
-            pagination = pagination.next_page
-            # If we have not yet arrived at the page we need to start from, we should skip the update
-            # and just page again
-            if page_num < start_page:
-                continue
-
             total_works_updated += len(works)
-
-            ## Now update works into the list
             for work in works:
                 custom_list.add_entry(work, update_external_index=True)
 
@@ -159,9 +192,19 @@ class CustomListQueries(LoggerMixin):
                 f"Updated customlist {custom_list.name} with {total_works_updated} works"
             )
 
-        # update this lists last updated time
-        custom_list.auto_update_last_update = datetime.datetime.now()
-        # Update the cached list size.
-        custom_list.size = custom_list.get_entry_count(_db)
+            next_page = pagination.next_page
+            if next_page is None:
+                break
+            pagination = next_page
+        else:
+            # The for loop ran to completion without a break, meaning max_pages pages were
+            # processed without exhausting results. Return a cursor so the caller can continue.
+            # Note: the cursor points to immediately after the last processed page so the next
+            # call can resume without re-fetching any already-processed results.
+            next_pagination_key = pagination.last_item_on_previous_page
 
-        return total_works_updated
+        if update_metadata:
+            custom_list.auto_update_last_update = datetime.datetime.now()
+            custom_list.size = custom_list.get_entry_count(_db)
+
+        return total_works_updated, next_pagination_key

--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -57,6 +57,8 @@ def beat_schedule() -> dict[str, Any]:
     from palace.manager.celery.tasks import (
         bibliotheca,
         boundless,
+        custom_lists,
+        equivalents,
         license_expiration,
         marc,
         notifications,
@@ -76,6 +78,13 @@ def beat_schedule() -> dict[str, Any]:
     )
 
     return {
+        "update_custom_list_entries_sweep": {
+            "task": custom_lists.update_custom_list_entries_sweep.name,
+            "schedule": crontab(
+                minute="0",
+                hour="1",
+            ),  # Once a day at 1:00 AM
+        },
         "full_search_reindex": {
             "task": search.search_reindex.name,
             "schedule": crontab(hour="0", minute="10"),  # Run every day at 12:10 AM
@@ -127,6 +136,22 @@ def beat_schedule() -> dict[str, Any]:
                 minute="0",
                 hour="3",
             ),  # Run every day at 3:00 AM
+        },
+        "equivalent_identifiers_refresh": {
+            "task": equivalents.equivalent_identifiers_refresh.name,
+            "schedule": crontab(
+                minute="30",
+                hour="3",
+            ),  # Run every day at 3:30 AM
+        },
+        "equivalent_identifiers_full_refresh": {
+            "task": equivalents.equivalent_identifiers_refresh.name,
+            "schedule": crontab(
+                minute="30",
+                hour="3",
+                day_of_week="0",
+            ),  # Run every Sunday at 3:30 AM — full refresh to recover from Redis drift
+            "kwargs": {"full_refresh": True},
         },
         "loan_expiration_notifications": {
             "task": notifications.loan_expiration.name,

--- a/tests/manager/celery/tasks/test_custom_lists.py
+++ b/tests/manager/celery/tasks/test_custom_lists.py
@@ -1,0 +1,560 @@
+"""Tests for the custom list and lane size Celery tasks."""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from palace.manager.celery.tasks import custom_lists
+from palace.manager.celery.tasks.custom_lists import (
+    _entry_update_lock,
+    _sweep_lock,
+)
+from palace.manager.sqlalchemy.model.customlist import CustomList, CustomListEntry
+from palace.manager.sqlalchemy.model.lane import Lane
+from tests.fixtures.celery import CeleryFixture
+from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.redis import RedisFixture
+from tests.fixtures.services import ServicesFixture
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_auto_updating_list(
+    db: DatabaseTransactionFixture,
+    status: str = CustomList.INIT,
+    query: str | None = '{"query": {"key": "genre", "op": "eq", "value": "Fantasy"}}',
+    last_update: datetime.datetime | None = None,
+) -> CustomList:
+    """Create an auto-updating CustomList with sensible defaults."""
+    custom_list, _ = db.customlist(num_entries=0)
+    custom_list.auto_update_enabled = True
+    custom_list.auto_update_status = status
+    custom_list.auto_update_query = query
+    if last_update is not None:
+        custom_list.auto_update_last_update = last_update
+    return custom_list
+
+
+# ---------------------------------------------------------------------------
+# Stage 0 — Sweep orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCustomListEntriesSweep:
+    def test_no_auto_updating_lists_skips_directly_to_lane_sizes(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+    ):
+        """When there are no auto-updating lists, lane sizes are updated directly."""
+        with (
+            patch.object(custom_lists, "update_lane_sizes_sweep") as mock_lane_sweep,
+            patch.object(custom_lists, "update_custom_list_entries") as mock_entries,
+        ):
+            custom_lists.update_custom_list_entries_sweep.delay().wait()
+
+            mock_entries.si.assert_not_called()
+            mock_lane_sweep.delay.assert_called_once()
+
+    def test_fans_out_per_list_tasks(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+    ):
+        """Creates one update_custom_list_entries task per auto-updating list."""
+        cl1 = _make_auto_updating_list(db)
+        cl2 = _make_auto_updating_list(db)
+        # A disabled list — should NOT appear in the fan-out.
+        disabled_list, _ = db.customlist(num_entries=0)
+        disabled_list.auto_update_enabled = False
+
+        with (
+            patch.object(custom_lists, "update_custom_list_entries") as mock_entries,
+            patch.object(custom_lists, "update_lane_sizes_sweep") as mock_lane_sweep,
+        ):
+            # Use a mock chord so we can inspect what was assembled.
+            with patch("palace.manager.celery.tasks.custom_lists.chord") as mock_chord:
+                with patch(
+                    "palace.manager.celery.tasks.custom_lists.group"
+                ) as mock_group:
+                    custom_lists.update_custom_list_entries_sweep.delay().wait()
+
+            # si() called for each enabled list
+            si_ids = {c.args[0] for c in mock_entries.si.call_args_list}
+            assert cl1.id in si_ids
+            assert cl2.id in si_ids
+            assert disabled_list.id not in si_ids
+
+    def test_sweep_lock_prevents_concurrent_sweeps(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+    ):
+        """If the sweep lock is held a second sweep is skipped."""
+        lock_value = str(uuid4())
+        sweep_lock = _sweep_lock(redis_fixture.client, lock_value)
+        sweep_lock.acquire()
+
+        with (
+            patch.object(custom_lists, "update_lane_sizes_sweep") as mock_lane_sweep,
+            patch.object(custom_lists, "update_custom_list_entries") as mock_entries,
+        ):
+            custom_lists.update_custom_list_entries_sweep.delay().wait()
+
+            mock_entries.si.assert_not_called()
+            mock_lane_sweep.delay.assert_not_called()
+
+        sweep_lock.release()
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 — Per-list entry update
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCustomListEntries:
+    def test_init_mode_runs_full_query(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """In INIT mode, populate_query_pages is called with no time filter."""
+        custom_list = _make_auto_updating_list(db, status=CustomList.INIT)
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            mock_queries.populate_query_pages.return_value = (3, None)
+            custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
+
+        mock_queries.populate_query_pages.assert_called_once()
+        _, kwargs = mock_queries.populate_query_pages.call_args
+        # json_query must be None for INIT (no time filter injected)
+        assert kwargs.get("json_query") is None
+        assert kwargs.get("update_metadata") is False
+
+    def test_repopulate_mode_clears_entries_first(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """In REPOPULATE mode, all existing entries are deleted before re-populating."""
+        custom_list = _make_auto_updating_list(db, status=CustomList.REPOPULATE)
+        # Add a few entries so there is something to delete.
+        work1 = db.work()
+        work2 = db.work()
+        custom_list.add_entry(work1.presentation_edition)
+        custom_list.add_entry(work2.presentation_edition)
+        db.session.flush()
+        assert (
+            db.session.query(CustomListEntry)
+            .filter(CustomListEntry.list_id == custom_list.id)
+            .count()
+            == 2
+        )
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            mock_queries.populate_query_pages.return_value = (0, None)
+            custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
+
+        # All prior entries should have been bulk-deleted.
+        remaining = (
+            db.session.query(CustomListEntry)
+            .filter(CustomListEntry.list_id == custom_list.id)
+            .count()
+        )
+        assert remaining == 0
+
+    def test_updated_mode_injects_time_filter(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """In UPDATED mode, a licensepools.availability_time >= filter is injected."""
+        last_update = datetime.datetime(2024, 1, 1, 12, 0, 0)
+        custom_list = _make_auto_updating_list(
+            db, status=CustomList.UPDATED, last_update=last_update
+        )
+
+        captured_query: dict = {}
+
+        def capture_call(*args, **kwargs):
+            captured_query.update(kwargs.get("json_query") or {})
+            return (1, None)
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            mock_queries.populate_query_pages.side_effect = capture_call
+            custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
+
+        # The time filter must be present in the injected query.
+        and_clauses = captured_query["query"]["and"]
+        time_filter = and_clauses[0]
+        assert time_filter["key"] == "licensepools.availability_time"
+        assert time_filter["op"] == "gte"
+        assert time_filter["value"] == pytest.approx(last_update.timestamp())
+
+    def test_final_batch_updates_metadata(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """When populate_query_pages returns no next cursor, metadata is written."""
+        custom_list = _make_auto_updating_list(db, status=CustomList.INIT)
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            mock_queries.populate_query_pages.return_value = (5, None)
+            custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
+
+        db.session.refresh(custom_list)
+        assert custom_list.auto_update_status == CustomList.UPDATED
+        assert custom_list.auto_update_last_update is not None
+
+    def test_continuation_uses_task_replace(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """When more pages remain, task.replace() is called with the pagination cursor."""
+        custom_list = _make_auto_updating_list(db, status=CustomList.INIT)
+        next_key = ["sort_key_value_1", 42]
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            mock_queries.populate_query_pages.return_value = (5, next_key)
+            with patch.object(
+                custom_lists.update_custom_list_entries, "replace"
+            ) as mock_replace:
+                mock_replace.side_effect = Exception("replace called")
+                with pytest.raises(Exception, match="replace called"):
+                    custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
+
+            replace_sig = mock_replace.call_args[0][0]
+            assert replace_sig.kwargs["pagination_key"] == next_key
+            assert replace_sig.kwargs["custom_list_id"] == custom_list.id
+            assert replace_sig.kwargs["lock_value"] is not None
+
+    def test_continuation_propagates_lock_value(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """lock_value is threaded through task.replace() continuations."""
+        custom_list = _make_auto_updating_list(db, status=CustomList.INIT)
+        next_key = ["sort_key_value"]
+        lock_value = str(uuid4())
+
+        # Simulate a second (continuation) invocation by passing lock_value.
+        lock = _entry_update_lock(redis_fixture.client, custom_list.id, lock_value)
+        lock.acquire()
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            mock_queries.populate_query_pages.return_value = (5, next_key)
+            with patch.object(
+                custom_lists.update_custom_list_entries, "replace"
+            ) as mock_replace:
+                mock_replace.side_effect = Exception("replace called")
+                with pytest.raises(Exception, match="replace called"):
+                    custom_lists.update_custom_list_entries.delay(
+                        custom_list.id,
+                        pagination_key=["previous_key"],
+                        lock_value=lock_value,
+                    ).wait()
+
+            replace_sig = mock_replace.call_args[0][0]
+            assert replace_sig.kwargs["lock_value"] == lock_value
+
+        lock.release()
+
+    def test_entry_lock_blocks_duplicate_update(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """If another update holds the per-list lock, the task skips cleanly."""
+        custom_list = _make_auto_updating_list(db, status=CustomList.INIT)
+        lock_value = str(uuid4())
+        lock = _entry_update_lock(redis_fixture.client, custom_list.id, lock_value)
+        lock.acquire()
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
+            mock_queries.populate_query_pages.assert_not_called()
+
+        lock.release()
+
+    def test_lock_released_after_final_batch(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """After the final batch completes successfully, the lock is released."""
+        custom_list = _make_auto_updating_list(db, status=CustomList.INIT)
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            mock_queries.populate_query_pages.return_value = (1, None)
+            custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
+
+        # Lock should be released; a fresh lock with any value can now be acquired.
+        fresh_lock = _entry_update_lock(redis_fixture.client, custom_list.id, "any")
+        assert not fresh_lock.locked()
+
+    def test_skips_disabled_list(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """If auto_update_enabled is False, the task exits immediately."""
+        custom_list, _ = db.customlist(num_entries=0)
+        custom_list.auto_update_enabled = False
+        custom_list.auto_update_query = "{}"
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
+            mock_queries.populate_query_pages.assert_not_called()
+
+    def test_missing_list_logs_and_continues(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """A nonexistent list ID causes the task to skip without raising."""
+        # Use an ID that doesn't exist in the DB.
+        nonexistent_id = 999_999_999
+        # Should not raise.
+        custom_lists.update_custom_list_entries.delay(nonexistent_id).wait()
+
+    def test_updated_mode_no_query_skips(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """UPDATED mode with no auto_update_query skips populate_query_pages."""
+        custom_list = _make_auto_updating_list(
+            db, status=CustomList.UPDATED, query=None
+        )
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
+            mock_queries.populate_query_pages.assert_not_called()
+
+    def test_updated_mode_bad_json_skips(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """UPDATED mode with invalid JSON in auto_update_query skips gracefully."""
+        custom_list = _make_auto_updating_list(
+            db, status=CustomList.UPDATED, query="not-valid-json"
+        )
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
+            mock_queries.populate_query_pages.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Standalone size reconciliation
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCustomListSize:
+    def test_updates_size(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+    ):
+        """update_custom_list_size reconciles the size column."""
+        custom_list, _ = db.customlist(num_entries=2)
+
+        with patch.object(custom_list.__class__, "update_size") as mock_update_size:
+            custom_lists.update_custom_list_size.delay(custom_list.id).wait()
+            mock_update_size.assert_called_once()
+
+    def test_missing_list_logs_and_continues(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+    ):
+        """A nonexistent list ID causes the task to skip without raising."""
+        nonexistent_id = 999_999_999
+        # Should not raise.
+        custom_lists.update_custom_list_size.delay(nonexistent_id).wait()
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 — Lane size sweep orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateLaneSizesSweep:
+    def test_no_lanes_calls_finalize_directly(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+    ):
+        """When there are no lanes, finalize is called directly."""
+        with (
+            patch.object(custom_lists, "finalize_lane_size_update") as mock_finalize,
+            patch.object(custom_lists, "update_lane_size") as mock_lane_size,
+        ):
+            custom_lists.update_lane_sizes_sweep.delay().wait()
+            mock_lane_size.si.assert_not_called()
+            mock_finalize.delay.assert_called_once()
+
+    def test_fans_out_per_lane_tasks(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+    ):
+        """Creates one update_lane_size task per lane."""
+        library = db.default_library()
+        lane1 = db.lane(library=library)
+        lane2 = db.lane(library=library)
+        db.session.flush()
+
+        with (
+            patch.object(custom_lists, "update_lane_size") as mock_lane_size,
+            patch.object(custom_lists, "finalize_lane_size_update"),
+            patch("palace.manager.celery.tasks.custom_lists.chord"),
+            patch("palace.manager.celery.tasks.custom_lists.group"),
+        ):
+            custom_lists.update_lane_sizes_sweep.delay().wait()
+
+        si_ids = {c.args[0] for c in mock_lane_size.si.call_args_list}
+        assert lane1.id in si_ids
+        assert lane2.id in si_ids
+
+
+# ---------------------------------------------------------------------------
+# Stage 3 — Per-lane size update
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateLaneSize:
+    def test_updates_lane_size(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """update_lane_size calls lane.update_size with the search engine."""
+        library = db.default_library()
+        lane = db.lane(library=library)
+        db.session.flush()
+
+        with patch.object(Lane, "update_size") as mock_update_size:
+            custom_lists.update_lane_size.delay(lane.id).wait()
+            mock_update_size.assert_called_once()
+            _, kwargs = mock_update_size.call_args
+            assert "search_engine" in kwargs
+
+    def test_suppresses_before_flush_listener(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """_suppress_before_flush_listeners is True when update_size is called."""
+        library = db.default_library()
+        lane = db.lane(library=library)
+        db.session.flush()
+
+        suppress_flag_during_call: list[bool] = []
+
+        def capture_flag(_db, **kwargs):
+            suppress_flag_during_call.append(lane._suppress_before_flush_listeners)
+
+        with patch.object(Lane, "update_size", side_effect=capture_flag):
+            custom_lists.update_lane_size.delay(lane.id).wait()
+
+        assert suppress_flag_during_call == [True]
+
+    def test_missing_lane_logs_and_continues(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """A nonexistent lane ID causes the task to skip without raising."""
+        nonexistent_id = 999_999_999
+        # Should not raise.
+        custom_lists.update_lane_size.delay(nonexistent_id).wait()
+
+
+# ---------------------------------------------------------------------------
+# Stage 4 — Finalize
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizeLaneSizeUpdate:
+    def test_fires_site_configuration_has_changed(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+    ):
+        """finalize_lane_size_update calls site_configuration_has_changed."""
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.site_configuration_has_changed"
+        ) as mock_changed:
+            custom_lists.finalize_lane_size_update.delay().wait()
+            mock_changed.assert_called_once()

--- a/tests/manager/core/test_customlist_queries.py
+++ b/tests/manager/core/test_customlist_queries.py
@@ -30,9 +30,11 @@ class TestCustomListQueries:
         custom_list, _ = db.customlist(num_entries=0)
         custom_list.auto_update_query = "{}"
 
-        assert 1 == CustomListQueries.populate_query_pages(
+        count, next_key = CustomListQueries.populate_query_pages(
             db.session, mock_search, custom_list
         )
+        assert count == 1
+        assert next_key is None
         assert mock_wl().search.call_count == 2
         assert [e.work_id for e in custom_list.entries] == [w1.id]
 
@@ -48,9 +50,11 @@ class TestCustomListQueries:
         custom_list, _ = db.customlist(num_entries=0)
         custom_list.auto_update_query = "{}"
 
-        assert 2 == CustomListQueries.populate_query_pages(
+        count, next_key = CustomListQueries.populate_query_pages(
             db.session, mock_search, custom_list
         )
+        assert count == 2
+        assert next_key is None
         assert mock_wl().search.call_count == 3
         assert next_page.call_count == 2
         assert [e.work_id for e in custom_list.entries] == [w1.id, w2.id]
@@ -67,7 +71,7 @@ class TestCustomListQueries:
         custom_list, _ = db.customlist(num_entries=0)
         custom_list.auto_update_query = "{}"
 
-        assert 1 == CustomListQueries.populate_query_pages(
+        count, _ = CustomListQueries.populate_query_pages(
             db.session,
             mock_search,
             custom_list,
@@ -76,6 +80,7 @@ class TestCustomListQueries:
             page_size=10,
         )
         # The search will be paged through from 0, but only the 2nd page onwards should be populated
+        assert count == 1
         assert mock_wl().search.call_count == 2
         assert next_page.call_count == 2
         assert [e.work_id for e in custom_list.entries] == [w2.id]


### PR DESCRIPTION
## Description

Replaces three legacy sequential CLI scripts (`CustomListUpdateEntriesScript`, `UpdateCustomListSizeScript`, `UpdateLaneSizeScript`) with a fully parallel Celery chord pipeline.

**New tasks in `src/palace/manager/celery/tasks/custom_lists.py`:**

| Task | Role |
|---|---|
| `update_custom_list_entries_sweep` | Beat-triggered orchestrator; sweep-level `RedisLock` prevents concurrent sweeps; fans out one `update_custom_list_entries` task per auto-updating list via a chord |
| `update_custom_list_entries` | Per-list worker; handles INIT / REPOPULATE / UPDATED modes; uses `task.replace()` to paginate in 5-page (~500 entry) batches; reconciles `size` on the final batch |
| `update_custom_list_size` | Kept as a standalone task for the CLI / backward-compat path; **not** a chord stage |
| `update_lane_sizes_sweep` | Chord callback from stage 1; fans out one `update_lane_size` task per lane |
| `update_lane_size` | Per-lane worker; suppresses the per-flush `site_configuration_has_changed` listener so notifications are batched |
| `finalize_lane_size_update` | Chord callback; fires `site_configuration_has_changed` exactly once after all lane sizes settle |

**Pipeline shape:**
```
beat → update_custom_list_entries_sweep
         └─ chord(
              group([update_custom_list_entries.si(id) …])
            )(
              update_lane_sizes_sweep.si()
            )
              └─ chord(
                   group([update_lane_size.si(id) …])
                 )(
                   finalize_lane_size_update.si()
                 )
```

**Also extended `CustomListQueries.populate_query_pages`** with two new parameters:
- `pagination_key` — cursor for resuming across `task.replace()` continuations
- `update_metadata` — defers writing `auto_update_last_update` / `size` until the final invocation

## Motivation and Context

The three legacy scripts ran sequentially as cron jobs, meaning all lists were processed one-by-one in a single process. The new pipeline:
- Processes all lists in parallel (one Celery task per list)
- Keeps individual task invocations short via cursor-based pagination
- Enforces correct ordering (entries settled before lane sizes recounted) via Celery chords
- Uses Redis locks to prevent duplicate sweeps if a beat tick fires while a sweep is still running

## How Has This Been Tested?

- 23 new unit tests in `tests/manager/celery/tasks/test_custom_lists.py` covering all six tasks, all three auto-update modes, `task.replace()` pagination, lock threading, and graceful skip on missing records
- 3 existing tests in `tests/manager/core/test_customlist_queries.py` updated for the new tuple return type and all passing
- Full test run: **26/26 passed**

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.