### PR TITLE
Mark subjects with no classifier as checked (PP-4472)

### DIFF
--- a/src/palace/manager/sqlalchemy/model/classification.py
+++ b/src/palace/manager/sqlalchemy/model/classification.py
@@ -278,10 +278,17 @@ class Subject(Base):
 
     def assign_to_genre(self) -> None:
         """Assign this subject to a genre."""
+        # Mark the subject as checked even when no classifier handles its type.
+        # Otherwise types we can never classify (e.g. Lexile and ATOS reading
+        # measures, schema:Place/Person/Organization) stay unchecked forever and
+        # are re-examined -- and their works re-indexed -- every night by
+        # classify_unchecked_subjects, with no change to show for it. A migration
+        # can reset checked=False to force reprocessing if a classifier is later
+        # added for the type.
+        self.checked = True
         classifier = lookup_classifier(self.type)
         if not classifier:
             return
-        self.checked = True
         log = logging.getLogger("Subject-genre assignment")
 
         genredata, audience, target_age, fiction = classifier.classify(self)

--- a/tests/manager/sqlalchemy/model/test_classification.py
+++ b/tests/manager/sqlalchemy/model/test_classification.py
@@ -77,6 +77,26 @@ class TestSubject:
         assert None == subject.genre
         assert None == subject.fiction
 
+    def test_assign_to_genre_marks_unclassifiable_subject_checked(
+        self, db: DatabaseTransactionFixture
+    ):
+        # Lexile is a reading measure with no registered classifier, so there
+        # is nothing for assign_to_genre() to classify. It must still mark the
+        # Subject checked; otherwise it stays unchecked forever and is
+        # re-examined -- and its works re-indexed -- every night by
+        # classify_unchecked_subjects, with nothing to show for it.
+        subject = db.subject(Subject.LEXILE_SCORE, "720L")
+        assert subject.checked is False
+
+        subject.assign_to_genre()
+
+        assert subject.checked is True
+        # With no classifier, no genre/audience data is invented.
+        assert subject.genre is None
+        assert subject.audience is None
+        assert subject.fiction is None
+        assert subject.target_age is None
+
 
 class TestGenre:
     def test_name_is_unique(self, db: DatabaseTransactionFixture):


### PR DESCRIPTION
## Description

`Subject.assign_to_genre()` returned early without setting `checked=True` when no classifier was registered for the subject's `type`. Reading-measure types like `Lexile` and `ATOS` (and `schema:Place/Person/Organization`) have no classifier, so those subjects stayed `checked=False` forever. This moves `self.checked = True` ahead of the no-classifier early return so a subject we can never classify is marked checked once instead of being re-examined every night.

## Motivation and Context

`classify_unchecked_subjects` runs nightly and reprocesses **every work linked to an unchecked subject**, re-dirtying it for search indexing. Because of the bug above, a small set of permanently-unchecked subjects anchored a huge, recurring set of works:

- In production ~165 `Lexile` subjects per CM (attached by Overdrive) each attach to most of the catalog, anchoring ~10–20k works per CM (RI 19,753; FL 14,945; IL 13,066; CA 9,265; …).
- Across all 30 CMs the nightly job re-indexed **~234k works every night** for no benefit — recalculating presentation changed nothing for these subjects.

That nightly write surge (~7k docs/s vs a ~600/s baseline) left a multi-hour OpenSearch segment-merge tail that degraded read latency, producing user-facing `ConnectionTimeout` errors on `/<library>/crawlable` feeds (the Aspen Discovery crawler). This was surfaced while investigating those timeouts after #3412.

Marking the subject checked even when there is no classifier is safe: with no classifier, nothing about the subject's genre/audience/fiction/target_age changes on reprocessing. A migration can reset `checked=False` if a classifier is later added for a type (the existing contract that `classify_unchecked_subjects` already relies on).

After this ships, the next nightly run processes the current backlog one last time (marking those subjects checked as it goes), after which the set collapses to only genuinely-new unchecked subjects from daily imports.

Related: #3412 (the read-timeout failover change whose investigation surfaced this root cause).

JIRA: PP-4472

## How Has This Been Tested?

- Added `TestSubject::test_assign_to_genre_marks_unclassifiable_subject_checked`: a `Lexile` subject becomes `checked=True` after `assign_to_genre()` while genre/audience/fiction/target_age remain `None` (no data invented).
- Existing `assign_to_genre` coverage (e.g. `test_assign_to_genre_can_remove_genre`) still passes.
- `tox -e py312-docker -- --no-cov tests/manager/sqlalchemy/model/test_classification.py` → 7 passed.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.