### PR TITLE
Treat empty Bibliotheca MARC response as no records

### DIFF
--- a/src/palace/manager/integration/license/bibliotheca.py
+++ b/src/palace/manager/integration/license/bibliotheca.py
@@ -284,6 +284,17 @@ class BibliothecaAPI(
         response = self.request(url)
         if response.status_code != 200:
             raise ErrorParser().process_first(response.content)
+        if not response.content.strip():
+            # Bibliotheca sometimes returns an empty body (HTTP 200 with no
+            # XML document) for a window that contains no purchase records.
+            # pymarc's parse_xml_to_array raises SAXException("no element
+            # found") on an empty document, so treat an empty body as "no
+            # records" and yield nothing rather than letting it propagate.
+            self.log.info(
+                f"Bibliotheca MARC request to '{url}' returned an empty "
+                "response body; treating as no records."
+            )
+            return
         yield from parse_xml_to_array(BytesIO(response.content))
 
     def bibliographic_lookup_request(self, identifiers: CollectionT[str]) -> bytes:

--- a/src/palace/manager/integration/license/bibliotheca.py
+++ b/src/palace/manager/integration/license/bibliotheca.py
@@ -269,8 +269,9 @@ class BibliothecaAPI(
         :param end: A datetime to stop looking for purchases.
         :param offset: An offset used to paginate results.
         :param limit: A limit used to paginate results.
-        :raise: An appropriate exception if the request did not return
-          MARC records.
+        :raise: An appropriate exception if the request returned a non-200
+          status code. An empty response body is not an error: it is treated
+          as "no records" and the generator simply yields nothing.
         :yield: A list of MARC records.
         """
         start_param = start.strftime(self.ARGUMENT_TIME_FORMAT)

--- a/tests/manager/integration/license/test_bibliotheca.py
+++ b/tests/manager/integration/license/test_bibliotheca.py
@@ -407,6 +407,28 @@ class TestBibliothecaAPI:
         with pytest.raises(RemoteInitiatedServerError) as excinfo:
             [x for x in bibliotheca_fixture.api.marc_request(start, end, 10, 20)]
 
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param(b"", id="empty"),
+            pytest.param(b"   \n  ", id="whitespace"),
+        ],
+    )
+    def test_marc_request_empty_response(
+        self,
+        content: bytes,
+        bibliotheca_fixture: BibliothecaAPITestFixture,
+    ):
+        # Bibliotheca sometimes returns an empty 200 response for a window
+        # with no purchase records. This must yield no records rather than
+        # raising the SAXException("no element found") that pymarc would
+        # otherwise raise on an empty document.
+        start = datetime_utc(2012, 1, 2, 3, 4, 5)
+        end = datetime_utc(2014, 5, 6, 7, 8, 9)
+        bibliotheca_fixture.api.queue_response(200, content=content)
+        records = [x for x in bibliotheca_fixture.api.marc_request(start, end, 10, 20)]
+        assert records == []
+
     def test_sync_patron_activity(self, bibliotheca_fixture: BibliothecaAPITestFixture):
         db = bibliotheca_fixture.db
         patron = db.patron()


### PR DESCRIPTION
## Description

`marc_request` in `BibliothecaAPI` now treats an empty (or whitespace-only) HTTP 200 response body as "no records" and yields nothing, instead of passing it to pymarc's `parse_xml_to_array`.

## Motivation and Context

The `bibliotheca.import_purchase_records_by_collection` Celery task was crashing in production with `SAXException('no element found')`. Bibliotheca occasionally returns an HTTP 200 with an empty body for a date window that contains no purchase records. pymarc's `parse_xml_to_array` raises `SAXException('no element found')` on an empty document rather than returning an empty list, so the exception propagated up and failed the task. Because the importer pages through one day at a time, a stretch of empty days produced repeated failures (the alert showed 7 occurrences over 2 minutes).

`import_day` already handles a zero-record page correctly (it marks the day complete and advances), so guarding against the empty body lets the import checkpoint and move on instead of crashing.

## How Has This Been Tested?

Added `test_marc_request_empty_response` (parametrized over empty and whitespace-only response bodies) asserting that `marc_request` yields no records. Ran the full `marc_request` test suite (`tox -e py312-docker -- --no-cov tests/manager/integration/license/test_bibliotheca.py -k marc_request`) — all pass — and confirmed mypy is clean on the changed module.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
