### PR TITLE
Add explicit anonymous-access authentication provider (PP-4541)

### DIFF
--- a/src/palace/manager/api/admin/controller/patron_auth_services.py
+++ b/src/palace/manager/api/admin/controller/patron_auth_services.py
@@ -13,6 +13,7 @@ from palace.manager.api.admin.controller.integration_settings import (
 )
 from palace.manager.api.admin.form_data import ProcessFormData
 from palace.manager.api.admin.problem_details import (
+    EXCLUSIVE_ANONYMOUS_AUTH_SERVICE,
     FAILED_TO_RUN_SELF_TESTS,
     INVALID_CONFIGURATION_OPTION,
     MULTIPLE_BASIC_AUTH_SERVICES,
@@ -28,6 +29,9 @@ from palace.manager.api.authentication.patron_blocking_rules.rule_engine import 
     validate_rule_expression,
 )
 from palace.manager.integration.goals import Goals
+from palace.manager.integration.patron_auth.anonymous_authentication import (
+    AnonymousAuthenticationProvider,
+)
 from palace.manager.integration.settings import BaseSettings
 from palace.manager.sqlalchemy.listeners import site_configuration_has_changed
 from palace.manager.sqlalchemy.model.integration import (
@@ -48,6 +52,14 @@ class PatronAuthServicesController(
             name
             for name, api in self.registry
             if issubclass(api, BasicAuthenticationProvider)
+        }
+
+    @property
+    def anonymous_auth_protocols(self) -> set[str]:
+        return {
+            name
+            for name, api in self.registry
+            if issubclass(api, AnonymousAuthenticationProvider)
         }
 
     def process_patron_auth_services(self) -> Response | ProblemDetail:
@@ -103,24 +115,45 @@ class PatronAuthServicesController(
         """Validate a library integration after its settings have been saved.
 
         Ensures the library does not end up with more than one basic-auth
-        patron authentication service.
+        patron authentication service, and that anonymous access is not
+        combined with any other patron authentication service.
         """
         library = integration.library
-        basic_auth_integrations = (
+        patron_auth_query = (
             self._db.query(IntegrationConfiguration)
             .join(IntegrationLibraryConfiguration)
             .filter(
                 IntegrationLibraryConfiguration.library_id == library.id,
                 IntegrationConfiguration.goal == Goals.PATRON_AUTH_GOAL,
-                IntegrationConfiguration.protocol.in_(self.basic_auth_protocols),
             )
-            .count()
         )
+
+        basic_auth_integrations = patron_auth_query.filter(
+            IntegrationConfiguration.protocol.in_(self.basic_auth_protocols)
+        ).count()
         if basic_auth_integrations > 1:
             raise ProblemDetailException(
                 MULTIPLE_BASIC_AUTH_SERVICES.detailed(
                     "You tried to add a patron authentication service that uses basic auth "
                     f"to {library.short_name}, but it already has one."
+                )
+            )
+
+        # Anonymous access is mutually exclusive with every other kind of
+        # patron authentication. Reject the configuration here so it never
+        # reaches LibraryAuthenticator, where the conflict would otherwise be
+        # resolved unpredictably depending on integration load order.
+        anonymous_auth_integrations = patron_auth_query.filter(
+            IntegrationConfiguration.protocol.in_(self.anonymous_auth_protocols)
+        ).count()
+        total_patron_auth_integrations = patron_auth_query.count()
+        if anonymous_auth_integrations >= 1 and total_patron_auth_integrations > 1:
+            raise ProblemDetailException(
+                EXCLUSIVE_ANONYMOUS_AUTH_SERVICE.detailed(
+                    "You tried to configure anonymous access for "
+                    f"{library.short_name} alongside another patron authentication "
+                    "service. Anonymous access cannot be combined with any other "
+                    "authentication provider."
                 )
             )
 

--- a/src/palace/manager/api/admin/problem_details.py
+++ b/src/palace/manager/api/admin/problem_details.py
@@ -360,6 +360,16 @@ MULTIPLE_BASIC_AUTH_SERVICES = pd(
     ),
 )
 
+EXCLUSIVE_ANONYMOUS_AUTH_SERVICE = pd(
+    "http://librarysimplified.org/terms/problem/exclusive-anonymous-auth-service",
+    status_code=400,
+    title=_("Anonymous access cannot be combined with other authentication"),
+    detail=_(
+        "A library configured for anonymous access cannot have any other patron "
+        "authentication service."
+    ),
+)
+
 NO_SUCH_PATRON = pd(
     "http://librarysimplified.org/terms/problem/no-such-patron",
     status_code=404,

--- a/src/palace/manager/api/authentication/base.py
+++ b/src/palace/manager/api/authentication/base.py
@@ -15,7 +15,6 @@ from palace.util.datetime_helpers import utc_now
 from palace.util.exceptions import BasePalaceException
 from palace.util.log import LoggerMixin
 
-from palace.manager.api.authentication.opds import OPDSAuthenticationFlow
 from palace.manager.core.selftest import HasSelfTests
 from palace.manager.integration.base import HasLibraryIntegrationConfiguration
 from palace.manager.integration.settings import BaseSettings
@@ -73,13 +72,19 @@ LibrarySettingsType = TypeVar(
 
 
 class AuthenticationProvider(
-    OPDSAuthenticationFlow,
     HasLibraryIntegrationConfiguration[SettingsType, LibrarySettingsType],
     HasSelfTests,
     LoggerMixin,
     ABC,
 ):
-    """Handle a specific patron authentication scheme."""
+    """Handle a specific patron authentication scheme.
+
+    Most providers also advertise themselves as an Authentication Flow in the
+    Authentication For OPDS document by additionally inheriting
+    :class:`~palace.manager.api.authentication.opds.OPDSAuthenticationFlow`.
+    That is a separate, opt-in capability: a provider that never advertises a
+    flow (such as anonymous access) simply does not inherit it.
+    """
 
     def __init__(
         self,

--- a/src/palace/manager/api/authentication/basic.py
+++ b/src/palace/manager/api/authentication/basic.py
@@ -38,6 +38,7 @@ from palace.manager.api.authentication.base import (
     PatronData,
     PatronLookupNotSupported,
 )
+from palace.manager.api.authentication.opds import OPDSAuthenticationFlow
 from palace.manager.api.authentication.patron_blocking_rules.mixin import (
     HasPatronBlockingRules,
 )
@@ -405,7 +406,11 @@ class BasicAuthProviderLibrarySettings(AuthProviderLibrarySettings):
 class BasicAuthenticationProvider[
     SettingsType: BasicAuthProviderSettings,
     LibrarySettingsType: BasicAuthProviderLibrarySettings,
-](AuthenticationProvider[SettingsType, LibrarySettingsType], ABC):
+](
+    AuthenticationProvider[SettingsType, LibrarySettingsType],
+    OPDSAuthenticationFlow,
+    ABC,
+):
     """Verify a username/password, obtained through HTTP Basic Auth, with
     a remote source of truth.
     """

--- a/src/palace/manager/api/authentication/basic_token.py
+++ b/src/palace/manager/api/authentication/basic_token.py
@@ -18,6 +18,7 @@ from palace.manager.api.authentication.base import (
     AuthProviderSettings,
 )
 from palace.manager.api.authentication.basic import BasicAuthenticationProvider
+from palace.manager.api.authentication.opds import OPDSAuthenticationFlow
 from palace.manager.core.selftest import SelfTestResult
 from palace.manager.sqlalchemy.model.patron import Patron
 from palace.manager.sqlalchemy.util import get_one
@@ -28,7 +29,8 @@ if TYPE_CHECKING:
 
 
 class BasicTokenAuthenticationProvider(
-    AuthenticationProvider[AuthProviderSettings, AuthProviderLibrarySettings]
+    AuthenticationProvider[AuthProviderSettings, AuthProviderLibrarySettings],
+    OPDSAuthenticationFlow,
 ):
     """Patron Authentication based on a CM generated Access Token
     It is a companion to the basic authentication, and has no meaning without it.

--- a/src/palace/manager/api/authenticator.py
+++ b/src/palace/manager/api/authenticator.py
@@ -47,6 +47,9 @@ from palace.manager.api.util.flask import get_request_library
 from palace.manager.core.config import CannotLoadConfiguration
 from palace.manager.core.user_profile import ProfileController
 from palace.manager.integration.goals import Goals
+from palace.manager.integration.patron_auth.anonymous_authentication import (
+    AnonymousAuthenticationProvider,
+)
 from palace.manager.service.analytics.analytics import Analytics
 from palace.manager.service.integration_registry.base import IntegrationRegistry
 from palace.manager.service.integration_registry.patron_auth import PatronAuthRegistry
@@ -293,6 +296,7 @@ class LibraryAuthenticator(LoggerMixin):
         self.access_token_authentication_provider: (
             BasicTokenAuthenticationProvider | None
         ) = None
+        self.anonymous_provider: AnonymousAuthenticationProvider | None = None
         if basic_auth_provider:
             self.register_basic_auth_provider(basic_auth_provider)
 
@@ -331,6 +335,18 @@ class LibraryAuthenticator(LoggerMixin):
             return False
         matches = list(self.providers)
         return len(matches) > 0 and all([x.identifies_individuals for x in matches])
+
+    @property
+    def allows_anonymous_access(self) -> bool:
+        """Does this library explicitly allow anonymous (unauthenticated) access?
+
+        This is true only when an :class:`AnonymousAuthenticationProvider` has
+        been deliberately configured. The mere absence of authentication
+        providers is *not* enough -- that could just as easily mean the library
+        is mid-setup or being decommissioned, neither of which should grant
+        anonymous access.
+        """
+        return self.anonymous_provider is not None
 
     @property
     def library(self) -> Library | None:
@@ -395,17 +411,20 @@ class LibraryAuthenticator(LoggerMixin):
             self.register_saml_provider(provider)
         elif isinstance(provider, BaseOIDCAuthenticationProvider):
             self.register_oidc_provider(provider)
+        elif isinstance(provider, AnonymousAuthenticationProvider):
+            self.register_anonymous_provider(provider)
         else:
             raise CannotLoadConfiguration(
-                f"Authentication provider {impl_cls.__name__} is neither BasicAuthenticationProvider, "
-                "BaseSAMLAuthenticationProvider, nor BaseOIDCAuthenticationProvider. "
-                "I can create it, but not sure where to put it."
+                f"Authentication provider {impl_cls.__name__} is none of BasicAuthenticationProvider, "
+                "BaseSAMLAuthenticationProvider, BaseOIDCAuthenticationProvider, nor "
+                "AnonymousAuthenticationProvider. I can create it, but not sure where to put it."
             )
 
     def register_basic_auth_provider(
         self,
         provider: BasicAuthenticationProvider,
     ):
+        self._guard_against_anonymous_provider()
         if (
             self.basic_auth_provider is not None
             and self.basic_auth_provider != provider
@@ -423,6 +442,7 @@ class LibraryAuthenticator(LoggerMixin):
         self,
         provider: BaseSAMLAuthenticationProvider,
     ):
+        self._guard_against_anonymous_provider()
         already_registered = self.saml_providers_by_name.get(provider.label())
         if already_registered and already_registered != provider:
             raise CannotLoadConfiguration(
@@ -434,12 +454,41 @@ class LibraryAuthenticator(LoggerMixin):
         self,
         provider: BaseOIDCAuthenticationProvider,
     ) -> None:
+        self._guard_against_anonymous_provider()
         already_registered = self.oidc_providers_by_name.get(provider.label())
         if already_registered and already_registered != provider:
             raise CannotLoadConfiguration(
                 'Two different OIDC providers claim the name "%s"' % (provider.label())
             )
         self.oidc_providers_by_name[provider.label()] = provider
+
+    def register_anonymous_provider(
+        self,
+        provider: AnonymousAuthenticationProvider,
+    ) -> None:
+        # Anonymous access is mutually exclusive with every other kind of
+        # authentication: a library either identifies its patrons or it
+        # deliberately serves everyone anonymously, never both.
+        if self.supports_patron_authentication:
+            raise CannotLoadConfiguration(
+                "Anonymous access cannot be combined with another authentication provider."
+            )
+        if self.anonymous_provider is not None and self.anonymous_provider != provider:
+            raise CannotLoadConfiguration("Two anonymous access providers configured")
+        self.anonymous_provider = provider
+
+    def _guard_against_anonymous_provider(self) -> None:
+        """Reject identifying providers when anonymous access is already configured.
+
+        The reverse guard (rejecting an anonymous provider when an identifying
+        provider exists) lives in :meth:`register_anonymous_provider`. Together
+        they make it impossible to end up with both kinds registered, regardless
+        of the order in which the integrations are loaded.
+        """
+        if self.anonymous_provider is not None:
+            raise CannotLoadConfiguration(
+                "Anonymous access cannot be combined with another authentication provider."
+            )
 
     @property
     def providers(self) -> Iterable[AuthenticationProvider]:

--- a/src/palace/manager/api/authenticator.py
+++ b/src/palace/manager/api/authenticator.py
@@ -34,6 +34,7 @@ from palace.manager.api.authentication.basic import BasicAuthenticationProvider
 from palace.manager.api.authentication.basic_token import (
     BasicTokenAuthenticationProvider,
 )
+from palace.manager.api.authentication.opds import OPDSAuthenticationFlow
 from palace.manager.api.config import Configuration
 from palace.manager.api.problem_details import (
     INVALID_SAML_BEARER_TOKEN,
@@ -891,6 +892,7 @@ class LibraryAuthenticator(LoggerMixin):
             authentication=[
                 provider.authentication_flow_document(self._db)
                 for provider in self.providers
+                if isinstance(provider, OPDSAuthenticationFlow)
             ],
             links=links,
             # The library's mobile color scheme, if it has one.
@@ -947,7 +949,11 @@ class LibraryAuthenticator(LoggerMixin):
 
 class BaseSAMLAuthenticationProvider[
     SettingsType: AuthProviderSettings, LibrarySettingsType: AuthProviderLibrarySettings
-](AuthenticationProvider[SettingsType, LibrarySettingsType], ABC):
+](
+    AuthenticationProvider[SettingsType, LibrarySettingsType],
+    OPDSAuthenticationFlow,
+    ABC,
+):
     """
     Base class for SAML authentication providers
     """
@@ -959,7 +965,11 @@ class BaseSAMLAuthenticationProvider[
 
 class BaseOIDCAuthenticationProvider[
     SettingsType: AuthProviderSettings, LibrarySettingsType: AuthProviderLibrarySettings
-](AuthenticationProvider[SettingsType, LibrarySettingsType], ABC):
+](
+    AuthenticationProvider[SettingsType, LibrarySettingsType],
+    OPDSAuthenticationFlow,
+    ABC,
+):
     """Base class for OIDC authentication providers."""
 
     @property

--- a/src/palace/manager/api/circulation_manager.py
+++ b/src/palace/manager/api/circulation_manager.py
@@ -423,6 +423,9 @@ class CirculationManager(LoggerMixin):
         library_identifies_patrons = (
             authenticator is not None and authenticator.identifies_individuals
         )
+        library_allows_anonymous_access = (
+            authenticator is not None and authenticator.allows_anonymous_access
+        )
         annotator_class = kwargs.pop("annotator_class", LibraryAnnotator)
         return annotator_class(
             self.circulation_apis[library.id],
@@ -430,6 +433,7 @@ class CirculationManager(LoggerMixin):
             library,
             top_level_title="All Books",
             library_identifies_patrons=library_identifies_patrons,
+            library_allows_anonymous_access=library_allows_anonymous_access,
             facets=facets,
             *args,
             **kwargs,

--- a/src/palace/manager/api/controller/loan.py
+++ b/src/palace/manager/api/controller/loan.py
@@ -480,8 +480,8 @@ class LoanController(CirculationManagerController):
         # The library is explicitly anonymous, so no individual patron can be
         # identified and no Loan can be created. Whether direct fulfillment is
         # acceptable is up to the CirculationAPI object. Most of them will say
-        # no. (This would indicate that the collection is improperly associated
-        # with a library that doesn't identify its patrons.)
+        # no, since most content requires a loan; typically only open-access
+        # titles can be fulfilled this way.
         return self.circulation.can_fulfill_without_loan(patron, pool, lpdm)
 
     def revoke(self, license_pool_id: int) -> OPDSEntryResponse | ProblemDetail:

--- a/src/palace/manager/api/controller/loan.py
+++ b/src/palace/manager/api/controller/loan.py
@@ -467,19 +467,21 @@ class LoanController(CirculationManagerController):
         :param lpdm: A LicensePoolDeliveryMechanism.
         """
         authenticator = self.manager.auth.library_authenticators.get(library.short_name)
-        if authenticator and authenticator.identifies_individuals:
-            # This library identifies individual patrons, so there is
-            # no reason to fulfill books without a loan. Even if the
-            # books are free and the 'loans' are nominal, having a
-            # Loan object makes it possible for a patron to sync their
-            # collection across devices, so that's the way we do it.
+        if not (authenticator and authenticator.allows_anonymous_access):
+            # Unless the library is explicitly configured for anonymous
+            # access, we never fulfill without a loan. This covers libraries
+            # that identify individual patrons (for whom a Loan object is
+            # always worthwhile, since it lets a patron sync their collection
+            # across devices even when the books are free) as well as
+            # libraries that are unconfigured or being decommissioned, which
+            # should not be serving content at all.
             return False
 
-        # If the library doesn't require that individual patrons
-        # identify themselves, it's up to the CirculationAPI object.
-        # Most of them will say no. (This would indicate that the
-        # collection is improperly associated with a library that
-        # doesn't identify its patrons.)
+        # The library is explicitly anonymous, so no individual patron can be
+        # identified and no Loan can be created. Whether direct fulfillment is
+        # acceptable is up to the CirculationAPI object. Most of them will say
+        # no. (This would indicate that the collection is improperly associated
+        # with a library that doesn't identify its patrons.)
         return self.circulation.can_fulfill_without_loan(patron, pool, lpdm)
 
     def revoke(self, license_pool_id: int) -> OPDSEntryResponse | ProblemDetail:

--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -707,7 +707,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
 
         :param library_allows_anonymous_access: A boolean indicating
           whether this library is explicitly configured for anonymous
-          access. If this is true, some extra links may be added, for
+          access. If this is true, some extra links may be added for
           direct acquisition of titles that would normally require a
           loan. It is only ever true when ``library_identifies_patrons``
           is false.

--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -545,8 +545,9 @@ class CirculationManagerAnnotator(Annotator):
 
         # If this is an open-access book, add an open-access link for
         # every delivery mechanism with an associated resource.
-        # But only if this library allows it, generally this is if
-        # a library has no patron authentication attached to it
+        # But only if the caller allows it (add_open_access_links); for
+        # a library this is true only when it is explicitly configured
+        # for anonymous access.
         if (
             add_open_access_links
             and active_license_pool

--- a/src/palace/manager/feed/annotator/circulation.py
+++ b/src/palace/manager/feed/annotator/circulation.py
@@ -690,6 +690,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         facet_view: str = "feed",
         top_level_title: str = "All Books",
         library_identifies_patrons: bool = True,
+        library_allows_anonymous_access: bool = False,
         facets: FacetsWithEntryPoint | None = None,
     ) -> None:
         """Constructor.
@@ -701,10 +702,14 @@ class LibraryAnnotator(CirculationManagerAnnotator):
           way that does not allow it to keep track of individuals.
 
           If this is false, links that imply the library can
-          distinguish between patrons will not be included. Depending
-          on the configured collections, some extra links may be
-          added, for direct acquisition of titles that would normally
-          require a loan.
+          distinguish between patrons will not be included.
+
+        :param library_allows_anonymous_access: A boolean indicating
+          whether this library is explicitly configured for anonymous
+          access. If this is true, some extra links may be added, for
+          direct acquisition of titles that would normally require a
+          loan. It is only ever true when ``library_identifies_patrons``
+          is false.
         """
         super().__init__(
             lane,
@@ -720,6 +725,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
         self._adobe_id_cache: dict[str, DRMLicensor | None] = {}
         self._top_level_title = top_level_title
         self.identifies_patrons = library_identifies_patrons
+        self.allows_anonymous_access = library_allows_anonymous_access
         self.facets = facets or None
 
     @cached_property
@@ -1236,7 +1242,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             set_mechanism_at_borrow = (
                 api.SET_DELIVERY_MECHANISM_AT == BaseCirculationAPI.BORROW_STEP
             )
-            if active_license_pool and not self.identifies_patrons and not active_loan:
+            if active_license_pool and self.allows_anonymous_access and not active_loan:
                 for lpdm in active_license_pool.available_delivery_mechanisms:
                     if api.can_fulfill_without_loan(None, active_license_pool, lpdm):
                         # This title can be fulfilled without an
@@ -1270,7 +1276,7 @@ class LibraryAnnotator(CirculationManagerAnnotator):
             ),
             set_mechanism_at_borrow=set_mechanism_at_borrow,
             direct_fulfillment_delivery_mechanisms=direct_fulfillment_delivery_mechanisms,
-            add_open_access_links=(not self.identifies_patrons),
+            add_open_access_links=self.allows_anonymous_access,
         )
 
     def revoke_link(

--- a/src/palace/manager/integration/patron_auth/anonymous_authentication.py
+++ b/src/palace/manager/integration/patron_auth/anonymous_authentication.py
@@ -6,8 +6,6 @@ from typing import Any
 from sqlalchemy.orm import Session
 from werkzeug.datastructures import Authorization
 
-from palace.opds.authentication.document import PalaceAuthentication
-
 from palace.manager.api.authentication.base import (
     AuthenticationProvider,
     AuthProviderLibrarySettings,
@@ -38,6 +36,11 @@ class AnonymousAuthenticationProvider(
     It cannot be combined with any other authentication provider; the
     :class:`~palace.manager.api.authenticator.LibraryAuthenticator` enforces
     that mutual exclusion at configuration-load time.
+
+    Unlike the identifying providers, this one is deliberately *not* an
+    :class:`~palace.manager.api.authentication.opds.OPDSAuthenticationFlow`: it
+    has no authentication flow to advertise, so it never appears in a library's
+    Authentication For OPDS document.
     """
 
     @classmethod
@@ -65,17 +68,6 @@ class AnonymousAuthenticationProvider(
     @property
     def identifies_individuals(self) -> bool:
         return False
-
-    @property
-    def flow_type(self) -> str:
-        return "http://palaceproject.io/authtype/anonymous"
-
-    def _authentication_flow_document(self, _db: Session) -> PalaceAuthentication:
-        # Anonymous access is never advertised as an authentication flow: the
-        # provider is excluded from ``LibraryAuthenticator.providers``, so this
-        # is never rendered into an Authentication For OPDS document. It exists
-        # only to satisfy the abstract interface.
-        return PalaceAuthentication(type=self.flow_type, description=self.label())
 
     def _run_self_tests(self, _db: Session) -> Generator[SelfTestResult]:
         # Anonymous access has nothing to test.

--- a/src/palace/manager/integration/patron_auth/anonymous_authentication.py
+++ b/src/palace/manager/integration/patron_auth/anonymous_authentication.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+
+from sqlalchemy.orm import Session
+from werkzeug.datastructures import Authorization
+
+from palace.opds.authentication.document import PalaceAuthentication
+
+from palace.manager.api.authentication.base import (
+    AuthenticationProvider,
+    AuthProviderLibrarySettings,
+    AuthProviderSettings,
+    PatronData,
+)
+from palace.manager.core.selftest import SelfTestResult
+from palace.manager.sqlalchemy.model.patron import Patron
+from palace.manager.util.problem_detail import ProblemDetail
+
+
+class AnonymousAuthenticationProvider(
+    AuthenticationProvider[AuthProviderSettings, AuthProviderLibrarySettings]
+):
+    """An explicit marker that a library allows anonymous access.
+
+    This provider never authenticates anyone -- anonymous requests carry no
+    credentials, so there is no individual patron to identify. Its sole purpose
+    is to record, as a deliberate configuration choice, that a library intends
+    to serve its open-access content without authentication.
+
+    Without this marker the mere *absence* of authentication providers is
+    ambiguous: it could mean the library is intentionally anonymous, but it
+    could equally mean the library is still being set up or is being
+    decommissioned. By requiring an explicit provider, the default for a
+    library with no configured authentication becomes "deny."
+
+    It cannot be combined with any other authentication provider; the
+    :class:`~palace.manager.api.authenticator.LibraryAuthenticator` enforces
+    that mutual exclusion at configuration-load time.
+    """
+
+    @classmethod
+    def label(cls) -> str:
+        return "Anonymous Access"
+
+    @classmethod
+    def description(cls) -> str:
+        return (
+            "Explicitly allow anonymous (unauthenticated) access to this library's "
+            "open-access content. Patrons are not identified and cannot borrow, place "
+            "holds, or sync a bookshelf; they may only directly fulfill titles that are "
+            "available without a loan. This provider cannot be combined with any other "
+            "authentication provider."
+        )
+
+    @classmethod
+    def settings_class(cls) -> type[AuthProviderSettings]:
+        return AuthProviderSettings
+
+    @classmethod
+    def library_settings_class(cls) -> type[AuthProviderLibrarySettings]:
+        return AuthProviderLibrarySettings
+
+    @property
+    def identifies_individuals(self) -> bool:
+        return False
+
+    @property
+    def flow_type(self) -> str:
+        return "http://palaceproject.io/authtype/anonymous"
+
+    def _authentication_flow_document(self, _db: Session) -> PalaceAuthentication:
+        # Anonymous access is never advertised as an authentication flow: the
+        # provider is excluded from ``LibraryAuthenticator.providers``, so this
+        # is never rendered into an Authentication For OPDS document. It exists
+        # only to satisfy the abstract interface.
+        return PalaceAuthentication(type=self.flow_type, description=self.label())
+
+    def _run_self_tests(self, _db: Session) -> Generator[SelfTestResult]:
+        # Anonymous access has nothing to test.
+        yield from ()
+
+    def authenticated_patron(
+        self, _db: Session, header: dict[str, Any] | str
+    ) -> Patron | ProblemDetail | None:
+        # Anonymous access never authenticates an individual patron.
+        return None
+
+    def get_credential_from_header(self, auth: Authorization) -> str | None:
+        return None
+
+    def remote_patron_lookup(
+        self, patron_or_patrondata: PatronData | Patron
+    ) -> PatronData | ProblemDetail | None:
+        return None

--- a/src/palace/manager/service/integration_registry/patron_auth.py
+++ b/src/palace/manager/service/integration_registry/patron_auth.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
 class PatronAuthRegistry(IntegrationRegistry["AuthenticationProviderType"]):
     def __init__(self) -> None:
         super().__init__(Goals.PATRON_AUTH_GOAL)
+        from palace.manager.integration.patron_auth.anonymous_authentication import (
+            AnonymousAuthenticationProvider,
+        )
         from palace.manager.integration.patron_auth.kansas_patron import (
             KansasAuthenticationAPI,
         )
@@ -53,4 +56,7 @@ class PatronAuthRegistry(IntegrationRegistry["AuthenticationProviderType"]):
         self.register(
             SirsiDynixHorizonAuthenticationProvider,
             canonical="api.sirsidynix_authentication_provider",
+        )
+        self.register(
+            AnonymousAuthenticationProvider, canonical="api.anonymous_authentication"
         )

--- a/tests/manager/api/admin/controller/test_patron_auth.py
+++ b/tests/manager/api/admin/controller/test_patron_auth.py
@@ -16,6 +16,7 @@ from palace.manager.api.admin.controller.patron_auth_services import (
 from palace.manager.api.admin.exceptions import AdminNotAuthorized
 from palace.manager.api.admin.problem_details import (
     CANNOT_CHANGE_PROTOCOL,
+    EXCLUSIVE_ANONYMOUS_AUTH_SERVICE,
     FAILED_TO_RUN_SELF_TESTS,
     INCOMPLETE_CONFIGURATION,
     INTEGRATION_NAME_ALREADY_IN_USE,
@@ -42,6 +43,9 @@ from palace.manager.api.authentication.patron_blocking_rules.mixin import (
 from palace.manager.core.problem_details import INVALID_INPUT
 from palace.manager.core.selftest import HasSelfTests
 from palace.manager.integration.goals import Goals
+from palace.manager.integration.patron_auth.anonymous_authentication import (
+    AnonymousAuthenticationProvider,
+)
 from palace.manager.integration.patron_auth.millenium_patron import (
     AuthenticationMode,
     MilleniumPatronAPI,
@@ -717,6 +721,76 @@ class TestPatronAuth:
             response = controller.process_patron_auth_services()
         assert isinstance(response, ProblemDetail)
         assert response.uri == MULTIPLE_BASIC_AUTH_SERVICES.uri
+
+    def test_patron_auth_services_post_anonymous_alongside_existing_basic(
+        self,
+        controller_fixture: ControllerFixture,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+        default_library: Library,
+    ):
+        # Anonymous access cannot be added to a library that already has an
+        # identifying patron authentication service.
+        controller = controller_fixture.controller
+        db.simple_auth_integration(default_library)
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "anonymous access"),
+                    (
+                        "protocol",
+                        controller_fixture.get_protocol(
+                            AnonymousAuthenticationProvider
+                        ),
+                    ),
+                    (
+                        "libraries",
+                        json.dumps([{"short_name": default_library.short_name}]),
+                    ),
+                ]
+            )
+            response = controller.process_patron_auth_services()
+        assert isinstance(response, ProblemDetail)
+        assert response.uri == EXCLUSIVE_ANONYMOUS_AUTH_SERVICE.uri
+
+    def test_patron_auth_services_post_basic_alongside_existing_anonymous(
+        self,
+        controller_fixture: ControllerFixture,
+        flask_app_fixture: FlaskAppFixture,
+        db: DatabaseTransactionFixture,
+        default_library: Library,
+        common_args: list[tuple[str, str]],
+    ):
+        # An identifying patron authentication service cannot be added to a
+        # library that is already configured for anonymous access.
+        controller = controller_fixture.controller
+        db.auth_integration(AnonymousAuthenticationProvider, default_library)
+        with flask_app_fixture.test_request_context_system_admin("/", method="POST"):
+            flask.request.form = ImmutableMultiDict(
+                [
+                    ("name", "testing auth name"),
+                    (
+                        "protocol",
+                        controller_fixture.get_protocol(SimpleAuthenticationProvider),
+                    ),
+                    (
+                        "libraries",
+                        json.dumps(
+                            [
+                                {
+                                    "short_name": default_library.short_name,
+                                    "library_identifier_restriction_type": LibraryIdentifierRestriction.NONE.value,
+                                    "library_identifier_field": "barcode",
+                                }
+                            ]
+                        ),
+                    ),
+                ]
+                + common_args
+            )
+            response = controller.process_patron_auth_services()
+        assert isinstance(response, ProblemDetail)
+        assert response.uri == EXCLUSIVE_ANONYMOUS_AUTH_SERVICE.uri
 
     def test_patron_auth_services_post_invalid_library_identifier_restriction_regex(
         self,

--- a/tests/manager/api/admin/controller/test_patron_auth.py
+++ b/tests/manager/api/admin/controller/test_patron_auth.py
@@ -315,7 +315,7 @@ class TestPatronAuth:
 
         protocols = response_data.get("protocols")
         assert isinstance(protocols, list)
-        assert len(protocols) == 8
+        assert len(protocols) == 9
         assert "settings" in protocols[0]
         assert "library_settings" in protocols[0]
 

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -175,23 +175,40 @@ class TestLoanController:
         lpdm = MagicMock()
         assert False == m(loan_fixture.db.default_library(), patron, pool, lpdm)
 
-        # If the library does not authenticate patrons, then this
-        # _may_ be possible, but
-        # CirculationAPI.can_fulfill_without_loan also has to say it's
-        # okay.
-        class MockLibraryAuthenticator:
-            identifies_individuals = False
-
         short_name = loan_fixture.db.default_library().short_name
         assert short_name is not None
-        loan_fixture.manager.auth.library_authenticators[short_name] = (
-            MockLibraryAuthenticator()
-        )
 
         def mock_can_fulfill_without_loan(patron, pool, lpdm):
             self.called_with = (patron, pool, lpdm)
             return True
 
+        # A library that has no authentication configured at all -- because
+        # it is mid-setup or being decommissioned, not because it is
+        # deliberately anonymous -- never fulfills without a loan, and the
+        # CirculationAPI is not even consulted.
+        class UnconfiguredLibraryAuthenticator:
+            allows_anonymous_access = False
+
+        self.called_with = None
+        loan_fixture.manager.auth.library_authenticators[short_name] = (
+            UnconfiguredLibraryAuthenticator()
+        )
+        with loan_fixture.request_context_with_library("/"):
+            loan_fixture.manager.loans.circulation.can_fulfill_without_loan = (
+                mock_can_fulfill_without_loan
+            )
+            assert False == m(loan_fixture.db.default_library(), patron, pool, lpdm)
+            assert self.called_with is None
+
+        # If the library is explicitly configured for anonymous access, then
+        # this _may_ be possible, but CirculationAPI.can_fulfill_without_loan
+        # also has to say it's okay.
+        class AnonymousLibraryAuthenticator:
+            allows_anonymous_access = True
+
+        loan_fixture.manager.auth.library_authenticators[short_name] = (
+            AnonymousLibraryAuthenticator()
+        )
         with loan_fixture.request_context_with_library("/"):
             loan_fixture.manager.loans.circulation.can_fulfill_without_loan = (
                 mock_can_fulfill_without_loan

--- a/tests/manager/api/test_authenticator.py
+++ b/tests/manager/api/test_authenticator.py
@@ -67,6 +67,9 @@ from palace.manager.core.config import CannotLoadConfiguration
 from palace.manager.core.exceptions import IntegrationException
 from palace.manager.core.user_profile import ProfileController
 from palace.manager.integration.goals import Goals
+from palace.manager.integration.patron_auth.anonymous_authentication import (
+    AnonymousAuthenticationProvider,
+)
 from palace.manager.integration.patron_auth.millenium_patron import (
     MilleniumPatronAPI,
     MilleniumPatronSettings,
@@ -877,6 +880,92 @@ class TestLibraryAuthenticator:
         with pytest.raises(CannotLoadConfiguration) as excinfo:
             authenticator.register_basic_auth_provider(basic2)
         assert "Two basic auth providers configured" in str(excinfo.value)
+
+    def test_allows_anonymous_access(self, db: DatabaseTransactionFixture):
+        # The mere absence of authentication providers does not grant
+        # anonymous access -- that requires an explicit anonymous provider.
+        authenticator = LibraryAuthenticator(
+            _db=db.session,
+            library=db.default_library(),
+        )
+        assert authenticator.allows_anonymous_access is False
+
+        # An anonymous provider does not count as "patron authentication"
+        # and is kept out of the providers iterator (so it contributes no
+        # auth-document flow), but it does flip allows_anonymous_access.
+        anonymous = MagicMock(spec=AnonymousAuthenticationProvider)
+        authenticator.register_anonymous_provider(anonymous)
+        assert authenticator.allows_anonymous_access is True
+        assert authenticator.supports_patron_authentication is False
+        assert authenticator.identifies_individuals is False
+        assert anonymous not in list(authenticator.providers)
+
+    def test_register_provider_anonymous(self, db: DatabaseTransactionFixture):
+        library = db.default_library()
+        integration = db.auth_integration(AnonymousAuthenticationProvider, library)
+        library_integration = integration.for_library(library)
+        assert isinstance(library_integration, IntegrationLibraryConfiguration)
+        auth = LibraryAuthenticator(_db=db.session, library=library)
+        auth.register_provider(library_integration)
+        assert isinstance(auth.anonymous_provider, AnonymousAuthenticationProvider)
+        assert auth.allows_anonymous_access is True
+
+    def test_anonymous_provider_registration_is_idempotent(
+        self, db: DatabaseTransactionFixture
+    ):
+        authenticator = LibraryAuthenticator(
+            _db=db.session,
+            library=db.default_library(),
+        )
+        anonymous1 = MagicMock(spec=AnonymousAuthenticationProvider)
+        anonymous2 = MagicMock(spec=AnonymousAuthenticationProvider)
+
+        # Registering the same anonymous provider twice is fine.
+        authenticator.register_anonymous_provider(anonymous1)
+        authenticator.register_anonymous_provider(anonymous1)
+
+        # But a second, different anonymous provider is rejected.
+        with pytest.raises(CannotLoadConfiguration) as excinfo:
+            authenticator.register_anonymous_provider(anonymous2)
+        assert "Two anonymous access providers configured" in str(excinfo.value)
+
+    @pytest.mark.parametrize("anonymous_first", [True, False])
+    def test_anonymous_and_identifying_providers_are_mutually_exclusive(
+        self,
+        db: DatabaseTransactionFixture,
+        mock_basic: MockBasicFixture,
+        anonymous_first: bool,
+    ):
+        # Anonymous access cannot coexist with any identifying provider,
+        # regardless of the order in which they are registered.
+        authenticator = LibraryAuthenticator(
+            _db=db.session,
+            library=db.default_library(),
+        )
+        anonymous = MagicMock(spec=AnonymousAuthenticationProvider)
+        basic = mock_basic()
+
+        with pytest.raises(CannotLoadConfiguration) as excinfo:
+            if anonymous_first:
+                authenticator.register_anonymous_provider(anonymous)
+                authenticator.register_basic_auth_provider(basic)
+            else:
+                authenticator.register_basic_auth_provider(basic)
+                authenticator.register_anonymous_provider(anonymous)
+        assert "Anonymous access cannot be combined" in str(excinfo.value)
+
+    def test_anonymous_provider_excludes_saml(self, db: DatabaseTransactionFixture):
+        authenticator = LibraryAuthenticator(
+            _db=db.session,
+            library=db.default_library(),
+        )
+        authenticator.register_anonymous_provider(
+            MagicMock(spec=AnonymousAuthenticationProvider)
+        )
+        saml = MagicMock(spec=BaseSAMLAuthenticationProvider)
+        with pytest.raises(CannotLoadConfiguration) as excinfo:
+            authenticator.register_saml_provider(saml)
+        assert "Anonymous access cannot be combined" in str(excinfo.value)
 
     def test_authenticated_patron_basic(
         self, db: DatabaseTransactionFixture, mock_basic: MockBasicFixture

--- a/tests/manager/api/test_authenticator.py
+++ b/tests/manager/api/test_authenticator.py
@@ -954,7 +954,24 @@ class TestLibraryAuthenticator:
                 authenticator.register_anonymous_provider(anonymous)
         assert "Anonymous access cannot be combined" in str(excinfo.value)
 
-    def test_anonymous_provider_excludes_saml(self, db: DatabaseTransactionFixture):
+    @pytest.mark.parametrize(
+        "provider_spec, register_method",
+        [
+            (BaseSAMLAuthenticationProvider, "register_saml_provider"),
+            (BaseOIDCAuthenticationProvider, "register_oidc_provider"),
+        ],
+    )
+    def test_anonymous_provider_excludes_oauth_provider(
+        self,
+        db: DatabaseTransactionFixture,
+        provider_spec: type[
+            BaseSAMLAuthenticationProvider | BaseOIDCAuthenticationProvider
+        ],
+        register_method: str,
+    ):
+        # An already-registered anonymous provider blocks every identifying
+        # OAuth-style provider (SAML and OIDC), via the guard shared by their
+        # register_* methods.
         authenticator = LibraryAuthenticator(
             _db=db.session,
             library=db.default_library(),
@@ -962,9 +979,9 @@ class TestLibraryAuthenticator:
         authenticator.register_anonymous_provider(
             MagicMock(spec=AnonymousAuthenticationProvider)
         )
-        saml = MagicMock(spec=BaseSAMLAuthenticationProvider)
+        provider = MagicMock(spec=provider_spec)
         with pytest.raises(CannotLoadConfiguration) as excinfo:
-            authenticator.register_saml_provider(saml)
+            getattr(authenticator, register_method)(provider)
         assert "Anonymous access cannot be combined" in str(excinfo.value)
 
     def test_authenticated_patron_basic(

--- a/tests/manager/api/test_controller_cm.py
+++ b/tests/manager/api/test_controller_cm.py
@@ -14,6 +14,9 @@ from palace.manager.feed.annotator.circulation import (
 )
 from palace.manager.feed.facets.feed import Facets
 from palace.manager.feed.worklist.base import WorkList
+from palace.manager.integration.patron_auth.anonymous_authentication import (
+    AnonymousAuthenticationProvider,
+)
 from palace.manager.integration.patron_auth.saml.controller import SAMLController
 from palace.manager.sqlalchemy.model.discovery_service_registration import (
     DiscoveryServiceRegistration,
@@ -173,6 +176,8 @@ class TestCirculationManager:
         )
         assert "All Books" == annotator.top_level_title()
         assert True == annotator.identifies_patrons
+        # A library that identifies patrons does not allow anonymous access.
+        assert annotator.allows_anonymous_access is False
 
         # Try again using a library that has no patron authentication.
         library2 = circulation_fixture.db.library()
@@ -191,6 +196,33 @@ class TestCirculationManager:
         # implies it has any way of authenticating or differentiating
         # between patrons.
         assert False == annotator.identifies_patrons
+        # But a library with no authentication configured is not the same
+        # as one that is explicitly anonymous, so anonymous access is not
+        # allowed either.
+        assert annotator.allows_anonymous_access is False
+
+        # A library explicitly configured for anonymous access produces an
+        # annotator that knows anonymous access is allowed (and, as always
+        # for anonymous access, that it does not identify patrons).
+        library3 = circulation_fixture.db.library()
+        lane3 = circulation_fixture.db.lane(library=library3)
+        assert library3.short_name is not None
+        circulation_fixture.manager.circulation_apis[library3.id] = object()
+        anonymous_authenticator = LibraryAuthenticator(
+            _db=circulation_fixture.db.session, library=library3
+        )
+        anonymous_authenticator.register_anonymous_provider(
+            MagicMock(spec=AnonymousAuthenticationProvider)
+        )
+        circulation_fixture.manager.auth.library_authenticators[library3.short_name] = (
+            anonymous_authenticator
+        )
+
+        annotator = circulation_fixture.manager.annotator(lane3, facets)
+        assert isinstance(annotator, LibraryAnnotator)
+        assert library3 == annotator.library
+        assert annotator.identifies_patrons is False
+        assert annotator.allows_anonymous_access is True
 
         # Any extra positional or keyword arguments passed into annotator()
         # are propagated to the Annotator constructor.

--- a/tests/manager/feed/test_library_annotator.py
+++ b/tests/manager/feed/test_library_annotator.py
@@ -1662,9 +1662,10 @@ class TestLibraryAnnotator:
         assert fulfill.href and "fulfill" in fulfill.href
         assert fulfill.rel and "http://opds-spec.org/acquisition" == fulfill.rel
 
-        # Allow direct open-access downloads
-        # This will also filter out loan revoke links
+        # Make the library explicitly anonymous: this allows direct
+        # open-access downloads and also filters out loan revoke links.
         annotator.identifies_patrons = False
+        annotator.allows_anonymous_access = True
         loan1_links = annotator.acquisition_links(
             loan1.license_pool, loan1, None, None, loan1.license_pool.identifier
         )
@@ -1681,6 +1682,7 @@ class TestLibraryAnnotator:
 
         # Revert the annotator state
         annotator.identifies_patrons = True
+        annotator.allows_anonymous_access = False
 
         assert strftime(loan1.start) == fulfill.availability_since
         assert loan1.end == fulfill.availability_until == None
@@ -1759,9 +1761,10 @@ class TestLibraryAnnotator:
         # assert loan5.end == availability.until
         assert None == loan5.end
 
-        # If patron authentication is turned off for the library, then
+        # If the library is explicitly configured for anonymous access, then
         # only open-access links are displayed.
         annotator.identifies_patrons = False
+        annotator.allows_anonymous_access = True
 
         [open_access] = annotator.acquisition_links(
             loan1.license_pool, loan1, None, None, loan1.license_pool.identifier
@@ -1802,6 +1805,30 @@ class TestLibraryAnnotator:
             hold.license_pool, None, hold, None, hold.license_pool.identifier
         )
         assert [] == hold_links
+
+    def test_acquisition_links_unconfigured_library_is_locked(
+        self,
+        annotator_fixture: LibraryAnnotatorFixture,
+    ):
+        # A library that does not identify patrons but is *not* explicitly
+        # configured for anonymous access (e.g. it is mid-setup or being
+        # decommissioned) offers neither patron-specific links nor anonymous
+        # open-access links -- it is effectively locked.
+        annotator = LibraryLoanAndHoldAnnotator(
+            None, None, annotator_fixture.db.default_library()
+        )
+        annotator.identifies_patrons = False
+        annotator.allows_anonymous_access = False
+
+        patron = annotator_fixture.db.patron()
+        work = annotator_fixture.db.work(with_open_access_download=True)
+        loan, _ = work.license_pools[0].loan_to(patron, start=utc_now())
+
+        links = annotator.acquisition_links(
+            loan.license_pool, loan, None, None, loan.license_pool.identifier
+        )
+        # No open-access link, no borrow link, no revoke link.
+        assert links == []
 
     def test_acquisition_links_multiple_links(
         self,

--- a/tests/manager/integration/patron_auth/test_anonymous_authentication.py
+++ b/tests/manager/integration/patron_auth/test_anonymous_authentication.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from palace.opds.authentication.document import PalaceAuthentication
-
 from palace.manager.api.authentication.base import (
     AuthProviderLibrarySettings,
     AuthProviderSettings,
 )
+from palace.manager.api.authentication.opds import OPDSAuthenticationFlow
 from palace.manager.integration.patron_auth.anonymous_authentication import (
     AnonymousAuthenticationProvider,
 )
@@ -51,11 +50,9 @@ class TestAnonymousAuthenticationProvider:
         # The provider has nothing to self-test.
         assert list(self._provider()._run_self_tests(MagicMock())) == []
 
-    def test_flow_document(self) -> None:
-        # The flow document exists only to satisfy the interface; anonymous
-        # access is never advertised as an authentication flow because the
-        # provider is excluded from LibraryAuthenticator.providers.
-        provider = self._provider()
-        flow = provider._authentication_flow_document(MagicMock())
-        assert isinstance(flow, PalaceAuthentication)
-        assert flow.type == provider.flow_type
+    def test_is_not_an_opds_authentication_flow(self) -> None:
+        # Anonymous access has no authentication flow to advertise, so unlike
+        # the identifying providers it is deliberately not an
+        # OPDSAuthenticationFlow and never appears in an Authentication For
+        # OPDS document.
+        assert not isinstance(self._provider(), OPDSAuthenticationFlow)

--- a/tests/manager/integration/patron_auth/test_anonymous_authentication.py
+++ b/tests/manager/integration/patron_auth/test_anonymous_authentication.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from palace.opds.authentication.document import PalaceAuthentication
+
+from palace.manager.api.authentication.base import (
+    AuthProviderLibrarySettings,
+    AuthProviderSettings,
+)
+from palace.manager.integration.patron_auth.anonymous_authentication import (
+    AnonymousAuthenticationProvider,
+)
+
+
+class TestAnonymousAuthenticationProvider:
+    def _provider(self) -> AnonymousAuthenticationProvider:
+        return AnonymousAuthenticationProvider(
+            library_id=1,
+            integration_id=2,
+            settings=AuthProviderSettings(),
+            library_settings=AuthProviderLibrarySettings(),
+        )
+
+    def test_metadata(self) -> None:
+        assert AnonymousAuthenticationProvider.label() == "Anonymous Access"
+        assert "anonymous" in AnonymousAuthenticationProvider.description().lower()
+        assert AnonymousAuthenticationProvider.settings_class() is AuthProviderSettings
+        assert (
+            AnonymousAuthenticationProvider.library_settings_class()
+            is AuthProviderLibrarySettings
+        )
+
+    def test_does_not_identify_individuals(self) -> None:
+        # Anonymous access never identifies an individual patron.
+        assert self._provider().identifies_individuals is False
+
+    def test_never_authenticates(self) -> None:
+        provider = self._provider()
+        db = MagicMock()
+        # No header value ever produces a Patron.
+        assert provider.authenticated_patron(db, "Bearer abc") is None
+        assert provider.authenticated_patron(db, {"username": "u"}) is None
+
+    def test_no_credential_or_lookup(self) -> None:
+        provider = self._provider()
+        assert provider.get_credential_from_header(MagicMock()) is None
+        assert provider.remote_patron_lookup(MagicMock()) is None
+
+    def test_self_tests_are_empty(self) -> None:
+        # The provider has nothing to self-test.
+        assert list(self._provider()._run_self_tests(MagicMock())) == []
+
+    def test_flow_document(self) -> None:
+        # The flow document exists only to satisfy the interface; anonymous
+        # access is never advertised as an authentication flow because the
+        # provider is excluded from LibraryAuthenticator.providers.
+        provider = self._provider()
+        flow = provider._authentication_flow_document(MagicMock())
+        assert isinstance(flow, PalaceAuthentication)
+        assert flow.type == provider.flow_type


### PR DESCRIPTION
## Description

Adds an explicit `AnonymousAuthenticationProvider`. A library now opts into anonymous (unauthenticated) access by deliberately configuring this provider, rather than getting it implicitly from having no patron-auth providers. The provider never identifies a patron; its sole purpose is to record anonymous access as a deliberate configuration choice. It is mutually exclusive with every other patron-auth provider, enforced both at config-save time (admin controller) and at authenticator load time.

## Motivation and Context

Previously, a library with no configured patron authentication implicitly behaved as anonymous: it advertised open-access download links and allowed loanless ("direct") fulfillment. That made an intentionally-anonymous library indistinguishable from one that is mid-setup, being decommissioned, or simply misconfigured. This change makes anonymous access a deliberate, explicit choice and makes the default for an unconfigured library "deny".

**⚠️ Incompatible change:** Libraries relying on the old implicit "no auth = anonymous" behavior will stop serving open-access content and loanless fulfillment until an `AnonymousAuthenticationProvider` is explicitly configured for them. This is the intended effect: it fixes the several libraries currently misconfigured into unintended anonymous access, while the one library that legitimately needs anonymous access will have the provider configured explicitly.

JIRA: PP-4541

## How Has This Been Tested?

New unit tests cover the provider itself, the authenticator registration / mutual-exclusion logic (both registration orders, idempotency, exclusion of SAML/basic), the annotator and loan-controller gating (including the "unconfigured library is locked" case), and the admin save-time validation (rejecting anonymous alongside an identifying provider in either direction). The full existing patron-auth and authenticator suites pass.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
