### PR TITLE
Remove orphaned static image route and login button image

### DIFF
--- a/src/palace/manager/api/authentication/basic.py
+++ b/src/palace/manager/api/authentication/basic.py
@@ -9,7 +9,6 @@ from functools import partial
 from re import Pattern
 from typing import Annotated, Any, cast
 
-from flask import url_for
 from pydantic import PositiveInt, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from sqlalchemy.orm import Session
@@ -23,7 +22,6 @@ from palace.opds.authentication.palace import (
     AuthenticationInput,
     AuthenticationInputs,
 )
-from palace.opds.rwpm import Link
 from palace.util.log import elapsed_time_logging
 
 from palace.manager.api.admin.problem_details import (
@@ -876,20 +874,6 @@ class BasicAuthenticationProvider[
             maximum_length=self.password_maximum_length,
         )
 
-        links: list[Link] = []
-        if self.login_button_image:
-            # TODO: I'm not sure if logo is appropriate for this, since it's a button
-            # with the logo on it rather than a plain logo. Perhaps we should use plain
-            # logos instead.
-            links.append(
-                Link(
-                    rel="logo",
-                    href=url_for(
-                        "static_image", filename=self.login_button_image, _external=True
-                    ),
-                )
-            )
-
         return PalaceAuthentication(
             type=self.flow_type,
             description=str(self.label()),
@@ -898,17 +882,7 @@ class BasicAuthenticationProvider[
                 password=self.password_label,
             ),
             inputs=AuthenticationInputs(login=login_input, password=password_input),
-            links=links,
         )
-
-    @property
-    def login_button_image(self) -> str | None:
-        # An AuthenticationProvider may define a custom button image for
-        # clients to display when letting a user choose between different
-        # AuthenticationProviders. Image files MUST be stored in the
-        # `resources/images` directory - the value here should be the
-        # file name.
-        return None
 
     @property
     def identifies_individuals(self):

--- a/src/palace/manager/api/routes.py
+++ b/src/palace/manager/api/routes.py
@@ -713,8 +713,3 @@ def application_version():
 @app.route("/healthcheck.html")
 def health_check():
     return Response("", 200)
-
-
-@app.route("/images/<filename>")
-def static_image(filename):
-    return app.manager.static_files.image(filename)

--- a/tests/manager/api/test_authenticator.py
+++ b/tests/manager/api/test_authenticator.py
@@ -157,10 +157,6 @@ class MockBasic(
     def description(cls) -> str:
         return "A mock authentication provider"
 
-    @property
-    def login_button_image(self) -> str | None:
-        return "login.png"
-
     def remote_authenticate(self, username, password):
         return RemoteAuthResult(patron_data=self.patrondata)
 
@@ -2904,42 +2900,29 @@ class TestBasicAuthenticationProvider:
 
         db = MagicMock(spec=Session)
 
-        # Mock url_for so that the document can be generated.
-        with patch("palace.manager.api.authentication.basic.url_for") as url_for_patch:
-            url_for_patch.return_value = "http://localhost/"
-            doc = provider.authentication_flow_document(db).serialize()
-            assert doc["description"] == provider.label()
-            assert doc["type"] == provider.flow_type
+        doc = provider.authentication_flow_document(db).serialize()
+        assert doc["description"] == provider.label()
+        assert doc["type"] == provider.flow_type
 
-            labels = doc["labels"]
-            assert labels["login"] == provider.identifier_label
-            assert labels["password"] == provider.password_label
+        labels = doc["labels"]
+        assert labels["login"] == provider.identifier_label
+        assert labels["password"] == provider.password_label
 
-            inputs = doc["inputs"]
-            assert inputs["login"]["keyboard"] == provider.identifier_keyboard.value
-            assert inputs["password"]["keyboard"] == provider.password_keyboard.value
+        inputs = doc["inputs"]
+        assert inputs["login"]["keyboard"] == provider.identifier_keyboard.value
+        assert inputs["password"]["keyboard"] == provider.password_keyboard.value
 
-            assert (
-                inputs["login"]["barcode_format"]
-                == provider.identifier_barcode_format.value
-            )
+        assert (
+            inputs["login"]["barcode_format"]
+            == provider.identifier_barcode_format.value
+        )
 
-            assert (
-                inputs["login"]["maximum_length"] == provider.identifier_maximum_length
-            )
-            assert (
-                inputs["password"]["maximum_length"] == provider.password_maximum_length
-            )
+        assert inputs["login"]["maximum_length"] == provider.identifier_maximum_length
+        assert inputs["password"]["maximum_length"] == provider.password_maximum_length
 
-            [logo_link] = doc["links"]
-            assert "logo" == logo_link["rel"]
-            assert "http://localhost/" == logo_link["href"]
-            url_for_patch.assert_called_once()
-            assert "filename" in url_for_patch.call_args.kwargs
-            assert (
-                url_for_patch.call_args.kwargs["filename"]
-                == provider.login_button_image
-            )
+        # Basic auth providers no longer supply a custom login button image, so
+        # the flow document has no links.
+        assert "links" not in doc
 
     def test_scrub_credential(self, mock_basic: MockBasicFixture):
         # Verify that the scrub_credential helper method strips extra whitespace


### PR DESCRIPTION
## Description

Removes the dead `GET /images/<filename>` route and the orphaned basic-auth login-button-image mechanism that was its only intended caller.

- `routes.py` — delete the `/images/<filename>` route and its `static_image` handler.
- `basic.py` — delete the `login_button_image` property (hardcoded to `None`), the now-unreachable `if self.login_button_image:` link branch in `_authentication_flow_document`, and the now-unused `url_for` / `Link` imports.
- `test_authenticator.py` — drop the mock provider's `login_button_image` override and the logo-link assertions; the flow document now has no `links`.

Requests to `/images/...` now return a normal `404` instead of a `500`.

## Motivation and Context

The `/images/<filename>` route called `app.manager.static_files.image()`, but the `static_files` controller and its `image()` method were removed in #1642 ("Remove first book auth API"), along with the only image it ever served (`FirstBookLoginButton280.png`) and the `resources/images` directory. The route handler was left behind, so every request to `/images/...` raised `'CirculationManager' object has no attribute 'static_files'` and returned a 500.

This fires in production whenever a client requests anything under `/images/` — for example browsers probing for a favicon at `/images/favicon-196x196.png` ([example from #palace-alerts](https://lyrasis.slack.com/archives/C049AA32E3S/p1781709443829049)).

The route's only intended caller was the basic-auth `login_button_image` mechanism, which is itself dead: the base property is hardcoded to `None`, and the one provider that overrode it (First Book) was removed in #1642. So the whole chain — route, extension point, and `url_for("static_image", ...)` link branch — is orphaned and is removed here.

## How Has This Been Tested?

- `mypy` on the changed source files: clean.
- `tox -e py312-docker -- --no-cov tests/manager/api/test_authenticator.py tests/manager/api/test_routes.py`: 183 passed.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.