### PR TITLE
Test OpenSearch 2.19 and 3.5 against the opensearch marker (PP-4546)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,54 @@ jobs:
           files: ./coverage.xml
           name: test-${{ matrix.python-version }}
           verbose: true
+
+  # Temporary bandaid for the OpenSearch 1.x -> 2.19 -> 3.5 migration. The `test`
+  # job above still runs the full suite against OpenSearch 1.x (current prod);
+  # this job additionally runs just the OpenSearch-marked tests against the
+  # intermediate (2.19) and target (3.5) versions. These are separate, non-required
+  # status checks, so the existing required `Tests (Py X.Y)` checks and branch
+  # protection are untouched. Remove this whole job once production is on 3.5.
+  opensearch-version:
+    name: OpenSearch ${{ matrix.opensearch.version }} tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        opensearch:
+          - { version: "2.19", factor: "os219" }
+          - { version: "3.5", factor: "os35" }
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
+      - name: Disable network offload
+        run: sudo ethtool -K eth0 tx off rx off
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          activate-environment: true
+
+      - name: Install Tox
+        run: uv sync --frozen --only-group ci
+
+      - name: Run OpenSearch tests
+        run: tox -e py312-docker-${{ matrix.opensearch.factor }}
+        env:
+          # Workaround for tox-docker not supporting Docker 29+, which removed
+          # the top-level NetworkSettings.Gateway key from the container API.
+          # This can be removed once tox-docker merges the fix.
+          # Docker 29 rollout: https://github.com/actions/runner-images/issues/13474
+          # tox-docker fix: https://github.com/tox-dev/tox-docker/pull/196
+          TOX_DOCKER_GATEWAY: "0.0.0.0"

--- a/docker/Dockerfile.os2.ci
+++ b/docker/Dockerfile.os2.ci
@@ -1,0 +1,7 @@
+# OpenSearch 2.19 -- the required intermediate hop for the AWS upgrade path
+# (1.x -> 2.x -> 3.x). Temporary: used only by the opensearch-version CI job
+# while production migrates to 3.5; remove once production is on 3.5. Pinned to a
+# specific patch because OpenSearch publishes no floating :2.19 minor tag.
+# analysis-icu is required by the search schema (see src/palace/manager/search/v5.py).
+FROM opensearchproject/opensearch:2.19.5
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch analysis-icu

--- a/docker/Dockerfile.os3.ci
+++ b/docker/Dockerfile.os3.ci
@@ -1,0 +1,8 @@
+# OpenSearch 3.5 -- the migration target (AWS OpenSearch Service does not yet
+# support 3.7). Temporary: used only by the opensearch-version CI job while
+# production migrates; once production is on 3.5 this becomes the default (fold
+# into Dockerfile.os.ci). Pinned to a specific patch: OpenSearch publishes no
+# floating :3.5 minor tag and :3 would drift to 3.6/3.7. analysis-icu is required
+# by the search schema (see src/palace/manager/search/v5.py).
+FROM opensearchproject/opensearch:3.5.0
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch analysis-icu

--- a/tests/manager/search/test_external_search.py
+++ b/tests/manager/search/test_external_search.py
@@ -521,14 +521,19 @@ class TestExternalSearchWithWorks:
         # Search in publisher name.
         expect(data.moby_dick, "gutenberg")
 
-        # Title > subtitle > word found in summary > publisher
-        order = [
-            data.title_match,
-            data.subtitle_match,
-            data.summary_match,
-            data.publisher_match,
-        ]
-        expect(order, "match")
+        # Matches in the title and subtitle (short, high-weight fields) reliably
+        # rank ahead of matches in the summary and publisher fields, in that
+        # order, and all four field matches are returned. We deliberately do not
+        # assert the relative order of the summary-match vs the publisher-match:
+        # it is a near-tie whose ordering depends on Lucene's BM25 field-length
+        # normalization, which changed in OpenSearch 3.x (Lucene 10) and flips
+        # those two relative to 1.3/2.19.
+        match_hits = [hit.work_id for hit in query("match")]
+        assert match_hits[:2] == [data.title_match.id, data.subtitle_match.id]
+        assert set(match_hits[2:]) == {
+            data.summary_match.id,
+            data.publisher_match.id,
+        }
 
         # A search for a partial title match + a partial author match
         # considers only books that match both fields.

--- a/tests/manager/search/test_service.py
+++ b/tests/manager/search/test_service.py
@@ -134,19 +134,16 @@ class TestService:
         documents: list[SearchDocument] = [
             {
                 "_index": revision.name_for_index("base"),
-                "_type": "_doc",
                 "_id": 1,
                 "_source": {"x": 23, "y": 24},
             },
             {
                 "_index": revision.name_for_index("base"),
-                "_type": "_doc",
                 "_id": 2,
                 "_source": {"x": 25, "y": 26},
             },
             {
                 "_index": revision.name_for_index("base"),
-                "_type": "_doc",
                 "_id": 3,
                 "_source": {"x": 27, "y": 28},
             },

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,12 @@ runner = uv-venv-lock-runner
 commands_pre =
     python -m textblob.download_corpora
 commands =
-    pytest {posargs:tests}
+    !os219-!os35: pytest {posargs:tests}
+    # Temporary bandaid: the os219/os35 factors run only the OpenSearch-marked
+    # tests against the migration versions. Remove these two lines once
+    # production is on 3.5.
+    os219: pytest -m opensearch --no-cov {posargs:tests}
+    os35: pytest -m opensearch --no-cov {posargs:tests}
 passenv =
     PALACE_*
     CI
@@ -21,10 +26,16 @@ setenv =
     docker: PALACE_TEST_MINIO_PASSWORD=palace123
     docker: PALACE_TEST_REDIS_URL_SCHEME=redis
 docker =
-    docker: os-circ
     docker: db-circ
     docker: minio-circ
     docker: redis-circ
+    # Default OpenSearch is the current production version (1.x). The os219/os35
+    # factors are a temporary bandaid for the migration to 3.5: they swap in a
+    # newer OpenSearch container. Remove them (and the sections below) once
+    # production is on 3.5.
+    docker-!os219-!os35: os-circ
+    os219: os-circ-219
+    os35: os-circ-35
 allowlist_externals =
     python
     pytest
@@ -61,6 +72,44 @@ expose =
     PALACE_TEST_SEARCH_URL_PORT=9200/tcp
 host_var =
     PALACE_TEST_SEARCH_URL_HOST
+
+# Temporary bandaid for the OpenSearch 1.x -> 2.19 -> 3.5 migration. Selected by
+# the os219/os35 env factors; only one OpenSearch container runs per env, so they
+# reuse the same exposed port / host var as os-circ. A healthcheck is required
+# because tox-docker only waits for readiness when a container reports a health
+# state, and 2.x/3.x boot slower than 1.x. Remove both sections once production
+# is on 3.5.
+[docker:os-circ-219]
+dockerfile = {toxinidir}/docker/Dockerfile.os2.ci
+environment =
+    discovery.type=single-node
+    DISABLE_SECURITY_PLUGIN=true
+    DISABLE_INSTALL_DEMO_CONFIG=true
+expose =
+    PALACE_TEST_SEARCH_URL_PORT=9200/tcp
+host_var =
+    PALACE_TEST_SEARCH_URL_HOST
+healthcheck_cmd = curl --silent --fail http://localhost:9200/_cluster/health?wait_for_status=yellow
+healthcheck_interval = 5
+healthcheck_timeout = 10
+healthcheck_retries = 30
+healthcheck_start_period = 15
+
+[docker:os-circ-35]
+dockerfile = {toxinidir}/docker/Dockerfile.os3.ci
+environment =
+    discovery.type=single-node
+    DISABLE_SECURITY_PLUGIN=true
+    DISABLE_INSTALL_DEMO_CONFIG=true
+expose =
+    PALACE_TEST_SEARCH_URL_PORT=9200/tcp
+host_var =
+    PALACE_TEST_SEARCH_URL_HOST
+healthcheck_cmd = curl --silent --fail http://localhost:9200/_cluster/health?wait_for_status=yellow
+healthcheck_interval = 5
+healthcheck_timeout = 10
+healthcheck_retries = 30
+healthcheck_start_period = 15
 
 [docker:minio-circ]
 dockerfile = {toxinidir}/docker/Dockerfile.minio.ci

--- a/tox.ini
+++ b/tox.ini
@@ -72,13 +72,20 @@ expose =
     PALACE_TEST_SEARCH_URL_PORT=9200/tcp
 host_var =
     PALACE_TEST_SEARCH_URL_HOST
+# Wait for the cluster to be ready before running tests. tox-docker only blocks
+# for readiness when a container reports a health state; without this it starts
+# the container and proceeds immediately, working today only because later setup
+# steps happen to give OpenSearch time to boot.
+healthcheck_cmd = curl --silent --fail http://localhost:9200/_cluster/health?wait_for_status=yellow
+healthcheck_interval = 5
+healthcheck_timeout = 10
+healthcheck_retries = 30
+healthcheck_start_period = 15
 
 # Temporary bandaid for the OpenSearch 1.x -> 2.19 -> 3.5 migration. Selected by
 # the os219/os35 env factors; only one OpenSearch container runs per env, so they
-# reuse the same exposed port / host var as os-circ. A healthcheck is required
-# because tox-docker only waits for readiness when a container reports a health
-# state, and 2.x/3.x boot slower than 1.x. Remove both sections once production
-# is on 3.5.
+# reuse the same exposed port / host var (and the healthcheck) as os-circ. Remove
+# both sections once production is on 3.5.
 [docker:os-circ-219]
 dockerfile = {toxinidir}/docker/Dockerfile.os2.ci
 environment =

--- a/tox.ini
+++ b/tox.ini
@@ -72,10 +72,7 @@ expose =
     PALACE_TEST_SEARCH_URL_PORT=9200/tcp
 host_var =
     PALACE_TEST_SEARCH_URL_HOST
-# Wait for the cluster to be ready before running tests. tox-docker only blocks
-# for readiness when a container reports a health state; without this it starts
-# the container and proceeds immediately, working today only because later setup
-# steps happen to give OpenSearch time to boot.
+# Wait for the cluster to be ready before running tests.
 healthcheck_cmd = curl --silent --fail http://localhost:9200/_cluster/health?wait_for_status=yellow
 healthcheck_interval = 5
 healthcheck_timeout = 10


### PR DESCRIPTION
## Description

> This PR is **stacked on #3490** (which makes the `opensearch` marker actually apply)

We are migrating production OpenSearch **1.x → 2.19 → 3.5** over next few sprints, after that is complete we'll test only on 3.5. Because the OpenSearch *version* is the only thing that varies, we just run the **`opensearch`-marked tests** against the new versions rather than the whole suite three times.

**Removal later:** once production is on 3.5, delete the `opensearch-version` job, the `os219`/`os35` factor lines, the two `[docker:os-circ-*]` tox sections, and `Dockerfile.os2.ci`, and point `Dockerfile.os.ci` at 3.5. The two test fixes stay (correct for 3.5).

## Motivation and Context

Upgrading our production opensearch clusters.

## How Has This Been Tested?

Locally, faithful to how CI runs them: `tox -e py312-docker-os35` and `tox -e py312-docker-os219` each run the 62 `opensearch`-marked tests against 3.5 / 2.19 and pass. Confirmed via `tox config` that the default `py312-docker` env still uses the 1.x `os-circ` container and runs the full `pytest tests` command (verified `tox -e py312-docker -- tests/manager/search/test_service.py` runs all 19 tests, not just the marked one). `mypy` clean on the changed files; pre-commit (incl. workflow validation) green.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
