### PR TITLE
Treat empty Bibliotheca bibliographic_lookup response as a retryable error (PP-4665)

### DIFF
--- a/src/palace/manager/celery/tasks/bibliotheca.py
+++ b/src/palace/manager/celery/tasks/bibliotheca.py
@@ -76,12 +76,19 @@ def import_all_collections(task: Task) -> None:
     )
 
 
+# BibliothecaAPI.bibliographic_lookup, called per event by BibliothecaEventImporter,
+# raises RemoteInitiatedServerError when Bibliotheca returns an empty response body
+# (HTTP 200 with no XML document) -- a transient Bibliotheca-side condition. As with the
+# purchase-record and circulation-update tasks, it must be retried rather than surfacing
+# as an unhandled task exception. RemoteInitiatedServerError is a sibling of
+# RemoteIntegrationException (both derive from IntegrationException), not a subclass, so it
+# must be listed explicitly in both autoretry_for and throws.
 @shared_task(
     queue=QueueNames.default,
     bind=True,
     max_retries=4,
-    autoretry_for=(BadResponseException, RequestTimedOut),
-    throws=(RemoteIntegrationException,),
+    autoretry_for=(BadResponseException, RequestTimedOut, RemoteInitiatedServerError),
+    throws=(RemoteIntegrationException, RemoteInitiatedServerError),
     retry_backoff=60,
 )
 def import_collection(
@@ -382,12 +389,22 @@ def circulation_update_all_collections(task: Task) -> None:
     )
 
 
+# BibliothecaAPI.bibliographic_lookup raises RemoteInitiatedServerError when
+# Bibliotheca returns an empty response body (HTTP 200 with no XML document) --
+# a transient Bibliotheca-side condition, handled the same way marc_request
+# treats empty/malformed responses. It must be retried rather than allowed to
+# zero out the batch's availability (an empty body is not an authoritative
+# "these titles are gone") or to surface as an unhandled task exception.
+# RemoteInitiatedServerError is a sibling of RemoteIntegrationException (both
+# derive from IntegrationException), not a subclass, so it must be listed
+# explicitly in both autoretry_for and throws -- otherwise an exhausted retry
+# surfaces as an unhandled task exception.
 @shared_task(
     queue=QueueNames.default,
     bind=True,
     max_retries=4,
-    autoretry_for=(BadResponseException, RequestTimedOut),
-    throws=(RemoteIntegrationException,),
+    autoretry_for=(BadResponseException, RequestTimedOut, RemoteInitiatedServerError),
+    throws=(RemoteIntegrationException, RemoteInitiatedServerError),
     retry_backoff=60,
 )
 def circulation_update_collection(

--- a/src/palace/manager/integration/license/bibliotheca.py
+++ b/src/palace/manager/integration/license/bibliotheca.py
@@ -318,6 +318,10 @@ class BibliothecaAPI(
 
         :param identifiers: A list containing either Identifier
             objects or Bibliotheca identifier strings.
+        :raise RemoteInitiatedServerError: If Bibliotheca returns an empty
+            response body (HTTP 200 with no XML document). See the comment
+            below for why this is treated as a transient error rather than as
+            "no items found".
         """
         identifiers_list = (
             [identifiers]
@@ -331,6 +335,23 @@ class BibliothecaAPI(
             identifier_strings.append(i)
 
         data = self.bibliographic_lookup_request(identifier_strings)
+        if not data.strip():
+            # Bibliotheca occasionally returns an empty body (HTTP 200 with no
+            # XML document). An empty document cannot be parsed as XML (lxml
+            # raises "Document is empty" even in recovery mode). Unlike a
+            # well-formed document that simply omits some of the requested
+            # items, an empty body tells us nothing about which titles still
+            # exist, so we must not treat it as "no items returned": that would
+            # make BibliothecaCirculationUpdater._process_batch zero out the
+            # availability of every requested identifier as if it had been
+            # removed from circulation. Instead, raise a transient remote error
+            # -- mirroring how marc_request/ErrorParser treat empty or malformed
+            # Bibliotheca responses -- so the caller retries rather than
+            # corrupting availability data.
+            raise RemoteInitiatedServerError(
+                "Bibliotheca returned an empty response body for a bibliographic lookup.",
+                self.SERVICE_NAME,
+            )
         return [
             bibliographic for bibliographic in self.item_list_parser.process_all(data)
         ]

--- a/tests/manager/celery/tasks/test_bibliotheca.py
+++ b/tests/manager/celery/tasks/test_bibliotheca.py
@@ -350,6 +350,62 @@ class TestBibliothecaImportCollection:
         )
         assert workflow_lock.locked()
 
+    def test_remote_initiated_server_error_retried_and_expected(
+        self,
+        bibliotheca_task_fixture: BibliothecaTaskFixture,
+        celery_fixture: CeleryFixture,
+        redis_fixture: RedisFixture,
+    ) -> None:
+        """bibliographic_lookup (called per event by the importer) raises
+        RemoteInitiatedServerError when Bibliotheca returns an empty response body —
+        a transient condition that must be retried, not surfaced as an unhandled task
+        exception.
+
+        RemoteInitiatedServerError is a sibling of RemoteIntegrationException (both
+        derive from IntegrationException), not a subclass, so it has to be listed
+        explicitly in autoretry_for and throws. This guards against either being dropped.
+        """
+        task = bibliotheca.import_collection
+        assert RemoteInitiatedServerError in task.autoretry_for
+        assert RemoteInitiatedServerError in task.throws
+
+        collection = bibliotheca_task_fixture.collection
+        bibliotheca_task_fixture.stamp_event_import(
+            finish=utc_now() - timedelta(minutes=10)
+        )
+
+        fake_event = (
+            "d5rf89",
+            "9781101190623",
+            None,
+            datetime(2016, 4, 28, 11, 4, 6, tzinfo=timezone.utc),
+            None,
+            CirculationEvent.DISTRIBUTOR_LICENSE_ADD,
+        )
+
+        with (
+            # Return a list (re-iterable across retries) of one event so the importer
+            # reaches _handle_event -> bibliographic_lookup, which raises.
+            patch.object(
+                BibliothecaAPI, "get_events_between", return_value=[fake_event]
+            ),
+            patch.object(
+                BibliothecaAPI,
+                "bibliographic_lookup",
+                side_effect=RemoteInitiatedServerError(
+                    "boom", BibliothecaAPI.SERVICE_NAME
+                ),
+            ) as mock_lookup,
+        ):
+            with celery_fixture.patch_retry_backoff():
+                bibliotheca.import_collection.delay(collection_id=collection.id).get(
+                    propagate=False
+                )
+
+            # Retried on every attempt (1 initial + max_retries=4) rather than
+            # failing immediately as an unhandled exception.
+            assert mock_lookup.call_count == 5
+
     def test_events_processed_end_to_end(
         self,
         bibliotheca_task_fixture: BibliothecaTaskFixture,
@@ -1458,6 +1514,45 @@ class TestCirculationUpdateCollection:
             redis_fixture.client, collection.id, random_value="any"
         )
         assert workflow_lock.locked()
+
+    def test_remote_initiated_server_error_retried_and_expected(
+        self,
+        bibliotheca_circulation_update_task_fixture: BibliothecaCirculationUpdateTaskFixture,
+        celery_fixture: CeleryFixture,
+        redis_fixture: RedisFixture,
+    ) -> None:
+        """bibliographic_lookup raises RemoteInitiatedServerError when Bibliotheca
+        returns an empty response body — a transient Bibliotheca-side condition. It
+        must be retried and declared expected rather than zeroing out the batch's
+        availability or surfacing as an unhandled task exception.
+
+        RemoteInitiatedServerError is a sibling of RemoteIntegrationException (both
+        derive from IntegrationException), not a subclass, so it has to be listed
+        explicitly in autoretry_for and throws. This guards against either being dropped.
+        """
+        task = bibliotheca.circulation_update_collection
+        assert RemoteInitiatedServerError in task.autoretry_for
+        assert RemoteInitiatedServerError in task.throws
+
+        collection = bibliotheca_circulation_update_task_fixture.collection
+
+        with patch(
+            "palace.manager.celery.tasks.bibliotheca.BibliothecaCirculationUpdater"
+        ) as mock_updater_cls:
+            mock_updater = mock_updater_cls.return_value
+            mock_updater.get_offset.return_value = 0
+            mock_updater.update_batch.side_effect = RemoteInitiatedServerError(
+                "boom", BibliothecaAPI.SERVICE_NAME
+            )
+
+            with celery_fixture.patch_retry_backoff():
+                bibliotheca.circulation_update_collection.delay(
+                    collection_id=collection.id
+                ).get(propagate=False)
+
+            # Retried on every attempt (1 initial + max_retries=4) rather than
+            # failing immediately as an unhandled exception.
+            assert mock_updater.update_batch.call_count == 5
 
     def test_circulation_update_lock_independent_from_event_import_and_purchase_record_locks(
         self,

--- a/tests/manager/integration/license/test_bibliotheca.py
+++ b/tests/manager/integration/license/test_bibliotheca.py
@@ -269,6 +269,32 @@ class TestBibliothecaAPI:
             bibliotheca_fixture.api.bibliographic_lookup(identifier)
         assert "Got status code 500" in str(excinfo.value)
 
+    @pytest.mark.parametrize(
+        "content",
+        [
+            pytest.param(b"", id="empty"),
+            pytest.param(b"   \n  ", id="whitespace"),
+        ],
+    )
+    def test_bibliographic_lookup_empty_response_raises(
+        self,
+        content: bytes,
+        bibliotheca_fixture: BibliothecaAPITestFixture,
+    ):
+        # Bibliotheca occasionally returns an empty (or whitespace-only) HTTP
+        # 200 body. An empty document cannot be parsed as XML, and treating it
+        # as "no items returned" would make the circulation updater zero out
+        # every requested identifier. So bibliographic_lookup raises a transient
+        # RemoteInitiatedServerError instead of returning an empty list or
+        # letting lxml's "Document is empty" error propagate.
+        db = bibliotheca_fixture.db
+        bibliotheca_fixture.api.queue_response(200, content=content)
+        identifier = db.identifier()
+        with pytest.raises(RemoteInitiatedServerError) as excinfo:
+            bibliotheca_fixture.api.bibliographic_lookup(identifier)
+        assert "empty response body" in str(excinfo.value)
+        assert excinfo.value.service_name == bibliotheca_fixture.api.SERVICE_NAME
+
     def test_put_request(self, bibliotheca_fixture: BibliothecaAPITestFixture):
         # This is a basic test to make sure the method calls line up
         # right--there are more thorough tests in the circulation

--- a/tests/manager/integration/license/test_bibliotheca_circulation_updater.py
+++ b/tests/manager/integration/license/test_bibliotheca_circulation_updater.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from palace.manager.api.circulation.exceptions import RemoteInitiatedServerError
 from palace.manager.celery.tasks import apply
 from palace.manager.integration.license.bibliotheca import BibliothecaAPI
 from palace.manager.integration.license.bibliotheca_circulation_updater import (
@@ -220,6 +223,48 @@ class TestBibliothecaCirculationUpdaterUpdateBatch:
 
         assert pool.licenses_owned == 0
         assert pool.licenses_available == 0
+
+    def test_empty_api_response_does_not_zero_out_availability(
+        self, db: DatabaseTransactionFixture
+    ) -> None:
+        """A transient empty response must not be mistaken for "all titles removed".
+
+        When Bibliotheca returns an empty body, ``bibliographic_lookup`` raises
+        ``RemoteInitiatedServerError`` rather than an empty list (see
+        ``BibliothecaAPI.bibliographic_lookup``).  The error must propagate so the
+        Celery task retries, and the batch's availability must be left untouched —
+        the opposite of the not-mentioned case, where a zero-count is applied.
+        """
+        updater, mock_api = _make_updater(db)
+        collection = mock_api.collection
+
+        ident = db.identifier(
+            identifier_type=Identifier.BIBLIOTHECA_ID, foreign_id="keepme"
+        )
+        pool, _ = LicensePool.for_foreign_id(
+            db.session,
+            mock_api.data_source,
+            Identifier.BIBLIOTHECA_ID,
+            ident.identifier,
+            collection=collection,
+        )
+        pool.licenses_owned = 5
+        pool.licenses_available = 3
+        db.session.flush()
+
+        with patch.object(
+            BibliothecaAPI,
+            "bibliographic_lookup",
+            side_effect=RemoteInitiatedServerError(
+                "empty body", BibliothecaAPI.SERVICE_NAME
+            ),
+        ):
+            with pytest.raises(RemoteInitiatedServerError):
+                updater.update_batch(0)
+
+        # Availability is untouched — the book was NOT removed from circulation.
+        assert pool.licenses_owned == 5
+        assert pool.licenses_available == 3
 
     def test_needs_apply_true_queues_bibliographic_apply(
         self, db: DatabaseTransactionFixture


### PR DESCRIPTION
## Description

`BibliothecaAPI.bibliographic_lookup` now treats an empty (or whitespace-only) HTTP 200 response body as a transient remote error: it raises `RemoteInitiatedServerError` instead of letting lxml's `Document is empty` error propagate. The two Celery tasks whose `bibliographic_lookup` call sites lacked it — `circulation_update_collection` and `import_collection` — now retry `RemoteInitiatedServerError` and declare it expected, matching `import_purchase_records_by_collection` (#3475).

## Motivation and Context

JIRA (PP-4665)
Observed in production as an unhandled exception in `circulation_update_collection`:

```
lxml.etree.Error: Document is empty, line 1, column 1
  .../bibliotheca.py", line 335, in bibliographic_lookup
  .../util/xmlparser.py", line 90, in _load_xml
    return etree.parse(BytesIO(xml), parser)
```

Bibliotheca occasionally returns an HTTP 200 with an empty body — the same quirk already handled for MARC (#3476) and events (#3442). `bibliographic_lookup` was the last unguarded XML-parse path, so an empty body crashed the circulation sweep.

Crucially, an empty body must **not** be collapsed into "no items returned". `BibliothecaCirculationUpdater._process_batch` treats any identifier *absent* from the response as removed and zeroes out its availability. Returning `[]` on an empty body would therefore wipe out the availability of every identifier in the batch (or a single title on the on-demand `update_availability` path) on every transient glitch. Raising a transient error keeps "empty body" distinct from "a valid document that omits an identifier", so the work is retried rather than corrupting data.

`bibliographic_lookup` is shared by three tasks. `import_purchase_records_by_collection` already retried `RemoteInitiatedServerError` (#3475); this PR adds the same handling to `circulation_update_collection` and to `import_collection` (which calls `bibliographic_lookup` once per event). `RemoteInitiatedServerError` is a sibling of `RemoteIntegrationException` (both derive from `IntegrationException`), not a subclass, so it must be listed explicitly in both `autoretry_for` and `throws`.

Note on behavior: a *persistently* empty response will, after exhausting the 4 retries, fail that task run (logged as expected via `throws`, not as an unhandled exception) without advancing the chain — failing safe rather than corrupting availability. Transient empties are absorbed by the retries.

## How Has This Been Tested?

New tests (all passing):

- `test_bibliographic_lookup_empty_response_raises` — parametrized over empty and whitespace-only bodies; asserts `RemoteInitiatedServerError`.
- `test_empty_api_response_does_not_zero_out_availability` — asserts an empty response leaves a pool's `licenses_owned`/`licenses_available` untouched (the safety property).
- `test_remote_initiated_server_error_retried_and_expected` added to both `TestCirculationUpdateCollection` and `TestBibliothecaImportCollection` — assert membership in `autoretry_for`/`throws` and behavioral retry (1 initial + 4 retries).

Ran the full test files for every `bibliographic_lookup` caller and all Bibliotheca tasks:

```
tox -e py312-docker -- --no-cov \
  tests/manager/integration/license/test_bibliotheca.py \
  tests/manager/integration/license/test_bibliotheca_circulation_updater.py \
  tests/manager/integration/license/test_bibliotheca_importer.py \
  tests/manager/integration/license/test_bibliotheca_purchase_record_importer.py \
  tests/manager/celery/tasks/test_bibliotheca.py
# 170 passed
```

`mypy` clean on all changed files.

- I will test on minotaur before releasing in hotfix release to production.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
