### PR TITLE
Make date-boundary tests deterministic with freezegun

### DIFF
--- a/tests/fixtures/announcements.py
+++ b/tests/fixtures/announcements.py
@@ -1,6 +1,8 @@
 import datetime
+from collections.abc import Generator
 
 import pytest
+from freezegun import freeze_time
 from sqlalchemy.orm import Session
 
 from palace.manager.sqlalchemy.model.announcements import Announcement, AnnouncementData
@@ -10,13 +12,21 @@ from palace.manager.sqlalchemy.model.library import Library
 class AnnouncementFixture:
     """A fixture for tests that need to create announcements."""
 
-    # Create raw data to be used in tests.
     format = "%Y-%m-%d"
-    today: datetime.date = datetime.date.today()
-    yesterday = today - datetime.timedelta(days=1)
-    tomorrow = today + datetime.timedelta(days=1)
-    a_week_ago = today - datetime.timedelta(days=7)
-    in_a_week = today + datetime.timedelta(days=7)
+
+    def __init__(self) -> None:
+        # Capture the dates relative to "today" when the fixture is
+        # instantiated. The ``announcement_fixture`` below freezes the
+        # clock for the duration of the test, so these match the
+        # ``datetime.date.today()`` calls the model and validator make at
+        # runtime -- without that, a test running across the midnight UTC
+        # boundary would compute its expectations against one date and the
+        # code under test against the next.
+        self.today = datetime.date.today()
+        self.yesterday = self.today - datetime.timedelta(days=1)
+        self.tomorrow = self.today + datetime.timedelta(days=1)
+        self.a_week_ago = self.today - datetime.timedelta(days=7)
+        self.in_a_week = self.today + datetime.timedelta(days=7)
 
     def create_announcement(
         self,
@@ -76,5 +86,9 @@ class AnnouncementFixture:
 
 
 @pytest.fixture(scope="function")
-def announcement_fixture() -> AnnouncementFixture:
-    return AnnouncementFixture()
+def announcement_fixture() -> Generator[AnnouncementFixture]:
+    # Freeze the clock so the fixture's dates and the runtime
+    # ``datetime.date.today()`` calls in the model and validator agree,
+    # even when the test runs across the midnight UTC boundary.
+    with freeze_time():
+        yield AnnouncementFixture()

--- a/tests/manager/api/admin/controller/test_dashboard.py
+++ b/tests/manager/api/admin/controller/test_dashboard.py
@@ -5,6 +5,7 @@ from typing import cast
 from unittest import mock
 
 import pytest
+from freezegun import freeze_time
 
 from palace.manager.api.local_analytics_exporter import LocalAnalyticsExporter
 from palace.manager.sqlalchemy.model.circulationevent import CirculationEvent
@@ -38,6 +39,10 @@ def dashboard_fixture(controller_fixture: ControllerFixture) -> DashboardFixture
 
 
 class TestDashboardController:
+    # Freeze the clock at midday so the event created at ``now() - 1 minute``
+    # and the "current day" the controller queries for can't land on
+    # different dates when the test happens to run near midnight.
+    @freeze_time("2024-01-01 12:00:00")
     def test_bulk_circulation_events(self, dashboard_fixture: DashboardFixture):
         [lp] = dashboard_fixture.english_1.license_pools
         edition = dashboard_fixture.english_1.presentation_edition


### PR DESCRIPTION
## Description

Make the announcement and dashboard tests deterministic so they no longer fail when CI happens to run across the midnight UTC boundary.

`AnnouncementFixture` captured `today`/`yesterday`/`tomorrow`/`a_week_ago`/`in_a_week` as class attributes evaluated at *import* time, while the model (`announcements.py`) and validator (`announcement_list_validator.py`) call `datetime.date.today()` at *runtime*. When the import landed on one date and the test executed on the next, expectations and code-under-test disagreed. These dates are now instance attributes, and the `announcement_fixture` freezes the clock for the duration of each test so both sides read the same date.

`test_bulk_circulation_events` creates a `CirculationEvent` at `now() - 1 minute` and then queries for events on the "current day"; within a minute of midnight the event lands on the previous day. It's now frozen at midday.

## Motivation and Context

The boto3 dependabot PR (#3428) failed CI purely because the run started at `2026-06-03T00:06:14Z` — six minutes past midnight UTC — and these three time-of-day-sensitive tests broke at the date boundary. The change under test was innocent; the tests were flaky. This removes the recurring midnight failure.

## How Has This Been Tested?

Ran the changed tests plus every other consumer of `announcement_fixture` in the docker tox env:

```
tox -e py312-docker -- --no-cov \
  tests/manager/sqlalchemy/model/test_announcements.py \
  tests/manager/api/admin/test_announcement_list_validator.py \
  tests/manager/api/admin/controller/test_dashboard.py \
  tests/manager/api/test_authenticator.py \
  tests/manager/api/admin/controller/test_library.py \
  tests/manager/api/admin/controller/test_announcement_service.py
```

173 passed. `mypy` is clean on the changed files.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
