### PR TITLE
Treat empty Overdrive collection as empty page, not an error

### DIFF
--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -712,6 +712,13 @@ class OverdriveAPI(
             async_task_list = list()
             response_products = data.get("products")
             if response_products is None:
+                # Overdrive omits the 'products' key entirely when a collection
+                # (or page) contains no titles. In that case 'totalItems' is 0
+                # and there is simply nothing to import, so we treat it as an
+                # empty page rather than an error.
+                if data.get("totalItems") == 0:
+                    return [], next_endpoint
+
                 self.log.warning(
                     f"Overdrive response missing 'products' key for endpoint {endpoint.url}.",
                     extra={

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -2916,7 +2916,9 @@ class TestSyncBookshelf:
         api = overdrive_api_fixture.api
         mock_async_client = overdrive_api_fixture.mock_async_client
 
-        mock_async_client.queue_response(200, content={"no_products_key": True})
+        # totalItems is non-zero, so the missing 'products' key is a genuinely
+        # malformed response rather than an empty collection.
+        mock_async_client.queue_response(200, content={"totalItems": 5})
 
         initial_endpoint = api.book_info_initial_endpoint(start=None, page_size=1)
         with pytest.raises(BadResponseException, match="missing 'products' key"):

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -2910,8 +2910,9 @@ class TestSyncBookshelf:
         self,
         overdrive_api_fixture: OverdriveAPIFixture,
     ):
-        """When the Overdrive API returns a response without a 'products' key,
-        a BadResponseException is raised so the Celery task can retry."""
+        """When the Overdrive API returns a response without a 'products' key
+        and a non-empty collection, a BadResponseException is raised so the
+        Celery task can retry."""
         api = overdrive_api_fixture.api
         mock_async_client = overdrive_api_fixture.mock_async_client
 
@@ -2920,3 +2921,22 @@ class TestSyncBookshelf:
         initial_endpoint = api.book_info_initial_endpoint(start=None, page_size=1)
         with pytest.raises(BadResponseException, match="missing 'products' key"):
             await api.fetch_book_info_list(initial_endpoint)
+
+    async def test_fetch_book_info_list_empty_collection(
+        self,
+        overdrive_api_fixture: OverdriveAPIFixture,
+    ):
+        """Overdrive omits the 'products' key for an empty collection
+        (totalItems == 0). This is not an error: we return an empty page."""
+        api = overdrive_api_fixture.api
+        mock_async_client = overdrive_api_fixture.mock_async_client
+
+        mock_async_client.queue_response(
+            200, content={"totalItems": 0, "limit": 100, "offset": 0}
+        )
+
+        initial_endpoint = api.book_info_initial_endpoint(start=None, page_size=1)
+        book_info_list, next_endpoint = await api.fetch_book_info_list(initial_endpoint)
+
+        assert book_info_list == []
+        assert next_endpoint is None


### PR DESCRIPTION
## Description

When an Overdrive collection or page contains no titles, the API omits the `products` key entirely and reports `"totalItems": 0`. `OverdriveAPI.fetch_book_info_list` treated any missing `products` key as a malformed response and raised `BadResponseException`. Since the Overdrive import Celery task uses `autoretry`, this turned a normal empty collection into a retry storm that eventually surfaced as a production exception.

This change distinguishes the empty-collection case (`products` missing **and** `totalItems == 0`) and returns an empty page, while still raising `BadResponseException` for genuinely malformed responses so real errors continue to retry.

## Motivation and Context

Production was intermittently raising:

```
IntegrationException: Overdrive response missing 'products' key. Response data: {'limit': 100, 'offset': 0, 'totalItems': 0, 'id': 'v1L1BdnEAAA2v', 'links': {...}}
```

The response is simply an empty collection (`totalItems: 0`), not an error condition, so it should not raise or trigger retries.

## How Has This Been Tested?

- Updated `test_fetch_book_info_list_missing_products_key` to clarify it covers the non-empty malformed case (still raises).
- Added `test_fetch_book_info_list_empty_collection`, which feeds a `totalItems: 0` response and asserts an empty list and `None` next endpoint are returned without raising.
- Ran `tox -e py312-docker -- --no-cov tests/manager/integration/license/overdrive/test_api.py -k fetch_book_info_list` — all 5 tests pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.