### PR TITLE
Make script and OIDC logout tests robust to serial (-n0) execution

### DIFF
--- a/tests/manager/integration/patron_auth/oidc/test_controller.py
+++ b/tests/manager/integration/patron_auth/oidc/test_controller.py
@@ -971,6 +971,7 @@ class TestOIDCControllerLogout:
 
         Should redirect directly with logout_status=partial and log a warning.
         """
+        caplog.set_level(logging.INFO)
         controller = logout_controller
         patron = db.patron()
         patron.authorization_identifier = "user123@example.com"

--- a/tests/manager/scripts/test_equivalents.py
+++ b/tests/manager/scripts/test_equivalents.py
@@ -20,7 +20,7 @@ class TestEquivalentIdentifiersRefreshScript:
         with patch(
             "palace.manager.scripts.equivalents.equivalent_identifiers_refresh"
         ) as task_mock:
-            EquivalentIdentifiersRefreshScript(db.session).do_run()
+            EquivalentIdentifiersRefreshScript(db.session).do_run(cmd_args=[])
             task_mock.delay.assert_called_once_with(full_refresh=False)
             assert "delta" in caplog.text
 

--- a/tests/manager/scripts/test_novelist.py
+++ b/tests/manager/scripts/test_novelist.py
@@ -44,7 +44,7 @@ class TestNovelistSnapshotScript:
             script = NovelistSnapshotScript(
                 db.session,
             )
-            script.do_run()
+            script.do_run(cmd_args=[])
             update.delay.assert_called_once_with(library_id=l1.id)
             assert (
                 f'Queued novelist_update task for library: name="{l1.name}", id={l1.id}'

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -16,7 +16,7 @@ class TestRebuildSearchIndexScript:
         services_fixture: ServicesFixture,
     ):
         # If we are called with no arguments, we default to asynchronously rebuilding the search index.
-        RebuildSearchIndexScript(db.session).do_run()
+        RebuildSearchIndexScript(db.session, cmd_args=[]).do_run()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
         # But we don't delete the index before rebuilding.
         services_fixture.search_index.clear_search_documents.assert_not_called()


### PR DESCRIPTION
## Description

Makes four tests robust to running serially with pytest-xdist disabled (`-n0`). They pass under the normal xdist test run but fail under `-n0`, which is how the backwards-compatibility CI check (#3506) runs a previous release's database suite against the current schema.

- **Three script tests** (`test_equivalents`, `test_novelist`, `test_search`) constructed a `Script` with no `cmd_args` and called `do_run()`, so the script's argparse fell back to `sys.argv[1:]`. Under xdist each worker has a clean execnet `sys.argv`, but under `-n0` `sys.argv` is the real pytest command line. That caused argparse to error on unrecognized arguments (`equivalents`, `novelist`), and the leaked `-m db` marker matched `RebuildSearchIndexScript`'s `-m/--migration` flag, sending it down the migration path so `search_reindex.delay` was never called (`search`). Each now passes an explicit `cmd_args=[]` to express "no arguments" independent of `sys.argv`.
- **The OIDC logout test** (`test_oidc_logout_initiate_no_stored_id_token`) asserted on `caplog` without setting a capture level. Under serial execution the effective log level is left raised by an earlier test, so the warning was not captured and `caplog.text` was empty. It now sets the level explicitly, matching its passing sibling `test_oidc_logout_initiate_revocation_only`.

No production code changes — scripts intentionally default `cmd_args` to `sys.argv` for real CLI use via `Script.run()`.

## Motivation and Context

The backwards-compatibility check added in #3506 runs the previous release's `-m db` suite under `-n0` (external-schema mode requires serial execution — the single shared database can't be used by parallel xdist workers). Its first real run surfaced these four latent test-isolation bugs, which xdist had been masking. None are schema-compatibility failures; all four fail identically against the previous release's own schema. Fixing them here means that once a release containing these fixes becomes the "previous release", the check will pass against it.

## How Has This Been Tested?

Reproduced the failures on the unfixed tests by running them under `-n0` in the docker test environment (`tox -e py312-docker -- -n0 ...`), observing the argparse `unrecognized arguments` errors. With the fixes applied, all four pass under `-n0` (including with `-m db` present, which exercises the `search` flag-collision case): `60 passed, 19 deselected`.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
