### PR TITLE
Give a clear error when uploading an oversized library logo

### DIFF
--- a/src/palace/manager/api/admin/controller/library_settings.py
+++ b/src/palace/manager/api/admin/controller/library_settings.py
@@ -4,7 +4,7 @@ import base64
 import json
 import uuid
 from io import BytesIO
-from typing import Any
+from typing import Any, cast
 
 import flask
 from flask import Response
@@ -422,7 +422,7 @@ class LibrarySettingsController(AdminPermissionsControllerMixin):
             # actionable message rather than a generic "unable to open" error.
             # MAX_IMAGE_PIXELS is None when the check is disabled, but in that
             # case this exception can't be raised, so the limit is always set.
-            pixel_limit = 2 * (Image.MAX_IMAGE_PIXELS or 0)
+            pixel_limit = 2 * cast(int, Image.MAX_IMAGE_PIXELS)
             raise ProblemDetailException(
                 INVALID_CONFIGURATION_OPTION.detailed(
                     f"Uploaded image has too many pixels and could not be "

--- a/src/palace/manager/api/admin/controller/library_settings.py
+++ b/src/palace/manager/api/admin/controller/library_settings.py
@@ -10,7 +10,7 @@ import flask
 from flask import Response
 from flask_babel import lazy_gettext as _
 from PIL import Image, UnidentifiedImageError
-from PIL.Image import Resampling
+from PIL.Image import DecompressionBombError, Resampling
 from pydantic import BaseModel, ValidationError
 from werkzeug.datastructures import FileStorage
 
@@ -415,6 +415,18 @@ class LibrarySettingsController(AdminPermissionsControllerMixin):
 
         try:
             image = Image.open(image_file.stream)
+        except DecompressionBombError:
+            # Pillow raises this when an image's pixel count (width * height)
+            # is large enough to be a potential decompression bomb, well before
+            # we ever get a chance to scale it down. Give the admin an
+            # actionable message rather than a generic "unable to open" error.
+            raise ProblemDetailException(
+                INVALID_CONFIGURATION_OPTION.detailed(
+                    f"Uploaded image has too many pixels and could not be "
+                    f"processed. Please upload an image smaller than "
+                    f"{2 * Image.MAX_IMAGE_PIXELS:,} total pixels (width x height)."
+                )
+            )
         except UnidentifiedImageError:
             raise ProblemDetailException(
                 INVALID_CONFIGURATION_OPTION.detailed(

--- a/src/palace/manager/api/admin/controller/library_settings.py
+++ b/src/palace/manager/api/admin/controller/library_settings.py
@@ -420,11 +420,14 @@ class LibrarySettingsController(AdminPermissionsControllerMixin):
             # is large enough to be a potential decompression bomb, well before
             # we ever get a chance to scale it down. Give the admin an
             # actionable message rather than a generic "unable to open" error.
+            # MAX_IMAGE_PIXELS is None when the check is disabled, but in that
+            # case this exception can't be raised, so the limit is always set.
+            pixel_limit = 2 * (Image.MAX_IMAGE_PIXELS or 0)
             raise ProblemDetailException(
                 INVALID_CONFIGURATION_OPTION.detailed(
                     f"Uploaded image has too many pixels and could not be "
                     f"processed. Please upload an image smaller than "
-                    f"{2 * Image.MAX_IMAGE_PIXELS:,} total pixels (width x height)."
+                    f"{pixel_limit:,} total pixels (width x height)."
                 )
             )
         except UnidentifiedImageError:

--- a/tests/manager/api/admin/controller/test_library.py
+++ b/tests/manager/api/admin/controller/test_library.py
@@ -280,6 +280,8 @@ class TestLibrarySettings:
         flask_app_fixture: FlaskAppFixture,
         controller: LibrarySettingsController,
         db: DatabaseTransactionFixture,
+        logo_properties: dict[str, Any],
+        monkeypatch: pytest.MonkeyPatch,
     ):
         with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
             flask.request.form = ImmutableMultiDict([])
@@ -461,6 +463,30 @@ class TestLibrarySettings:
             assert excinfo.value.problem_detail.detail is not None
             assert (
                 "Unable to open uploaded image" in excinfo.value.problem_detail.detail
+            )
+
+        # Test uploading a logo with too many pixels (a potential
+        # decompression bomb). Lower Pillow's limit so a small fixture image
+        # trips it rather than allocating a real multi-hundred-megapixel image.
+        monkeypatch.setattr(Image, "MAX_IMAGE_PIXELS", 0)
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = self.library_form(library)
+            flask.request.files = ImmutableMultiDict(
+                {
+                    "logo": FileStorage(
+                        stream=BytesIO(logo_properties["raw_bytes"]),
+                        content_type="image/png",
+                        filename="logo.png",
+                    )
+                }
+            )
+            with pytest.raises(ProblemDetailException) as excinfo:
+                controller.process_post()
+            assert excinfo.value.problem_detail.uri == INVALID_CONFIGURATION_OPTION.uri
+            assert excinfo.value.problem_detail.detail is not None
+            assert (
+                "Uploaded image has too many pixels"
+                in excinfo.value.problem_detail.detail
             )
 
     def test__process_image(self, logo_properties: dict[str, Any]):


### PR DESCRIPTION
## Description

`scale_and_store_logo` only caught `UnidentifiedImageError` when opening an uploaded library logo. Pillow's decompression-bomb guard raises a separate `DecompressionBombError` *inside* `Image.open` when an image's pixel count exceeds its limit — before our scaling code ever runs. That exception was uncaught and surfaced as a generic 500. This catches it and returns an `INVALID_CONFIGURATION_OPTION` problem detail telling the admin the image has too many pixels and what the limit is.

## Motivation and Context

A OPs team member tried repeatedly to upload a library logo that was huge by pixel dimensions (~326 megapixels) — not necessarily large in file size. Each attempt failed with an opaque 500 and no explanation, so they kept retrying. Rejecting the image is the correct behavior, but the admin had no way to understand why. This gives them an actionable message.

Note this is a pixel-count limit, not a file-size limit, so a small file can still trip it.

See these slack messages: 
https://lyrasis.slack.com/archives/CCY3PH8JD/p1780577648186309?thread_ts=1780489931.830289&cid=CCY3PH8JD
https://lyrasis.slack.com/archives/C049AA32E3S/p1780577271279769

## How Has This Been Tested?

Added a case to `test_libraries_post_errors` that monkeypatches `Image.MAX_IMAGE_PIXELS` down so a small fixture image trips the same guard (avoiding allocating a real multi-hundred-megapixel image), and asserts the new problem-detail message. Ran the full test via the docker tox env; it passes.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
