### PR TITLE
Support alternate OIDC auth flow with prompt param (PP-4429)

### DIFF
--- a/src/palace/manager/integration/patron_auth/oidc/auth.py
+++ b/src/palace/manager/integration/patron_auth/oidc/auth.py
@@ -279,6 +279,7 @@ class OIDCAuthenticationManager(LoggerMixin):
         state: str,
         nonce: str,
         code_challenge: str | None = None,
+        prompt: str | None = None,
     ) -> str:
         """Build authorization URL with parameters.
 
@@ -286,6 +287,7 @@ class OIDCAuthenticationManager(LoggerMixin):
         :param state: State parameter for CSRF protection
         :param nonce: Nonce for ID token validation
         :param code_challenge: PKCE code challenge (if PKCE enabled)
+        :param prompt: OIDC prompt parameter to forward to the provider
         :return: Complete authorization URL
         """
         metadata = self.get_provider_metadata()
@@ -309,6 +311,9 @@ class OIDCAuthenticationManager(LoggerMixin):
         # Add access_type for refresh token support
         if self._settings.access_type:
             params["access_type"] = self._settings.access_type
+
+        if prompt:
+            params["prompt"] = prompt
 
         # Construct URL
         auth_url = f"{auth_endpoint}?{urlencode(params)}"

--- a/src/palace/manager/integration/patron_auth/oidc/controller.py
+++ b/src/palace/manager/integration/patron_auth/oidc/controller.py
@@ -87,12 +87,17 @@ class OIDCController(LoggerMixin):
     ERROR = "error"
     REDIRECT_URI = "redirect_uri"
     PROVIDER_NAME = "provider"
+    PROMPT = "prompt"
     STATE = "state"
     CODE = "code"
     ACCESS_TOKEN = "access_token"
     PATRON_INFO = "patron_info"
     LOGOUT_STATUS = "logout_status"
     LOGOUT_TOKEN = "logout_token"
+
+    VALID_PROMPT_VALUES: frozenset[str] = frozenset(
+        {"none", "login", "consent", "select_account"}
+    )
 
     def __init__(
         self, circulation_manager: CirculationManager, authenticator: Authenticator
@@ -149,6 +154,18 @@ class OIDCController(LoggerMixin):
         params = {self.ERROR: problem_detail_json}
         return self._add_params_to_url(redirect_uri, params)
 
+    @classmethod
+    def _is_valid_prompt(cls, prompt: str) -> bool:
+        """Return True if every space-separated token is a recognised OIDC prompt value.
+
+        :param prompt: Raw prompt string from the request.
+        :return: True if all tokens are valid.
+        """
+        tokens = prompt.split()
+        return bool(tokens) and all(
+            token in cls.VALID_PROMPT_VALUES for token in tokens
+        )
+
     @staticmethod
     def _get_request_parameter(
         params: dict[str, str], name: str, default_value: str | None = None
@@ -197,6 +214,10 @@ class OIDCController(LoggerMixin):
         if isinstance(redirect_uri, ProblemDetail):
             return redirect_uri
 
+        prompt = params.get(self.PROMPT)
+        if prompt is not None and not self._is_valid_prompt(prompt):
+            return OIDC_INVALID_REQUEST.detailed(_(f"Invalid prompt value: {prompt!r}"))
+
         # TODO: Validate redirect_uri against configured patron web client URLs
         #  to prevent open redirect attacks. This should be done consistently
         #  for both OIDC and SAML.
@@ -235,6 +256,7 @@ class OIDCController(LoggerMixin):
             state=state,
             nonce=nonce,
             code_challenge=code_challenge,
+            prompt=prompt,
         )
 
         return redirect(authorization_url)

--- a/src/palace/manager/integration/patron_auth/oidc/controller.py
+++ b/src/palace/manager/integration/patron_auth/oidc/controller.py
@@ -156,15 +156,20 @@ class OIDCController(LoggerMixin):
 
     @classmethod
     def _is_valid_prompt(cls, prompt: str) -> bool:
-        """Return True if every space-separated token is a recognised OIDC prompt value.
+        """Return True if the prompt string is a valid OIDC prompt value.
+
+        Each space-separated token must be a recognised OIDC value, and
+        ``none`` must not appear alongside any other token (OIDC Core §3.1.2.1).
 
         :param prompt: Raw prompt string from the request.
-        :return: True if all tokens are valid.
+        :return: True if the prompt is valid per the OIDC spec.
         """
         tokens = prompt.split()
-        return bool(tokens) and all(
-            token in cls.VALID_PROMPT_VALUES for token in tokens
-        )
+        if not tokens:
+            return False
+        if len(tokens) > 1 and "none" in tokens:
+            return False
+        return all(token in cls.VALID_PROMPT_VALUES for token in tokens)
 
     @staticmethod
     def _get_request_parameter(
@@ -216,7 +221,10 @@ class OIDCController(LoggerMixin):
 
         prompt = params.get(self.PROMPT)
         if prompt is not None and not self._is_valid_prompt(prompt):
-            return OIDC_INVALID_REQUEST.detailed(_(f"Invalid prompt value: {prompt!r}"))
+            return self._redirect_with_error(
+                redirect_uri,
+                OIDC_INVALID_REQUEST.detailed(_(f"Invalid prompt value: {prompt!r}")),
+            )
 
         # TODO: Validate redirect_uri against configured patron web client URLs
         #  to prevent open redirect attacks. This should be done consistently

--- a/tests/manager/integration/patron_auth/oidc/test_auth.py
+++ b/tests/manager/integration/patron_auth/oidc/test_auth.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import time
+from typing import Any
 from unittest.mock import Mock, patch
 from urllib.parse import quote
 
@@ -24,6 +25,7 @@ from palace.manager.integration.patron_auth.oidc.util import OIDCDiscoveryError
 from palace.manager.util.http.exception import (
     RequestNetworkException,
 )
+from tests.fixtures.redis import RedisFixture
 
 # Test constants
 TEST_ISSUER_URL = "https://oidc.test.example.com"
@@ -224,19 +226,20 @@ class TestOIDCAuthenticationManagerAuthorizationURL:
     """Tests for authorization URL building."""
 
     @pytest.mark.parametrize(
-        "use_pkce,scopes,access_type,code_challenge,expected_in_url,expected_not_in_url",
+        "use_pkce,scopes,access_type,code_challenge,prompt,expected_in_url,expected_not_in_url",
         [
             pytest.param(
                 True,
                 None,
                 "offline",
                 "test-challenge",
+                None,
                 [
                     "code_challenge=test-challenge",
                     "code_challenge_method=S256",
                     "access_type=offline",
                 ],
-                [],
+                ["prompt="],
                 id="with-pkce",
             ),
             pytest.param(
@@ -244,14 +247,16 @@ class TestOIDCAuthenticationManagerAuthorizationURL:
                 None,
                 "offline",
                 None,
+                None,
                 ["access_type=offline"],
-                ["code_challenge", "code_challenge_method"],
+                ["code_challenge", "code_challenge_method", "prompt="],
                 id="without-pkce",
             ),
             pytest.param(
                 True,
                 ["openid", "profile", "custom_scope"],
                 "offline",
+                None,
                 None,
                 ["scope=openid+profile+custom_scope"],
                 [],
@@ -262,22 +267,44 @@ class TestOIDCAuthenticationManagerAuthorizationURL:
                 None,
                 "online",
                 None,
+                None,
                 ["access_type=online"],
-                [],
+                ["prompt="],
                 id="online-access",
+            ),
+            pytest.param(
+                False,
+                None,
+                "offline",
+                None,
+                "select_account",
+                ["prompt=select_account"],
+                [],
+                id="with-prompt-select-account",
+            ),
+            pytest.param(
+                False,
+                None,
+                "offline",
+                None,
+                "login",
+                ["prompt=login"],
+                [],
+                id="with-prompt-login",
             ),
         ],
     )
     def test_build_authorization_url(
         self,
-        use_pkce,
-        scopes,
-        access_type,
-        code_challenge,
-        expected_in_url,
-        expected_not_in_url,
-        redis_fixture,
-        mock_discovery_document,
+        use_pkce: bool,
+        scopes: list[str] | None,
+        access_type: str,
+        code_challenge: str | None,
+        prompt: str | None,
+        expected_in_url: list[str],
+        expected_not_in_url: list[str],
+        redis_fixture: RedisFixture,
+        mock_discovery_document: dict[str, Any],
     ):
         """Test authorization URL building with different configurations."""
         # Build settings with only non-None optional parameters
@@ -315,6 +342,8 @@ class TestOIDCAuthenticationManagerAuthorizationURL:
             }
             if code_challenge:
                 build_kwargs["code_challenge"] = code_challenge
+            if prompt:
+                build_kwargs["prompt"] = prompt
 
             url = manager.build_authorization_url(**build_kwargs)
 

--- a/tests/manager/integration/patron_auth/oidc/test_controller.py
+++ b/tests/manager/integration/patron_auth/oidc/test_controller.py
@@ -364,6 +364,7 @@ class TestOIDCController:
         [
             pytest.param("invalid_value", id="unknown-single"),
             pytest.param("select_account invalid_value", id="unknown-token-in-multi"),
+            pytest.param("none login", id="none-combined"),
             pytest.param("", id="empty-string"),
             pytest.param("   ", id="whitespace-only"),
         ],
@@ -371,7 +372,7 @@ class TestOIDCController:
     def test_oidc_authentication_redirect_invalid_prompt(
         self, controller: OIDCController, prompt: str
     ):
-        """Test that any unrecognised prompt token is rejected with OIDC_INVALID_REQUEST."""
+        """Test that invalid prompt values are redirected back with an encoded error."""
         params = {
             "provider": "OpenID Connect",
             "redirect_uri": "https://app.example.com",
@@ -380,8 +381,8 @@ class TestOIDCController:
 
         result = controller.oidc_authentication_redirect(params, MagicMock())
 
-        assert result.uri == OIDC_INVALID_REQUEST.uri
-        assert prompt in str(result.detail)
+        assert result.status_code == 302
+        assert "error=" in result.location
 
     @pytest.mark.parametrize(
         "params,expected_error_substring",

--- a/tests/manager/integration/patron_auth/oidc/test_controller.py
+++ b/tests/manager/integration/patron_auth/oidc/test_controller.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import jwt
 import pytest
@@ -297,6 +297,91 @@ class TestOIDCController:
             assert result.status_code == 302
             assert "code_challenge=" in result.location
             assert "code_challenge_method=S256" in result.location
+
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            pytest.param("select_account", id="select-account"),
+            pytest.param("login", id="login"),
+            pytest.param("consent", id="consent"),
+            pytest.param("none", id="none"),
+            pytest.param("select_account consent", id="select-account-consent"),
+            pytest.param("login consent", id="login-consent"),
+        ],
+    )
+    def test_oidc_authentication_redirect_with_valid_prompt(
+        self,
+        db: DatabaseTransactionFixture,
+        controller: OIDCController,
+        mock_authenticator: MagicMock,
+        oidc_provider: OIDCAuthenticationProvider,
+        prompt: str,
+    ):
+        """Test that valid OIDC prompt values are forwarded to build_authorization_url."""
+        library = db.default_library()
+        params = {
+            "provider": "OpenID Connect",
+            "redirect_uri": "https://app.example.com",
+            "prompt": prompt,
+        }
+
+        mock_auth_manager = MagicMock()
+        mock_auth_manager.build_authorization_url.return_value = (
+            f"https://idp.example.com/authorize?prompt={prompt}"
+        )
+
+        mock_authenticator.oidc_provider_lookup.return_value = oidc_provider
+        mock_authenticator.library_authenticators = {
+            library.short_name: MagicMock(bearer_token_signing_secret="test-secret")
+        }
+
+        with (
+            patch(
+                "palace.manager.integration.patron_auth.oidc.controller.url_for"
+            ) as mock_url_for,
+            patch.object(
+                oidc_provider,
+                "get_authentication_manager",
+                return_value=mock_auth_manager,
+            ),
+        ):
+            mock_url_for.return_value = "https://cm.example.com/oidc_callback"
+
+            result = controller.oidc_authentication_redirect(params, db.session)
+
+            assert result.status_code == 302
+            # `prompt` is the focus here. Using ANY for dynamic values.
+            mock_auth_manager.build_authorization_url.assert_called_once_with(
+                redirect_uri="https://cm.example.com/oidc_callback",
+                state=ANY,
+                nonce=ANY,
+                code_challenge=ANY,
+                prompt=prompt,
+            )
+
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            pytest.param("invalid_value", id="unknown-single"),
+            pytest.param("select_account invalid_value", id="unknown-token-in-multi"),
+            pytest.param("", id="empty-string"),
+            pytest.param("   ", id="whitespace-only"),
+        ],
+    )
+    def test_oidc_authentication_redirect_invalid_prompt(
+        self, controller: OIDCController, prompt: str
+    ):
+        """Test that any unrecognised prompt token is rejected with OIDC_INVALID_REQUEST."""
+        params = {
+            "provider": "OpenID Connect",
+            "redirect_uri": "https://app.example.com",
+            "prompt": prompt,
+        }
+
+        result = controller.oidc_authentication_redirect(params, MagicMock())
+
+        assert result.uri == OIDC_INVALID_REQUEST.uri
+        assert prompt in str(result.detail)
 
     @pytest.mark.parametrize(
         "params,expected_error_substring",


### PR DESCRIPTION
> [!NOTE]
> Reopens #3452, which was accidentally opened from a fork. 

## Description

Adds support for the OIDC `prompt` query parameter on the `/oidc/authenticate` endpoint. When present, the value is validated against the OIDC-defined set of tokens (`none`, `login`, `consent`, `select_account`) and forwarded as-is to the upstream IdP's authorization URL. Multi-value prompts (e.g. `select_account consent`) are supported per the OIDC spec, which defines the parameter as a space-separated list.

## Motivation and Context

The web patron client (CPW) shows a "Use a different account" button when an OIDC authentication error occurs or the user cancels sign-in. Clicking it retries authentication with `prompt=select_account` appended to the CM's `/oidc/authenticate` URL, which forces the IdP to show its account chooser even when a session already exists. Previously the CM silently ignored any `prompt` parameter; this change wires it through end-to-end.

[Jira PP-4429]

## How Has This Been Tested?

- New updated test cases for new functionality.
- Manual testing in local environment to verify valid values passing through.
- All tests and checks pass locally.
- CI tests and checks pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
