### PR TITLE
Harden Redis connection resilience across all three connections (PP-4545)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,11 @@ Celery and caching, we recommend that you use a separate database for each purpo
         ```
 - `PALACE_REDIS_KEY_PREFIX`: The prefix to use for keys stored in the Redis instance. The default is `palace`.
     This is useful if you want to use the same Redis database for multiple Circulation Manager instances (optional).
+- `PALACE_REDIS_SOCKET_KEEPALIVE`: Whether to enable TCP keepalive on Redis connections, so the OS can
+    reclaim a connection whose peer has gone away. The default is `true` (optional).
+- `PALACE_REDIS_HEALTH_CHECK_INTERVAL`: How often, in seconds, an idle Redis connection is health-checked
+    (PINGed) before reuse, so a connection left stale by a Redis restart is transparently re-established
+    rather than failing a command. The default is `30` (optional).
 
 #### General
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,15 @@ pass a broker URL and a result backend URL to the application.
         ```sh
         export PALACE_CELERY_RESULT_BACKEND="redis://localhost:6379/2"
         ```
+- `PALACE_CELERY_BROKER_TRANSPORT_OPTIONS_HEALTH_CHECK_INTERVAL`: How often, in seconds, the Celery broker's
+    Redis connection is health-checked (PINGed) before reuse, so a connection left stale by a Redis restart is
+    transparently re-established. Ignored by the SQS broker. The default is `30` (optional).
+- `PALACE_CELERY_REDIS_BACKEND_HEALTH_CHECK_INTERVAL`: How often, in seconds, the Celery result backend's Redis
+    connection is health-checked (PINGed) before reuse, with the same effect as above. The default is `30` (optional).
+- `PALACE_CELERY_RESULT_BACKEND_ALWAYS_RETRY`: Whether a result-backend write that hits a transient connection
+    error is retried, rather than failing a task that has already done its work. The default is `true` (optional).
+- `PALACE_CELERY_RESULT_BACKEND_MAX_RETRIES`: The maximum number of times a result-backend write is retried when
+    `PALACE_CELERY_RESULT_BACKEND_ALWAYS_RETRY` is enabled. The default is `3` (optional).
 
 We support overriding a number of other Celery settings via environment variables, but in most cases
 the defaults should be sufficient. The full list of settings can be found in

--- a/README.md
+++ b/README.md
@@ -247,8 +247,6 @@ Celery and caching, we recommend that you use a separate database for each purpo
         ```
 - `PALACE_REDIS_KEY_PREFIX`: The prefix to use for keys stored in the Redis instance. The default is `palace`.
     This is useful if you want to use the same Redis database for multiple Circulation Manager instances (optional).
-- `PALACE_REDIS_SOCKET_KEEPALIVE`: Whether to enable TCP keepalive on Redis connections, so the OS can
-    reclaim a connection whose peer has gone away. The default is `true` (optional).
 - `PALACE_REDIS_HEALTH_CHECK_INTERVAL`: How often, in seconds, an idle Redis connection is health-checked
     (PINGed) before reuse, so a connection left stale by a Redis restart is transparently re-established
     rather than failing a command. The default is `30` (optional).

--- a/src/palace/manager/celery/monitoring.py
+++ b/src/palace/manager/celery/monitoring.py
@@ -106,6 +106,15 @@ class Cloudwatch(Polaroid):
 
     clear_after = True  # clear after flush (incl, state.event_count).
 
+    # The camera opens its own redis-py connection to the broker Redis, separate
+    # from the connections kombu manages for publish/consume. Unlike kombu's
+    # consume connection -- which uses blocking BRPOP and so must not carry a
+    # socket_timeout -- the camera only issues instant reads (LINDEX/LLEN), so it
+    # can safely fail fast on a dead socket rather than hang. These mirror the
+    # application Redis client's socket timeouts (see service/redis).
+    SOCKET_TIMEOUT = 15.0
+    SOCKET_CONNECT_TIMEOUT = 5.0
+
     def __init__(
         self,
         *args: Any,
@@ -126,19 +135,34 @@ class Cloudwatch(Polaroid):
         self.cloudwatch_client = (
             boto3.client("cloudwatch", region_name=region) if not dryrun else None
         )
-        self.manager_name = self.app.conf.get("broker_transport_options", {}).get(
-            "global_keyprefix"
+        broker_transport_options = self.app.conf.get("broker_transport_options", {})
+        self.manager_name = broker_transport_options.get("global_keyprefix")
+        self.redis_client = self.get_redis_client(
+            broker_url,
+            self.manager_name,
+            broker_transport_options.get("health_check_interval", 0),
         )
-        self.redis_client = self.get_redis_client(broker_url, self.manager_name)
         self.namespace = self.app.conf.get("cloudwatch_statistics_namespace")
         self.upload_size = self.app.conf.get("cloudwatch_statistics_upload_size")
         self.queues = {queue.name for queue in self.app.conf.get("task_queues")}
 
     @classmethod
     def get_redis_client(
-        cls, broker_url: str, global_keyprefix: str | None
+        cls,
+        broker_url: str,
+        global_keyprefix: str | None,
+        health_check_interval: int,
     ) -> _PrefixedRedis:
-        connection_pool = ConnectionPool.from_url(broker_url)
+        # health_check_interval is threaded through from the broker's
+        # PALACE_CELERY_BROKER_TRANSPORT_OPTIONS_HEALTH_CHECK_INTERVAL so this
+        # idle monitoring connection is PING-checked and re-established after a
+        # Redis restart, the same way the other connections now are.
+        connection_pool = ConnectionPool.from_url(
+            broker_url,
+            socket_timeout=cls.SOCKET_TIMEOUT,
+            socket_connect_timeout=cls.SOCKET_CONNECT_TIMEOUT,
+            health_check_interval=health_check_interval,
+        )
         return _PrefixedRedis(
             connection_pool=connection_pool, global_keyprefix=global_keyprefix
         )

--- a/src/palace/manager/celery/monitoring.py
+++ b/src/palace/manager/celery/monitoring.py
@@ -106,15 +106,6 @@ class Cloudwatch(Polaroid):
 
     clear_after = True  # clear after flush (incl, state.event_count).
 
-    # The camera opens its own redis-py connection to the broker Redis, separate
-    # from the connections kombu manages for publish/consume. Unlike kombu's
-    # consume connection -- which uses blocking BRPOP and so must not carry a
-    # socket_timeout -- the camera only issues instant reads (LINDEX/LLEN), so it
-    # can safely fail fast on a dead socket rather than hang. These mirror the
-    # application Redis client's socket timeouts (see service/redis).
-    SOCKET_TIMEOUT = 15.0
-    SOCKET_CONNECT_TIMEOUT = 5.0
-
     def __init__(
         self,
         *args: Any,
@@ -155,14 +146,14 @@ class Cloudwatch(Polaroid):
         global_keyprefix: str | None,
         health_check_interval: int,
     ) -> _PrefixedRedis:
-        # health_check_interval is threaded through from the broker's
-        # PALACE_CELERY_BROKER_TRANSPORT_OPTIONS_HEALTH_CHECK_INTERVAL so this
-        # idle monitoring connection is PING-checked and re-established after a
-        # Redis restart, the same way the other connections now are.
         connection_pool = ConnectionPool.from_url(
             broker_url,
-            socket_timeout=cls.SOCKET_TIMEOUT,
-            socket_connect_timeout=cls.SOCKET_CONNECT_TIMEOUT,
+            # The camera opens its own redis-py connection to the broker Redis.
+            # We set timeouts to match the application redis service configuration.
+            socket_timeout=15.0,
+            socket_connect_timeout=5.0,
+            # health_check_interval is threaded through from the broker's
+            # PALACE_CELERY_BROKER_TRANSPORT_OPTIONS_HEALTH_CHECK_INTERVAL.
             health_check_interval=health_check_interval,
         )
         return _PrefixedRedis(

--- a/src/palace/manager/celery/monitoring.py
+++ b/src/palace/manager/celery/monitoring.py
@@ -140,7 +140,9 @@ class Cloudwatch(Polaroid):
         self.redis_client = self.get_redis_client(
             broker_url,
             self.manager_name,
-            broker_transport_options.get("health_check_interval", 0),
+            # Fall back to the same default CeleryConfiguration uses, so a missing
+            # value keeps health checks on rather than silently disabling them.
+            broker_transport_options.get("health_check_interval", 30),
         )
         self.namespace = self.app.conf.get("cloudwatch_statistics_namespace")
         self.upload_size = self.app.conf.get("cloudwatch_statistics_upload_size")

--- a/src/palace/manager/service/celery/configuration.py
+++ b/src/palace/manager/service/celery/configuration.py
@@ -35,6 +35,21 @@ class CeleryConfiguration(ServiceConfiguration):
 
     # Broker options for both Redis and SQS
     broker_transport_options_visibility_timeout: int = 3600  # 1 hour
+
+    # Redis broker/result-backend connection resilience. The broker and the
+    # result backend each open their own Redis connection, separate from the
+    # application Redis client (see service/redis). socket_keepalive and
+    # health_check_interval let a stale connection be detected and replaced
+    # before it's used, and result_backend_always_retry transparently retries a
+    # result write that hits a transient connection error rather than failing a
+    # task that has already done its work. These are ignored by the SQS broker.
+    broker_transport_options_socket_keepalive: bool = True
+    broker_transport_options_health_check_interval: int = 30
+    redis_socket_keepalive: bool = True
+    redis_backend_health_check_interval: int = 30
+    result_backend_always_retry: bool = True
+    result_backend_max_retries: int = 3
+
     result_expires: int = 3600  # 1 hour  (default is 1 day)
     result_backend_transport_options_global_keyprefix: str = "palace-"
     task_acks_late: bool = True

--- a/src/palace/manager/service/celery/configuration.py
+++ b/src/palace/manager/service/celery/configuration.py
@@ -38,14 +38,12 @@ class CeleryConfiguration(ServiceConfiguration):
 
     # Redis broker/result-backend connection resilience. The broker and the
     # result backend each open their own Redis connection, separate from the
-    # application Redis client (see service/redis). socket_keepalive and
-    # health_check_interval let a stale connection be detected and replaced
-    # before it's used, and result_backend_always_retry transparently retries a
-    # result write that hits a transient connection error rather than failing a
-    # task that has already done its work. These are ignored by the SQS broker.
-    broker_transport_options_socket_keepalive: bool = True
+    # application Redis client (see service/redis). health_check_interval lets a
+    # stale connection be detected and replaced before it's used, and
+    # result_backend_always_retry transparently retries a result write that hits
+    # a transient connection error rather than failing a task that has already
+    # done its work. These are ignored by the SQS broker.
     broker_transport_options_health_check_interval: int = 30
-    redis_socket_keepalive: bool = True
     redis_backend_health_check_interval: int = 30
     result_backend_always_retry: bool = True
     result_backend_max_retries: int = 3

--- a/src/palace/manager/service/redis/configuration.py
+++ b/src/palace/manager/service/redis/configuration.py
@@ -14,16 +14,11 @@ class RedisConfiguration(ServiceConfiguration):
     socket_timeout: float | None = 15.0
     socket_connect_timeout: float | None = 5.0
 
-    # Connection resilience. health_check_interval is what actually bounds
-    # detection: redis-py PINGs an idle connection before reuse, and if the PING
-    # fails (e.g. the connection was left stale by a Redis reboot) it disconnects
-    # and re-establishes it transparently, so the pool stops handing out dead
-    # sockets within ~30s instead of blocking on them. socket_keepalive just
-    # turns on TCP keepalive so the OS can eventually reclaim a connection whose
-    # peer vanished without a clean close -- with the default OS probe timing
-    # that is a slow (hours) backstop, not fast detection. We deliberately do not
-    # enable command retries here: re-running a command that reached the server
-    # but whose response was lost would double-execute non-idempotent operations
-    # like SPOP and the lock Lua scripts.
+    # Connection resilience settings
+    # socket_keepalive turns on TCP keepalive so the OS can eventually reclaim 
+    # a connection whose peer vanished without a clean close.
     socket_keepalive: bool = True
+    # health_check_interval caused redis-py to PING an idle connection before
+    # reuse, and if the PING fails (e.g. the connection was left stale by a Redis
+    # reboot) it disconnects and re-establishes it transparently. 
     health_check_interval: int = 30

--- a/src/palace/manager/service/redis/configuration.py
+++ b/src/palace/manager/service/redis/configuration.py
@@ -13,3 +13,17 @@ class RedisConfiguration(ServiceConfiguration):
 
     socket_timeout: float | None = 15.0
     socket_connect_timeout: float | None = 5.0
+
+    # Connection resilience. health_check_interval is what actually bounds
+    # detection: redis-py PINGs an idle connection before reuse, and if the PING
+    # fails (e.g. the connection was left stale by a Redis reboot) it disconnects
+    # and re-establishes it transparently, so the pool stops handing out dead
+    # sockets within ~30s instead of blocking on them. socket_keepalive just
+    # turns on TCP keepalive so the OS can eventually reclaim a connection whose
+    # peer vanished without a clean close -- with the default OS probe timing
+    # that is a slow (hours) backstop, not fast detection. We deliberately do not
+    # enable command retries here: re-running a command that reached the server
+    # but whose response was lost would double-execute non-idempotent operations
+    # like SPOP and the lock Lua scripts.
+    socket_keepalive: bool = True
+    health_check_interval: int = 30

--- a/src/palace/manager/service/redis/configuration.py
+++ b/src/palace/manager/service/redis/configuration.py
@@ -14,11 +14,8 @@ class RedisConfiguration(ServiceConfiguration):
     socket_timeout: float | None = 15.0
     socket_connect_timeout: float | None = 5.0
 
-    # Connection resilience settings
-    # socket_keepalive turns on TCP keepalive so the OS can eventually reclaim 
-    # a connection whose peer vanished without a clean close.
-    socket_keepalive: bool = True
-    # health_check_interval caused redis-py to PING an idle connection before
+    # Connection resilience settings.
+    # health_check_interval causes redis-py to PING an idle connection before
     # reuse, and if the PING fails (e.g. the connection was left stale by a Redis
-    # reboot) it disconnects and re-establishes it transparently. 
+    # reboot) it disconnects and re-establishes it transparently.
     health_check_interval: int = 30

--- a/src/palace/manager/service/redis/container.py
+++ b/src/palace/manager/service/redis/container.py
@@ -15,6 +15,8 @@ class RedisContainer(DeclarativeContainer):
         decode_responses=True,
         socket_timeout=config.socket_timeout,
         socket_connect_timeout=config.socket_connect_timeout,
+        socket_keepalive=config.socket_keepalive,
+        health_check_interval=config.health_check_interval,
     )
 
     key_generator: providers.Provider[RedisKeyGenerator] = providers.Singleton(

--- a/src/palace/manager/service/redis/container.py
+++ b/src/palace/manager/service/redis/container.py
@@ -15,7 +15,6 @@ class RedisContainer(DeclarativeContainer):
         decode_responses=True,
         socket_timeout=config.socket_timeout,
         socket_connect_timeout=config.socket_connect_timeout,
-        socket_keepalive=config.socket_keepalive,
         health_check_interval=config.health_check_interval,
     )
 

--- a/tests/manager/celery/test_monitoring.py
+++ b/tests/manager/celery/test_monitoring.py
@@ -54,7 +54,10 @@ class CloudwatchCameraFixture:
             "result_backend": result_backend,
             "cloudwatch_statistics_region": region,
             "cloudwatch_statistics_dryrun": dry_run,
-            "broker_transport_options": {"global_keyprefix": manager_name},
+            "broker_transport_options": {
+                "global_keyprefix": manager_name,
+                "health_check_interval": 30,
+            },
             "cloudwatch_statistics_namespace": namespace,
             "cloudwatch_statistics_upload_size": upload_size,
             "task_queues": [self.mock_queue(queue) for queue in queues],
@@ -118,6 +121,7 @@ class TestCloudwatch:
         cloudwatch_camera.mock_get_redis.assert_called_once_with(
             "redis://testtesttest:1234/0",
             "manager",
+            30,
         )
 
     def test__init__error(self, cloudwatch_camera: CloudwatchCameraFixture):
@@ -131,10 +135,30 @@ class TestCloudwatch:
         cloudwatch = cloudwatch_camera.create_cloudwatch()
         assert cloudwatch.cloudwatch_client is None
 
+    def test_get_redis_client_connection_resilience(self):
+        # The camera's own broker connection must carry the resilience settings:
+        # the configured health_check_interval (so a connection left stale by a
+        # Redis restart is re-established) and fail-fast socket timeouts (so a
+        # read against a dead socket doesn't hang the monitoring thread).
+        # Building the pool does not open a connection, so we can assert on its
+        # connection_kwargs directly.
+        client = Cloudwatch.get_redis_client(
+            "redis://localhost", "prefix", health_check_interval=30
+        )
+        connection_kwargs = client.connection_pool.connection_kwargs
+        assert connection_kwargs["health_check_interval"] == 30
+        assert connection_kwargs["socket_timeout"] == Cloudwatch.SOCKET_TIMEOUT
+        assert (
+            connection_kwargs["socket_connect_timeout"]
+            == Cloudwatch.SOCKET_CONNECT_TIMEOUT
+        )
+
     def test_get_redis_client_prefixes_lindex(self):
         # kombu's PrefixedStrictRedis does not include LINDEX in its prefixed-command list,
         # so we need to patch it to make sure we can read the timestamp on the oldest message.
-        client = Cloudwatch.get_redis_client("redis://localhost", "prefix")
+        client = Cloudwatch.get_redis_client(
+            "redis://localhost", "prefix", health_check_interval=30
+        )
         with patch.object(redis.Redis, "execute_command") as mock_execute:
             client.lindex("apply", -1)
             client.llen("apply")

--- a/tests/manager/celery/test_monitoring.py
+++ b/tests/manager/celery/test_monitoring.py
@@ -47,17 +47,20 @@ class CloudwatchCameraFixture:
         namespace: str = "namespace",
         upload_size: int = 100,
         queues: list[str] | None = None,
+        health_check_interval: int | None = 30,
     ) -> None:
         queues = queues or ["queue1", "queue2"]
+        broker_transport_options: dict[str, str | int] = {
+            "global_keyprefix": manager_name
+        }
+        if health_check_interval is not None:
+            broker_transport_options["health_check_interval"] = health_check_interval
         self.app.conf = {
             "broker_url": broker_url,
             "result_backend": result_backend,
             "cloudwatch_statistics_region": region,
             "cloudwatch_statistics_dryrun": dry_run,
-            "broker_transport_options": {
-                "global_keyprefix": manager_name,
-                "health_check_interval": 30,
-            },
+            "broker_transport_options": broker_transport_options,
             "cloudwatch_statistics_namespace": namespace,
             "cloudwatch_statistics_upload_size": upload_size,
             "task_queues": [self.mock_queue(queue) for queue in queues],
@@ -118,6 +121,20 @@ class TestCloudwatch:
         assert cloudwatch.upload_size == 100
         assert cloudwatch.queues == {"queue1", "queue2"}
         assert cloudwatch.redis_client == cloudwatch_camera.mock_get_redis.return_value
+        cloudwatch_camera.mock_get_redis.assert_called_once_with(
+            "redis://testtesttest:1234/0",
+            "manager",
+            30,
+        )
+
+    def test__init__health_check_interval_defaults_when_unset(
+        self, cloudwatch_camera: CloudwatchCameraFixture
+    ):
+        # When broker_transport_options omits health_check_interval, the camera
+        # falls back to the same default CeleryConfiguration uses (30s) rather
+        # than silently disabling health checks.
+        cloudwatch_camera.configure_app(health_check_interval=None)
+        cloudwatch_camera.create_cloudwatch()
         cloudwatch_camera.mock_get_redis.assert_called_once_with(
             "redis://testtesttest:1234/0",
             "manager",

--- a/tests/manager/celery/test_monitoring.py
+++ b/tests/manager/celery/test_monitoring.py
@@ -163,12 +163,13 @@ class TestCloudwatch:
             "redis://localhost", "prefix", health_check_interval=30
         )
         connection_kwargs = client.connection_pool.connection_kwargs
+        # health_check_interval is threaded through, so pin the value we passed.
         assert connection_kwargs["health_check_interval"] == 30
-        assert connection_kwargs["socket_timeout"] == Cloudwatch.SOCKET_TIMEOUT
-        assert (
-            connection_kwargs["socket_connect_timeout"]
-            == Cloudwatch.SOCKET_CONNECT_TIMEOUT
-        )
+        # The socket timeouts are fixed inside get_redis_client; assert they are
+        # configured (a real fail-fast timeout, not None) without coupling the
+        # test to the specific values.
+        assert connection_kwargs["socket_timeout"] is not None
+        assert connection_kwargs["socket_connect_timeout"] is not None
 
     def test_get_redis_client_prefixes_lindex(self):
         # kombu's PrefixedStrictRedis does not include LINDEX in its prefixed-command list,

--- a/tests/manager/service/celery/test_configuration.py
+++ b/tests/manager/service/celery/test_configuration.py
@@ -87,15 +87,12 @@ class TestCeleryConfiguration:
         result = config.model_dump()
 
         broker_options = result["broker_transport_options"]
-        assert broker_options["socket_keepalive"] is True
         assert broker_options["health_check_interval"] == 30
-        assert "broker_transport_options_socket_keepalive" not in result
         assert "broker_transport_options_health_check_interval" not in result
 
         # These look superficially like transport-option keys but must stay
         # top-level; if extract_keys_by_prefix ever swallowed them (e.g. by
         # matching on "result_backend_") these lookups would KeyError.
-        assert result["redis_socket_keepalive"] is True
         assert result["redis_backend_health_check_interval"] == 30
         assert result["result_backend_always_retry"] is True
         assert result["result_backend_max_retries"] == 3

--- a/tests/manager/service/celery/test_configuration.py
+++ b/tests/manager/service/celery/test_configuration.py
@@ -75,6 +75,37 @@ class TestCeleryConfiguration:
         assert options.get("global_keyprefix") == "z"
         assert "result_backend_transport_options_global_keyprefix" not in result
 
+    def test_dict_merge_resilience_options(
+        self, celery_configuration: CeleryConfFixture
+    ):
+        # The connection-resilience settings must land where Celery expects them.
+        # broker_transport_options_* keys are folded into the
+        # broker_transport_options dict, while redis_* and result_backend_* keys
+        # (which are *not* *_transport_options_ keys) are top-level Celery
+        # settings and must survive model_dump's prefix extraction unchanged.
+        config = celery_configuration()
+        result = config.model_dump()
+
+        broker_options = result["broker_transport_options"]
+        assert broker_options["socket_keepalive"] is True
+        assert broker_options["health_check_interval"] == 30
+        assert "broker_transport_options_socket_keepalive" not in result
+        assert "broker_transport_options_health_check_interval" not in result
+
+        # These look superficially like transport-option keys but must stay
+        # top-level; if extract_keys_by_prefix ever swallowed them (e.g. by
+        # matching on "result_backend_") these lookups would KeyError.
+        assert result["redis_socket_keepalive"] is True
+        assert result["redis_backend_health_check_interval"] == 30
+        assert result["result_backend_always_retry"] is True
+        assert result["result_backend_max_retries"] == 3
+
+        # ...and they must not have leaked into the result-backend options dict
+        # (which by default only holds the global_keyprefix).
+        backend_options = result["result_backend_transport_options"]
+        assert "always_retry" not in backend_options
+        assert "max_retries" not in backend_options
+
 
 class TestPydanticSerialization:
     def test_pydantic_object(self, opds2_files_fixture: OPDS2FilesFixture) -> None:

--- a/tests/manager/service/redis/test_configuration.py
+++ b/tests/manager/service/redis/test_configuration.py
@@ -1,0 +1,26 @@
+from palace.manager.service.redis.configuration import RedisConfiguration
+from palace.manager.service.redis.container import RedisContainer
+
+
+class TestRedisConfiguration:
+    def test_connection_resilience_defaults(self) -> None:
+        # The connection-resilience knobs default on, with a 30s health-check
+        # interval. These defaults are what keep the connection pool from getting
+        # stuck handing out stale sockets after a Redis restart.
+        config = RedisConfiguration(url="redis://localhost:6379/0")
+        assert config.socket_keepalive is True
+        assert config.health_check_interval == 30
+
+
+class TestRedisContainer:
+    def test_settings_are_threaded_into_the_connection_pool(self) -> None:
+        # The container must pass the resilience settings through to the
+        # underlying redis connection pool. Building the pool does not open a
+        # connection, so we can assert on its connection_kwargs directly.
+        container = RedisContainer()
+        container.config.from_dict(
+            RedisConfiguration(url="redis://localhost:6379/0").model_dump()
+        )
+        pool = container.connection_pool()
+        assert pool.connection_kwargs["socket_keepalive"] is True
+        assert pool.connection_kwargs["health_check_interval"] == 30

--- a/tests/manager/service/redis/test_configuration.py
+++ b/tests/manager/service/redis/test_configuration.py
@@ -4,11 +4,10 @@ from palace.manager.service.redis.container import RedisContainer
 
 class TestRedisConfiguration:
     def test_connection_resilience_defaults(self) -> None:
-        # The connection-resilience knobs default on, with a 30s health-check
-        # interval. These defaults are what keep the connection pool from getting
-        # stuck handing out stale sockets after a Redis restart.
+        # health_check_interval defaults to 30s -- this is what keeps the
+        # connection pool from getting stuck handing out stale sockets after a
+        # Redis restart.
         config = RedisConfiguration(url="redis://localhost:6379/0")
-        assert config.socket_keepalive is True
         assert config.health_check_interval == 30
 
 
@@ -22,5 +21,4 @@ class TestRedisContainer:
             RedisConfiguration(url="redis://localhost:6379/0").model_dump()
         )
         pool = container.connection_pool()
-        assert pool.connection_kwargs["socket_keepalive"] is True
         assert pool.connection_kwargs["health_check_interval"] == 30


### PR DESCRIPTION
## Description

Hardens connection resilience for all three of our Redis connections — the application Redis client, the Celery broker, and the Celery result backend — so a dropped connection is detected and replaced instead of leaving the pool stuck handing out dead sockets.

The mechanism is `health_check_interval`: redis-py PINGs an idle connection before reuse, and if the PING fails (e.g. the connection was left stale by a Redis reboot) it disconnects and re-establishes the connection transparently within ~30s instead of blocking on a dead socket. The Celery result backend additionally gets `result_backend_always_retry`, since result writes are keyed by task id and therefore idempotent.

## Motivation and Context

A transient network blip between the workers and ElastiCache caused a burst of "Connection reset by peer" errors across all prod shards, killing Celery tasks and spiking web 5xx. None of our three Redis connections were configured to detect or recover from a dropped connection, so they stayed stuck after the blip.

Companion to #3467 (PP-4545), which makes web requests survive a Redis outage while it is being detected. The two are independent and can merge in either order.

## How Has This Been Tested?

- `mypy` passes on the changed files.
- Added unit tests: one asserting the new Celery resilience settings route correctly through `CeleryConfiguration.model_dump()` (the `broker_transport_options_*` keys fold into the options dict while the `redis_backend_*` / `result_backend_*` keys stay top-level), and one for `RedisConfiguration`/`RedisContainer` confirming `health_check_interval` defaults to 30 and is threaded into the connection pool.
- Ran the Redis and Celery configuration suites against a real Redis in the `py312-docker` tox env; all pass and the client constructs/connects with the new settings.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.