### PR TITLE
Fix audience erased to NULL when reclassifying works (PP-4508)

### DIFF
--- a/bin/work_reclassify_null_audience
+++ b/bin/work_reclassify_null_audience
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
-"""(Re)classify works whose audience is NULL.
+"""Queue the reclassify_null_audience_works Celery task.
 
-Manually drives the FB BISAC audience repair (the `reclassify_null_audience_works`
-Celery task). Run with --dry-run to report how many works are affected, --inline
-to recalculate synchronously in this process (optionally with --limit N for a
-sample), or with no arguments to queue the Celery task for a worker.
+Convenience wrapper that manually dispatches the FB BISAC null-audience repair
+(the `reclassify_null_audience_works` Celery task) for a worker to process.
 """
 
 from palace.manager.scripts.work import ReclassifyNullAudienceWorksScript

--- a/bin/work_reclassify_null_audience
+++ b/bin/work_reclassify_null_audience
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""(Re)classify works whose audience is NULL.
+
+Manually drives the FB BISAC audience repair (the `reclassify_null_audience_works`
+Celery task). Run with --dry-run to report how many works are affected, --inline
+to recalculate synchronously in this process (optionally with --limit N for a
+sample), or with no arguments to queue the Celery task for a worker.
+"""
+
+from palace.manager.scripts.work import ReclassifyNullAudienceWorksScript
+
+ReclassifyNullAudienceWorksScript().run()

--- a/src/palace/manager/scripts/work.py
+++ b/src/palace/manager/scripts/work.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import sys
 from collections.abc import Iterator, Sequence
 from typing import Any
@@ -8,13 +9,17 @@ from sqlalchemy.orm import Query, Session
 
 from palace.util.exceptions import PalaceValueError
 
-from palace.manager.celery.tasks.work import classify_unchecked_subjects
+from palace.manager.celery.tasks.work import (
+    classify_unchecked_subjects,
+    reclassify_null_audience_works,
+)
 from palace.manager.data_layer.policy.presentation import (
     PresentationCalculationPolicy,
 )
 from palace.manager.scripts.base import Script
 from palace.manager.scripts.input import IdentifierInputScript, SupportsReadlines
 from palace.manager.scripts.timestamp import TimestampScript
+from palace.manager.service.celery.celery import QueueNames
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import LicensePool
@@ -247,3 +252,167 @@ class WorkOPDSScript(WorkPresentationScript):
         choose_cover=False,
         update_search_index=True,
     )
+
+
+class ReclassifyNullAudienceWorksScript(Script):
+    """Manually (re)classify Works whose ``audience`` is ``NULL``.
+
+    This mirrors the one-time :func:`reclassify_null_audience_works` Celery task
+    (dispatched by the ``2026_05_12_reclassify_fb_misclassified_works`` startup
+    task) so the repair can be triggered on demand -- for example, to confirm on
+    a live instance that recalculating presentation actually clears the ``NULL``
+    audiences left behind by the FB BISAC mis-classification repair, or to finish
+    a repair run that did not complete.
+
+    Modes:
+
+    * (default) -- queue the ``reclassify_null_audience_works`` Celery task for a
+      worker to process.
+    * ``--inline`` -- recalculate synchronously in this process. This does not
+      depend on a worker consuming the queue, runs to completion before
+      returning, and reports which works were fixed and which stayed ``NULL``.
+    * ``--dry-run`` -- only report how many works have a ``NULL`` audience.
+
+    Note: like the Celery task, this uses the ``recalculate_classification``
+    policy, which updates the database but does **not** flag works for a search
+    index update -- a separate reindex is needed for the new audiences to appear
+    in patron-facing search.
+
+    TODO: Remove along with the rest of the one-time FB BISAC repair tooling
+    (see PP-4330).
+    """
+
+    name = "Reclassify works whose audience is NULL."
+
+    @classmethod
+    def arg_parser(cls, _db: Session) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser(
+            description="Reclassify works whose audience is NULL."
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report how many works have a NULL audience, then exit without "
+            "changing anything or queuing the task.",
+        )
+        parser.add_argument(
+            "--inline",
+            action="store_true",
+            help="Recalculate presentation synchronously in this process instead "
+            "of queuing the Celery task. Useful for a controlled live test, since "
+            "it does not depend on a worker and reports its results.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="In --inline mode, process at most this many works (useful for a "
+            "small sample test before a full run). Ignored without --inline.",
+        )
+        return parser
+
+    def do_run(self, *args: str) -> None:
+        parsed = self.parse_command_line(self._db, cmd_args=list(args) or None)
+
+        before = self._null_audience_count()
+        self.log.info("Works with a NULL audience: %d", before)
+        if before == 0:
+            self.log.info("Nothing to do.")
+            return
+
+        sample = [
+            work_id
+            for (work_id,) in (
+                self._db.query(Work.id)
+                .filter(Work.audience.is_(None))
+                .order_by(Work.id)
+                .limit(20)
+            )
+        ]
+        self.log.info(
+            "Sample of NULL-audience work ids (first %d): %s", len(sample), sample
+        )
+
+        if parsed.dry_run:
+            self.log.info(
+                "--dry-run: leaving works untouched and not queuing the task."
+            )
+            return
+
+        if parsed.inline:
+            self._run_inline(limit=parsed.limit)
+        else:
+            reclassify_null_audience_works.delay()
+            self.log.info(
+                'Queued the "reclassify_null_audience_works" task on the "%s" '
+                "queue. Make sure a worker is consuming that queue, then re-run "
+                "this script with --dry-run to watch the count fall. See the celery "
+                "logs for task execution details.",
+                QueueNames.default,
+            )
+
+    def _null_audience_count(self) -> int:
+        """Count the works whose audience is currently NULL."""
+        return self._db.query(Work).filter(Work.audience.is_(None)).count()
+
+    def _run_inline(self, *, limit: int | None) -> None:
+        """Recalculate presentation for NULL-audience works in this process.
+
+        Mirrors :func:`reclassify_null_audience_works`: walk works with a NULL
+        audience in ascending id order, calling ``calculate_presentation`` with
+        the classification policy and committing after each so progress survives
+        an interruption. The id cursor means a work that stays NULL (because it
+        has no usable audience classification) is visited once and then skipped;
+        such works are reported, since they indicate a different problem than the
+        one this repair addresses.
+        """
+        policy = PresentationCalculationPolicy.recalculate_classification()
+        processed = 0
+        fixed = 0
+        still_null: list[int] = []
+        last_id: int | None = None
+
+        while limit is None or processed < limit:
+            query = (
+                self._db.query(Work).filter(Work.audience.is_(None)).order_by(Work.id)
+            )
+            if last_id is not None:
+                query = query.filter(Work.id > last_id)
+            work = query.first()
+            if work is None:
+                break
+
+            last_id = work.id
+            work.calculate_presentation(policy=policy)
+            self._db.commit()
+
+            processed += 1
+            if work.audience is None:
+                still_null.append(work.id)
+            else:
+                fixed += 1
+
+            if processed % 100 == 0:
+                self.log.info(
+                    "Processed %d works (%d fixed, %d still NULL)...",
+                    processed,
+                    fixed,
+                    len(still_null),
+                )
+
+        self.log.info(
+            "Inline reclassification done. Processed %d work(s): %d now have an "
+            "audience, %d are still NULL.",
+            processed,
+            fixed,
+            len(still_null),
+        )
+        if still_null:
+            self.log.warning(
+                "%d processed work(s) are still NULL after reclassification. These "
+                "are NOT fixed by this repair -- they have no usable audience "
+                "classification, which points to a separate (import-time) issue. "
+                "First ids: %s",
+                len(still_null),
+                still_null[:50],
+            )

--- a/src/palace/manager/scripts/work.py
+++ b/src/palace/manager/scripts/work.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 import sys
 from collections.abc import Iterator, Sequence
 from typing import Any
@@ -19,7 +18,6 @@ from palace.manager.data_layer.policy.presentation import (
 from palace.manager.scripts.base import Script
 from palace.manager.scripts.input import IdentifierInputScript, SupportsReadlines
 from palace.manager.scripts.timestamp import TimestampScript
-from palace.manager.service.celery.celery import QueueNames
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import LicensePool
@@ -255,164 +253,19 @@ class WorkOPDSScript(WorkPresentationScript):
 
 
 class ReclassifyNullAudienceWorksScript(Script):
-    """Manually (re)classify Works whose ``audience`` is ``NULL``.
+    """Manually dispatch the ``reclassify_null_audience_works`` Celery task.
 
-    This mirrors the one-time :func:`reclassify_null_audience_works` Celery task
-    (dispatched by the ``2026_05_12_reclassify_fb_misclassified_works`` startup
-    task) so the repair can be triggered on demand -- for example, to confirm on
-    a live instance that recalculating presentation actually clears the ``NULL``
-    audiences left behind by the FB BISAC mis-classification repair, or to finish
-    a repair run that did not complete.
+    The work itself happens in the Celery task; this script just queues it. It
+    exists for convenience, in case we need to re-run the null-audience repair
+    on demand.
 
-    Modes:
-
-    * (default) -- queue the ``reclassify_null_audience_works`` Celery task for a
-      worker to process.
-    * ``--inline`` -- recalculate synchronously in this process. This does not
-      depend on a worker consuming the queue, runs to completion before
-      returning, and reports which works were fixed and which stayed ``NULL``.
-    * ``--dry-run`` -- only report how many works have a ``NULL`` audience.
-
-    Note: like the Celery task, this uses the ``recalculate_classification``
-    policy, which updates the database but does **not** flag works for a search
-    index update -- a separate reindex is needed for the new audiences to appear
-    in patron-facing search.
-
-    TODO: Remove along with the rest of the one-time FB BISAC repair tooling
-    (see PP-4330).
+    TODO: Remove this script when the ``reclassify_null_audience_works`` Celery
+    task is removed (see PP-4330).
     """
 
-    name = "Reclassify works whose audience is NULL."
-
-    @classmethod
-    def arg_parser(cls, _db: Session) -> argparse.ArgumentParser:
-        parser = argparse.ArgumentParser(
-            description="Reclassify works whose audience is NULL."
-        )
-        parser.add_argument(
-            "--dry-run",
-            action="store_true",
-            help="Report how many works have a NULL audience, then exit without "
-            "changing anything or queuing the task.",
-        )
-        parser.add_argument(
-            "--inline",
-            action="store_true",
-            help="Recalculate presentation synchronously in this process instead "
-            "of queuing the Celery task. Useful for a controlled live test, since "
-            "it does not depend on a worker and reports its results.",
-        )
-        parser.add_argument(
-            "--limit",
-            type=int,
-            default=None,
-            help="In --inline mode, process at most this many works (useful for a "
-            "small sample test before a full run). Ignored without --inline.",
-        )
-        return parser
-
-    def do_run(self, *args: str) -> None:
-        parsed = self.parse_command_line(self._db, cmd_args=list(args) or None)
-
-        before = self._null_audience_count()
-        self.log.info("Works with a NULL audience: %d", before)
-        if before == 0:
-            self.log.info("Nothing to do.")
-            return
-
-        sample = [
-            work_id
-            for (work_id,) in (
-                self._db.query(Work.id)
-                .filter(Work.audience.is_(None))
-                .order_by(Work.id)
-                .limit(20)
-            )
-        ]
+    def do_run(self, *args: Any, **kwargs: Any) -> None:
+        reclassify_null_audience_works.delay()
         self.log.info(
-            "Sample of NULL-audience work ids (first %d): %s", len(sample), sample
+            'The "reclassify_null_audience_works" task has been queued for '
+            "execution. See the celery logs for details about task execution."
         )
-
-        if parsed.dry_run:
-            self.log.info(
-                "--dry-run: leaving works untouched and not queuing the task."
-            )
-            return
-
-        if parsed.inline:
-            self._run_inline(limit=parsed.limit)
-        else:
-            reclassify_null_audience_works.delay()
-            self.log.info(
-                'Queued the "reclassify_null_audience_works" task on the "%s" '
-                "queue. Make sure a worker is consuming that queue, then re-run "
-                "this script with --dry-run to watch the count fall. See the celery "
-                "logs for task execution details.",
-                QueueNames.default,
-            )
-
-    def _null_audience_count(self) -> int:
-        """Count the works whose audience is currently NULL."""
-        return self._db.query(Work).filter(Work.audience.is_(None)).count()
-
-    def _run_inline(self, *, limit: int | None) -> None:
-        """Recalculate presentation for NULL-audience works in this process.
-
-        Mirrors :func:`reclassify_null_audience_works`: walk works with a NULL
-        audience in ascending id order, calling ``calculate_presentation`` with
-        the classification policy and committing after each so progress survives
-        an interruption. The id cursor means a work that stays NULL (because it
-        has no usable audience classification) is visited once and then skipped;
-        such works are reported, since they indicate a different problem than the
-        one this repair addresses.
-        """
-        policy = PresentationCalculationPolicy.recalculate_classification()
-        processed = 0
-        fixed = 0
-        still_null: list[int] = []
-        last_id: int | None = None
-
-        while limit is None or processed < limit:
-            query = (
-                self._db.query(Work).filter(Work.audience.is_(None)).order_by(Work.id)
-            )
-            if last_id is not None:
-                query = query.filter(Work.id > last_id)
-            work = query.first()
-            if work is None:
-                break
-
-            last_id = work.id
-            work.calculate_presentation(policy=policy)
-            self._db.commit()
-
-            processed += 1
-            if work.audience is None:
-                still_null.append(work.id)
-            else:
-                fixed += 1
-
-            if processed % 100 == 0:
-                self.log.info(
-                    "Processed %d works (%d fixed, %d still NULL)...",
-                    processed,
-                    fixed,
-                    len(still_null),
-                )
-
-        self.log.info(
-            "Inline reclassification done. Processed %d work(s): %d now have an "
-            "audience, %d are still NULL.",
-            processed,
-            fixed,
-            len(still_null),
-        )
-        if still_null:
-            self.log.warning(
-                "%d processed work(s) are still NULL after reclassification. These "
-                "are NOT fixed by this repair -- they have no usable audience "
-                "classification, which points to a separate (import-time) issue. "
-                "First ids: %s",
-                len(still_null),
-                still_null[:50],
-            )

--- a/src/palace/manager/sqlalchemy/model/work.py
+++ b/src/palace/manager/sqlalchemy/model/work.py
@@ -932,16 +932,24 @@ class Work(Base, LoggerMixin):
         )
         return changed
 
-    def _get_default_audience(self) -> str | None:
-        """Return the default audience.
+    def _get_default_audience(self) -> str:
+        """Return the default audience to assume when classification finds no
+        audience evidence.
 
-        :return: Default audience
+        Uses a license pool's collection-level ``default_audience`` if one is
+        configured; otherwise falls back to ``AUDIENCE_ADULT``. This never
+        returns ``None``: recalculating a Work's presentation must not be able
+        to *erase* its audience (see the FB BISAC repair, PP-4204), so the
+        worst case for an evidence-less Work is ``Adult`` rather than a ``NULL``
+        audience.
+
+        :return: A default audience string (never ``None``).
         """
         for license_pool in self.license_pools:
             if license_pool.collection.default_audience:
                 return license_pool.collection.default_audience
 
-        return None
+        return Classifier.AUDIENCE_ADULT
 
     def calculate_presentation(
         self,
@@ -1378,6 +1386,12 @@ class Work(Base, LoggerMixin):
 
         if new_fiction != old_fiction:
             self.fiction = new_fiction
+        # Never let a recalculation erase a known audience. If the classifier
+        # came back with no audience (e.g. it gathered no usable
+        # classifications on this pass), keep whatever we already had rather
+        # than writing NULL over a previously-determined audience.
+        if new_audience is None and old_audience is not None:
+            new_audience = old_audience
         if new_audience != old_audience:
             self.audience = new_audience
 

--- a/startup_tasks/2026_06_17_repair_remaining_null_audience_works.py
+++ b/startup_tasks/2026_06_17_repair_remaining_null_audience_works.py
@@ -1,0 +1,34 @@
+"""Re-run the null-audience reclassification now that recalculation is non-destructive.
+
+A backlog of works with ``audience IS NULL`` remained for two reasons:
+
+- The earlier one-time repair (startup task
+  ``2026_05_12_reclassify_fb_misclassified_works``) is recorded as run on
+  *dispatch*, not completion, so an interrupted Celery run would not re-fire on
+  later restarts -- some works may never have been reprocessed.
+- Until the default-audience fix landed, recalculating a work that gathered no
+  decisive audience evidence wrote ``NULL`` back over its audience, so bulk
+  reclassification was *adding* nulls rather than only repairing them.
+
+Now that ``Work._get_default_audience()`` falls back to ``AUDIENCE_ADULT`` (and
+``assign_genres`` no longer overwrites a known audience with ``NULL``), re-running
+``calculate_presentation()`` on the remaining ``audience IS NULL`` works is safe and
+repairs them: ``Adult`` for evidence-less works, ``Children`` for juvenile titles.
+This dispatches the existing one-time Celery job to do so.
+
+TODO: Remove this task, the earlier startup task, and
+``reclassify_null_audience_works`` once it has run on all deployments (PP-4330)."""
+
+from __future__ import annotations
+
+import logging
+
+from celery.canvas import Signature
+from sqlalchemy.orm import Session
+
+from palace.manager.celery.tasks.work import reclassify_null_audience_works
+from palace.manager.service.container import Services
+
+
+def run(services: Services, session: Session, log: logging.Logger) -> Signature | None:
+    return reclassify_null_audience_works.s()

--- a/tests/manager/scripts/test_startup.py
+++ b/tests/manager/scripts/test_startup.py
@@ -15,10 +15,7 @@ from sqlalchemy.orm import Session
 
 from palace.util.datetime_helpers import utc_now
 
-from palace.manager.celery.tasks.work import reclassify_null_audience_works
 from palace.manager.scripts.startup import (
-    STARTUP_TASKS_DIR,
-    _load_module_from_file,
     _slugify,
     create_startup_task,
     discover_startup_tasks,
@@ -388,18 +385,3 @@ class TestCreateStartupTask:
             create_startup_task()
 
         assert exc_info.value.code == 1
-
-
-class TestRepairStartupTasks:
-    def test_repair_remaining_null_audience_works_dispatches_celery_task(self) -> None:
-        """The 2026-06-17 startup task dispatches the reclassify_null_audience_works
-        Celery job, so the post-fix repair runs once on the next deploy."""
-        module = _load_module_from_file(
-            "repair_remaining_null_audience_works",
-            STARTUP_TASKS_DIR / "2026_06_17_repair_remaining_null_audience_works.py",
-        )
-
-        signature = module.run(MagicMock(), MagicMock(), logging.getLogger())
-
-        assert isinstance(signature, Signature)
-        assert signature.task == reclassify_null_audience_works.name

--- a/tests/manager/scripts/test_startup.py
+++ b/tests/manager/scripts/test_startup.py
@@ -15,7 +15,10 @@ from sqlalchemy.orm import Session
 
 from palace.util.datetime_helpers import utc_now
 
+from palace.manager.celery.tasks.work import reclassify_null_audience_works
 from palace.manager.scripts.startup import (
+    STARTUP_TASKS_DIR,
+    _load_module_from_file,
     _slugify,
     create_startup_task,
     discover_startup_tasks,
@@ -385,3 +388,18 @@ class TestCreateStartupTask:
             create_startup_task()
 
         assert exc_info.value.code == 1
+
+
+class TestRepairStartupTasks:
+    def test_repair_remaining_null_audience_works_dispatches_celery_task(self) -> None:
+        """The 2026-06-17 startup task dispatches the reclassify_null_audience_works
+        Celery job, so the post-fix repair runs once on the next deploy."""
+        module = _load_module_from_file(
+            "repair_remaining_null_audience_works",
+            STARTUP_TASKS_DIR / "2026_06_17_repair_remaining_null_audience_works.py",
+        )
+
+        signature = module.run(MagicMock(), MagicMock(), logging.getLogger())
+
+        assert isinstance(signature, Signature)
+        assert signature.task == reclassify_null_audience_works.name

--- a/tests/manager/scripts/test_work.py
+++ b/tests/manager/scripts/test_work.py
@@ -7,16 +7,13 @@ import pytest
 
 from palace.util.exceptions import PalaceValueError
 
-from palace.manager.core.classifier import Classifier
 from palace.manager.scripts.work import (
     ReclassifyNullAudienceWorksScript,
     ReclassifyWorksForUncheckedSubjectsScript,
     WorkProcessingScript,
 )
-from palace.manager.sqlalchemy.model.classification import Subject
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.identifier import Identifier
-from palace.manager.sqlalchemy.model.work import Work
 from tests.fixtures.database import DatabaseTransactionFixture
 
 
@@ -194,80 +191,10 @@ class TestReclassifyWorksForUncheckedSubjectsScript:
 
 
 class TestReclassifyNullAudienceWorksScript:
-    def test_run_queues_task(self, db: DatabaseTransactionFixture):
-        """By default the underlying Celery task is queued."""
-        work = db.work(with_license_pool=True)
-        work.audience = None
-        db.session.commit()
-
+    def test_run(self, db: DatabaseTransactionFixture):
+        """The script queues the reclassify_null_audience_works Celery task."""
         with patch(
             "palace.manager.scripts.work.reclassify_null_audience_works"
         ) as task:
-            ReclassifyNullAudienceWorksScript(db.session).do_run()
-
-        assert task.delay.call_count == 1
-
-    def test_dry_run_does_not_queue_or_modify(self, db: DatabaseTransactionFixture):
-        """--dry-run reports counts without queuing the task or touching works."""
-        work = db.work(with_license_pool=True)
-        work.audience = None
-        db.session.commit()
-
-        with patch(
-            "palace.manager.scripts.work.reclassify_null_audience_works"
-        ) as task:
-            ReclassifyNullAudienceWorksScript(db.session).do_run("--dry-run")
-
-        assert task.delay.call_count == 0
-        assert work.audience is None
-
-    def test_nothing_to_do_when_no_null_works(self, db: DatabaseTransactionFixture):
-        """With no NULL-audience works, nothing is queued."""
-        db.work(with_license_pool=True)  # audience defaults to "Adult"
-        db.session.commit()
-
-        with patch(
-            "palace.manager.scripts.work.reclassify_null_audience_works"
-        ) as task:
-            ReclassifyNullAudienceWorksScript(db.session).do_run()
-
-        assert task.delay.call_count == 0
-
-    def test_inline_clears_null_audience(self, db: DatabaseTransactionFixture):
-        """--inline recalculates in-process, turning a NULL audience into the
-        audience implied by the work's classifications (Children for FBJUV*)."""
-        work = db.work(with_license_pool=True)
-        work.audience = None
-        # FBJUV000000 scrubs to JUV000000 -> Juvenile Fiction -> Children.
-        subject = db.subject(Subject.BISAC, "FBJUV000000")
-        db.classification(
-            work.presentation_edition.primary_identifier,
-            subject,
-            work.license_pools[0].data_source,
-        )
-        db.session.commit()
-
-        with patch(
-            "palace.manager.scripts.work.reclassify_null_audience_works"
-        ) as task:
-            ReclassifyNullAudienceWorksScript(db.session).do_run("--inline")
-
-        # The task itself is never queued in --inline mode.
-        assert task.delay.call_count == 0
-        assert work.audience == Classifier.AUDIENCE_CHILDREN
-
-    def test_inline_limit_bounds_work_processed(self, db: DatabaseTransactionFixture):
-        """--limit caps how many works are processed in --inline mode."""
-        for _ in range(3):
-            work = db.work(with_license_pool=True)
-            work.audience = None
-        db.session.commit()
-
-        with patch.object(Work, "calculate_presentation") as calc_pres:
-            ReclassifyNullAudienceWorksScript(db.session).do_run(
-                "--inline", "--limit", "2"
-            )
-
-        assert calc_pres.call_count == 2
-        for call_obj in calc_pres.call_args_list:
-            assert call_obj[1]["policy"].classify is True
+            ReclassifyNullAudienceWorksScript(db.session).run()
+            assert task.delay.call_count == 1

--- a/tests/manager/scripts/test_work.py
+++ b/tests/manager/scripts/test_work.py
@@ -7,12 +7,16 @@ import pytest
 
 from palace.util.exceptions import PalaceValueError
 
+from palace.manager.core.classifier import Classifier
 from palace.manager.scripts.work import (
+    ReclassifyNullAudienceWorksScript,
     ReclassifyWorksForUncheckedSubjectsScript,
     WorkProcessingScript,
 )
+from palace.manager.sqlalchemy.model.classification import Subject
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.identifier import Identifier
+from palace.manager.sqlalchemy.model.work import Work
 from tests.fixtures.database import DatabaseTransactionFixture
 
 
@@ -187,3 +191,83 @@ class TestReclassifyWorksForUncheckedSubjectsScript:
 
             ReclassifyWorksForUncheckedSubjectsScript().run()
             assert task.delay.call_count == 1
+
+
+class TestReclassifyNullAudienceWorksScript:
+    def test_run_queues_task(self, db: DatabaseTransactionFixture):
+        """By default the underlying Celery task is queued."""
+        work = db.work(with_license_pool=True)
+        work.audience = None
+        db.session.commit()
+
+        with patch(
+            "palace.manager.scripts.work.reclassify_null_audience_works"
+        ) as task:
+            ReclassifyNullAudienceWorksScript(db.session).do_run()
+
+        assert task.delay.call_count == 1
+
+    def test_dry_run_does_not_queue_or_modify(self, db: DatabaseTransactionFixture):
+        """--dry-run reports counts without queuing the task or touching works."""
+        work = db.work(with_license_pool=True)
+        work.audience = None
+        db.session.commit()
+
+        with patch(
+            "palace.manager.scripts.work.reclassify_null_audience_works"
+        ) as task:
+            ReclassifyNullAudienceWorksScript(db.session).do_run("--dry-run")
+
+        assert task.delay.call_count == 0
+        assert work.audience is None
+
+    def test_nothing_to_do_when_no_null_works(self, db: DatabaseTransactionFixture):
+        """With no NULL-audience works, nothing is queued."""
+        db.work(with_license_pool=True)  # audience defaults to "Adult"
+        db.session.commit()
+
+        with patch(
+            "palace.manager.scripts.work.reclassify_null_audience_works"
+        ) as task:
+            ReclassifyNullAudienceWorksScript(db.session).do_run()
+
+        assert task.delay.call_count == 0
+
+    def test_inline_clears_null_audience(self, db: DatabaseTransactionFixture):
+        """--inline recalculates in-process, turning a NULL audience into the
+        audience implied by the work's classifications (Children for FBJUV*)."""
+        work = db.work(with_license_pool=True)
+        work.audience = None
+        # FBJUV000000 scrubs to JUV000000 -> Juvenile Fiction -> Children.
+        subject = db.subject(Subject.BISAC, "FBJUV000000")
+        db.classification(
+            work.presentation_edition.primary_identifier,
+            subject,
+            work.license_pools[0].data_source,
+        )
+        db.session.commit()
+
+        with patch(
+            "palace.manager.scripts.work.reclassify_null_audience_works"
+        ) as task:
+            ReclassifyNullAudienceWorksScript(db.session).do_run("--inline")
+
+        # The task itself is never queued in --inline mode.
+        assert task.delay.call_count == 0
+        assert work.audience == Classifier.AUDIENCE_CHILDREN
+
+    def test_inline_limit_bounds_work_processed(self, db: DatabaseTransactionFixture):
+        """--limit caps how many works are processed in --inline mode."""
+        for _ in range(3):
+            work = db.work(with_license_pool=True)
+            work.audience = None
+        db.session.commit()
+
+        with patch.object(Work, "calculate_presentation") as calc_pres:
+            ReclassifyNullAudienceWorksScript(db.session).do_run(
+                "--inline", "--limit", "2"
+            )
+
+        assert calc_pres.call_count == 2
+        for call_obj in calc_pres.call_args_list:
+            assert call_obj[1]["policy"].classify is True

--- a/tests/manager/sqlalchemy/model/test_work.py
+++ b/tests/manager/sqlalchemy/model/test_work.py
@@ -15,6 +15,9 @@ from palace.util.log import LogLevel
 
 from palace.manager.core.classifier import Classifier, Fantasy, Romance, Science_Fiction
 from palace.manager.core.exceptions import InconsistentLicensePoolState
+from palace.manager.data_layer.policy.presentation import (
+    PresentationCalculationPolicy,
+)
 from palace.manager.service.redis.models.search import WaitingForIndexing
 from palace.manager.sqlalchemy.model.classification import Genre, Subject
 from palace.manager.sqlalchemy.model.contributor import Contributor
@@ -350,6 +353,40 @@ class TestWork:
         work.calculate_presentation()
 
         assert default_audience == work.audience
+
+    def test_calculate_presentation_defaults_audience_to_adult_not_null(
+        self, db: DatabaseTransactionFixture
+    ):
+        # Regression (FB BISAC repair, PP-4204): recalculating an evidence-less
+        # Work that has no collection-level default audience must yield
+        # AUDIENCE_ADULT, never NULL. Recalculation must never *erase* a Work's
+        # audience -- the bug that made bulk reclassification turn non-null
+        # audiences into null.
+        work = db.work(with_license_pool=True)
+        assert not work.license_pools[0].collection.default_audience
+        work.audience = None
+        db.session.commit()
+
+        work.calculate_presentation(
+            policy=PresentationCalculationPolicy.recalculate_classification()
+        )
+
+        assert work.audience == Classifier.AUDIENCE_ADULT
+
+    def test_assign_genres_does_not_overwrite_audience_with_null(
+        self, db: DatabaseTransactionFixture
+    ):
+        # Defensive invariant: when a recalculation pass produces no audience
+        # (e.g. it gathered no usable classifications), a previously-determined
+        # audience must be kept rather than overwritten with NULL.
+        work = db.work(with_license_pool=True)
+        work.audience = Classifier.AUDIENCE_CHILDREN
+        db.session.commit()
+
+        # Force the no-evidence + null-default path directly.
+        work.assign_genres(work._direct_identifier_ids, default_audience=None)
+
+        assert work.audience == Classifier.AUDIENCE_CHILDREN
 
     def test__choose_summary(self, db: DatabaseTransactionFixture):
         # Test the _choose_summary helper method, called by


### PR DESCRIPTION
## Description

Recalculating a Work's presentation could overwrite a known audience with `NULL`, so running bulk classification recalculation across the catalog **erased** audiences from existing works (null-audience counts rose while non-null counts fell).

Root cause: `Work._get_default_audience()` returned `None` when a collection had no configured `default_audience`, and `WorkClassifier.audience()` returns that `None` default whenever it gathers no audience weight for a work. `assign_genres()` then wrote the `None` back over the work's existing audience, so any work whose recompute lacked decisive audience evidence was nulled.

This PR makes recalculation non-destructive:

- **`_get_default_audience()` now falls back to `AUDIENCE_ADULT` instead of `None`** (`src/palace/manager/sqlalchemy/model/work.py`). The `None` default was intended for the metadata-wrangler context, not the manager; in the manager the worst case for an evidence-less work should be `Adult`, never a `NULL` audience.
- **`assign_genres()` no longer overwrites a known audience with `NULL`** — a defensive invariant: if a recalculation pass produces no audience, keep whatever the work already had.

Repair tooling for the works already nulled:

- **Startup task `2026_06_17_repair_remaining_null_audience_works`** — dispatches the existing `reclassify_null_audience_works` Celery job once on the next deploy, so the accumulated `audience IS NULL` backlog is repaired automatically. The earlier `2026_05_12` startup task is recorded as run on *dispatch* (not completion) and ran *before* this fix, so it won't re-fire; this one runs under the now-non-destructive recalculation.
- **`ReclassifyNullAudienceWorksScript`** + `bin/work_reclassify_null_audience` — a convenience wrapper that dispatches the `reclassify_null_audience_works` Celery task on demand, in case we need to re-run the repair manually. (Marked with a TODO to remove when the Celery task is, per PP-4330.)

## Motivation and Context
JIRA (PP-4508)
While completing the FB BISAC juvenile-audience repair, running bulk reclassification was observed to *increase* the number of works with a `NULL` audience and decrease non-null counts — i.e. recalculation was erasing audiences from existing works rather than only fixing FBJUV juvenile titles. The `None` default audience was the root cause. FBJUV juvenile works still classify correctly to `Children` (they have decisive evidence); this fix only changes the evidence-less fallback from `NULL` to `Adult`.

Related: PP-4204 / #3284 / #3295 / #3344.

## Behavior change

Repairing `audience = NULL → Adult` (and the new non-destructive default) is **safe for the patron age-gate**: `Work.age_appropriate_for_patron` denies a juvenile patron a work whose audience is `None` *or* `Adult` (neither is in `AUDIENCES_JUVENILE`), so nothing becomes visible to minors that wasn't already blocked.

There is one observable shift, in **library audience filtering**. Several places currently never filter a `NULL`-audience work — `audience IS NULL` is explicitly treated as "don't filter":
- `feed/worklist/database.py` — `or_(Work.audience.is_(None), not_(Work.audience.in_(filtered_audiences)))`
- `search/filter.py` — `Bool(must_not=[Terms(audience=excluded_audiences)])` (a null-audience doc isn't matched, so it's not excluded)
- `Work.is_filtered_by` — `if self.audience and filtered_audiences` (a null audience skips the check)

Once these works become `Adult`:
- A library filtering out **Children / Young Adult** audiences: no change (the works are `Adult`, still shown).
- A library filtering out **Adult / Adults Only** (e.g. a children's library): these works flip from **shown → hidden**. This is intentional and safer — it closes a gap where unknown-audience works slipped past a library's audience filter — but it does reduce what such libraries surface.

Similarly, audience-scoped lanes/search (`Work.audience IN (...)` / `Terms(audience=...)`) currently exclude `NULL`-audience works entirely (they are invisible in every audience lane); after repair they appear in **Adult** lanes (and stay out of Children/YA). Expect per-library / per-lane visibility counts to shift as the backlog converts.

## How Has This Been Tested?

- New regression tests in `tests/manager/sqlalchemy/model/test_work.py`:
  - `test_calculate_presentation_defaults_audience_to_adult_not_null` — an evidence-less work with no collection default recalculates to `Adult`, not `NULL`.
  - `test_assign_genres_does_not_overwrite_audience_with_null` — a recompute that yields no audience keeps the work's existing audience.
- `tests/manager/scripts/test_work.py` — asserts the convenience script queues the Celery task.
- `tests/manager/scripts/test_startup.py` — asserts the startup task loads and dispatches `reclassify_null_audience_works`.
- Full `TestWork` suite passes (74 tests); script + startup suites pass. `mypy` clean on changed files.

```
tox -e py312-docker -- --no-cov tests/manager/sqlalchemy/model/test_work.py tests/manager/scripts/test_work.py tests/manager/scripts/test_startup.py
```

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
