### PR TITLE
Bump Admin UI version to 1.42.2

### DIFF
--- a/src/palace/manager/api/admin/config.py
+++ b/src/palace/manager/api/admin/config.py
@@ -86,7 +86,7 @@ class OperationalMode(str, Enum):
 class Configuration(LoggerMixin):
     APP_NAME = "Palace Collection Manager"
     PACKAGE_NAME = "@thepalaceproject/circulation-admin"
-    PACKAGE_VERSION = "1.42.1"
+    PACKAGE_VERSION = "1.42.2"
 
     STATIC_ASSETS = {
         "admin_js": "circulation-admin.js",


### PR DESCRIPTION
## Description

Bump Admin UI version to 1.42.2:
https://github.com/ThePalaceProject/circulation-admin/releases/tag/v1.42.2

## Motivation and Context

Updates the bundled `@thepalaceproject/circulation-admin` web UI
dependency to the latest released version (1.42.2).

## How Has This Been Tested?

Existing tests reference `Configuration.PACKAGE_VERSION` dynamically
rather than a hardcoded string, so the version bump is covered by the
existing suite. Verified via CI.

## Checklist

- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.