### PR TITLE
Speed up slow tests by removing avoidable real waits

### DIFF
--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -64,13 +64,20 @@ def test_get_work_search_documents(db: DatabaseTransactionFixture) -> None:
 
 
 @pytest.mark.parametrize("batch_size", [2, 3, 500])
+@patch("palace.manager.celery.tasks.search.random")
 def test_search_reindex(
+    mock_random: MagicMock,
     batch_size: int,
     db: DatabaseTransactionFixture,
     celery_fixture: CeleryFixture,
     search_reindex_task_lock_fixture: SearchReindexTaskLockFixture,
     end_to_end_search_fixture: EndToEndSearchFixture,
 ) -> None:
+    # When a batch fills up, search_reindex requeues itself with a random
+    # `countdown` cooldown that the real Celery worker honours as an actual wait.
+    # Mock it out so pagination is still exercised without the multi-second sleep.
+    mock_random.uniform.return_value = 0.0
+
     client = end_to_end_search_fixture.external_search.write_client
     index = end_to_end_search_fixture.external_search_index
 

--- a/tests/manager/core/test_monitor.py
+++ b/tests/manager/core/test_monitor.py
@@ -5,6 +5,7 @@ import pytest
 from freezegun import freeze_time
 from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
+from tenacity import wait_none
 
 from palace.util.datetime_helpers import datetime_utc, utc_now
 
@@ -660,7 +661,19 @@ class TestSweepMonitor:
         self,
         db: DatabaseTransactionFixture,
         sweep_monitor_fixture: SweepMonitorFixture,
+        monkeypatch: pytest.MonkeyPatch,
     ):
+        # process_batch retries with a real exponential `time.sleep` backoff
+        # (1s + 2s + 4s). This test only asserts retry behaviour, not timing, so
+        # neutralize the wait to avoid ~7s of real sleeping. tenacity's @retry
+        # decorator attaches the controller as `.retry` at runtime, which mypy
+        # can't see on the wrapped function.
+        monkeypatch.setattr(
+            SweepMonitor.process_batch.retry,  # type: ignore[attr-defined]
+            "wait",
+            wait_none(),
+        )
+
         identifier = db.identifier()
 
         class FailOnFirstTwoCallsSucceedOnThird(MockSweepMonitor):

--- a/tests/manager/integration/patron_auth/oidc/test_util.py
+++ b/tests/manager/integration/patron_auth/oidc/test_util.py
@@ -184,7 +184,6 @@ class TestOIDCUtilityState:
         data = {"library_short_name": "TESTLIB"}
 
         state = OIDCUtility.generate_state(data, TEST_SECRET_KEY)
-        time.sleep(1)
 
         decoded = OIDCUtility.validate_state(
             state, TEST_SECRET_KEY, max_age=custom_max_age


### PR DESCRIPTION
## Description

Removes three avoidable real-time waits from the test suite that don't exercise any behaviour under test:

- Mock `random` in `test_search_reindex` so the requeue cooldown countdown (`random.uniform(5, 15)`, honoured by the real Celery worker as an ETA) doesn't add ~32s of real sleep across its parameters. Pagination is still exercised — this mirrors the existing `test_search_indexing` pattern.
- Neutralize the tenacity exponential backoff in `test_retries` (1+2+4s of real `time.sleep`) with `wait_none()`; the test asserts retry behaviour, not timing.
- Drop an inert `time.sleep(1)` from an OIDC `max_age` test — the assertion passes with or without it.

## Motivation and Context

Try to get our tests running a little faster then they were. Nice to keep an eye on slow tests.

## How Has This Been Tested?

`tox -e py312-docker` — the full suite passes (6022 tests), and the three affected tests pass individually. The ablation confirmed these changes remove the real waits without changing any assertions or test outcomes.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
