### PR TITLE
Fix duplicate 'status' kwarg when borrow returns an OPDS message

### DIFF
--- a/src/palace/manager/api/controller/loan.py
+++ b/src/palace/manager/api/controller/loan.py
@@ -143,12 +143,11 @@ class LoanController(CirculationManagerController):
         # If we have a loan, serve a feed that tells the patron how to fulfill the loan. If a hold,
         # serve a feed that talks about the hold. We also need to drill in the Accept header, so that
         # it eventually gets sent to core.feed.opds.BaseOPDSFeed.entry_as_response
-        response_kwargs = {
-            "status": 201 if is_new else 200,
-            "mime_types": flask.request.accept_mimetypes,
-        }
         return OPDSAcquisitionFeed.single_entry_loans_feed(
-            self.circulation, loan_or_hold, **response_kwargs  # type: ignore[arg-type]
+            self.circulation,
+            loan_or_hold,
+            status=201 if is_new else 200,
+            mime_types=flask.request.accept_mimetypes,
         )
 
     def _borrow(

--- a/src/palace/manager/feed/acquisition.py
+++ b/src/palace/manager/feed/acquisition.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Unpack
 
 from dependency_injector.wiring import Provide, inject
 from sqlalchemy.orm import Query, Session
+from werkzeug.datastructures import MIMEAccept
 
 from palace.util.datetime_helpers import utc_now
 from palace.util.exceptions import PalaceValueError
@@ -46,7 +47,11 @@ from palace.manager.sqlalchemy.model.lane import (
 from palace.manager.sqlalchemy.model.licensing import LicensePool
 from palace.manager.sqlalchemy.model.patron import Hold, Loan, Patron
 from palace.manager.sqlalchemy.model.work import Work
-from palace.manager.util.flask_util import OPDSEntryResponse, OPDSFeedResponse
+from palace.manager.util.flask_util import (
+    OPDSEntryResponse,
+    OPDSFeedResponse,
+    ResponseKwargs,
+)
 from palace.manager.util.opds_writer import AtomFeed, OPDSMessage
 from palace.manager.util.problem_detail import ProblemDetail
 
@@ -220,7 +225,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
             default_facet=is_default,
         )
 
-    def as_error_response(self, **kwargs: Any) -> OPDSFeedResponse:
+    def as_error_response(self, **kwargs: Unpack[ResponseKwargs]) -> OPDSFeedResponse:
         """Convert this feed into an OPDSFeedResponse that should be treated
         by intermediaries as an error -- that is, treated as private
         and not cached.
@@ -557,7 +562,8 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         item: LicensePool | Loan | Hold | None,
         annotator: LibraryAnnotator | None = None,
         fulfillment: UrlFulfillment | None = None,
-        **response_kwargs: Any,
+        mime_types: MIMEAccept | None = None,
+        **response_kwargs: Unpack[ResponseKwargs],
     ) -> OPDSEntryResponse | ProblemDetail:
         """A single entry as a standalone feed specific to a patron"""
         if not item:
@@ -617,7 +623,7 @@ class OPDSAcquisitionFeed(BaseOPDSFeed):
         if isinstance(entry, OPDSMessage):
             response_kwargs["max_age"] = 0
 
-        return cls.entry_as_response(entry, **response_kwargs)
+        return cls.entry_as_response(entry, mime_types=mime_types, **response_kwargs)
 
     @classmethod
     def single_entry(

--- a/src/palace/manager/feed/navigation.py
+++ b/src/palace/manager/feed/navigation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Self
+from typing import Self, Unpack
 
 from sqlalchemy.orm import Session
 from werkzeug.datastructures import MIMEAccept
@@ -15,7 +15,7 @@ from palace.manager.feed.types import DataEntry, DataEntryTypes, Link, LinkConte
 from palace.manager.feed.util import strftime
 from palace.manager.feed.worklist.base import WorkList
 from palace.manager.search.pagination import Pagination
-from palace.manager.util.flask_util import OPDSFeedResponse
+from palace.manager.util.flask_util import OPDSFeedResponse, ResponseKwargs
 from palace.manager.util.opds_writer import OPDSFeed
 
 
@@ -90,7 +90,7 @@ class NavigationFeed(BaseOPDSFeed):
     def as_response(
         self,
         mime_types: MIMEAccept | None = None,
-        **kwargs: Any,
+        **kwargs: Unpack[ResponseKwargs],
     ) -> OPDSFeedResponse:
         response = super().as_response(mime_types=mime_types, **kwargs)
         # OPDS1 navigation feeds use a distinct content type from acquisition feeds.

--- a/src/palace/manager/feed/opds.py
+++ b/src/palace/manager/feed/opds.py
@@ -66,9 +66,6 @@ class BaseOPDSFeed(FeedInterface, LoggerMixin):
     ) -> OPDSFeedResponse:
         """Serialize the feed using the serializer protocol"""
         serializer = get_serializer(mime_types)
-        # The serializer dictates the content type, so set it directly rather
-        # than passing it as a second explicit argument alongside ``**kwargs``
-        # (which would be a duplicate keyword once ``kwargs`` is typed).
         kwargs["content_type"] = serializer.content_type()
         return OPDSFeedResponse(
             serializer.serialize_feed(
@@ -85,15 +82,10 @@ class BaseOPDSFeed(FeedInterface, LoggerMixin):
         **response_kwargs: Unpack[ResponseKwargs],
     ) -> OPDSEntryResponse:
         serializer = get_serializer(mime_types)
-        # The serializer dictates the content type, so set it directly rather
-        # than passing it as a second explicit argument alongside the forwarded
-        # ``**response_kwargs`` (which would be a duplicate keyword).
         response_kwargs["content_type"] = serializer.entry_content_type()
         if isinstance(entry, OPDSMessage):
             # An OPDSMessage represents an error condition, so its own status
-            # code always wins over any status supplied by the caller (e.g. the
-            # 200/201 used for a successful borrow). Setting it into the kwargs
-            # dict overrides the caller value without passing ``status`` twice.
+            # code always wins over any status supplied by the caller.
             response_kwargs["status"] = entry.status_code
             return OPDSEntryResponse(
                 response=serializer.to_string(serializer.serialize_opds_message(entry)),

--- a/src/palace/manager/feed/opds.py
+++ b/src/palace/manager/feed/opds.py
@@ -79,6 +79,12 @@ class BaseOPDSFeed(FeedInterface, LoggerMixin):
     ) -> OPDSEntryResponse:
         serializer = get_serializer(mime_types)
         if isinstance(entry, OPDSMessage):
+            # An OPDSMessage represents an error condition, so its own
+            # status code takes precedence over any status supplied by the
+            # caller (e.g. the 200/201 used for a successful borrow). Drop a
+            # caller-supplied status to avoid passing ``status`` twice to
+            # OPDSEntryResponse.
+            response_kwargs.pop("status", None)
             return OPDSEntryResponse(
                 response=serializer.to_string(serializer.serialize_opds_message(entry)),
                 status=entry.status_code,

--- a/src/palace/manager/feed/opds.py
+++ b/src/palace/manager/feed/opds.py
@@ -17,7 +17,11 @@ from palace.manager.feed.serializer.opds import (
 )
 from palace.manager.feed.serializer.opds2 import OPDS2Serializer
 from palace.manager.feed.types import FeedData, LinkKwargs, WorkEntry
-from palace.manager.util.flask_util import OPDSEntryResponse, OPDSFeedResponse
+from palace.manager.util.flask_util import (
+    OPDSEntryResponse,
+    OPDSFeedResponse,
+    ResponseKwargs,
+)
 from palace.manager.util.opds_writer import OPDSMessage
 
 
@@ -58,15 +62,18 @@ class BaseOPDSFeed(FeedInterface, LoggerMixin):
     def as_response(
         self,
         mime_types: MIMEAccept | None = None,
-        **kwargs: Any,
+        **kwargs: Unpack[ResponseKwargs],
     ) -> OPDSFeedResponse:
         """Serialize the feed using the serializer protocol"""
         serializer = get_serializer(mime_types)
+        # The serializer dictates the content type, so set it directly rather
+        # than passing it as a second explicit argument alongside ``**kwargs``
+        # (which would be a duplicate keyword once ``kwargs`` is typed).
+        kwargs["content_type"] = serializer.content_type()
         return OPDSFeedResponse(
             serializer.serialize_feed(
                 self._feed, precomposed_entries=self._precomposed_entries
             ),
-            content_type=serializer.content_type(),
             **kwargs,
         )
 
@@ -75,20 +82,21 @@ class BaseOPDSFeed(FeedInterface, LoggerMixin):
         cls,
         entry: WorkEntry | OPDSMessage,
         mime_types: MIMEAccept | None = None,
-        **response_kwargs: Any,
+        **response_kwargs: Unpack[ResponseKwargs],
     ) -> OPDSEntryResponse:
         serializer = get_serializer(mime_types)
+        # The serializer dictates the content type, so set it directly rather
+        # than passing it as a second explicit argument alongside the forwarded
+        # ``**response_kwargs`` (which would be a duplicate keyword).
+        response_kwargs["content_type"] = serializer.entry_content_type()
         if isinstance(entry, OPDSMessage):
-            # An OPDSMessage represents an error condition, so its own
-            # status code takes precedence over any status supplied by the
-            # caller (e.g. the 200/201 used for a successful borrow). Drop a
-            # caller-supplied status to avoid passing ``status`` twice to
-            # OPDSEntryResponse.
-            response_kwargs.pop("status", None)
+            # An OPDSMessage represents an error condition, so its own status
+            # code always wins over any status supplied by the caller (e.g. the
+            # 200/201 used for a successful borrow). Setting it into the kwargs
+            # dict overrides the caller value without passing ``status`` twice.
+            response_kwargs["status"] = entry.status_code
             return OPDSEntryResponse(
                 response=serializer.to_string(serializer.serialize_opds_message(entry)),
-                status=entry.status_code,
-                content_type=serializer.entry_content_type(),
                 **response_kwargs,
             )
 
@@ -100,7 +108,6 @@ class BaseOPDSFeed(FeedInterface, LoggerMixin):
             response=serializer.to_string(
                 serializer.serialize_work_entry(entry.computed)
             ),
-            content_type=serializer.entry_content_type(),
             **response_kwargs,
         )
 

--- a/src/palace/manager/feed/opds.py
+++ b/src/palace/manager/feed/opds.py
@@ -84,8 +84,9 @@ class BaseOPDSFeed(FeedInterface, LoggerMixin):
         serializer = get_serializer(mime_types)
         response_kwargs["content_type"] = serializer.entry_content_type()
         if isinstance(entry, OPDSMessage):
-            # An OPDSMessage represents an error condition, so its own status
-            # code always wins over any status supplied by the caller.
+            # An OPDSMessage carries its own status code reflecting the real
+            # outcome for the work (e.g. 403 when unfulfillable), so it always
+            # wins over any status supplied by the caller.
             response_kwargs["status"] = entry.status_code
             return OPDSEntryResponse(
                 response=serializer.to_string(serializer.serialize_opds_message(entry)),

--- a/src/palace/manager/util/flask_util.py
+++ b/src/palace/manager/util/flask_util.py
@@ -22,10 +22,7 @@ class ResponseKwargs(TypedDict, total=False):
     """The optional keyword arguments accepted by :class:`Response`.
 
     Mirrors every parameter of ``Response.__init__`` except the positional
-    ``response`` body. Typing the ``**kwargs`` that get forwarded through the
-    OPDS response/feed helpers with ``Unpack[ResponseKwargs]`` lets mypy
-    statically catch duplicate, unknown, or mistyped response options -- which
-    a bare ``**kwargs: Any`` silently hides until they raise at runtime.
+    ``response`` body.
     """
 
     status: int | None

--- a/src/palace/manager/util/flask_util.py
+++ b/src/palace/manager/util/flask_util.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import time
 from json import JSONDecodeError
-from typing import Any
+from typing import Any, TypedDict, Unpack
 from wsgiref.handlers import format_date_time
 
 from flask import Response as FlaskResponse
@@ -16,6 +16,25 @@ from werkzeug.datastructures import MultiDict
 from palace.util.datetime_helpers import utc_now
 
 from palace.manager.util.opds_writer import OPDSFeed
+
+
+class ResponseKwargs(TypedDict, total=False):
+    """The optional keyword arguments accepted by :class:`Response`.
+
+    Mirrors every parameter of ``Response.__init__`` except the positional
+    ``response`` body. Typing the ``**kwargs`` that get forwarded through the
+    OPDS response/feed helpers with ``Unpack[ResponseKwargs]`` lets mypy
+    statically catch duplicate, unknown, or mistyped response options -- which
+    a bare ``**kwargs: Any`` silently hides until they raise at runtime.
+    """
+
+    status: int | None
+    headers: dict[str, Any]
+    mimetype: str
+    content_type: str
+    direct_passthrough: bool
+    max_age: int | str
+    private: bool | None
 
 
 class Response(FlaskResponse):
@@ -165,7 +184,7 @@ class OPDSFeedResponse(Response):
 class OPDSEntryResponse(Response):
     """A convenience specialization of Response for typical OPDS entries."""
 
-    def __init__(self, response: Any = None, **kwargs: Any) -> None:
+    def __init__(self, response: Any = None, **kwargs: Unpack[ResponseKwargs]) -> None:
         kwargs.setdefault("mimetype", OPDSFeed.ENTRY_TYPE)
         super().__init__(response, **kwargs)
 

--- a/tests/manager/feed/test_opds_acquisition_feed.py
+++ b/tests/manager/feed/test_opds_acquisition_feed.py
@@ -126,6 +126,16 @@ class TestOPDSFeedProtocol:
         assert response.status_code == 204
         assert dict(description="Test OPDS Message", urn="URN") == response.json
 
+        # A caller-supplied status (e.g. the 200/201 used for a successful
+        # borrow) must not collide with the message's own status code. The
+        # message's status code wins, since it represents an error condition.
+        response = BaseOPDSFeed.entry_as_response(
+            OPDSMessage("URN", 403, "Test OPDS Message"),
+            status=201,
+        )
+        assert isinstance(response, OPDSEntryResponse)
+        assert response.status_code == 403
+
 
 class MockAnnotator(CirculationManagerAnnotator):
     def __init__(self):

--- a/tests/manager/feed/test_opds_acquisition_feed.py
+++ b/tests/manager/feed/test_opds_acquisition_feed.py
@@ -933,8 +933,7 @@ class TestOPDSAcquisitionFeed:
 
         # Regression test for the borrow flow: borrow() passes a status (200/201)
         # for a successful loan/hold, but when single_entry yields an OPDSMessage
-        # the message's own status code must win -- without the caller-supplied
-        # status colliding with it (which previously raised a TypeError).
+        # the message's own status code must win.
         response = OPDSAcquisitionFeed.single_entry_loans_feed(
             MagicMock(),
             pool,

--- a/tests/manager/feed/test_opds_acquisition_feed.py
+++ b/tests/manager/feed/test_opds_acquisition_feed.py
@@ -272,12 +272,9 @@ class TestOPDSAcquisitionFeed:
         feed.generate_feed()
 
         # Some other piece of code set expectations for how this feed should
-        # be cached.
-        kwargs = dict(max_age=101, private=False)
-
-        # But we know that something has gone wrong and the feed is
+        # be cached, but we know that something has gone wrong and the feed is
         # being served as an error message.
-        response = feed.as_error_response(**kwargs)
+        response = feed.as_error_response(max_age=101, private=False)
         assert isinstance(response, OPDSFeedResponse)
 
         # The content of the feed is unchanged.
@@ -933,6 +930,21 @@ class TestOPDSAcquisitionFeed:
         response = OPDSAcquisitionFeed.single_entry_loans_feed(MagicMock(), pool)
         assert isinstance(response, OPDSEntryResponse)
         assert response.status_code == 403
+
+        # Regression test for the borrow flow: borrow() passes a status (200/201)
+        # for a successful loan/hold, but when single_entry yields an OPDSMessage
+        # the message's own status code must win -- without the caller-supplied
+        # status colliding with it (which previously raised a TypeError).
+        response = OPDSAcquisitionFeed.single_entry_loans_feed(
+            MagicMock(),
+            pool,
+            status=201,
+            mime_types=MIMEAccept([("application/opds+json", 1.0)]),
+        )
+        assert isinstance(response, OPDSEntryResponse)
+        assert response.status_code == 403
+        # An error response is never cached.
+        assert response.max_age == 0
 
     def test_single_entry_with_edition(self, db: DatabaseTransactionFixture):
         work = db.work(with_license_pool=True)


### PR DESCRIPTION
## Description

`BaseOPDSFeed.entry_as_response` passes `status=entry.status_code` explicitly when the entry is an `OPDSMessage`. The borrow flow (`LoanController.borrow`) also passes a status (`201` for a new loan, `200` otherwise) through `response_kwargs`. When `single_entry` returns an `OPDSMessage` instead of a `WorkEntry`, both ended up in the same `OPDSEntryResponse(...)` call, raising `TypeError: OPDSEntryResponse() got multiple values for keyword argument 'status'`.

The fix drops the caller-supplied `status` from `response_kwargs` for `OPDSMessage` responses, so the message's own status code wins. This matches the pre-existing intent: the `OPDSMessage` branch has always used `entry.status_code`. An error message status (e.g. `403`) is the correct response when the work cannot be presented, rather than the `200`/`201` from the borrow.

## Motivation and Context

Observed intermittently in production on the borrow endpoint:

```
GET /<library>/works/<identifier_type>/<identifier>/borrow
TypeError: palace.manager.util.flask_util.OPDSEntryResponse() got multiple values for keyword argument 'status'
```

It surfaced as an unhandled web-app exception (HTTP 500). It only triggers when a borrow/hold succeeds but `single_entry` cannot build a work entry and instead returns an `OPDSMessage` (no active edition, or an `UnfulfillableWork`). Without the fix the patron sees a 500 instead of the intended error message.

## How Has This Been Tested?

- Added a regression test in `TestOPDSFeedProtocol::test_entry_as_response` that calls `entry_as_response` with an `OPDSMessage` and a colliding `status=201`, asserting the response uses the message's status code (`403`) and no longer raises.
- `tox -e py312-docker -- --no-cov tests/manager/feed/test_opds_acquisition_feed.py` — 37 passed.
- `mypy` clean on the changed file.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
