### PR TITLE
Allow empty authentication list in served auth document (PP-3842)

### DIFF
--- a/packages/palace-opds/src/palace/opds/authentication/document.py
+++ b/packages/palace-opds/src/palace/opds/authentication/document.py
@@ -91,11 +91,6 @@ class AuthenticationDocument(BaseOpdsModel):
     def _validate_authentication(
         cls, value: Sequence[Authentication]
     ) -> Sequence[Authentication]:
-        if not value:
-            raise ValueError(
-                "Authentication document must have at least one authentication object."
-            )
-
         auth_types = set()
         for auth in value:
             if auth.type in auth_types:

--- a/tests/palace_opds/test_authentication.py
+++ b/tests/palace_opds/test_authentication.py
@@ -67,10 +67,13 @@ class TestAuthenticationDocument:
             document.by_type("some-other-type")
 
     def test_validate_authentication_empty(self) -> None:
-        with pytest.raises(ValidationError, match="at least one authentication"):
-            AuthenticationDocument(
-                id="http://example.com/auth", title="Library", authentication=[]
-            )
+        # The spec requires the ``authentication`` key but imposes no minItems,
+        # so an empty list is valid (e.g. a library with no/misconfigured auth
+        # providers). It must not raise.
+        document = AuthenticationDocument(
+            id="http://example.com/auth", title="Library", authentication=[]
+        )
+        assert document.authentication == []
 
     def test_validate_authentication_duplicate_types(self) -> None:
         with pytest.raises(ValidationError, match="Duplicate authentication type"):


### PR DESCRIPTION
## Description

A library with no working patron-auth providers serves an authentication document with an empty `authentication` array. The pydantic refactor in #3394 added a `_validate_authentication` check that rejects an empty list, so building the document now raises a `ValidationError` and the request 500s. This drops the non-empty check (keeping the duplicate-type check, which backs `by_type`).

## Motivation and Context

This is a production regression. Any feed request for an affected library hits `authenticated_patron_from_request` → `create_authentication_document` and crashes with:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for PalaceAuthenticationDocument
authentication
  Value error, Authentication document must have at least one authentication object. [type=value_error, input_value=[], input_type=list]
```

The empty-providers state is reachable and deliberately tolerated: `LibraryAuthenticator.from_config` catches per-provider config errors and continues (added in #3130, "Incomplete collection and authenticator config not catastrophic"), and a library may have no patron-auth integrations configured at all. Before #3394 the legacy `AuthenticationDocumentData.to_dict()` served `"authentication": []` without complaint.

The added validator was also stricter than the spec: the [Authentication for OPDS 1.0 schema](https://drafts.opds.io/schema/authentication.schema.json) lists `authentication` in `required` (the key must be present) but defines **no `minItems`**, so an empty array is spec-compliant — both for the document we serve and for documents we parse from remote servers.

## How Has This Been Tested?

`tests/palace_opds/test_authentication.py` updated: `test_validate_authentication_empty` now asserts an empty list is accepted.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
