### PR TITLE
Throttle search_indexing so a backlog can't flood OpenSearch (PP-4472)

### DIFF
--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import random
 from collections.abc import Sequence
+from datetime import timedelta
 from typing import Any
 
 from celery import chain, shared_task
@@ -21,13 +22,6 @@ from palace.manager.service.redis.models.lock import LockNotAcquired, TaskLock
 from palace.manager.service.redis.models.search import WaitingForIndexing
 from palace.manager.sqlalchemy.model.work import Work
 from palace.manager.util.backoff import exponential_backoff
-
-# Cooldown (min, max seconds) between search_indexing batches when draining a
-# backlog. A batch is batch_size works, so the drain rate is bounded to roughly
-# batch_size / cooldown works/sec -- fast enough to stay in sync with the normal
-# dirty rate but slow enough that a large burst can't flood OpenSearch. Kept
-# shorter than the reindex cooldown because indexing must stay roughly current.
-SEARCH_INDEXING_COOLDOWN = (1.0, 3.0)
 
 
 def get_work_search_documents(
@@ -140,15 +134,11 @@ def update_read_pointer(task: Task) -> None:
 @shared_task(queue=QueueNames.default, bind=True, throws=(LockNotAcquired,))
 def search_indexing(task: Task, batch_size: int = 500) -> None:
     redis_client = task.services.redis.client()
-    task_lock = TaskLock(task)
+    task_lock = TaskLock(task, lock_timeout=timedelta(minutes=15))
 
     # Hold the lock across our self-replacements (release_on_exit=False) so the
-    # every-minute beat schedule can't start a second, concurrent drain. A beat
-    # run that fires while a drain is in progress fails to acquire the lock and
-    # exits via LockNotAcquired (declared in ``throws`` so Celery treats it as an
-    # expected, non-error outcome). Combined with the per-batch cooldown below,
-    # this turns a large backlog into a single paced stream rather than an
-    # unbounded fan-out of index_works tasks that floods OpenSearch.
+    # every-minute beat schedule can't start a second, concurrent search_indexing
+    # task.
     with task_lock.lock(release_on_exit=False, ignored_exceptions=(Retry, Ignore)):
         waiting = WaitingForIndexing(redis_client)
         works = waiting.pop(batch_size)
@@ -158,10 +148,10 @@ def search_indexing(task: Task, batch_size: int = 500) -> None:
 
         if len(works) == batch_size:
             # There are more works waiting to be indexed. Requeue ourselves to
-            # process the next batch after a short cooldown so we drain at a
-            # bounded rate instead of flooding the index. The lock is held
-            # across the replacement, so no other run drains in parallel.
-            delay = random.uniform(*SEARCH_INDEXING_COOLDOWN)
+            # process the next batch after a short cooldown so we don't flood the
+            # opensearch index and degrade search performance. This is shorter than
+            # the reindex cooldown because indexing must stay roughly current.
+            delay = random.uniform(1.0, 3.0)
             raise task.replace(signature_with(task).set(countdown=delay))
 
     # The queue is drained; release the lock so the next beat run can start fresh.

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -17,10 +17,17 @@ from palace.manager.celery.task import Task
 from palace.manager.celery.utils import signature_with
 from palace.manager.search.external_search import ExternalSearchIndex
 from palace.manager.service.celery.celery import QueueNames
-from palace.manager.service.redis.models.lock import TaskLock
+from palace.manager.service.redis.models.lock import LockNotAcquired, TaskLock
 from palace.manager.service.redis.models.search import WaitingForIndexing
 from palace.manager.sqlalchemy.model.work import Work
 from palace.manager.util.backoff import exponential_backoff
+
+# Cooldown (min, max seconds) between search_indexing batches when draining a
+# backlog. A batch is batch_size works, so the drain rate is bounded to roughly
+# batch_size / cooldown works/sec -- fast enough to stay in sync with the normal
+# dirty rate but slow enough that a large burst can't flood OpenSearch. Kept
+# shorter than the reindex cooldown because indexing must stay roughly current.
+SEARCH_INDEXING_COOLDOWN = (1.0, 3.0)
 
 
 def get_work_search_documents(
@@ -130,23 +137,36 @@ def update_read_pointer(task: Task) -> None:
     )
 
 
-@shared_task(queue=QueueNames.default, bind=True)
+@shared_task(queue=QueueNames.default, bind=True, throws=(LockNotAcquired,))
 def search_indexing(task: Task, batch_size: int = 500) -> None:
     redis_client = task.services.redis.client()
-    with TaskLock(task).lock():
+    task_lock = TaskLock(task)
+
+    # Hold the lock across our self-replacements (release_on_exit=False) so the
+    # every-minute beat schedule can't start a second, concurrent drain. A beat
+    # run that fires while a drain is in progress fails to acquire the lock and
+    # exits via LockNotAcquired (declared in ``throws`` so Celery treats it as an
+    # expected, non-error outcome). Combined with the per-batch cooldown below,
+    # this turns a large backlog into a single paced stream rather than an
+    # unbounded fan-out of index_works tasks that floods OpenSearch.
+    with task_lock.lock(release_on_exit=False, ignored_exceptions=(Retry, Ignore)):
         waiting = WaitingForIndexing(redis_client)
         works = waiting.pop(batch_size)
 
         if len(works) > 0:
             index_works.delay(works=works)
 
-    if len(works) == batch_size:
-        # This task is complete, but there are more works waiting to be indexed. Requeue ourselves
-        # to process the next batch.
-        raise task.replace(signature_with(task))
+        if len(works) == batch_size:
+            # There are more works waiting to be indexed. Requeue ourselves to
+            # process the next batch after a short cooldown so we drain at a
+            # bounded rate instead of flooding the index. The lock is held
+            # across the replacement, so no other run drains in parallel.
+            delay = random.uniform(*SEARCH_INDEXING_COOLDOWN)
+            raise task.replace(signature_with(task).set(countdown=delay))
 
-    task.log.info(f"Finished queuing indexing tasks.")
-    return
+    # The queue is drained; release the lock so the next beat run can start fresh.
+    task_lock.release()
+    task.log.info("Finished queuing indexing tasks.")
 
 
 @shared_task(queue=QueueNames.default, bind=True, max_retries=4)

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -412,13 +412,18 @@ def test_search_indexing_lock(
 
 
 @pytest.mark.parametrize("batch_size", [3, 5, 500])
+@patch("palace.manager.celery.tasks.search.random")
 @patch("palace.manager.celery.tasks.search.index_works")
 def test_search_indexing(
     mock_index_works: MagicMock,
+    mock_random: MagicMock,
     batch_size: int,
     celery_fixture: CeleryFixture,
     search_indexing_fixture: SearchIndexingFixture,
 ):
+    # The cooldown countdown is honoured by the real Celery workers, so mock it
+    # out to avoid adding several seconds of real wait between requeued batches.
+    mock_random.uniform.return_value = 0.0
     # No works to index, so we should not call index_works
     search_indexing.delay(batch_size=batch_size).wait()
     assert search_indexing_fixture.lock.locked() is False

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -10,7 +10,6 @@ from opensearchpy import OpenSearchException
 from palace.util.exceptions import BasePalaceException
 
 from palace.manager.celery.tasks.search import (
-    SEARCH_INDEXING_COOLDOWN,
     get_migrate_search_chain,
     get_work_search_documents,
     index_works,
@@ -473,9 +472,8 @@ def test_search_indexing_cooldown_between_batches(
 
     search_indexing.delay(batch_size=3).wait()
 
-    # A cooldown was taken after each full batch, using the configured range.
+    # A cooldown was taken after each full batch
     assert mock_random.uniform.call_count == 3
-    mock_random.uniform.assert_called_with(*SEARCH_INDEXING_COOLDOWN)
 
     # The backlog still fully drained and the lock was released at the end.
     assert search_indexing_fixture.lock.locked() is False

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -10,6 +10,7 @@ from opensearchpy import OpenSearchException
 from palace.util.exceptions import BasePalaceException
 
 from palace.manager.celery.tasks.search import (
+    SEARCH_INDEXING_COOLDOWN,
     get_migrate_search_chain,
     get_work_search_documents,
     index_works,
@@ -453,6 +454,38 @@ def test_search_indexing(
 
     # No works are left in the waiting list
     assert search_indexing_fixture.waiting.get(10) == []
+
+
+@patch("palace.manager.celery.tasks.search.random")
+@patch("palace.manager.celery.tasks.search.index_works")
+def test_search_indexing_cooldown_between_batches(
+    mock_index_works: MagicMock,
+    mock_random: MagicMock,
+    celery_fixture: CeleryFixture,
+    search_indexing_fixture: SearchIndexingFixture,
+):
+    # Each full batch requeues itself after a cooldown so a large backlog drains
+    # at a bounded rate instead of flooding the index. With 10 works and
+    # batch_size 3 the task pops 3, 3, 3, 1 -- the three full batches each
+    # schedule a cooldown; the final partial batch does not.
+    mock_random.uniform.return_value = 0.0
+    search_indexing_fixture.add_works()
+
+    search_indexing.delay(batch_size=3).wait()
+
+    # A cooldown was taken after each full batch, using the configured range.
+    assert mock_random.uniform.call_count == 3
+    mock_random.uniform.assert_called_with(*SEARCH_INDEXING_COOLDOWN)
+
+    # The backlog still fully drained and the lock was released at the end.
+    assert search_indexing_fixture.lock.locked() is False
+    assert search_indexing_fixture.waiting.get(10) == []
+    indexed = [
+        work
+        for call_args in mock_index_works.delay.call_args_list
+        for work in call_args.kwargs["works"]
+    ]
+    assert set(indexed) == search_indexing_fixture.mock_works
 
 
 def test_index_works(


### PR DESCRIPTION
## Description

`search_indexing` drains the `WaitingForIndexing` queue, but it released its lock every iteration and requeued itself with **no delay**, while the beat schedule also fires it **every minute**. When the queue is deep, this fans out `index_works` tasks, so a large burst causes a concentrated write spike.

This change paces the indexing:

- **Hold the lock across self-replacements** (`release_on_exit=False`) so the every-minute beat can't start a second, concurrent task. A beat run that fires mid-drain fails to acquire the lock and exits via `LockNotAcquired`, now declared in the task's `throws` so Celery logs it as expected rather than an error.
- **Add a short cooldown between batches** (`SEARCH_INDEXING_COOLDOWN`, 1–3s jittered) on the requeue, so a backlog drains as a single paced stream bounded to ~`batch_size / cooldown` works/sec.

## Motivation and Context

While investigating nightly `ConnectionTimeout` errors on `/<library>/crawlable` feeds (after #3412), the root cause was an OpenSearch write surge whose segment-merge tail degraded read latency. Log/metric analysis showed:

- Indexing churn is ~330–1,500 works/min steady, but a backlog drained in a concentrated burst (IndexingRate spiking ~10–20× baseline) because nothing paced the `index_works` fan-out.
- Per-batch indexing is cheap (p50 0.07s, p95 0.45s for a 500-work batch), so the bottleneck was concurrency, not OpenSearch throughput.

With `batch_size=500` and a 1–3s cooldown the drain is ~6–13k works/min — comfortably above the steady dirty rate (indexing stays in sync; bursts smaller than one batch never hit the cooldown path), but far below the unbounded fan-out that caused the flood. The result: **no single dirty-burst can saturate the index again, regardless of size.**

This is a structural safeguard and complements #3438, which removes today's specific trigger (the nightly Lexile reclassification churn). Together they eliminate the surge *and* prevent its recurrence.

JIRA: PP-4472

## How Has This Been Tested?

- New `test_search_indexing_cooldown_between_batches`: with a backlog larger than `batch_size`, each full batch takes a cooldown from the configured range, the backlog still fully drains, and the lock is released at the end.
- Existing `test_search_indexing_lock` (a concurrent run raises `LockNotAcquired`) and `test_search_indexing` (drains correctly across self-replacements, lock released) still pass — the latter confirms the lock re-acquires across replacements now that it's held.
- `tox -e py312-docker -- --no-cov tests/manager/celery/tasks/test_search.py` → 19 passed.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.