### PR TITLE
Handle transient Redis/broker outages gracefully in web requests (PP-4545)

### DIFF
--- a/src/palace/manager/api/controller/loan.py
+++ b/src/palace/manager/api/controller/loan.py
@@ -32,6 +32,7 @@ from palace.manager.feed.acquisition import OPDSAcquisitionFeed
 from palace.manager.integration.license.boundless.constants import (
     BAKER_TAYLOR_KDRM_PARAMS,
 )
+from palace.manager.service.redis.exception import TRANSIENT_REDIS_ERRORS
 from palace.manager.service.redis.models.patron_activity import PatronActivity
 from palace.manager.sqlalchemy.model.library import Library
 from palace.manager.sqlalchemy.model.licensing import (
@@ -69,10 +70,25 @@ class LoanController(CirculationManagerController):
         if patron.authorization_identifier and refresh:
             header = self.authorization_header()
             credential = self.manager.auth.get_credential_from_header(header)
-            for collection in PatronActivity.collections_ready_for_sync(
-                self.redis_client, patron
-            ):
-                sync_patron_activity.apply_async((collection.id, patron.id, credential))
+            try:
+                for collection in PatronActivity.collections_ready_for_sync(
+                    self.redis_client, patron
+                ):
+                    # retry=False: fail fast instead of blocking the request on
+                    # Celery's publish-retry loop if the broker is down (see
+                    # _queue_patron_activity_sync). The error is swallowed below.
+                    sync_patron_activity.apply_async(
+                        (collection.id, patron.id, credential), retry=False
+                    )
+            except TRANSIENT_REDIS_ERRORS:
+                # Best-effort: both reading the sync state and queuing the tasks go
+                # through Redis. If it is briefly unavailable we still serve the
+                # loans feed; the patron sees fresh data on their next refresh.
+                self.log.warning(
+                    "Could not queue patron activity sync; Redis appears to be "
+                    "temporarily unavailable.",
+                    exc_info=True,
+                )
 
         # Then make the feed.
         feed = OPDSAcquisitionFeed.active_loans_for(self.circulation, patron)
@@ -83,6 +99,36 @@ class LoanController(CirculationManagerController):
         )
 
         return response
+
+    def _queue_patron_activity_sync(
+        self, collection_id: int, patron_id: int, credential: str | None
+    ) -> None:
+        """Best-effort queue of a forced patron-activity sync after a successful
+        borrow or revoke.
+
+        The loan or hold change has already succeeded; this task only refreshes
+        our local copy of the patron's activity from the remote provider. A
+        transient Redis/broker outage (e.g. an ElastiCache reboot) must therefore
+        not turn that success into an error for the patron, so we swallow it and
+        log a warning -- the patron will get fresh data on their next refresh.
+        """
+        try:
+            # retry=False: a dead broker should fail fast rather than block the
+            # web request through Celery's publish-retry loop. The resulting
+            # BrokerOperationalError is transient and swallowed below.
+            sync_patron_activity.apply_async(
+                (collection_id, patron_id, credential),
+                {"force": True},
+                countdown=5,
+                retry=False,
+            )
+        except TRANSIENT_REDIS_ERRORS:
+            self.log.warning(
+                "Could not queue patron activity sync for collection %s; Redis "
+                "appears to be temporarily unavailable.",
+                collection_id,
+                exc_info=True,
+            )
 
     def borrow(
         self, identifier_type: str, identifier: str, mechanism_id: int | None = None
@@ -134,10 +180,8 @@ class LoanController(CirculationManagerController):
         if is_new and self.circulation.supports_patron_activity(
             loan_or_hold.license_pool
         ):
-            sync_patron_activity.apply_async(
-                (loan_or_hold.license_pool.collection.id, patron.id, credential),
-                {"force": True},
-                countdown=5,
+            self._queue_patron_activity_sync(
+                loan_or_hold.license_pool.collection.id, patron.id, credential
             )
 
         # If we have a loan, serve a feed that tells the patron how to fulfill the loan. If a hold,
@@ -536,11 +580,7 @@ class LoanController(CirculationManagerController):
         # If the api supports it, queue up a task to sync the patron's activity with the remote.
         # That way we are sure we have the most up-to-date information.
         if self.circulation.supports_patron_activity(pool):
-            sync_patron_activity.apply_async(
-                (pool.collection.id, patron.id, credential),
-                {"force": True},
-                countdown=5,
-            )
+            self._queue_patron_activity_sync(pool.collection.id, patron.id, credential)
 
         annotator = self.manager.annotator(None)
         single_entry_feed = OPDSAcquisitionFeed.single_entry(work, annotator)

--- a/src/palace/manager/core/app_server.py
+++ b/src/palace/manager/core/app_server.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import flask
 from flask import Response, make_response, url_for
 from psycopg2 import OperationalError
+from redis.exceptions import AuthenticationError as RedisAuthenticationError
 from werkzeug.exceptions import HTTPException
 
 from palace.util.log import LoggerMixin
@@ -23,6 +24,7 @@ from palace.manager.core.problem_details import INVALID_URN
 from palace.manager.feed.acquisition import LookupAcquisitionFeed, OPDSAcquisitionFeed
 from palace.manager.feed.facets.feed import Facets
 from palace.manager.search.pagination import Pagination
+from palace.manager.service.redis.exception import TRANSIENT_REDIS_ERRORS
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.util.opds_writer import OPDSMessage
 from palace.manager.util.problem_detail import BaseProblemDetailException, ProblemDetail
@@ -276,10 +278,20 @@ class ErrorHandler(LoggerMixin):
                 # WARN.
                 log_method = self.log.warning
             response = make_response(document.response)
-        elif isinstance(exception, OperationalError):
-            # This is an error, but it is probably unavoidable. Likely it was caused by
-            # the database dropping our connection which can happen then the database is
-            # restarted for maintenance. We'll log it at log level WARN.
+        elif isinstance(
+            exception, (OperationalError, *TRANSIENT_REDIS_ERRORS)
+        ) and not isinstance(exception, RedisAuthenticationError):
+            # A backing service briefly dropped our connection, rather than a bug in
+            # our own code: the database (psycopg2 OperationalError, e.g. the
+            # connection dropping during a maintenance restart), the application
+            # Redis client, or the Celery broker while publishing a task. These are
+            # usually unavoidable blips (e.g. an ElastiCache reboot), so we log at
+            # WARN and ask the client to retry rather than returning a 500.
+            #
+            # A redis AuthenticationError is also a ConnectionError subclass, but it
+            # signals a persistent credential/ACL misconfiguration rather than a
+            # blip, so we exclude it -- it falls through to the 500/ERROR path below
+            # rather than being hidden behind a retryable 503.
             log_method = self.log.warning
             body = "Service temporarily unavailable. Please try again later."
             response = make_response(body, 503, {"Content-Type": "text/plain"})

--- a/src/palace/manager/service/redis/exception.py
+++ b/src/palace/manager/service/redis/exception.py
@@ -1,3 +1,9 @@
+from kombu.exceptions import OperationalError as BrokerOperationalError
+from redis.exceptions import (
+    ConnectionError as RedisConnectionError,
+    TimeoutError as RedisTimeoutError,
+)
+
 from palace.util.exceptions import BasePalaceException
 
 
@@ -5,3 +11,17 @@ class RedisKeyError(BasePalaceException, TypeError): ...
 
 
 class RedisValueError(BasePalaceException, ValueError): ...
+
+
+# Transient errors that mean Redis is briefly unreachable rather than that
+# something is wrong in our code: a dropped connection to the application Redis
+# client (ConnectionError / TimeoutError), or to the Celery broker while
+# publishing a task. The Celery broker is Redis-backed, and kombu wraps the
+# underlying redis connection error as its own OperationalError, so we catch
+# that here too. Best-effort callers swallow these; the web error handler (see
+# core.app_server.ErrorHandler) maps them to a 503 "try again later".
+TRANSIENT_REDIS_ERRORS: tuple[type[Exception], ...] = (
+    BrokerOperationalError,
+    RedisConnectionError,
+    RedisTimeoutError,
+)

--- a/tests/manager/api/controller/test_loan.py
+++ b/tests/manager/api/controller/test_loan.py
@@ -14,6 +14,7 @@ from flask import Response as FlaskResponse, url_for
 from werkzeug import Response as wkResponse
 
 from palace.util.datetime_helpers import utc_now
+from palace.util.log import LogLevel
 
 from palace.manager.api.circulation.base import BaseCirculationAPI
 from palace.manager.api.circulation.data import HoldInfo, LoanInfo
@@ -52,6 +53,7 @@ from palace.manager.core.problem_details import INTEGRATION_ERROR, INVALID_INPUT
 from palace.manager.feed.acquisition import OPDSAcquisitionFeed
 from palace.manager.integration.license.bibliotheca import BibliothecaAPI
 from palace.manager.integration.license.opds.opds1.api import OPDSAPI
+from palace.manager.service.redis.exception import TRANSIENT_REDIS_ERRORS
 from palace.manager.service.redis.models.patron_activity import PatronActivity
 from palace.manager.sqlalchemy.constants import MediaTypes
 from palace.manager.sqlalchemy.model.classification import Genre
@@ -311,6 +313,7 @@ class TestLoanController:
                 ),
                 {"force": True},
                 countdown=5,
+                retry=False,
             )
 
             # A loan has been created for this license pool.
@@ -1177,7 +1180,136 @@ class TestLoanController:
             ),
             {"force": True},
             countdown=5,
+            retry=False,
         )
+
+    @pytest.mark.parametrize("exception", TRANSIENT_REDIS_ERRORS)
+    def test_revoke_swallows_transient_redis_error(
+        self,
+        loan_fixture: LoanFixture,
+        caplog: pytest.LogCaptureFixture,
+        exception: type[Exception],
+    ):
+        # Revoking succeeds, but queuing the follow-up patron-activity sync hits a
+        # transient Redis/broker outage. The revoke must still succeed -- the blip
+        # is swallowed and logged rather than surfaced as an error to the patron.
+        caplog.set_level(LogLevel.warning)
+        headers = {"Authorization": loan_fixture.valid_auth}
+        with loan_fixture.request_context_with_library("/", headers=headers):
+            patron = loan_fixture.manager.loans.authenticated_patron_from_request()
+            assert isinstance(patron, Patron)
+            loan_fixture.pool.loan_to(patron)
+            loan_fixture.manager.d_circulation.queue_checkin(loan_fixture.pool)
+
+            with patch(
+                "palace.manager.api.controller.loan.sync_patron_activity"
+            ) as sync_task:
+                sync_task.apply_async.side_effect = exception("redis unavailable")
+                response = loan_fixture.manager.loans.revoke(loan_fixture.pool_id)
+
+        assert response.status_code == 200
+        sync_task.apply_async.assert_called_once()
+        assert "Could not queue patron activity sync" in caplog.text
+
+    @pytest.mark.parametrize("exception", TRANSIENT_REDIS_ERRORS)
+    def test_borrow_swallows_transient_redis_error(
+        self,
+        loan_fixture: LoanFixture,
+        caplog: pytest.LogCaptureFixture,
+        exception: type[Exception],
+    ):
+        # A new loan/hold queues the same best-effort follow-up sync as revoke (via
+        # the shared helper). A transient Redis/broker outage must not turn the
+        # successful borrow into an error -- it is swallowed and logged.
+        caplog.set_level(LogLevel.warning)
+        work = loan_fixture.db.work(
+            with_license_pool=True, with_open_access_download=False
+        )
+        pool = work.license_pools[0]
+        loan_fixture.manager.d_circulation.queue_checkout(
+            pool,
+            LoanInfo.from_license_pool(
+                pool,
+                start_date=utc_now(),
+                end_date=utc_now() + datetime.timedelta(seconds=3600),
+            ),
+        )
+        headers = {"Authorization": loan_fixture.valid_auth}
+        with loan_fixture.request_context_with_library("/", headers=headers):
+            loan_fixture.manager.loans.authenticated_patron_from_request()
+            with patch(
+                "palace.manager.api.controller.loan.sync_patron_activity"
+            ) as sync_task:
+                sync_task.apply_async.side_effect = exception("redis unavailable")
+                borrow_response = loan_fixture.manager.loans.borrow(
+                    loan_fixture.identifier_type, loan_fixture.identifier_identifier
+                )
+
+        assert isinstance(borrow_response, FlaskResponse)
+        assert borrow_response.status_code == 201
+        sync_task.apply_async.assert_called_once()
+        assert "Could not queue patron activity sync" in caplog.text
+
+    @pytest.mark.parametrize("exception", TRANSIENT_REDIS_ERRORS)
+    def test_sync_swallows_transient_redis_error(
+        self,
+        loan_fixture: LoanFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+        exception: type[Exception],
+    ):
+        # The Redis *read* (collections_ready_for_sync) fails here. If Redis is
+        # briefly unavailable we must still serve the loans feed rather than 500.
+        caplog.set_level(LogLevel.warning)
+        with (
+            loan_fixture.request_context_with_library(
+                "loans/?refresh=true",
+                headers=dict(Authorization=loan_fixture.valid_auth),
+            ),
+            patch.object(
+                PatronActivity,
+                "collections_ready_for_sync",
+                side_effect=exception("redis unavailable"),
+            ),
+        ):
+            loan_fixture.manager.loans.authenticated_patron_from_request()
+            response = loan_fixture.manager.loans.sync()
+
+        assert isinstance(response, FlaskResponse)
+        assert response.status_code == 200
+        assert "Could not queue patron activity sync" in caplog.text
+
+    @pytest.mark.parametrize("exception", TRANSIENT_REDIS_ERRORS)
+    def test_sync_swallows_transient_redis_error_when_queuing(
+        self,
+        loan_fixture: LoanFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+        exception: type[Exception],
+    ):
+        # Companion to the read-path test above: here the Redis read succeeds and
+        # returns at least one collection, but publishing the sync task to the
+        # broker fails. That apply_async call lives inside the same try block, so a
+        # broker outage must be swallowed too -- this guards against a future
+        # refactor that moves the publish call outside the guard.
+        caplog.set_level(LogLevel.warning)
+        with (
+            loan_fixture.request_context_with_library(
+                "loans/?refresh=true",
+                headers=dict(Authorization=loan_fixture.valid_auth),
+            ),
+            patch(
+                "palace.manager.api.controller.loan.sync_patron_activity"
+            ) as sync_task,
+        ):
+            sync_task.apply_async.side_effect = exception("redis unavailable")
+            loan_fixture.manager.loans.authenticated_patron_from_request()
+            response = loan_fixture.manager.loans.sync()
+
+        assert isinstance(response, FlaskResponse)
+        assert response.status_code == 200
+        sync_task.apply_async.assert_called_once()
+        assert "Could not queue patron activity sync" in caplog.text
 
     @pytest.mark.parametrize(
         *OPDSSerializationTestHelper.PARAMETRIZED_SINGLE_ENTRY_ACCEPT_HEADERS
@@ -1312,6 +1444,7 @@ class TestLoanController:
             ),
             {"force": True},
             countdown=5,
+            retry=False,
         )
 
     def test_revoke_hold_exception(
@@ -1548,6 +1681,7 @@ class TestLoanController:
         for collection in patron_collections:
             sync_task.apply_async.assert_any_call(
                 (collection.id, patron.id, loan_fixture.valid_credentials["password"]),
+                retry=False,
             )
 
         # Set up some loans and holds
@@ -1654,6 +1788,7 @@ class TestLoanController:
                 patron.id,
                 loan_fixture.valid_credentials["password"],
             ),
+            retry=False,
         )
 
     @pytest.mark.parametrize(

--- a/tests/manager/core/test_app_server.py
+++ b/tests/manager/core/test_app_server.py
@@ -11,6 +11,7 @@ from flask_babel import Babel, lazy_gettext as _
 from freezegun import freeze_time
 from psycopg2 import OperationalError
 from pytest import LogCaptureFixture
+from redis.exceptions import AuthenticationError as RedisAuthenticationError
 
 from palace.util.log import LogLevel
 
@@ -40,6 +41,7 @@ from palace.manager.feed.facets.feed import Facets
 from palace.manager.feed.facets.search import SearchFacets
 from palace.manager.feed.worklist.base import WorkList
 from palace.manager.search.pagination import Pagination
+from palace.manager.service.redis.exception import TRANSIENT_REDIS_ERRORS
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.util.opds_writer import OPDSFeed, OPDSMessage
 from palace.manager.util.problem_detail import (
@@ -602,6 +604,56 @@ class TestErrorHandler:
         assert len(caplog.records) == 1
         log_record = caplog.records[0]
         assert log_record.levelname == LogLevel.warning
+
+    @pytest.mark.parametrize("exception_cls", TRANSIENT_REDIS_ERRORS)
+    def test_handle_transient_redis_error(
+        self,
+        error_handler_fixture: ErrorHandlerFixture,
+        caplog: LogCaptureFixture,
+        exception_cls: type[Exception],
+    ):
+        # A transient failure reaching Redis -- either the application Redis client
+        # or the Celery broker while publishing a task -- is treated like the
+        # database OperationalError above: logged at WARN and returned as a 503 so
+        # the client retries, rather than surfaced as a 500.
+        caplog.set_level(LogLevel.warning)
+        handler = error_handler_fixture.handler()
+        with error_handler_fixture.app.test_request_context("/"):
+            try:
+                self.raise_exception(exception_cls("redis unavailable"))
+            except Exception as exception:
+                response = handler.handle(exception)
+
+            assert isinstance(response, Response)
+            assert 503 == response.status_code
+            assert (
+                "Service temporarily unavailable. Please try again later."
+                == response.get_data(as_text=True)
+            )
+
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == LogLevel.warning
+
+    def test_handle_redis_authentication_error_is_not_retryable(
+        self, error_handler_fixture: ErrorHandlerFixture, caplog: LogCaptureFixture
+    ):
+        # A redis AuthenticationError is a ConnectionError subclass, but it means a
+        # persistent credential/ACL misconfiguration, not a transient blip. It must
+        # NOT be mapped to a retryable 503; it falls through to the 500/ERROR path
+        # so the misconfiguration is visible rather than hidden behind "try again".
+        caplog.set_level(LogLevel.warning)
+        handler = error_handler_fixture.handler()
+        with error_handler_fixture.app.test_request_context("/"):
+            try:
+                self.raise_exception(RedisAuthenticationError("bad password"))
+            except Exception as exception:
+                response = handler.handle(exception)
+
+            assert isinstance(response, Response)
+            assert 500 == response.status_code
+
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == LogLevel.error
 
 
 class TestCompressibleAnnotator:


### PR DESCRIPTION
## Description

When Redis briefly goes away (e.g. an ElastiCache reboot), web requests that touch Redis — either directly or by publishing a Celery task through the Redis broker — previously failed with a raw 500. This handles the two cases at the right altitude:

- **Primary actions** (admin collection import/delete/reap, report generation, and any direct Redis use): the transient errors are mapped centrally in `ErrorHandler`, alongside the existing database `OperationalError` → 503 branch, so the client gets "Service temporarily unavailable. Please try again later." and can retry. No per-call-site wrapping.
- **Best-effort follow-ups** (the patron-activity syncs queued after a loans listing, borrow, or revoke): the error is swallowed and logged in the loan controller. The borrow/revoke has already succeeded, so failing to queue the follow-up sync must not become an error for the patron — they get fresh data on their next refresh.

The transient error set (kombu `OperationalError` for the broker, redis `ConnectionError` / `TimeoutError` for the client) is defined once as `TRANSIENT_REDIS_ERRORS` and shared by both paths.

## Motivation and Context

During the same incident that prompted #3466, requests that touched Redis returned 500s while the connection was down. Hardening the connections (#3466) shrinks that window; this PR makes the requests themselves degrade gracefully — returning a clean 503 where the action could not be performed, and quietly continuing where the Redis work was only a best-effort follow-up to an action that already succeeded.

Companion to #3466 (PP-4545). The two are independent and can merge in either order.

## How Has This Been Tested?

- `mypy` passes on all changed files.
- Added tests: `ErrorHandler` returns a 503 for each transient error type; the loan `revoke` path swallows each transient error type and still returns 200; the loan `sync` path swallows a Redis outage on the direct read and still serves the loans feed.
- Ran the full `test_app_server.py` and `test_loan.py` suites in the `py312-docker` tox env (121 passed), confirming the `borrow`/`revoke` refactor onto the shared helper produces identical task-queue calls (no regressions).

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.