### PR TITLE
Auto-apply the opensearch pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -383,7 +383,7 @@ filterwarnings = [
 markers = [
     "db: mark test as using the database (applied automatically to tests using the db fixture)",
     "minio: mark test as requiring minio",
-    "opensearch: mark test as requiring opensearch",
+    "opensearch: mark test as requiring opensearch (applied automatically to tests using the search fixtures)",
 ]
 timeout = "600"
 timeout_method = "thread"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,18 +38,30 @@ pytest_plugins = [
 fg_configure(extend_ignore_list=["pyinstrument", "celery"])
 
 
+# Tests acquire a real OpenSearch instance through one of these fixtures (directly or
+# transitively). The fake search fixture is intentionally excluded: it needs no running
+# OpenSearch and therefore must not be marked ``opensearch``.
+OPENSEARCH_FIXTURES = frozenset(
+    {"external_search_fixture", "end_to_end_search_fixture"}
+)
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    """Automatically apply the ``db`` marker to tests that use the ``db`` fixture.
+    """Automatically apply the ``db`` and ``opensearch`` markers based on fixture usage.
 
-    Database-backed tests are too numerous to mark by hand, so we derive the marker from
-    fixture usage at collection time. This lets a run include or exclude them with ``-m db``
-    or ``-m 'not db'`` (e.g. the backwards-compatibility CI check runs ``-m db`` against an
-    externally applied schema). Runs ``tryfirst`` so the marker is present before pytest
-    evaluates any ``-m`` expression.
+    These test sets are too numerous to mark by hand, so we derive the markers from fixture
+    usage at collection time. This lets a run include or exclude them with ``-m db`` /
+    ``-m 'not db'`` (e.g. the backwards-compatibility CI check runs ``-m db`` against an
+    externally applied schema) and ``-m opensearch`` / ``-m 'not opensearch'`` (e.g. to skip
+    tests that need a running OpenSearch instance). Runs ``tryfirst`` so the markers are
+    present before pytest evaluates any ``-m`` expression.
     """
     for item in items:
-        if "db" in getattr(item, "fixturenames", ()):
+        fixturenames = getattr(item, "fixturenames", ())
+        if "db" in fixturenames:
             item.add_marker("db")
+        if not OPENSEARCH_FIXTURES.isdisjoint(fixturenames):
+            item.add_marker("opensearch")


### PR DESCRIPTION
## Description

The `opensearch` pytest marker was registered in `pyproject.toml` but never applied to any test — there were no `@pytest.mark.opensearch` decorators and no auto-application — so `-m opensearch` selected nothing and `-m 'not opensearch'` did not actually exclude tests that require a running OpenSearch instance. This makes the marker work by deriving it from fixture usage, mirroring how the `db` marker is already handled in `tests/conftest.py`.

The `pytest_collection_modifyitems` hook now adds the `opensearch` marker to any test whose fixtures include one of the real search fixtures (`external_search_fixture` / `end_to_end_search_fixture`, directly or transitively). The fake search fixture (`external_search_fake_fixture`) is intentionally excluded, since those tests need no running OpenSearch.

After this change, `-m opensearch` selects 62 tests across the repo (25 in `tests/manager/search`, plus tests in feed, scripts, celery, and the work/lane models) — all of which were previously unselectable.

## Motivation and Context

Being able to select or skip the OpenSearch-backed tests (e.g. `-m 'not opensearch'` when no OpenSearch instance is available, or `-m opensearch` to target just those) only works if the marker is actually applied. As registered, it was a no-op. This was noticed while adding multi-version OpenSearch CI coverage in a separate PR.

## How Has This Been Tested?

Verified collection counts at `--collect-only`: `-m opensearch tests/manager/search` now collects 25 tests (was 0), `-m 'not opensearch'` collects the remaining 114 unit/fake-fixture tests, and `-m opensearch tests/` collects 62 across the repo. Confirmed the selected tests actually run and pass against a real OpenSearch via `tox -e py312-docker -- -m opensearch tests/manager/search` (25 passed). Also ran `mypy` on the changed file.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
