### PR TITLE
Add admin endpoint to force a collection reap on demand (PP-4363)

### DIFF
--- a/src/palace/manager/api/admin/controller/collection_settings.py
+++ b/src/palace/manager/api/admin/controller/collection_settings.py
@@ -17,10 +17,15 @@ from palace.manager.api.admin.problem_details import (
     MISSING_PARENT,
     MISSING_SERVICE,
     PROTOCOL_DOES_NOT_SUPPORT_PARENTS,
+    REAP_NOT_SUPPORTED,
     UNKNOWN_PROTOCOL,
 )
 from palace.manager.api.admin.util.flask import get_request_admin
-from palace.manager.api.circulation.base import CirculationApiType, SupportsImport
+from palace.manager.api.circulation.base import (
+    CirculationApiType,
+    SupportsImport,
+    SupportsReaping,
+)
 from palace.manager.celery.tasks.collection_delete import collection_delete
 from palace.manager.celery.tasks.reaper import (
     reap_unassociated_holds,
@@ -231,6 +236,49 @@ class CollectionSettingsController(
         impl_cls.import_task(collection.id, force=force).apply_async()
 
         return Response("Import task queued.", 200)
+
+    def process_reap(self, service_id: int) -> Response | ProblemDetail:
+        """Queue a collection reap task on demand.
+
+        Reaping re-reads the collection's feed and marks any identifiers that
+        are no longer present in the feed as unavailable, removing those titles
+        from the catalog. This is useful when items have been accidentally added
+        to the catalog and need to be removed without waiting for the collection's
+        scheduled reap.
+
+        :param service_id: The integration configuration ID of the collection to reap.
+        :return: A 200 response on success, or a ProblemDetail on error.
+        """
+        self.require_system_admin()
+
+        integration = get_one(
+            self._db,
+            IntegrationConfiguration,
+            id=service_id,
+            goal=self.registry.goal,
+        )
+        if not integration:
+            return MISSING_SERVICE
+
+        collection = integration.collection
+        if not collection:
+            return MISSING_COLLECTION
+
+        if collection.marked_for_deletion:
+            return MISSING_COLLECTION
+
+        protocol = integration.protocol
+        if protocol not in self.registry:
+            return UNKNOWN_PROTOCOL
+
+        impl_cls = self.registry[protocol]
+
+        if not issubclass(impl_cls, SupportsReaping):
+            return REAP_NOT_SUPPORTED
+
+        impl_cls.reap_task(collection.id).apply_async()
+
+        return Response("Reap task queued.", 200)
 
     def process_collection_self_tests(
         self, identifier: int | None

--- a/src/palace/manager/api/admin/problem_details.py
+++ b/src/palace/manager/api/admin/problem_details.py
@@ -489,6 +489,13 @@ IMPORT_NOT_SUPPORTED = pd(
     detail=_("The collection's protocol does not support import."),
 )
 
+REAP_NOT_SUPPORTED = pd(
+    "http://palaceproject.io/terms/problem/reap-not-supported",
+    status_code=400,
+    title=_("Reap not supported"),
+    detail=_("The collection's protocol does not support reaping."),
+)
+
 COLLECTION_DOES_NOT_SUPPORT_REGISTRATION = pd(
     "http://librarysimplified.org/terms/problem/collection-does-not-support-registration",
     status_code=400,

--- a/src/palace/manager/api/admin/routes.py
+++ b/src/palace/manager/api/admin/routes.py
@@ -434,6 +434,19 @@ def collection_import(collection_id):
     )
 
 
+@app.route("/admin/collection/<collection_id>/reap", methods=["POST"])
+@returns_json_or_response_or_problem_detail
+@requires_admin
+@requires_csrf_token
+def collection_reap(collection_id):
+    try:
+        integration_id = int(collection_id)
+    except ValueError:
+        return INVALID_INPUT
+
+    return app.manager.admin_collection_settings_controller.process_reap(integration_id)
+
+
 @app.route("/admin/collection_self_tests/<identifier>", methods=["GET", "POST"])
 @returns_json_or_response_or_problem_detail
 @requires_admin

--- a/src/palace/manager/api/circulation/base.py
+++ b/src/palace/manager/api/circulation/base.py
@@ -79,6 +79,24 @@ class SupportsImport(ABC):
         ...
 
 
+class SupportsReaping(ABC):
+    """Mixin for circulation APIs that support on-demand collection reaping.
+
+    Reaping re-reads the collection's feed and marks any identifiers that are no
+    longer present in the feed as unavailable, removing those titles from the
+    catalog.
+    """
+
+    @classmethod
+    @abstractmethod
+    def reap_task(cls, collection_id: int) -> Signature:
+        """Return the Celery task signature for reaping the collection.
+
+        :param collection_id: The ID of the collection to reap.
+        """
+        ...
+
+
 class BaseCirculationAPI[
     SettingsType: BaseCirculationApiSettings, LibrarySettingsType: BaseSettings
 ](
@@ -224,10 +242,12 @@ class BaseCirculationAPI[
 
     @classmethod
     def protocol_details(cls, db: Session) -> dict[str, Any]:
-        """Include ``supports_import`` so the admin UI knows whether to
-        offer an import button for collections using this protocol."""
+        """Include ``supports_import`` and ``supports_reap`` so the admin UI
+        knows whether to offer import and reap buttons for collections using
+        this protocol."""
         details = super().protocol_details(db)
         details["supports_import"] = issubclass(cls, SupportsImport)
+        details["supports_reap"] = issubclass(cls, SupportsReaping)
         return details
 
     @property

--- a/src/palace/manager/integration/license/opds/for_distributors/api.py
+++ b/src/palace/manager/integration/license/opds/for_distributors/api.py
@@ -11,7 +11,11 @@ from sqlalchemy.orm import Session
 
 from palace.util.datetime_helpers import utc_now
 
-from palace.manager.api.circulation.base import BaseCirculationAPI, SupportsImport
+from palace.manager.api.circulation.base import (
+    BaseCirculationAPI,
+    SupportsImport,
+    SupportsReaping,
+)
 from palace.manager.api.circulation.data import HoldInfo, LoanInfo
 from palace.manager.api.circulation.exceptions import (
     CannotFulfill,
@@ -48,6 +52,7 @@ class OPDSForDistributorsAPI(
     BaseCirculationAPI[OPDSForDistributorsSettings, OPDSForDistributorsLibrarySettings],
     HasCollectionSelfTests,
     SupportsImport,
+    SupportsReaping,
 ):
     @classmethod
     def settings_class(cls) -> type[OPDSForDistributorsSettings]:
@@ -251,3 +256,14 @@ class OPDSForDistributorsAPI(
         from palace.manager.celery.tasks.opds_for_distributors import import_collection
 
         return import_collection.s(collection_id, force=force)
+
+    @classmethod
+    def reap_task(cls, collection_id: int) -> Signature:
+        # Local import to avoid a circular import between this module and the
+        # opds_for_distributors celery tasks module, which imports
+        # OPDSForDistributorsAPI.
+        from palace.manager.celery.tasks.opds_for_distributors import (
+            import_and_reap_not_found_chord,
+        )
+
+        return import_and_reap_not_found_chord(collection_id)

--- a/src/palace/manager/integration/license/opds/opds1/api.py
+++ b/src/palace/manager/integration/license/opds/opds1/api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from celery.canvas import Signature
 
-from palace.manager.api.circulation.base import SupportsImport
+from palace.manager.api.circulation.base import SupportsImport, SupportsReaping
 from palace.manager.integration.license.opds.base.api import BaseOPDSAPI
 from palace.manager.integration.license.opds.opds1.settings import (
     OPDSImporterLibrarySettings,
@@ -11,7 +11,9 @@ from palace.manager.integration.license.opds.opds1.settings import (
 
 
 class OPDSAPI(
-    BaseOPDSAPI[OPDSImporterSettings, OPDSImporterLibrarySettings], SupportsImport
+    BaseOPDSAPI[OPDSImporterSettings, OPDSImporterLibrarySettings],
+    SupportsImport,
+    SupportsReaping,
 ):
     @classmethod
     def settings_class(cls) -> type[OPDSImporterSettings]:
@@ -34,3 +36,11 @@ class OPDSAPI(
         from palace.manager.celery.tasks.opds1 import import_collection
 
         return import_collection.s(collection_id, force=force)
+
+    @classmethod
+    def reap_task(cls, collection_id: int) -> Signature:
+        # Local import to avoid a circular import between this module and the
+        # opds1 celery tasks module, which imports OPDSAPI.
+        from palace.manager.celery.tasks.opds1 import import_and_reap_not_found_chord
+
+        return import_and_reap_not_found_chord(collection_id)

--- a/src/palace/manager/integration/license/opds/opds2/api.py
+++ b/src/palace/manager/integration/license/opds/opds2/api.py
@@ -12,7 +12,11 @@ from uritemplate import URITemplate
 
 from palace.util.datetime_helpers import utc_now
 
-from palace.manager.api.circulation.base import BaseCirculationAPI, SupportsImport
+from palace.manager.api.circulation.base import (
+    BaseCirculationAPI,
+    SupportsImport,
+    SupportsReaping,
+)
 from palace.manager.api.circulation.exceptions import CannotFulfill
 from palace.manager.api.circulation.fulfillment import RedirectFulfillment
 from palace.manager.integration.license.opds.base.api import BaseOPDSAPI
@@ -50,7 +54,9 @@ SUPPORTED_TEMPLATE_VARIABLES: frozenset[str] = frozenset(TemplateVariable)
 
 
 class OPDS2API(
-    BaseOPDSAPI[OPDS2APISettings, OPDS2ImporterLibrarySettings], SupportsImport
+    BaseOPDSAPI[OPDS2APISettings, OPDS2ImporterLibrarySettings],
+    SupportsImport,
+    SupportsReaping,
 ):
     TOKEN_AUTH_CONFIG_KEY = "token_auth_endpoint"
     LAST_REAP_TIME_KEY = "last_reap_time"
@@ -290,6 +296,14 @@ class OPDS2API(
         from palace.manager.celery.tasks.opds2 import import_collection
 
         return import_collection.s(collection_id, force=force)
+
+    @classmethod
+    def reap_task(cls, collection_id: int) -> Signature:
+        # Local import to avoid a circular import between this module and the
+        # opds2 celery tasks module, which imports OPDS2API.
+        from palace.manager.celery.tasks.opds2 import import_and_reap_not_found_chord
+
+        return import_and_reap_not_found_chord(collection_id)
 
     @classmethod
     def update_collection_token_auth_url(cls, collection: Collection, url: str) -> bool:

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -11,6 +11,7 @@ from typing import Any, NamedTuple, Unpack, overload
 from urllib.parse import urlsplit
 
 import flask
+from celery.canvas import Signature
 from pydantic import ValidationError
 from requests import Response
 from requests.structures import CaseInsensitiveDict
@@ -22,6 +23,7 @@ from palace.manager.api.circulation.base import (
     BaseCirculationAPI,
     CirculationInternalFormatsMixin,
     PatronActivityCirculationAPI,
+    SupportsReaping,
 )
 from palace.manager.api.circulation.data import HoldInfo, LoanInfo
 from palace.manager.api.circulation.exceptions import (
@@ -140,6 +142,7 @@ class OverdriveAPI(
     HasCollectionSelfTests,
     HasChildIntegrationConfiguration[OverdriveSettings, OverdriveChildSettings],
     OverdriveConstants,
+    SupportsReaping,
 ):
     SET_DELIVERY_MECHANISM_AT = BaseCirculationAPI.FULFILL_STEP
 
@@ -280,6 +283,14 @@ class OverdriveAPI(
     @classmethod
     def description(cls) -> str:
         return "Integrate an Overdrive collection. For an Overdrive Advantage collection, select the consortium's Overdrive collection as the parent."
+
+    @classmethod
+    def reap_task(cls, collection_id: int) -> Signature:
+        # Local import to avoid a circular import between this module and the
+        # overdrive celery tasks module, which imports OverdriveAPI.
+        from palace.manager.celery.tasks.overdrive import reap_collection
+
+        return reap_collection.s(collection_id)
 
     def __init__(self, _db: Session, collection: Collection) -> None:
         super().__init__(_db, collection)

--- a/tests/manager/api/admin/controller/test_collections.py
+++ b/tests/manager/api/admin/controller/test_collections.py
@@ -26,14 +26,16 @@ from palace.manager.api.admin.problem_details import (
     NO_PROTOCOL_FOR_NEW_SERVICE,
     NO_SUCH_LIBRARY,
     PROTOCOL_DOES_NOT_SUPPORT_PARENTS,
+    REAP_NOT_SUPPORTED,
     UNKNOWN_PROTOCOL,
 )
 from palace.manager.api.selftest import HasCollectionSelfTests
-from palace.manager.celery.tasks import boundless, opds_odl
+from palace.manager.celery.tasks import boundless, opds2, opds_odl
 from palace.manager.core.selftest import HasSelfTests
 from palace.manager.integration.goals import Goals
 from palace.manager.integration.license.boundless.api import BoundlessApi
 from palace.manager.integration.license.opds.odl.api import OPDS2WithODLApi
+from palace.manager.integration.license.opds.opds2.api import OPDS2API
 from palace.manager.integration.license.overdrive.api import OverdriveAPI
 from palace.manager.integration.license.overdrive.settings import (
     OverdriveLibrarySettings,
@@ -1108,3 +1110,98 @@ class TestCollectionSettings:
         # OverdriveAPI does not implement SupportsImport, so supports_import should be False.
         overdrive_details = OverdriveAPI.protocol_details(db.session)
         assert overdrive_details["supports_import"] is False
+
+    def test_process_reap_requires_system_admin(
+        self,
+        controller: CollectionSettingsController,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        collection = db.collection(protocol=OPDS2API)
+        assert collection.integration_configuration.id is not None
+        with flask_app_fixture.test_request_context("/", method="POST"):
+            pytest.raises(
+                AdminNotAuthorized,
+                controller.process_reap,
+                collection.integration_configuration.id,
+            )
+
+    def test_process_reap_missing_service(
+        self,
+        controller: CollectionSettingsController,
+        flask_app_fixture: FlaskAppFixture,
+    ):
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            response = controller.process_reap(999999)
+        assert response == MISSING_SERVICE
+
+    def test_process_reap_marked_for_deletion(
+        self,
+        controller: CollectionSettingsController,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        collection = db.collection(protocol=OPDS2API)
+        collection.marked_for_deletion = True
+        assert collection.integration_configuration.id is not None
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            response = controller.process_reap(collection.integration_configuration.id)
+        assert response == MISSING_COLLECTION
+
+    def test_process_reap_unknown_protocol(
+        self,
+        controller: CollectionSettingsController,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        collection = db.collection(protocol=OPDS2API)
+        integration = collection.integration_configuration
+        integration.protocol = "UnknownProtocol"
+        assert integration.id is not None
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            response = controller.process_reap(integration.id)
+        assert response == UNKNOWN_PROTOCOL
+
+    def test_process_reap_unsupported_protocol(
+        self,
+        controller: CollectionSettingsController,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        # BoundlessApi supports import but does not implement SupportsReaping.
+        collection = db.collection(protocol=BoundlessApi)
+        assert collection.integration_configuration.id is not None
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            response = controller.process_reap(collection.integration_configuration.id)
+        assert response == REAP_NOT_SUPPORTED
+
+    def test_process_reap_success(
+        self,
+        controller: CollectionSettingsController,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        collection = db.collection(protocol=OPDS2API)
+        assert collection.integration_configuration.id is not None
+        with (
+            flask_app_fixture.test_request_context_system_admin("/", method="POST"),
+            patch.object(opds2, "import_and_reap_not_found_chord") as mock_reap,
+        ):
+            response = controller.process_reap(collection.integration_configuration.id)
+        assert isinstance(response, Response)
+        assert response.status_code == 200
+        assert response.get_data(as_text=True) == "Reap task queued."
+        mock_reap.assert_called_once_with(collection.id)
+        mock_reap.return_value.apply_async.assert_called_once()
+
+    def test_protocol_details_supports_reap(
+        self,
+        db: DatabaseTransactionFixture,
+    ):
+        # OPDS2API implements SupportsReaping, so supports_reap should be True.
+        opds2_details = OPDS2API.protocol_details(db.session)
+        assert opds2_details["supports_reap"] is True
+
+        # BoundlessApi supports import but not reaping, so supports_reap should be False.
+        boundless_details = BoundlessApi.protocol_details(db.session)
+        assert boundless_details["supports_reap"] is False

--- a/tests/manager/api/admin/controller/test_collections.py
+++ b/tests/manager/api/admin/controller/test_collections.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 from unittest.mock import MagicMock, create_autospec, patch
 
 import flask
@@ -29,12 +30,17 @@ from palace.manager.api.admin.problem_details import (
     REAP_NOT_SUPPORTED,
     UNKNOWN_PROTOCOL,
 )
+from palace.manager.api.circulation.base import BaseCirculationAPI
 from palace.manager.api.selftest import HasCollectionSelfTests
 from palace.manager.celery.tasks import boundless, opds2, opds_odl
 from palace.manager.core.selftest import HasSelfTests
 from palace.manager.integration.goals import Goals
 from palace.manager.integration.license.boundless.api import BoundlessApi
+from palace.manager.integration.license.opds.for_distributors.api import (
+    OPDSForDistributorsAPI,
+)
 from palace.manager.integration.license.opds.odl.api import OPDS2WithODLApi
+from palace.manager.integration.license.opds.opds1.api import OPDSAPI
 from palace.manager.integration.license.opds.opds2.api import OPDS2API
 from palace.manager.integration.license.overdrive.api import OverdriveAPI
 from palace.manager.integration.license.overdrive.settings import (
@@ -1194,14 +1200,28 @@ class TestCollectionSettings:
         mock_reap.assert_called_once_with(collection.id)
         mock_reap.return_value.apply_async.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "protocol",
+        [
+            pytest.param(OPDS2API, id="opds2"),
+            pytest.param(OPDSAPI, id="opds1"),
+            pytest.param(OPDSForDistributorsAPI, id="opds_for_distributors"),
+            pytest.param(OverdriveAPI, id="overdrive"),
+        ],
+    )
     def test_protocol_details_supports_reap(
+        self,
+        protocol: type[BaseCirculationAPI[Any, Any]],
+        db: DatabaseTransactionFixture,
+    ):
+        # These protocols implement SupportsReaping, so supports_reap should be True.
+        details = protocol.protocol_details(db.session)
+        assert details["supports_reap"] is True
+
+    def test_protocol_details_does_not_support_reap(
         self,
         db: DatabaseTransactionFixture,
     ):
-        # OPDS2API implements SupportsReaping, so supports_reap should be True.
-        opds2_details = OPDS2API.protocol_details(db.session)
-        assert opds2_details["supports_reap"] is True
-
         # BoundlessApi supports import but not reaping, so supports_reap should be False.
         boundless_details = BoundlessApi.protocol_details(db.session)
         assert boundless_details["supports_reap"] is False

--- a/tests/manager/api/admin/test_routes.py
+++ b/tests/manager/api/admin/test_routes.py
@@ -724,6 +724,28 @@ class TestAdminCollectionSettings:
         payload = json.loads(body)
         assert payload["type"] == INVALID_INPUT.uri
 
+    def test_process_reap(self, fixture: AdminRouteFixture):
+        url = "/admin/collection/123/reap"
+        fixture.assert_authenticated_request_calls(
+            url,
+            fixture.controller.process_reap,
+            123,
+            http_method="POST",
+        )
+        fixture.assert_supported_methods(url, "POST")
+
+    def test_process_reap_invalid_collection_id(self, fixture: AdminRouteFixture):
+        fixture.manager.admin_sign_in_controller.authenticated = True
+        try:
+            response = fixture.request("/admin/collection/not-a-number/reap", "POST")
+        finally:
+            fixture.manager.admin_sign_in_controller.authenticated = False
+
+        body, status_code, _ = response
+        assert status_code == INVALID_INPUT.status_code
+        payload = json.loads(body)
+        assert payload["type"] == INVALID_INPUT.uri
+
     def test_process_collection_self_tests(self, fixture: AdminRouteFixture):
         url = "/admin/collection_self_tests/<identifier>"
         fixture.assert_authenticated_request_calls(

--- a/tests/manager/integration/license/opds/for_distributors/test_api.py
+++ b/tests/manager/integration/license/opds/for_distributors/test_api.py
@@ -361,6 +361,16 @@ class TestOPDSForDistributorsAPI:
         mock_import.s.assert_called_once_with(collection_id, force=force)
         assert result == mock_import.s.return_value
 
+    def test_reap_task(self) -> None:
+        collection_id = MagicMock()
+        with patch.object(
+            opds_for_distributors, "import_and_reap_not_found_chord"
+        ) as mock_reap:
+            result = OPDSForDistributorsAPI.reap_task(collection_id)
+
+        mock_reap.assert_called_once_with(collection_id)
+        assert result == mock_reap.return_value
+
     @pytest.mark.parametrize(
         "url,token,expected",
         [

--- a/tests/manager/integration/license/opds/opds1/test_api.py
+++ b/tests/manager/integration/license/opds/opds1/test_api.py
@@ -201,3 +201,11 @@ class TestOPDSAPI:
 
         mock_import.s.assert_called_once_with(collection_id, force=force)
         assert result == mock_import.s.return_value
+
+    def test_reap_task(self) -> None:
+        collection_id = MagicMock()
+        with patch.object(opds1, "import_and_reap_not_found_chord") as mock_reap:
+            result = OPDSAPI.reap_task(collection_id)
+
+        mock_reap.assert_called_once_with(collection_id)
+        assert result == mock_reap.return_value

--- a/tests/manager/integration/license/opds/opds2/test_api.py
+++ b/tests/manager/integration/license/opds/opds2/test_api.py
@@ -218,6 +218,14 @@ class TestOpds2Api:
         mock_import.s.assert_called_once_with(collection_id, force=force)
         assert result == mock_import.s.return_value
 
+    def test_reap_task(self) -> None:
+        collection_id = MagicMock()
+        with patch.object(opds2_celery, "import_and_reap_not_found_chord") as mock_reap:
+            result = OPDS2API.reap_task(collection_id)
+
+        mock_reap.assert_called_once_with(collection_id)
+        assert result == mock_reap.return_value
+
     def test_get_authentication_token_with_saml_parameters(
         self, opds2_api_fixture: Opds2ApiFixture
     ):

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -28,6 +28,7 @@ from palace.manager.api.circulation.fulfillment import (
     StreamingFulfillment,
 )
 from palace.manager.api.config import Configuration
+from palace.manager.celery.tasks import overdrive as overdrive_celery
 from palace.manager.core.config import CannotLoadConfiguration
 from palace.manager.core.exceptions import IntegrationException
 from palace.manager.integration.license.overdrive.api import (
@@ -75,8 +76,6 @@ from tests.mocks.mock import MockRequestsResponse
 
 class TestOverdriveAPI:
     def test_reap_task(self) -> None:
-        from palace.manager.celery.tasks import overdrive as overdrive_celery
-
         collection_id = MagicMock()
         with patch.object(overdrive_celery, "reap_collection") as mock_reap:
             result = OverdriveAPI.reap_task(collection_id)

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -74,6 +74,16 @@ from tests.mocks.mock import MockRequestsResponse
 
 
 class TestOverdriveAPI:
+    def test_reap_task(self) -> None:
+        from palace.manager.celery.tasks import overdrive as overdrive_celery
+
+        collection_id = MagicMock()
+        with patch.object(overdrive_celery, "reap_collection") as mock_reap:
+            result = OverdriveAPI.reap_task(collection_id)
+
+        mock_reap.s.assert_called_once_with(collection_id)
+        assert result == mock_reap.s.return_value
+
     def test_patron_activity_exception_collection_none(
         self,
         overdrive_api_fixture: OverdriveAPIFixture,


### PR DESCRIPTION
## Description

Adds an admin endpoint to trigger a collection reap on demand, mirroring the existing force-import feature. Introduces a `SupportsReaping` mixin (parallel to `SupportsImport`), implements `reap_task` on `OPDS2API` using the existing `import_and_reap_not_found_chord`, exposes `supports_reap` in `protocol_details`, and adds a `process_reap` controller method behind a new `POST /admin/collection/<id>/reap` route.

## Motivation and Context

Reaping for OPDS2 collections only happens on a cron schedule (the `reap_schedule` setting). When items are accidentally added to a collection's feed and show up in the catalog, there is currently no way to remove them without filing a request for someone to manually trigger a reap. This adds a self-service way for admins to trigger a reap immediately.

The companion frontend changes (the "Queue Reap" button) live in ThePalaceProject/circulation-admin#273 and must be deployed together.

## How Has This Been Tested?

- Added unit tests for `process_reap` (success plus missing-service / missing-collection / marked-for-deletion / unknown-protocol / not-supported cases), the new route, `OPDS2API.reap_task`, and `supports_reap` in `protocol_details`.
- Ran the affected suites under `tox -e py312-docker` (all passing) and `mypy` (clean).

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.