### PR TITLE
Make lanes.size safe to drop: defer reads + server_default for writes (PP-4506)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,23 +152,17 @@ code stops using it. Removing a schema object is therefore a two-step process ac
 **"Stop using" an ORM column means stopping both reads _and_ writes.** SQLAlchemy eagerly includes every
 mapped column in its default `SELECT`, and eagerly emits any column that has a Python-side `default=` in every
 `INSERT`. So leaving a column mapped — even when no application code reads or assigns it — does **not** stop
-using it, and a later drop will break the still-running previous release. `test_model_definitions_match_ddl`
-passing does not catch this; it only checks that the model matches the schema, not that inserts avoid the
-column. To fully stop using a column in release 1, before dropping it in release 2:
+using it, and a later drop will break the still-running previous release. To fully stop using a column in
+release 1, before dropping it in release 2:
 
 - **Reads:** mark the column `deferred()` so it is excluded from the default `SELECT`.
 - **Writes:** remove any Python-side `default=`. If the column is `NOT NULL`, removing the Python default
   alone makes inserts fail the not-null constraint (SQLAlchemy sends no value and the database has none), so
-  first move the default into the database with a `server_default` via an `ALTER COLUMN ... SET DEFAULT`
-  migration — catalog-only in Postgres (instant, no rewrite) and backwards-compatible because N-1 still writes
-  the value explicitly, harmlessly overriding the default. With a `server_default` set and the Python
-  `default=` removed, SQLAlchemy omits the column from `INSERT`s and the database fills it in. A **nullable**
-  column with no default is already omitted from `INSERT`s, so it needs no write-side change.
+  first move the default into the database with a `server_default`. A **nullable** column with no default
+  is already omitted from `INSERT`s, so it needs no write-side change.
 
 Both the read-side (`deferred`) and write-side (`server_default`) changes are backwards-compatible, so they
-belong together in **release 1**; the drop is **release 2**. There is no ORM-only way to make the drop
-write-safe without this schema change: any attempt to stop emitting a `NOT NULL`/no-default column either
-keeps emitting it (drop still breaks) or fails inserts immediately.
+belong together in **release 1**; the drop is **release 2**.
 
 The same constraint applies in reverse when adding required schema: a new non-nullable column must first be
 added as nullable, or with a **server default** so the database fills it in for rows written by N-1 code (which

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,27 @@ code stops using it. Removing a schema object is therefore a two-step process ac
 1. **Release 1:** Stop using the object in the code, but leave it in the schema. No drop migration yet.
 2. **Release 2:** Drop the object in a migration, now that no running code (current or N-1) references it.
 
+**"Stop using" an ORM column means stopping both reads _and_ writes.** SQLAlchemy eagerly includes every
+mapped column in its default `SELECT`, and eagerly emits any column that has a Python-side `default=` in every
+`INSERT`. So leaving a column mapped — even when no application code reads or assigns it — does **not** stop
+using it, and a later drop will break the still-running previous release. `test_model_definitions_match_ddl`
+passing does not catch this; it only checks that the model matches the schema, not that inserts avoid the
+column. To fully stop using a column in release 1, before dropping it in release 2:
+
+- **Reads:** mark the column `deferred()` so it is excluded from the default `SELECT`.
+- **Writes:** remove any Python-side `default=`. If the column is `NOT NULL`, removing the Python default
+  alone makes inserts fail the not-null constraint (SQLAlchemy sends no value and the database has none), so
+  first move the default into the database with a `server_default` via an `ALTER COLUMN ... SET DEFAULT`
+  migration — catalog-only in Postgres (instant, no rewrite) and backwards-compatible because N-1 still writes
+  the value explicitly, harmlessly overriding the default. With a `server_default` set and the Python
+  `default=` removed, SQLAlchemy omits the column from `INSERT`s and the database fills it in. A **nullable**
+  column with no default is already omitted from `INSERT`s, so it needs no write-side change.
+
+Both the read-side (`deferred`) and write-side (`server_default`) changes are backwards-compatible, so they
+belong together in **release 1**; the drop is **release 2**. There is no ORM-only way to make the drop
+write-safe without this schema change: any attempt to stop emitting a `NOT NULL`/no-default column either
+keeps emitting it (drop still breaks) or fails inserts immediately.
+
 The same constraint applies in reverse when adding required schema: a new non-nullable column must first be
 added as nullable, or with a **server default** so the database fills it in for rows written by N-1 code (which
 does not yet know about the column). Never write a single migration that both adds a not-yet-used column as

--- a/alembic/versions/20260715_dbeb42224c1b_add_server_default_to_lanes_size.py
+++ b/alembic/versions/20260715_dbeb42224c1b_add_server_default_to_lanes_size.py
@@ -1,0 +1,33 @@
+"""Add server_default to lanes.size
+
+Revision ID: dbeb42224c1b
+Revises: a6c85605404c
+Create Date: 2026-07-15 13:42:28.828886+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "dbeb42224c1b"
+down_revision = "a6c85605404c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ``lanes.size`` is deprecated and no longer read or written by the current
+    # code, but it is NOT NULL with no database default. Moving the default into
+    # the database lets the ORM omit the column from INSERTs (it previously
+    # supplied a Python-side ``default=0``), so a follow-up release can drop the
+    # column without breaking the still-running previous release's inserts.
+    #
+    # ``SET DEFAULT`` is a catalog-only change in Postgres: instant, no table
+    # rewrite. It is backwards-compatible because the previous release still
+    # explicitly writes ``size=0``, which simply overrides the new default.
+    op.alter_column("lanes", "size", server_default=sa.text("0"))
+
+
+def downgrade() -> None:
+    op.alter_column("lanes", "size", server_default=None)

--- a/alembic/versions/20260715_dbeb42224c1b_add_server_default_to_lanes_size.py
+++ b/alembic/versions/20260715_dbeb42224c1b_add_server_default_to_lanes_size.py
@@ -22,10 +22,6 @@ def upgrade() -> None:
     # the database lets the ORM omit the column from INSERTs (it previously
     # supplied a Python-side ``default=0``), so a follow-up release can drop the
     # column without breaking the still-running previous release's inserts.
-    #
-    # ``SET DEFAULT`` is a catalog-only change in Postgres: instant, no table
-    # rewrite. It is backwards-compatible because the previous release still
-    # explicitly writes ``size=0``, which simply overrides the new default.
     op.alter_column("lanes", "size", server_default=sa.text("0"))
 
 

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -114,17 +114,10 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
     priority: Mapped[int] = Column(Integer, index=True, nullable=False, default=0)
 
     # Deprecated: these cached size estimates are no longer populated or read.
-    # They are mapped as ``deferred`` so the ORM excludes them from its default
-    # SELECT (the read side), and this release must also stop writing them so a
-    # follow-up migration can drop the columns without breaking the still-running
-    # previous release.
-    #
-    # ``size`` is NOT NULL, so removing the Python-side ``default=0`` alone would
-    # make inserts fail the not-null constraint. Instead we move the default into
-    # the database as a ``server_default``: with no Python default set, SQLAlchemy
-    # omits the column from INSERTs entirely and Postgres fills in 0. That is what
-    # makes the eventual DROP write-safe. ``size_by_entrypoint`` is nullable with
-    # no default, so SQLAlchemy already omits it from INSERTs.
+    # The code that maintained them (update_size and the lane-size Celery tasks)
+    # has been removed; the columns remain mapped only so the model continues to
+    # match the database schema, and will be dropped in a follow-up migration.
+    # TODO: Drop these next release when it is safe to do so.
     size = deferred(Column(Integer, nullable=False, server_default=text("0")))
     size_by_entrypoint = deferred(Column(JSON, nullable=True))
 

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Unicode,
     UniqueConstraint,
     or_,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, INT4RANGE, JSON
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -113,12 +114,18 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
     priority: Mapped[int] = Column(Integer, index=True, nullable=False, default=0)
 
     # Deprecated: these cached size estimates are no longer populated or read.
-    # They are mapped as ``deferred`` so the ORM does not include them in its
-    # default SELECT (nothing accesses them). This is the online-migration
-    # "stop using the column" step: once this release ships, a follow-up
-    # migration can drop the columns without breaking the still-running previous
-    # release, which would otherwise SELECT them and fail.
-    size = deferred(Column(Integer, nullable=False, default=0))
+    # They are mapped as ``deferred`` so the ORM excludes them from its default
+    # SELECT (the read side), and this release must also stop writing them so a
+    # follow-up migration can drop the columns without breaking the still-running
+    # previous release.
+    #
+    # ``size`` is NOT NULL, so removing the Python-side ``default=0`` alone would
+    # make inserts fail the not-null constraint. Instead we move the default into
+    # the database as a ``server_default``: with no Python default set, SQLAlchemy
+    # omits the column from INSERTs entirely and Postgres fills in 0. That is what
+    # makes the eventual DROP write-safe. ``size_by_entrypoint`` is nullable with
+    # no default, so SQLAlchemy already omits it from INSERTs.
+    size = deferred(Column(Integer, nullable=False, server_default=text("0")))
     size_by_entrypoint = deferred(Column(JSON, nullable=True))
 
     # A lane may have one parent lane and many sublanes.

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -18,6 +18,7 @@ from sqlalchemy.dialects.postgresql import ARRAY, INT4RANGE, JSON
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import (
     Mapped,
+    deferred,
     relationship,
 )
 from sqlalchemy.orm.session import Session
@@ -112,11 +113,13 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
     priority: Mapped[int] = Column(Integer, index=True, nullable=False, default=0)
 
     # Deprecated: these cached size estimates are no longer populated or read.
-    # The code that maintained them (update_size and the lane-size Celery tasks)
-    # has been removed; the columns remain mapped only so the model continues to
-    # match the database schema, and will be dropped in a follow-up migration.
-    size: Mapped[int] = Column(Integer, nullable=False, default=0)
-    size_by_entrypoint = Column(JSON, nullable=True)
+    # They are mapped as ``deferred`` so the ORM does not include them in its
+    # default SELECT (nothing accesses them). This is the online-migration
+    # "stop using the column" step: once this release ships, a follow-up
+    # migration can drop the columns without breaking the still-running previous
+    # release, which would otherwise SELECT them and fail.
+    size = deferred(Column(Integer, nullable=False, default=0))
+    size_by_entrypoint = deferred(Column(JSON, nullable=True))
 
     # A lane may have one parent lane and many sublanes.
     sublanes: Mapped[list[Lane]] = relationship(


### PR DESCRIPTION
## Description

Follow-up to #3424 (merged), which removed all lane-size *maintenance* but left `size` / `size_by_entrypoint` eagerly mapped on the `Lane` model. This is release-1 of the online-migration sequence to remove those columns: **stop using them**. The column drop is a stacked follow-up (release-2), gated on this shipping first.

"Stop using" an ORM column has two sides, and both must be handled before the column can be dropped safely:

- **Reads.** SQLAlchemy eagerly `SELECT`s every mapped column, so simply "keeping them mapped" (as #3424 did) does not stop the current code from reading them. Both columns are marked `deferred()`, which excludes them from the default `SELECT`.
- **Writes.** SQLAlchemy also emits any column with a Python-side `default=` in every `INSERT`. `size` is `NOT NULL` with `default=0`, so it was still written on every `Lane` insert — and lanes are created at runtime (`create_default_lanes`: reset lanes / configure a library / create a custom lane). A follow-up migration that dropped the column would then break the still-running previous release's inserts (`column "size" does not exist`). This PR moves the default into the database (`ALTER COLUMN size SET DEFAULT 0`) and removes the Python-side `default=0`. With a `server_default` and no Python default, SQLAlchemy omits the column from `INSERT`s and Postgres fills in `0`, so the eventual drop is write-safe. `size_by_entrypoint` is nullable with no default, so it was already omitted from inserts and needs no write-side change.

The `SET DEFAULT` migration is catalog-only in Postgres (instant, no table rewrite) and backwards-compatible: the previous release still writes `size=0` explicitly, harmlessly overriding the new default, and still reads `size` (the column is untouched). The columns stay in the model and the database, so `test_model_definitions_match_ddl` still passes and the previous release keeps working.

Once a release containing this change has shipped, the follow-up PR can drop both columns without breaking the then-previous release.

## Motivation and Context

JIRA: PP-4506

Completes the "stop using" step of the online-migration sequence for removing the lane-size columns (release-1). The column drop is release-2, gated on this shipping first, and is tracked by the `cleanup migration` label.

## How Has This Been Tested?

- `tests/migration/test_alembic_builtin_tests.py` passes, including `test_model_definitions_match_ddl` (model matches the migrated schema, with `compare_server_default=True`) and the up/down migration round-trip.
- `mypy` clean on the Lane model.
- Verified against a `NOT NULL` column with the same config that, with a `server_default` and no Python default, SQLAlchemy omits the column from `INSERT`s entirely (and the insert still succeeds after the column is dropped), whereas the previous `deferred`-only / Python-`default=0` version emitted it on every insert.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
