### PR TITLE
Switch CI test and docker compose infrastructure to Valkey (PP-4544)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,15 @@ CREATE USER palace with password 'test';
 grant all privileges on database circ to palace;
 ```
 
-### Redis
+### Valkey
 
-Redis is used as the broker for Celery and the caching layer. You can run Redis with docker using the following command:
+[Valkey](https://valkey.io/) is used as the broker for Celery and the caching layer. We run and test
+against Valkey, but Redis works as well — Valkey is a protocol- and command-compatible fork of Redis, so
+the same `redis://` connection URLs point at either. You can run Valkey with docker using the following
+command:
 
 ```sh
-docker run -d --name redis -p 6379:6379 redis/redis-stack-server
+docker run -d --name valkey -p 6379:6379 valkey/valkey:8.1.8
 ```
 
 ### Environment variables

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ the same `redis://` connection URLs point at either. You can run Valkey with doc
 command:
 
 ```sh
-docker run -d --name valkey -p 6379:6379 valkey/valkey:8.1.8
+docker run -d --name valkey -p 6379:6379 valkey/valkey:9.0
 ```
 
 ### Environment variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       retries: 5
 
   valkey:
-    image: "valkey/valkey:8.1.8"
+    image: "valkey/valkey:9.0"
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,11 @@ x-cm-variables: &cm
     PALACE_SECRET_KEY: "SECRET_KEY_USED_FOR_ADMIN_UI_COOKIES"
     PALACE_PATRON_WEB_HOSTNAMES: "*"
     PALACE_BASE_URL: "http://localhost:6500"
-    PALACE_CELERY_BROKER_URL: "redis://redis:6379/0"
-    PALACE_CELERY_RESULT_BACKEND: "redis://redis:6379/2"
+    PALACE_CELERY_BROKER_URL: "redis://valkey:6379/0"
+    PALACE_CELERY_RESULT_BACKEND: "redis://valkey:6379/2"
     PALACE_CELERY_BROKER_TRANSPORT_OPTIONS_GLOBAL_KEYPREFIX: "test"
     PALACE_CELERY_CLOUDWATCH_STATISTICS_DRYRUN: "true"
-    PALACE_REDIS_URL: "redis://redis:6379/1"
+    PALACE_REDIS_URL: "redis://valkey:6379/1"
     PALACE_GOOGLE_DRIVE_SERVICE_ACCOUNT_INFO_JSON: "${PALACE_GOOGLE_DRIVE_SERVICE_ACCOUNT_INFO_JSON-}"
 
     # Set up the environment variables used for testing as well
@@ -28,7 +28,7 @@ x-cm-variables: &cm
     PALACE_TEST_MINIO_URL: "http://minio:9000"
     PALACE_TEST_MINIO_USER: "palace"
     PALACE_TEST_MINIO_PASSWORD: "test123456789"
-    PALACE_TEST_REDIS_URL: "redis://redis:6379/3"
+    PALACE_TEST_REDIS_URL: "redis://valkey:6379/3"
 
   depends_on:
     pg:
@@ -37,7 +37,7 @@ x-cm-variables: &cm
       condition: service_healthy
     os:
       condition: service_healthy
-    redis:
+    valkey:
       condition: service_healthy
 
 x-cm-build: &cm-build
@@ -115,10 +115,10 @@ services:
       timeout: 10s
       retries: 5
 
-  redis:
-    image: "redis/redis-stack-server:7.4.0-v0"
+  valkey:
+    image: "valkey/valkey:8.1.8"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 30s
       timeout: 20s
       retries: 3

--- a/src/palace/manager/service/redis/redis.py
+++ b/src/palace/manager/service/redis/redis.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 import redis
@@ -151,17 +150,6 @@ class Redis(RedisClient, RedisPrefixCheckMixin):
             shard_hint,
             key_generator=self.get_key,
         )
-
-    @cached_property
-    def elasticache(self) -> bool:
-        """
-        Check if this Redis instances is actually connected to AWS ElastiCache rather than Redis.
-
-        AWS ElastiCache is supposed to be API compatible with Redis, but there are some differences
-        that can cause issues. This property can be used to detect if we are connected to ElastiCache
-        and handle those differences.
-        """
-        return self.info().get("os") == "Amazon ElastiCache"
 
 
 class Pipeline(RedisPipeline, RedisPrefixCheckMixin):

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ setenv =
 docker =
     docker: db-circ
     docker: minio-circ
-    docker: redis-circ
+    docker: valkey-circ
     # Default OpenSearch is the current production version (1.x). The os219/os35
     # factors are a temporary bandaid for the migration to 3.5: they swap in a
     # newer OpenSearch container. Remove them (and the sections below) once
@@ -123,8 +123,8 @@ expose =
 host_var =
     PALACE_TEST_MINIO_URL_HOST
 
-[docker:redis-circ]
-image = redis/redis-stack-server:7.4.0-v0
+[docker:valkey-circ]
+image = valkey/valkey:8.1.8
 expose =
     PALACE_TEST_REDIS_URL_PORT=6379/tcp
 host_var =

--- a/tox.ini
+++ b/tox.ini
@@ -124,7 +124,7 @@ host_var =
     PALACE_TEST_MINIO_URL_HOST
 
 [docker:valkey-circ]
-image = valkey/valkey:8.1.8
+image = valkey/valkey:9.0
 expose =
     PALACE_TEST_REDIS_URL_PORT=6379/tcp
 host_var =


### PR DESCRIPTION
## Description

Switches the test and dev infrastructure from `redis/redis-stack-server` to the `valkey/valkey:9.0` image, in both the tox (`[docker:valkey-circ]`) and `docker-compose` stacks. `9.0` is a rolling tag, so the stacks pick up the latest 9.0.x patch automatically (matching the floating `postgres:16` style already used here). The container/service is renamed to reflect the engine it actually runs (`valkey-circ` in tox; the `valkey` compose service, with its `depends_on` and `redis://valkey:6379` host references updated, and a `valkey-cli` healthcheck). The `redis://` URL scheme and all `PALACE_*REDIS*` config keys are deliberately left unchanged, since they name the protocol/contract rather than the instance — Valkey is protocol- and command-compatible and we still use the `redis-py` client.

The README `### Redis` section becomes `### Valkey`, noting that we run and test against Valkey while Redis remains a supported drop-in.

This change also drops the unused ElastiCache detection (`Redis.elasticache`) and its now-orphaned `cached_property` import. The property had no callers, and we run Valkey directly now.

> Note: I'm going to keep this in draft until we've updated our infrastructure to valkey, but its ready for code review any time.

## Motivation and Context

We want to evaluate (and move to) Valkey instead of Redis. Our usage is limited to core Redis commands (strings, sets, expiry, `WATCH`/pipelines, and Lua scripts via `EVALSHA`) plus Celery as a broker/result backend — none of the Redis Stack modules our old image bundled — so Valkey is a true drop-in. We pin to the `9.0` line because that is the version AWS ElastiCache for Valkey currently runs, which is our intended upgrade target; testing against it directly keeps the test stack aligned with production.

JIRA: PP-4544

## How Has This Been Tested?

- Tests run in CI

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
