### PR TITLE
Apply circulation-only updates during the Bibliotheca circulation sweep (PP-4666)

### DIFF
--- a/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
+++ b/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
@@ -159,8 +159,9 @@ class BibliothecaCirculationUpdater(LoggerMixin):
 
         Used by :meth:`~palace.manager.integration.license.bibliotheca.BibliothecaAPI.update_availability`
         and :class:`~palace.manager.scripts.availability.AvailabilityRefreshScript` for
-        on-demand single-title refreshes.  Applies the same hash-based deduplication
-        as :meth:`update_batch` so unchanged titles produce no database writes.
+        on-demand single-title refreshes.  Applies the same bibliographic- and
+        circulation-hash deduplication as :meth:`update_batch`, so titles whose
+        metadata and availability are both unchanged produce no database writes.
 
         Unlike the sweep (:meth:`update_batch`), changes are applied **synchronously**
         in the caller's session rather than queued as ``bibliographic_apply`` tasks, so
@@ -179,12 +180,17 @@ class BibliothecaCirculationUpdater(LoggerMixin):
         """Look up availability from Bibliotheca, apply changes, and zero out removed titles.
 
         For each :class:`~palace.manager.data_layer.bibliographic.BibliographicData`
-        returned by the API, applies the change when
+        returned by the API, applies the change when either
         :meth:`~palace.manager.data_layer.bibliographic.BibliographicData.needs_apply`
-        returns ``True`` (hash-based deduplication).  When ``synchronous`` is ``False``
-        (the sweep) the apply is queued as a ``bibliographic_apply`` Celery task; when
-        ``True`` (on-demand refreshes) it is applied directly in this session so the
-        result is immediately visible to the caller.
+        or :meth:`~palace.manager.data_layer.circulation.CirculationData.needs_apply`
+        returns ``True`` (hash-based deduplication).  The circulation check is
+        required because the bibliographic hash excludes circulation, so an
+        availability-only change is invisible to ``BibliographicData.needs_apply``
+        alone — the omission that previously caused circulation updates to be
+        dropped.  When ``synchronous`` is ``False`` (the sweep) the apply is queued
+        as a ``bibliographic_apply`` Celery task; when ``True`` (on-demand refreshes)
+        it is applied directly in this session so the result is immediately visible
+        to the caller.
 
         For identifiers the API does not return (indicating removed or expired
         licenses), calls

--- a/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
+++ b/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
@@ -212,7 +212,24 @@ class BibliothecaCirculationUpdater(LoggerMixin):
                     identifiers_by_bibliotheca_id[bibliotheca_id]
                 )
 
-            if bibliographic.needs_apply(self._session):
+            # Decide whether there is anything to apply. The circulation
+            # sweep exists to pick up *availability* changes, but
+            # BibliographicData.needs_apply() keys only on the bibliographic
+            # hash, which deliberately excludes circulation (see
+            # BibliographicData.fields_excluded_from_hash). Gating solely on it
+            # would silently drop availability-only updates for any title whose
+            # metadata is unchanged -- i.e. almost every title on almost every
+            # sweep. So we also consult CirculationData.needs_apply(), which
+            # checks the LicensePool hash (availability included). When either
+            # says yes we apply: for an unchanged-metadata title, apply() takes
+            # its circulation-only fallback and updates availability alone.
+            needs_apply = bibliographic.needs_apply(self._session) or (
+                bibliographic.circulation is not None
+                and bibliographic.circulation.needs_apply(
+                    self._session, self._collection
+                )
+            )
+            if needs_apply:
                 if synchronous:
                     # Apply in-band (mirrors the apply.bibliographic_apply task body)
                     # so the caller sees the updated availability in its own session.

--- a/tests/manager/integration/license/test_bibliotheca_circulation_updater.py
+++ b/tests/manager/integration/license/test_bibliotheca_circulation_updater.py
@@ -8,13 +8,18 @@ import pytest
 
 from palace.manager.api.circulation.exceptions import RemoteInitiatedServerError
 from palace.manager.celery.tasks import apply
+from palace.manager.data_layer.bibliographic import BibliographicData
+from palace.manager.data_layer.circulation import CirculationData
+from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.integration.license.bibliotheca import BibliothecaAPI
 from palace.manager.integration.license.bibliotheca_circulation_updater import (
     CIRCULATION_UPDATE_BATCH_SIZE,
     CIRCULATION_UPDATE_SERVICE_NAME,
     BibliothecaCirculationUpdater,
 )
+from palace.manager.sqlalchemy.constants import DataSourceConstants
 from palace.manager.sqlalchemy.model.coverage import Timestamp
+from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import LicensePool
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -299,10 +304,10 @@ class TestBibliothecaCirculationUpdaterUpdateBatch:
 
         mock_apply.delay.assert_called_once()
 
-    def test_needs_apply_false_does_not_queue_bibliographic_apply(
+    def test_no_changes_does_not_queue_bibliographic_apply(
         self, db: DatabaseTransactionFixture
     ) -> None:
-        """bibliographic_apply is not queued when needs_apply() returns False."""
+        """Nothing is queued when neither bibliographic nor circulation data changed."""
         updater, mock_api = _make_updater(db)
         collection = mock_api.collection
 
@@ -320,6 +325,7 @@ class TestBibliothecaCirculationUpdaterUpdateBatch:
 
         mock_bib = MagicMock()
         mock_bib.needs_apply.return_value = False
+        mock_bib.circulation.needs_apply.return_value = False
         mock_bib.primary_identifier_data.identifier = ident.identifier
 
         with (
@@ -331,6 +337,46 @@ class TestBibliothecaCirculationUpdaterUpdateBatch:
             updater.update_batch(0)
 
         mock_apply.delay.assert_not_called()
+
+    def test_circulation_change_queues_bibliographic_apply(
+        self, db: DatabaseTransactionFixture
+    ) -> None:
+        """A circulation-only change is queued even when metadata is unchanged.
+
+        Regression test: ``BibliographicData.needs_apply()`` excludes circulation
+        from its hash, so an availability-only change leaves it ``False``.  The
+        sweep must still dispatch, keyed on ``CirculationData.needs_apply()``.
+        """
+        updater, mock_api = _make_updater(db)
+        collection = mock_api.collection
+
+        ident = db.identifier(
+            identifier_type=Identifier.BIBLIOTHECA_ID, foreign_id="circchanged"
+        )
+        LicensePool.for_foreign_id(
+            db.session,
+            mock_api.data_source,
+            Identifier.BIBLIOTHECA_ID,
+            ident.identifier,
+            collection=collection,
+        )
+        db.session.flush()
+
+        mock_bib = MagicMock()
+        mock_bib.needs_apply.return_value = False
+        mock_bib.circulation.needs_apply.return_value = True
+        mock_bib.primary_identifier_data.identifier = ident.identifier
+
+        with (
+            patch.object(
+                BibliothecaAPI, "bibliographic_lookup", return_value=[mock_bib]
+            ),
+            patch.object(apply, "bibliographic_apply") as mock_apply,
+        ):
+            updater.update_batch(0)
+
+        mock_apply.delay.assert_called_once()
+        mock_bib.circulation.needs_apply.assert_called_once_with(db.session, collection)
 
 
 class TestBibliothecaCirculationUpdaterProcessIdentifiers:
@@ -399,10 +445,11 @@ class TestBibliothecaCirculationUpdaterProcessIdentifiers:
         assert mock_bib.apply.call_args.kwargs["create_coverage_record"] is False
         mock_apply.delay.assert_not_called()
 
-    def test_unchanged_title_is_not_applied(
+    def test_unchanged_title_and_circulation_is_not_applied(
         self, db: DatabaseTransactionFixture
     ) -> None:
-        """needs_apply() is honored on the synchronous path: no apply, no queue."""
+        """On the synchronous path, nothing is applied when neither bibliographic
+        nor circulation data changed."""
         updater, mock_api = _make_updater(db)
         collection = mock_api.collection
 
@@ -420,6 +467,7 @@ class TestBibliothecaCirculationUpdaterProcessIdentifiers:
 
         mock_bib = MagicMock()
         mock_bib.needs_apply.return_value = False
+        mock_bib.circulation.needs_apply.return_value = False
         mock_bib.primary_identifier_data.identifier = ident.identifier
 
         with (
@@ -432,3 +480,66 @@ class TestBibliothecaCirculationUpdaterProcessIdentifiers:
 
         mock_bib.apply.assert_not_called()
         mock_apply.delay.assert_not_called()
+
+    def test_circulation_applied_when_metadata_unchanged(
+        self, db: DatabaseTransactionFixture
+    ) -> None:
+        """Regression: availability updates land even when metadata is unchanged.
+
+        End-to-end proof that the sweep applies a circulation-only change. The
+        first lookup establishes the edition's bibliographic hash and the pool's
+        initial availability; the second carries identical metadata but fewer
+        available copies. Because ``BibliographicData``'s hash excludes
+        circulation, ``needs_apply()`` is ``False`` for the second lookup -- yet
+        the pool must still reflect the new availability.
+        """
+        updater, mock_api = _make_updater(db)
+        collection = mock_api.collection
+
+        edition, pool = db.edition(
+            identifier_type=Identifier.BIBLIOTHECA_ID,
+            data_source_name=DataSourceConstants.BIBLIOTHECA,
+            with_license_pool=True,
+            collection=collection,
+        )
+        bibliotheca_id = pool.identifier.identifier
+
+        def make_bib(owned: int, available: int) -> BibliographicData:
+            identifier_data = IdentifierData(
+                type=Identifier.BIBLIOTHECA_ID, identifier=bibliotheca_id
+            )
+            return BibliographicData(
+                data_source_name=DataSourceConstants.BIBLIOTHECA,
+                primary_identifier_data=identifier_data,
+                title="Unchanging Title",
+                medium=Edition.BOOK_MEDIUM,
+                circulation=CirculationData(
+                    data_source_name=DataSourceConstants.BIBLIOTHECA,
+                    primary_identifier_data=identifier_data,
+                    licenses_owned=owned,
+                    licenses_available=available,
+                    licenses_reserved=0,
+                    patrons_in_hold_queue=0,
+                ),
+            )
+
+        # First sweep: establishes the bibliographic hash and seeds availability.
+        with patch.object(
+            BibliothecaAPI, "bibliographic_lookup", return_value=[make_bib(5, 5)]
+        ):
+            updater.process_identifiers([pool.identifier])
+        assert pool.licenses_owned == 5
+        assert pool.licenses_available == 5
+
+        # Second sweep: identical metadata, so the bibliographic hash is unchanged...
+        second = make_bib(5, 0)
+        assert second.needs_apply(db.session) is False
+
+        # ...but the availability change must still be applied.
+        with patch.object(
+            BibliothecaAPI, "bibliographic_lookup", return_value=[second]
+        ):
+            updater.process_identifiers([pool.identifier])
+
+        assert pool.licenses_owned == 5
+        assert pool.licenses_available == 0


### PR DESCRIPTION
## Description

The Bibliotheca circulation sweep (`BibliothecaCirculationUpdater._process_batch`) gated its apply on `BibliographicData.needs_apply()`. That method hashes the bibliographic data, and `BibliographicData.fields_excluded_from_hash()` **deliberately excludes `circulation`**. So for any title whose metadata (title/author/cover/etc.) was unchanged — i.e. nearly every title on nearly every sweep — `needs_apply()` returned `False`, the `bibliographic_apply` task was never queued, and the fresh availability counts read from Bibliotheca were silently discarded. The sweep logged `handled N identifier(s)` with no failures while updating nothing.

The fix extends the gate to also consult `CirculationData.needs_apply(session, collection)`, which hashes the `LicensePool` (availability included). When only circulation changed, `BibliographicData.apply()` takes its existing circulation-only fallback and applies the availability alone.

```python
needs_apply = bibliographic.needs_apply(self._session) or (
    bibliographic.circulation is not None
    and bibliographic.circulation.needs_apply(self._session, self._collection)
)
```

## Motivation and Context

JIRA (PP-4666)
Bibliotheca availability stopped updating from the periodic circulation sweep: identifiers were processed 25 at a time with no errors, but copy/hold counts never changed in the database.

This is a regression introduced when the sweep was migrated to Celery in #3403. The previous `BibliothecaCirculationSweep` (an `IdentifierSweepMonitor`) called `bibliographic.apply()` **unconditionally** for every title the API returned, so `apply()`'s circulation-only fallback always ran. The Celery migration added a `needs_apply()` short-circuit as a dedup optimization, but keyed it on the bibliographic hash while it was guarding the circulation apply — the one field that hash excludes.

The fix preserves the skip-genuinely-unchanged optimization (it does not blindly fan out an apply task per identifier) while no longer being blind to availability changes. Both the async sweep path and the synchronous on-demand path (`process_identifiers` → `BibliothecaAPI.update_availability`) sat behind the same gate and are both fixed.

## How Has This Been Tested?

- Added `test_circulation_applied_when_metadata_unchanged` — an end-to-end regression test: it applies metadata once, then feeds a second lookup with identical metadata but fewer available copies, asserts `needs_apply()` is `False` for it (pinning the exact bug scenario), and asserts the pool availability still updates.
- Added `test_circulation_change_queues_bibliographic_apply` — covers the async/sweep path dispatching when only circulation changed.
- Updated the two pre-existing tests that encoded the broken behavior so they hold circulation unchanged too.
- Verified the regression tests **fail on the pre-fix code** (the end-to-end one left the pool stuck at `available=5` instead of `0`, matching the production symptom) and **pass with the fix**.
- Full local runs (against throwaway Postgres/Redis): all tests in `test_bibliotheca_circulation_updater.py` and `test_bibliotheca.py` (95) and the bibliotheca Celery task tests (47) pass. `mypy` clean; pre-commit hooks pass on the changed files.
- I will test on minotaur once merged.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
