### PR TITLE
Rename Bibliotheca circulation sweep service to fix Timestamp UniqueViolation (PP-4664)

### DIFF
--- a/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
+++ b/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
@@ -20,13 +20,6 @@ from palace.manager.sqlalchemy.model.coverage import Timestamp
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import LicensePool
 
-# NOTE: This intentionally differs from the legacy ``BibliothecaCirculationSweep``
-# monitor's "Bibliotheca Circulation Sweep" service name. The ``timestamps`` unique
-# constraint is on ``(service, collection_id)`` only -- it does not include
-# ``service_type`` -- so reusing the old name would collide with the existing
-# ``service_type='monitor'`` row when this task stamps with ``service_type='task'``.
-# Renaming (as the event/purchase Celery migrations did) starts a fresh timestamp row
-# and orphans the now-unused legacy monitor row.
 CIRCULATION_UPDATE_SERVICE_NAME = "Bibliotheca Circulation Update"
 CIRCULATION_UPDATE_BATCH_SIZE = 25
 

--- a/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
+++ b/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
@@ -20,7 +20,14 @@ from palace.manager.sqlalchemy.model.coverage import Timestamp
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import LicensePool
 
-CIRCULATION_UPDATE_SERVICE_NAME = "Bibliotheca Circulation Sweep"
+# NOTE: This intentionally differs from the legacy ``BibliothecaCirculationSweep``
+# monitor's "Bibliotheca Circulation Sweep" service name. The ``timestamps`` unique
+# constraint is on ``(service, collection_id)`` only -- it does not include
+# ``service_type`` -- so reusing the old name would collide with the existing
+# ``service_type='monitor'`` row when this task stamps with ``service_type='task'``.
+# Renaming (as the event/purchase Celery migrations did) starts a fresh timestamp row
+# and orphans the now-unused legacy monitor row.
+CIRCULATION_UPDATE_SERVICE_NAME = "Bibliotheca Circulation Update"
 CIRCULATION_UPDATE_BATCH_SIZE = 25
 
 


### PR DESCRIPTION
## Description

The `BibliothecaCirculationSweep` → Celery task migration (#3403) reused the legacy monitor's
`"Bibliotheca Circulation Sweep"` service name, but the new task stamps its `Timestamp` with
`service_type='task'` instead of the monitor's `service_type='monitor'`.

The `timestamps` unique constraint is on `(service, collection_id)` **only** — it does not include
`service_type`. So `Timestamp.stamp()` → `get_one_or_create()` filters its lookup by
`service_type='task'`, never finds the pre-existing `'monitor'` row, and attempts to `INSERT` a new
`'task'` row. That insert collides with the existing monitor row on `(service, collection_id)` and
raises:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "timestamps_service_collection_id_key"
DETAIL:  Key (service, collection_id)=(Bibliotheca Circulation Sweep, 1) already exists.
```

This renames the service to `"Bibliotheca Circulation Update"` so the task writes a fresh `Timestamp`
row and no longer collides. It mirrors the approach taken by the other two PRs in the
Bibliotheca → Celery series, which renamed their services (`Event Monitor` → `Event Import`,
`Purchase Monitor` → `Purchase Record Importer`).

## Motivation and Context

JIRA (PP-4664)

Production throws `UniqueViolation` on every `circulation_update_collection` run for any collection
that previously ran the legacy monitor (i.e. any collection with an existing
`"Bibliotheca Circulation Sweep"` / `service_type='monitor'` row). The sweep cannot record progress
and the task fails.

Consequences of the rename:

- The legacy `service_type='monitor'` rows are **orphaned** (harmless, unused) — the same outcome the
  event/purchase migrations left for their old monitor rows. A follow-up JIRA will track cleaning
  these up.
- The new sweep starts from `counter=0` (offset 0) on its first run after deploy, re-sweeping each
  collection from the beginning — the intended fresh-start behavior.

No Alembic migration is required.

- I have created a follow-on task to remove orphaned timestamps records.

## How Has This Been Tested?

- Ran the affected suites under `tox -e py312-docker`:
  `tests/manager/integration/license/test_bibliotheca_circulation_updater.py` and
  `tests/manager/celery/tasks/test_bibliotheca.py` — **58 passed**.
- Confirmed via `grep` that every reference to the service name goes through the
  `CIRCULATION_UPDATE_SERVICE_NAME` constant (no hardcoded literals), so the rename propagates
  everywhere it is used.
- I will test on minotaur before releasing in a hotfix.
## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
