### PR TITLE
Re-queue opds_import_task page chains with signature_with

### DIFF
--- a/src/palace/manager/celery/opds.py
+++ b/src/palace/manager/celery/opds.py
@@ -4,6 +4,7 @@ from typing import Any
 from palace.manager.celery.importer import import_key, workflow_lock_guard
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import apply
+from palace.manager.celery.utils import signature_with
 from palace.manager.integration.license.opds.importer import (
     FeedImportResult,
     OpdsImporter,
@@ -82,14 +83,7 @@ def opds_import_task[FeedType](
         if next_link is not None and should_continue:
             # This page is complete, but there are more pages to import, so we requeue ourselves with the
             # next page URL.
-            raise task.replace(
-                task.s(
-                    collection_id=collection.id,
-                    url=next_link,
-                    force=force,
-                    return_identifiers=return_identifiers,
-                )
-            )
+            raise task.replace(signature_with(task, url=next_link))
 
         if not should_continue:
             task.log.info(


### PR DESCRIPTION
## Description

`opds_import_task` rebuilt its next-page signature by hand — `task.s(collection_id=…, url=next_link, force=…, return_identifiers=…)` — re-listing every parameter. Replace that with `signature_with(task, url=next_link)`, which fills the unchanged parameters from the current invocation and overrides only the next-page URL.

This matches the Bibliotheca, Overdrive, and Boundless importers, which all re-queue via `signature_with`.

## Motivation and Context

The hand-rolled `task.s(...)` re-listed every parameter, so if `import_collection` ever gained a parameter it would be silently dropped on re-queue. `signature_with` derives the unchanged arguments from `task.request`, so a new parameter is carried forward automatically — exactly the footgun the helper's docstring exists to prevent.

The change is behavior-preserving: each OPDS `import_collection` is `(task, collection_id, url=None, *, force=False, return_identifiers=False)`, and `signature_with` reproduces the same effective kwargs (parameters left at their defaults are simply not re-listed rather than passed explicitly).

## How Has This Been Tested?

- Ran the OPDS task suites (`test_opds1`, `test_opds2`, `test_opds_for_distributors`) — 48 tests pass, including the multi-page chain tests that exercise the `task.replace()` re-queue path.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.