### PR TITLE
Tune OpenSearch read-path defaults: 10s timeout, no retries (PP-4472)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,10 @@ To let the application know which OpenSearch instance to use, you can set the fo
   backwards compatibility.
 - `PALACE_SEARCH_READ_TIMEOUT`: The timeout in seconds to use for the user-facing read/search path. The default is `10`
   (optional).
-- `PALACE_SEARCH_READ_RETRY_ON_TIMEOUT`: Whether a timed-out read should be retried. The default is `false` (optional).
-- `PALACE_SEARCH_READ_MAX_RETRIES`: The maximum number of retries for a timed-out read before the error is propagated.
-  The default is `0` (optional).
+- `PALACE_SEARCH_READ_RETRY_ON_TIMEOUT`: Whether a timed-out read should be retried. Must be `true` for
+  `PALACE_SEARCH_READ_MAX_RETRIES` to apply to timeout failures. The default is `false` (optional).
+- `PALACE_SEARCH_READ_MAX_RETRIES`: The maximum number of retries for a read before the error is propagated. For timeout
+  failures this only takes effect when `PALACE_SEARCH_READ_RETRY_ON_TIMEOUT` is `true`. The default is `0` (optional).
 - `PALACE_SEARCH_MAXSIZE`: The maximum size of the connection pool to use when connecting to the OpenSearch instance
   (optional).
 

--- a/README.md
+++ b/README.md
@@ -203,12 +203,11 @@ To let the application know which OpenSearch instance to use, you can set the fo
 - `PALACE_SEARCH_WRITE_TIMEOUT`: The timeout in seconds to use for indexing and admin operations against the OpenSearch
   instance. The default is `20` (optional). Replaces the deprecated `PALACE_SEARCH_TIMEOUT`, which is still honored for
   backwards compatibility.
-- `PALACE_SEARCH_READ_TIMEOUT`: The timeout in seconds to use for the user-facing read/search path. Kept short so a node
-  that briefly stalls during OpenSearch maintenance fails over quickly. The default is `4` (optional).
-- `PALACE_SEARCH_READ_RETRY_ON_TIMEOUT`: Whether a timed-out read should be retried against another node. The default is
-  `true` (optional).
+- `PALACE_SEARCH_READ_TIMEOUT`: The timeout in seconds to use for the user-facing read/search path. The default is `10`
+  (optional).
+- `PALACE_SEARCH_READ_RETRY_ON_TIMEOUT`: Whether a timed-out read should be retried. The default is `false` (optional).
 - `PALACE_SEARCH_READ_MAX_RETRIES`: The maximum number of retries for a timed-out read before the error is propagated.
-  The default is `2` (optional).
+  The default is `0` (optional).
 - `PALACE_SEARCH_MAXSIZE`: The maximum size of the connection pool to use when connecting to the OpenSearch instance
   (optional).
 

--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ To let the application know which OpenSearch instance to use, you can set the fo
   (optional).
 - `PALACE_SEARCH_READ_RETRY_ON_TIMEOUT`: Whether a timed-out read should be retried. Must be `true` for
   `PALACE_SEARCH_READ_MAX_RETRIES` to apply to timeout failures. The default is `false` (optional).
-- `PALACE_SEARCH_READ_MAX_RETRIES`: The maximum number of retries for a read before the error is propagated. For timeout
-  failures this only takes effect when `PALACE_SEARCH_READ_RETRY_ON_TIMEOUT` is `true`. The default is `0` (optional).
+- `PALACE_SEARCH_READ_MAX_RETRIES`: The maximum number of retries for a read before the error is propagated. The
+  default is `0` (optional).
 - `PALACE_SEARCH_MAXSIZE`: The maximum size of the connection pool to use when connecting to the OpenSearch instance
   (optional).
 

--- a/src/palace/manager/service/search/configuration.py
+++ b/src/palace/manager/service/search/configuration.py
@@ -32,7 +32,7 @@ class SearchConfiguration(ServiceConfiguration, LoggerMixin):
     )
     # Timeout (seconds) for the user-facing read path.
     read_timeout: int = 10
-    # Read-path timeout retries, applied only to the read client.
+    # Read-path request retries, applied only to the read client.
     read_max_retries: int = 0
     read_retry_on_timeout: bool = False
     maxsize: int = 25

--- a/src/palace/manager/service/search/configuration.py
+++ b/src/palace/manager/service/search/configuration.py
@@ -21,25 +21,20 @@ _WRITE_TIMEOUT_ENV = "PALACE_SEARCH_WRITE_TIMEOUT"
 class SearchConfiguration(ServiceConfiguration, LoggerMixin):
     url: HttpUrl
     index_prefix: str = "circulation-works"
-    # Timeout (seconds) for indexing and admin operations, which legitimately
-    # run longer. ``PALACE_SEARCH_TIMEOUT`` is the deprecated name for this
-    # setting and is still accepted; prefer ``PALACE_SEARCH_WRITE_TIMEOUT``.
+    # Timeout (seconds) for indexing and admin operations.
+    # ``PALACE_SEARCH_TIMEOUT`` is the deprecated name for this setting and is
+    # still accepted; prefer ``PALACE_SEARCH_WRITE_TIMEOUT``.
     write_timeout: int = Field(
         default=20,
         validation_alias=AliasChoices(
             _WRITE_TIMEOUT_ENV, _DEPRECATED_WRITE_TIMEOUT_ENV
         ),
     )
-    # Timeout (seconds) for the user-facing read path. Kept well below
-    # ``write_timeout`` so a node that goes briefly unresponsive during
-    # OpenSearch maintenance fails over quickly instead of stalling a web
-    # worker for the full write timeout.
-    read_timeout: int = 4
-    # Retry timed-out reads against another node. With two nodes per domain
-    # this lets a read survive a single node bouncing during maintenance. These
-    # apply only to the read path; indexing/admin calls are not retried.
-    read_max_retries: int = 2
-    read_retry_on_timeout: bool = True
+    # Timeout (seconds) for the user-facing read path.
+    read_timeout: int = 10
+    # Read-path timeout retries, applied only to the read client.
+    read_max_retries: int = 0
+    read_retry_on_timeout: bool = False
     maxsize: int = 25
     model_config = SettingsConfigDict(env_prefix="PALACE_SEARCH_")
 

--- a/src/palace/manager/service/search/container.py
+++ b/src/palace/manager/service/search/container.py
@@ -21,9 +21,10 @@ class Search(DeclarativeContainer):
         maxsize=config.maxsize,
     )
 
-    # Used for the user-facing read path. The shorter ``read_timeout`` plus
-    # timeout retries let a read fail over quickly to the domain's other node
-    # when one briefly stalls during OpenSearch maintenance.
+    # Used for the user-facing read path. A bounded ``read_timeout`` keeps a
+    # stalled read from holding a web worker for the full ``write_timeout``.
+    # Timeout retries default off (see config) since they cannot fail over when
+    # the host is a single endpoint; operators can enable them via config.
     read_client: Provider[OpenSearch] = providers.Singleton(
         OpenSearch,
         hosts=config.url,

--- a/src/palace/manager/service/search/container.py
+++ b/src/palace/manager/service/search/container.py
@@ -21,10 +21,8 @@ class Search(DeclarativeContainer):
         maxsize=config.maxsize,
     )
 
-    # Used for the user-facing read path. A bounded ``read_timeout`` keeps a
-    # stalled read from holding a web worker for the full ``write_timeout``.
-    # Timeout retries default off (see config) since they cannot fail over when
-    # the host is a single endpoint; operators can enable them via config.
+    # Used for the user-facing read path, with timeout and retry settings
+    # tunable independently of the write client to suit that path.
     read_client: Provider[OpenSearch] = providers.Singleton(
         OpenSearch,
         hosts=config.url,

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -28,9 +28,9 @@ from tests.mocks.search import SearchServiceFake
 class SearchTestConfiguration(FixtureTestUrlConfiguration):
     url: HttpUrl
     write_timeout: int = 20
-    read_timeout: int = 4
-    read_max_retries: int = 2
-    read_retry_on_timeout: bool = True
+    read_timeout: int = 10
+    read_max_retries: int = 0
+    read_retry_on_timeout: bool = False
     maxsize: int = 25
     model_config = SettingsConfigDict(env_prefix="PALACE_TEST_SEARCH_")
 

--- a/tests/manager/service/search/test_configuration.py
+++ b/tests/manager/service/search/test_configuration.py
@@ -9,7 +9,9 @@ class TestSearchConfiguration:
     def test_defaults(self):
         config = SearchConfiguration(url="http://localhost:9200")
         assert config.write_timeout == 20
-        assert config.read_timeout == 4
+        assert config.read_timeout == 10
+        assert config.read_max_retries == 0
+        assert config.read_retry_on_timeout is False
 
     def test_write_timeout_env(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv("PALACE_SEARCH_WRITE_TIMEOUT", "11")


### PR DESCRIPTION
## Description

Adjusts the OpenSearch read-path defaults introduced in #3412. The read/write client split, the dedicated read client, and the tunable env vars are all kept; only the defaults change:

- `read_timeout`: `4` → `10`
- `read_max_retries`: `2` → `0`
- `read_retry_on_timeout`: `true` → `false`

Operators can still restore the previous behavior via `PALACE_SEARCH_READ_TIMEOUT` / `PALACE_SEARCH_READ_MAX_RETRIES` / `PALACE_SEARCH_READ_RETRY_ON_TIMEOUT`.

## Motivation and Context

#3412 gave the read path a 4s timeout with 2 timeout retries on the theory that the nightly user-facing `500`s were connection stalls against a node bouncing during the OpenSearch maintenance window, so a fast retry would fail over to the healthy node.

A follow-up investigation after deploying contradicted that premise:

- The failures are not node bounces. Node count held steady at 2 across every night, the ES domain log group had zero recovery/master/transport events, and JVM/GC were flat in-window. Completed searches stayed ~15ms, so the stall is node-busy/IO contention, not query execution or GC.
- The real driver is the daily indexing operation, which produces a 10–20× write surge peaking ~7k docs/s at 01:00–02:00 UTC. 
- The 4s timeout cut into the legitimate slow tail of crawlable reads. The slowest *successful* crawlable read all week was ~7.4s, with zero successful reads between 7.4s and 20s. A read that genuinely needs 6s fails all three 4s attempts, so #3412 converted previously-successful reads into `500`s (crawlable 500s rose from a ~3–19/night baseline to 47 the night after deploy, with a `~12,300ms` = 3×4s latency fingerprint).

`10s` sits above 100% of observed successful reads (~2.6s margin) so it converts none of the legitimate slow tail into failures, while still giving up well before the 20s write timeout, bounding how long a genuinely-stuck read holds a uwsgi worker. Retries are disabled, since they didn't help, and we don't want to hold a worker for 3x10s (client will just timeout).

The remaining root cause is being worked on separately; this PR stops the regression I introduced.

JIRA: PP-4472

## How Has This Been Tested?

- `mypy` clean.
- `tests/manager/service/search/test_configuration.py::test_defaults` updated to assert the new defaults (`read_timeout=10`, `read_max_retries=0`, `read_retry_on_timeout=False`); test fixture defaults updated to match.
- Full `tests/manager/service/search/` and `tests/manager/search/test_service.py` suites pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
