### PR TITLE
Fix RecursionError in LicensePool.calculate_work

### DIFF
--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -1268,15 +1268,23 @@ class LicensePool(Base):
             # itself. All other LicensePools need to be kicked out and
             # associated with some other work.
             #
-            # This won't cause an infinite recursion because we're
-            # setting pool.work to None before calling
-            # pool.calculate_work(), and the recursive call only
-            # happens if self.work is set.
+            # We clear both pool.work *and* pool.presentation_edition.work
+            # before the recursive call. Clearing only pool.work is not
+            # enough: calculate_work() re-resolves a pool's work from its
+            # presentation edition (the ``elif presentation_edition.work``
+            # branch below), so if the edition still pointed at this Work the
+            # recursive call would re-adopt it and kick *self* back out,
+            # ping-ponging until the stack was exhausted (a RecursionError
+            # observed in production). This mirrors how
+            # Work.make_exclusive_open_access_for_permanent_work_id kicks
+            # pools out.
             for pool in list(work.license_pools):
                 if pool is self:
                     continue
                 if not (self.open_access and pool.open_access):
                     pool.work = None
+                    if pool.presentation_edition:
+                        pool.presentation_edition.work = None
                     pool.calculate_work(
                         exclude_search=exclude_search, even_if_no_title=even_if_no_title
                     )

--- a/tests/manager/sqlalchemy/model/test_work.py
+++ b/tests/manager/sqlalchemy/model/test_work.py
@@ -2491,6 +2491,52 @@ class TestWorkConsolidation:
         commercial_work = abcd_commercial.work
         assert (commercial_work, False) == abcd_commercial.calculate_work()
 
+    def test_calculate_work_does_not_recurse_when_editions_point_to_work(
+        self, db: DatabaseTransactionFixture
+    ):
+        # Regression test for a RecursionError seen in production
+        # (apply.bibliographic_apply -> calculate_work). When a Work
+        # erroneously contains two commercial LicensePools (with different
+        # identifiers) whose presentation editions both still point back at
+        # that Work, calculate_work() used to ping-pong between the two
+        # pools forever. It cleared ``pool.work`` before the recursive call
+        # but left ``pool.presentation_edition.work`` set, so the recursive
+        # call re-resolved the pool back to the same Work (via the
+        # ``elif presentation_edition.work`` branch) and kicked the other
+        # pool out again, and so on until the stack was exhausted.
+
+        # Here's a Work with a commercial edition of "abcd".
+        work = db.work(with_license_pool=True)
+        [commercial_1] = work.license_pools
+        commercial_1.open_access = False
+
+        # Due to an earlier error, the Work also contains a _second_
+        # commercial edition, with a different identifier.
+        edition, commercial_2 = db.edition(with_license_pool=True)
+        commercial_2.open_access = False
+        work.license_pools.append(commercial_2)
+
+        # Unlike the artificially-clean state in
+        # test_calculate_work_fixes_work_in_invalid_state, both presentation
+        # editions still point at the shared Work. This is the normal,
+        # internally-consistent state for a Work's license pools, and it is
+        # what triggered the infinite recursion in production.
+        commercial_1.presentation_edition.work = work
+        commercial_2.presentation_edition.work = work
+
+        # Calling calculate_work() terminates (rather than raising
+        # RecursionError) and separates the two pools into their own Works.
+        work_after, is_new = commercial_1.calculate_work()
+        assert work_after == work
+        assert is_new is False
+
+        # The pool we called calculate_work() on keeps the Work; the other
+        # one has been kicked out and given a Work of its own.
+        assert commercial_1.work == work
+        assert commercial_2.work is not None
+        assert commercial_2.work != work
+        assert [commercial_2] == commercial_2.work.license_pools
+
     def test_calculate_work_fixes_incorrectly_grouped_books(
         self, db: DatabaseTransactionFixture
     ):


### PR DESCRIPTION
## Description

Fixes an infinite recursion (`RecursionError: maximum recursion depth exceeded`) in `LicensePool.calculate_work`. The "kick-out" loop that removes mis-grouped license pools from a `Work` cleared `pool.work` before recursively calling `pool.calculate_work()`, but left `pool.presentation_edition.work` set. Because `calculate_work` re-resolves a pool's work from its presentation edition (the `elif presentation_edition.work:` branch), the recursive call re-adopted the pool back into the same `Work` and kicked the original pool out again, ping-ponging between the two pools until the stack was exhausted. The fix also clears `pool.presentation_edition.work` before recursing, mirroring how `Work.make_exclusive_open_access_for_permanent_work_id` already kicks pools out.

## Motivation and Context

This was observed in production as a Celery unhandled exception in `apply.bibliographic_apply` -> `data_layer/bibliographic.apply` -> `circulation.apply` -> `LicensePool.calculate_work`, with the traceback showing `licensing.py:1280` (`pool.calculate_work(...)`) repeated until `RecursionError`. The trigger is a `Work` that erroneously contains more than one commercial `LicensePool` (with different identifiers) whose presentation editions both still point back at that `Work` — which is the normal, internally-consistent state for a `Work`'s license pools, so the bug surfaces on real data. The existing `test_calculate_work_fixes_work_in_invalid_state` did not catch it because it left the kicked-out pools' `presentation_edition.work` as `None`.

A comment dating to 2018 claimed the recursion could not happen "because we're setting pool.work to None before calling pool.calculate_work()" — that guard was incomplete, and the comment has been corrected.

## How Has This Been Tested?

- Added `test_calculate_work_does_not_recurse_when_editions_point_to_work`, which reproduces the production `RecursionError` at `licensing.py:1280` on the unfixed code and passes with the fix.
- Ran the full `TestWorkConsolidation` suite (28 tests) — all pass, confirming the existing kick-out behavior (each kicked-out pool gets its own `Work`) is preserved.
- `mypy` clean on the changed module.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
