### PR TITLE
Replace per-page import_lock with the workflow lock

### DIFF
--- a/src/palace/manager/celery/importer.py
+++ b/src/palace/manager/celery/importer.py
@@ -73,16 +73,6 @@ def import_workflow_lock(
     )
 
 
-def import_lock(client: Redis, collection_id: int) -> RedisLock:
-    """
-    Create a lock for the given collection.
-
-    This makes sure only one task is importing data for the collection
-    at a time.
-    """
-    return RedisLock(client, import_key(collection_id), lock_timeout=timedelta(hours=1))
-
-
 def reap_workflow_key(collection_id: int) -> list[str]:
     """
     Generate a Redis key for the reap workflow-level lock for the given collection.

--- a/src/palace/manager/celery/opds.py
+++ b/src/palace/manager/celery/opds.py
@@ -45,11 +45,11 @@ def opds_import_task[FeedType](
 
     :return: An IdentifierSet if return_identifiers is True, otherwise None.
     """
-    redis = task.services.redis().client()
     with workflow_lock_guard(task, collection.id, label=label) as proceed:
         if not proceed:
             return None
 
+        redis = task.services.redis().client()
         # Create a set to store identifiers that will be imported
         identifier_set = (
             IdentifierSet(redis, import_key(collection.id, task.request.id))

--- a/src/palace/manager/celery/opds.py
+++ b/src/palace/manager/celery/opds.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from typing import Any
 
-from palace.manager.celery.importer import import_key, import_lock
+from palace.manager.celery.importer import import_key, workflow_lock_guard
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import apply
 from palace.manager.integration.license.opds.importer import (
@@ -18,6 +18,7 @@ def opds_import_task[FeedType](
     importer: OpdsImporter[FeedType, Any],
     url: str | None,
     *,
+    label: str,
     post_import_hook: Callable[[FeedImportResult[FeedType]], None] | None = None,
     force: bool = False,
     return_identifiers: bool = False,
@@ -25,14 +26,19 @@ def opds_import_task[FeedType](
     """
     Use the supplied importer to import an OPDS feed.
 
-    This function provides the shared logic for our OPDS import tasks. It handles locking, requeuing
+    This function provides the shared logic for our OPDS import tasks. It handles requeuing
     itself, calling a post-import hook (if provided), and returning a set of identifiers that were
-    imported (if requested).
+    imported (if requested). Concurrency is governed by
+    :func:`~palace.manager.celery.importer.workflow_lock_guard`, which holds a per-collection
+    Redis lock across both ``task.replace()`` calls and Celery retries so at most one import
+    runs per collection at a time; a run that finds the lock already held is skipped.
 
     :param task: The calling celery task.
     :param collection: The collection to import into.
     :param importer: The OpdsImporter to use for the import operation.
     :param url: The URL to import. If None, the importer's default URL will be used.
+    :param label: Human-readable name for the importing task (e.g. ``"OPDS2 import"``),
+        used in the workflow-lock skip warning so blocked runs identify their source.
     :param post_import_hook: A callable that will be called with the import result after each page is imported.
     :param force: If True, import even if the feed hasn't changed since the last import.
     :param return_identifiers: Return a set containing all the identifiers that were found in the feed.
@@ -40,7 +46,10 @@ def opds_import_task[FeedType](
     :return: An IdentifierSet if return_identifiers is True, otherwise None.
     """
     redis = task.services.redis().client()
-    with import_lock(redis, collection.id).lock():
+    with workflow_lock_guard(task, collection.id, label=label) as proceed:
+        if not proceed:
+            return None
+
         # Create a set to store identifiers that will be imported
         identifier_set = (
             IdentifierSet(redis, import_key(collection.id, task.request.id))
@@ -67,28 +76,28 @@ def opds_import_task[FeedType](
         if post_import_hook:
             post_import_hook(import_result)
 
-    unchanged_publication = import_result.found_unchanged_publication
-    next_link = import_result.next_url
-    should_continue = not unchanged_publication or return_identifiers or force
-    if next_link is not None and should_continue:
-        # This page is complete, but there are more pages to import, so we requeue ourselves with the
-        # next page URL.
-        raise task.replace(
-            task.s(
-                collection_id=collection.id,
-                url=next_link,
-                force=force,
-                return_identifiers=return_identifiers,
+        unchanged_publication = import_result.found_unchanged_publication
+        next_link = import_result.next_url
+        should_continue = not unchanged_publication or return_identifiers or force
+        if next_link is not None and should_continue:
+            # This page is complete, but there are more pages to import, so we requeue ourselves with the
+            # next page URL.
+            raise task.replace(
+                task.s(
+                    collection_id=collection.id,
+                    url=next_link,
+                    force=force,
+                    return_identifiers=return_identifiers,
+                )
             )
-        )
 
-    if not should_continue:
+        if not should_continue:
+            task.log.info(
+                f"Found unchanged publications in feed, stopping import without harvesting the rest of the feed"
+                f" for collection '{collection.name}' (id={collection.id}) "
+            )
+
         task.log.info(
-            f"Found unchanged publications in feed, stopping import without harvesting the rest of the feed"
-            f" for collection '{collection.name}' (id={collection.id}) "
+            f"Import complete for collection '{collection.name}' (id={collection.id})"
         )
-
-    task.log.info(
-        f"Import complete for collection '{collection.name}' (id={collection.id})"
-    )
-    return identifier_set
+        return identifier_set

--- a/src/palace/manager/celery/tasks/boundless.py
+++ b/src/palace/manager/celery/tasks/boundless.py
@@ -7,7 +7,7 @@ from palace.util.exceptions import PalaceValueError
 
 from palace.manager.celery.importer import (
     import_all as create_import_tasks,
-    import_lock,
+    workflow_lock_guard,
 )
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import apply
@@ -68,6 +68,11 @@ def import_collection(
     to process subsequent pages while maintaining the same modified_since timestamp
     and start_time across all pages.
 
+    Concurrency is governed by
+    :func:`~palace.manager.celery.importer.workflow_lock_guard`, which holds a
+    per-collection Redis lock across both ``task.replace()`` calls and Celery retries
+    so at most one import runs per collection at a time.
+
     :param collection_id: The ID of the collection to import
     :param import_all: If True, import all titles regardless of whether they have changed.
         If False, only import titles that have been modified since the last import.
@@ -87,16 +92,18 @@ def import_collection(
             "modified_since and start_time are required after the first page."
         )
 
-    redis = task.services.redis().client()
     registry = task.services.integration_registry().license_providers()
 
     if start_time is None:
         start_time = utc_now()
 
     with (
-        import_lock(redis, collection_id).lock(),
+        workflow_lock_guard(task, collection_id, label="Boundless import") as proceed,
         task.transaction() as session,
     ):
+        if not proceed:
+            return
+
         collection = load_from_id(session, Collection, collection_id)
         collection_name = collection.name
 
@@ -136,18 +143,18 @@ def import_collection(
                 f"Boundless import complete: '{collection_name}' Total time: {timestamp.elapsed}."
             )
 
-    if result.next_page is not None:
-        task.log.info(
-            f"Boundless import re-queueing: '{collection_name}' Next page: {result.next_page}."
-        )
-        raise task.replace(
-            signature_with(
-                task,
-                page=result.next_page,
-                # modified_since and start_time are resolved from None on the
-                # first page, so they must be carried forward explicitly rather
-                # than refilled from the original arguments.
-                modified_since=modified_since,
-                start_time=start_time,
+        if result.next_page is not None:
+            task.log.info(
+                f"Boundless import re-queueing: '{collection_name}' Next page: {result.next_page}."
             )
-        )
+            raise task.replace(
+                signature_with(
+                    task,
+                    page=result.next_page,
+                    # modified_since and start_time are resolved from None on the
+                    # first page, so they must be carried forward explicitly rather
+                    # than refilled from the original arguments.
+                    modified_since=modified_since,
+                    start_time=start_time,
+                )
+            )

--- a/src/palace/manager/celery/tasks/opds1.py
+++ b/src/palace/manager/celery/tasks/opds1.py
@@ -67,6 +67,7 @@ def import_collection(
             collection,
             importer,
             url,
+            label="OPDS1 import",
             force=force,
             return_identifiers=return_identifiers,
         )

--- a/src/palace/manager/celery/tasks/opds2.py
+++ b/src/palace/manager/celery/tasks/opds2.py
@@ -149,6 +149,7 @@ def import_collection(
             collection,
             importer,
             url,
+            label="OPDS2 import",
             post_import_hook=update_token_auth_link,
             force=force,
             return_identifiers=return_identifiers,

--- a/src/palace/manager/celery/tasks/opds_for_distributors.py
+++ b/src/palace/manager/celery/tasks/opds_for_distributors.py
@@ -85,6 +85,7 @@ def import_collection(
             collection,
             importer,
             url,
+            label="OPDS for Distributors import",
             force=force,
             return_identifiers=return_identifiers,
         )

--- a/tests/manager/celery/tasks/test_boundless.py
+++ b/tests/manager/celery/tasks/test_boundless.py
@@ -1,5 +1,6 @@
 from typing import Any
 from unittest.mock import call, create_autospec, patch
+from uuid import uuid4
 
 import pytest
 
@@ -7,7 +8,7 @@ from palace.util.datetime_helpers import utc_now
 from palace.util.exceptions import PalaceValueError
 from palace.util.log import LogLevel
 
-from palace.manager.celery.importer import import_lock
+from palace.manager.celery.importer import import_workflow_lock
 from palace.manager.celery.tasks import boundless
 from palace.manager.integration.license.boundless.api import BoundlessApi
 from palace.manager.integration.license.boundless.importer import (
@@ -20,7 +21,6 @@ from palace.manager.integration.license.boundless.model.json import (
     Title,
     TitleLicenseResponse,
 )
-from palace.manager.service.redis.models.lock import LockNotAcquired
 from palace.manager.sqlalchemy.model.coverage import Timestamp
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.util import get_one
@@ -35,20 +35,30 @@ from tests.mocks.mock import MockRequestsResponse
 
 
 class TestImportCollection:
-    def test_import_lock(
+    def test_skips_when_lock_held(
         self,
         celery_fixture: CeleryFixture,
         redis_fixture: RedisFixture,
         services_fixture: ServicesFixture,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """
-        The import_collection task is protected by a lock, so only one import can run at a time.
+        The import_collection task is protected by a workflow lock, so only one import
+        runs per collection at a time. When the lock is already held, the task logs a
+        warning and returns without importing.
         """
         mock_collection_id = 1234
         redis = services_fixture.services.redis().client()
-        import_lock(redis, mock_collection_id).acquire()
-        with pytest.raises(LockNotAcquired):
-            boundless.import_collection.delay(collection_id=mock_collection_id).wait()
+        import_workflow_lock(redis, mock_collection_id, str(uuid4())).acquire()
+
+        caplog.set_level(LogLevel.warning)
+
+        # Completes without raising: the task skips before loading the (nonexistent)
+        # collection. If the guard failed, load_from_id would raise instead.
+        boundless.import_collection.delay(collection_id=mock_collection_id).wait()
+
+        assert "skipped" in caplog.text
+        assert "already in progress" in caplog.text
 
     @pytest.mark.parametrize(
         "import_all",

--- a/tests/manager/celery/tasks/test_opds2.py
+++ b/tests/manager/celery/tasks/test_opds2.py
@@ -4,6 +4,7 @@ import datetime
 import json
 from functools import partial
 from unittest.mock import MagicMock, call, patch
+from uuid import uuid4
 
 import pytest
 from freezegun import freeze_time
@@ -15,6 +16,7 @@ from palace.util.log import LogLevel
 
 from palace.manager.api.circulation.dispatcher import CirculationApiDispatcher
 from palace.manager.api.circulation.fulfillment import RedirectFulfillment
+from palace.manager.celery.importer import import_workflow_lock
 from palace.manager.celery.tasks import identifiers, opds2
 from palace.manager.data_layer.circulation import CirculationData
 from palace.manager.data_layer.identifier import IdentifierData
@@ -1030,6 +1032,31 @@ class TestImportCollection:
             "Failed to import publication: urn:ISBN:9780792766919 (Past Imperfect)"
             in caplog.text
         )
+
+    def test_skips_when_lock_held(
+        self,
+        opds2_import_fixture: OPDS2ImportFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """When the per-collection workflow lock is already held (another run is in
+        progress), the shared opds_import_task skips: it makes no feed request and
+        logs a warning rather than raising."""
+        collection = opds2_import_fixture.collection
+
+        import_workflow_lock(
+            redis_fixture.client, collection.id, str(uuid4())
+        ).acquire()
+
+        caplog.set_level(LogLevel.warning)
+
+        # No HTTP response is queued: if the task did not skip it would fail trying to
+        # fetch the feed. It completes cleanly instead.
+        opds2.import_collection.delay(collection.id).wait()
+
+        assert opds2_import_fixture.client.requests == []
+        assert "OPDS2 import skipped" in caplog.text
+        assert "already in progress" in caplog.text
 
 
 class TestImportAndReapNotFoundChord:


### PR DESCRIPTION
## Description

Replaces the per-page `import_lock` with the whole-chain `workflow_lock_guard` at the two remaining call sites, so every paginated importer now shares one locking policy:

- `boundless.import_collection` — wrapped in `workflow_lock_guard`; the `task.replace()` re-queue moved inside the guard so the lock is held across pages and across its `autoretry_for` retries. Dropped the now-unused `redis` local.
- `opds.opds_import_task` (the shared helper behind opds1/opds2/opds_for_distributors) — same migration. The skip path returns `None`, which callers already tolerate (the import-failed path already returned `None`).
- `importer.import_lock` is now unused and removed. `import_key` stays — it still builds the `IdentifierSet` key.

This is a follow-up to #3418, which introduced `workflow_lock_guard` and migrated the Bibliotheca/Overdrive/OPDS2+ODL importers.

## Motivation and Context

`import_lock` was a per-page lock, released between `task.replace()` hand-offs. That left a window for a second run to interleave between pages, and a collision raised `LockNotAcquired` rather than backing off.

`workflow_lock_guard` is keyed on `task.request.id`, which Celery preserves across both `task.replace()` page hand-offs and `autoretry_for` retries. The lock is therefore held across the entire chain (and across retries), and a run that finds the lock already held is skipped with a warning instead of raising — matching the behavior of the other paginated importers.

## How Has This Been Tested?

- Rewrote `test_boundless.py::test_import_lock` → `test_skips_when_lock_held`: asserts the graceful skip + warning instead of expecting `LockNotAcquired`.
- Added `test_opds2.py::test_skips_when_lock_held`: the shared OPDS path had no lock coverage before; it now verifies the skip makes no feed request and logs the warning.
- Ran the affected suites (boundless, opds1/opds2/opds_for_distributors, importer = 70 tests) — all pass. `mypy` clean.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.