### PR TITLE
Retry RemoteInitiatedServerError in Bibliotheca purchase record import

### DIFF
--- a/src/palace/manager/celery/tasks/bibliotheca.py
+++ b/src/palace/manager/celery/tasks/bibliotheca.py
@@ -28,6 +28,7 @@ from celery import shared_task
 
 from palace.util.datetime_helpers import utc_now
 
+from palace.manager.api.circulation.exceptions import RemoteInitiatedServerError
 from palace.manager.celery.importer import workflow_lock_guard
 from palace.manager.celery.task import Task
 from palace.manager.celery.utils import ModelNotFoundError, load_from_id, signature_with
@@ -194,12 +195,20 @@ def import_purchase_records_for_all_collections(
     )
 
 
+# BibliothecaAPI.marc_request raises RemoteInitiatedServerError (via ErrorParser)
+# when Bibliotheca returns a non-200 body or a malformed/"Unknown error"/
+# "Authentication failed" document. ErrorParser documents these as transient
+# errors on the Bibliotheca side that happen relatively frequently, so they are
+# retried like the HTTP-level remote errors. RemoteInitiatedServerError is a
+# sibling of RemoteIntegrationException (both derive from IntegrationException),
+# not a subclass, so it must be listed explicitly in both autoretry_for and
+# throws — otherwise an exhausted retry surfaces as an unhandled task exception.
 @shared_task(
     queue=QueueNames.default,
     bind=True,
     max_retries=4,
-    autoretry_for=(BadResponseException, RequestTimedOut),
-    throws=(RemoteIntegrationException,),
+    autoretry_for=(BadResponseException, RequestTimedOut, RemoteInitiatedServerError),
+    throws=(RemoteIntegrationException, RemoteInitiatedServerError),
     retry_backoff=60,
 )
 def import_purchase_records_by_collection(

--- a/tests/manager/celery/tasks/test_bibliotheca.py
+++ b/tests/manager/celery/tasks/test_bibliotheca.py
@@ -12,6 +12,7 @@ import pytest
 from palace.util.datetime_helpers import datetime_utc, utc_now
 from palace.util.log import LogLevel
 
+from palace.manager.api.circulation.exceptions import RemoteInitiatedServerError
 from palace.manager.celery.importer import import_workflow_lock
 from palace.manager.celery.tasks import apply, bibliotheca
 from palace.manager.celery.tasks.bibliotheca import (
@@ -857,6 +858,45 @@ class TestImportPurchaseRecordsByCollection:
             redis_fixture.client, collection.id, random_value="any"
         )
         assert workflow_lock.locked()
+
+    def test_remote_initiated_server_error_retried_and_expected(
+        self,
+        bibliotheca_purchase_record_task_fixture: BibliothecaPurchaseRecordTaskFixture,
+        celery_fixture: CeleryFixture,
+        redis_fixture: RedisFixture,
+    ) -> None:
+        """marc_request raises RemoteInitiatedServerError for transient Bibliotheca-side
+        failures (non-200 body, malformed/"Unknown error" document). It must be retried
+        and declared expected rather than surfacing as an unhandled task exception.
+
+        RemoteInitiatedServerError is a sibling of RemoteIntegrationException (both derive
+        from IntegrationException), not a subclass, so it has to be listed explicitly in
+        autoretry_for and throws. This guards against either being dropped.
+        """
+        task = bibliotheca.import_purchase_records_by_collection
+        assert RemoteInitiatedServerError in task.autoretry_for
+        assert RemoteInitiatedServerError in task.throws
+
+        collection = bibliotheca_purchase_record_task_fixture.collection
+        bibliotheca_purchase_record_task_fixture.stamp_purchase_record(
+            finish=utc_now() - timedelta(days=5)
+        )
+
+        with patch(
+            "palace.manager.integration.license.bibliotheca_purchase_record_importer.BibliothecaAPI"
+        ) as mock_api_cls:
+            mock_api_cls.return_value.marc_request.side_effect = (
+                RemoteInitiatedServerError("boom", BibliothecaAPI.SERVICE_NAME)
+            )
+
+            with celery_fixture.patch_retry_backoff():
+                bibliotheca.import_purchase_records_by_collection.delay(
+                    collection_id=collection.id
+                ).get(propagate=False)
+
+            # Retried on every attempt (1 initial + max_retries=4) rather than
+            # failing immediately as an unhandled exception.
+            assert mock_api_cls.return_value.marc_request.call_count == 5
 
     @patch(
         "palace.manager.integration.license.bibliotheca_purchase_record_importer.BibliothecaAPI"


### PR DESCRIPTION
## Description

`import_purchase_records_by_collection` was paging on every occurrence of `RemoteInitiatedServerError`, raised by `BibliothecaAPI.marc_request` (via `ErrorParser`) when Bibliotheca returns a non-200 body or a malformed / `"Unknown error"` / `"Authentication failed"` document.

`RemoteInitiatedServerError` lives in `api.circulation.exceptions` (`InternalServerError` → `IntegrationException`) and is a **sibling** of `RemoteIntegrationException`, not a subclass. It therefore matched neither the task's `autoretry_for=(BadResponseException, RequestTimedOut)` nor its `throws=(RemoteIntegrationException,)`, so it was never retried and surfaced as an unhandled Celery task exception.

This change adds `RemoteInitiatedServerError` to both `autoretry_for` and `throws` so it is handled like the other transient remote errors: retried up to `max_retries`, then logged as an expected remote failure rather than an unhandled exception.

## Motivation and Context

Observed in production as a recurring unhandled-exception alert:

```
Task bibliotheca.import_purchase_records_by_collection[...] raised unexpected: RemoteInitiatedServerError('')
  File ".../celery/tasks/bibliotheca.py", line 294, in import_purchase_records_by_collection
    result = importer.import_day(current_day, cutoff, offset)
  File ".../bibliotheca_purchase_record_importer.py", line 135, in import_day
    records = list(
  File ".../bibliotheca.py", line 288, in marc_request
    raise ErrorParser().process_first(response.content)
palace.manager.api.circulation.exceptions.RemoteInitiatedServerError
```

`ErrorParser` itself documents these as transient errors on the Bibliotheca side that "happen relatively frequently," so retrying (and then treating an exhausted retry as expected) matches the existing handling of `BadResponseException` / `RequestTimedOut`. The 4xx/5xx case was already covered — the HTTP client raises `BadResponseException` for non-2xx/3xx responses. Only the `marc_request` `ErrorParser` path slipped through.

Scope is limited to `import_purchase_records_by_collection`; the sibling Bibliotheca tasks (`import_collection`, `circulation_update_collection`) don't route their responses through `ErrorParser`, so they don't surface this exception.

## How Has This Been Tested?

- Added `test_remote_initiated_server_error_retried_and_expected`, which asserts `RemoteInitiatedServerError` is present in both `autoretry_for` and `throws`, and behaviorally verifies the task retries 5× (1 initial + `max_retries=4`) instead of failing immediately.
- Ran the full `TestImportPurchaseRecordsByCollection` class (16 tests) — all pass.
- `mypy` clean on both changed files.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.