### PR TITLE
Reconcile Bibliotheca circulation against live pool columns instead of the data hash (PP-4691)

### DIFF
--- a/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
+++ b/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
@@ -312,11 +312,29 @@ class BibliothecaCirculationUpdater(LoggerMixin):
         :attr:`~palace.manager.sqlalchemy.model.licensing.LicensePool.updated_at_data_hash`,
         which is not a reliable proxy for the current column values (see
         :meth:`_process_batch`).
+
+        A field the snapshot leaves unset (``None``) is treated as "no assertion" and
+        does not, on its own, count as a mismatch — mirroring
+        :meth:`~palace.manager.sqlalchemy.model.licensing.LicensePool.update_availability`,
+        which skips ``None`` values rather than writing them. (Bibliotheca always
+        populates every count and ``status``, so this only matters defensively.)
         """
         return (
-            circulation.licenses_owned == pool.licenses_owned
-            and circulation.licenses_available == pool.licenses_available
-            and circulation.licenses_reserved == pool.licenses_reserved
-            and circulation.patrons_in_hold_queue == pool.patrons_in_hold_queue
+            (
+                circulation.licenses_owned is None
+                or circulation.licenses_owned == pool.licenses_owned
+            )
+            and (
+                circulation.licenses_available is None
+                or circulation.licenses_available == pool.licenses_available
+            )
+            and (
+                circulation.licenses_reserved is None
+                or circulation.licenses_reserved == pool.licenses_reserved
+            )
+            and (
+                circulation.patrons_in_hold_queue is None
+                or circulation.patrons_in_hold_queue == pool.patrons_in_hold_queue
+            )
             and (circulation.status is None or circulation.status == pool.status)
         )

--- a/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
+++ b/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
@@ -166,8 +166,9 @@ class BibliothecaCirculationUpdater(LoggerMixin):
         metadata and availability are both unchanged produces no database writes.
 
         Unlike the sweep (:meth:`update_batch`), changes are applied **synchronously**
-        in the caller's session rather than queued as ``bibliographic_apply`` tasks, so
-        the updated availability is visible as soon as this method returns.  Callers such
+        in the caller's session rather than queued as ``bibliographic_apply`` /
+        ``circulation_apply`` tasks, so the updated availability is visible as soon as
+        this method returns.  Callers such
         as :meth:`~palace.manager.integration.license.bibliotheca.BibliothecaAPI.update_availability`
         rely on this — e.g. the circulation dispatcher reads ``LicensePool.licenses_available``
         immediately after requesting an availability refresh.

--- a/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
+++ b/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
@@ -12,6 +12,7 @@ from palace.util.datetime_helpers import utc_now
 from palace.util.log import LoggerMixin
 
 from palace.manager.celery.tasks import apply
+from palace.manager.data_layer.circulation import CirculationData
 from palace.manager.data_layer.policy.replacement import ReplacementPolicy
 from palace.manager.integration.license.bibliotheca import BibliothecaAPI
 from palace.manager.sqlalchemy.constants import DataSourceConstants
@@ -159,9 +160,10 @@ class BibliothecaCirculationUpdater(LoggerMixin):
 
         Used by :meth:`~palace.manager.integration.license.bibliotheca.BibliothecaAPI.update_availability`
         and :class:`~palace.manager.scripts.availability.AvailabilityRefreshScript` for
-        on-demand single-title refreshes.  Applies the same bibliographic- and
-        circulation-hash deduplication as :meth:`update_batch`, so titles whose
-        metadata and availability are both unchanged produce no database writes.
+        on-demand single-title refreshes.  Reconciles the same way as
+        :meth:`update_batch` — bibliographic metadata is hash-deduplicated and
+        availability is compared against the pool's live columns — so a title whose
+        metadata and availability are both unchanged produces no database writes.
 
         Unlike the sweep (:meth:`update_batch`), changes are applied **synchronously**
         in the caller's session rather than queued as ``bibliographic_apply`` tasks, so
@@ -179,27 +181,41 @@ class BibliothecaCirculationUpdater(LoggerMixin):
     ) -> None:
         """Look up availability from Bibliotheca, apply changes, and zero out removed titles.
 
-        For each :class:`~palace.manager.data_layer.bibliographic.BibliographicData`
-        returned by the API, applies the change when either
-        :meth:`~palace.manager.data_layer.bibliographic.BibliographicData.needs_apply`
-        or :meth:`~palace.manager.data_layer.circulation.CirculationData.needs_apply`
-        returns ``True`` (hash-based deduplication).  The circulation check is
-        required because the bibliographic hash excludes circulation, so an
-        availability-only change is invisible to ``BibliographicData.needs_apply``
-        alone — the omission that previously caused circulation updates to be
-        dropped.  When ``synchronous`` is ``False`` (the sweep) the apply is queued
-        as a ``bibliographic_apply`` Celery task; when ``True`` (on-demand refreshes)
-        it is applied directly in this session so the result is immediately visible
-        to the caller.
+        Each returned record is reconciled along two independent tracks:
+
+        - **Bibliographic metadata** is deduplicated with
+          :meth:`~palace.manager.data_layer.bibliographic.BibliographicData.needs_apply`
+          (hash based).  This is reliable because an ``Edition``'s content is only
+          ever written through ``apply``, so its stored hash stays in sync with it.
+          Unchanged metadata is skipped.
+
+        - **Circulation/availability** is reconciled against the ``LicensePool``'s
+          *live* column values — not its
+          :attr:`~palace.manager.sqlalchemy.model.licensing.LicensePool.updated_at_data_hash`.
+          That hash is only maintained by
+          :meth:`~palace.manager.data_layer.circulation.CirculationData.apply`,
+          whereas ``licenses_*`` are also mutated out of band — by the event
+          importer and by loan/hold operations via
+          :meth:`~palace.manager.sqlalchemy.model.licensing.LicensePool.update_availability`
+          and :meth:`~palace.manager.sqlalchemy.model.licensing.LicensePool.update_availability_from_delta`,
+          neither of which touches the hash.  A matching hash therefore does **not**
+          mean the columns are correct, and gating the sweep on it makes it skip the
+          very drift it exists to reconcile.  So we compare the snapshot to the
+          actual columns and, when they differ, apply with
+          ``even_if_not_apparently_updated=True`` to bypass the stale hash;
+          ``update_availability`` still writes and logs only genuine differences.
+
+        When ``synchronous`` is ``False`` (the sweep) applies are queued as
+        ``bibliographic_apply`` / ``circulation_apply`` Celery tasks; when ``True``
+        (on-demand refreshes) they are applied directly in this session so the
+        result is immediately visible to the caller.
 
         For identifiers the API does not return (indicating removed or expired
-        licenses), calls
-        :meth:`~palace.manager.sqlalchemy.model.licensing.LicensePool.update_availability`
-        with all-zero counts.
+        licenses), zeroes out the ``LicensePool``'s availability.
 
         :param identifiers: Identifiers to process.
         :param synchronous: When ``True``, apply changes in-band instead of queuing
-            asynchronous ``bibliographic_apply`` tasks.
+            asynchronous Celery tasks.
         """
         identifiers_by_bibliotheca_id: dict[str, Identifier] = {
             i.identifier: i for i in identifiers
@@ -213,34 +229,23 @@ class BibliothecaCirculationUpdater(LoggerMixin):
                 if bibliographic.primary_identifier_data
                 else None
             )
-            if bibliotheca_id and bibliotheca_id in identifiers_by_bibliotheca_id:
-                identifiers_not_mentioned.discard(
-                    identifiers_by_bibliotheca_id[bibliotheca_id]
-                )
-
-            # Decide whether there is anything to apply. The circulation
-            # sweep exists to pick up *availability* changes, but
-            # BibliographicData.needs_apply() keys only on the bibliographic
-            # hash, which deliberately excludes circulation (see
-            # BibliographicData.fields_excluded_from_hash). Gating solely on it
-            # would silently drop availability-only updates for any title whose
-            # metadata is unchanged -- i.e. almost every title on almost every
-            # sweep. So we also consult CirculationData.needs_apply(), which
-            # checks the LicensePool hash (availability included). When either
-            # says yes we apply: for an unchanged-metadata title, apply() takes
-            # its circulation-only fallback and updates availability alone.
-            needs_apply = bibliographic.needs_apply(self._session) or (
-                bibliographic.circulation is not None
-                and bibliographic.circulation.needs_apply(
-                    self._session, self._collection
-                )
+            identifier = (
+                identifiers_by_bibliotheca_id.get(bibliotheca_id)
+                if bibliotheca_id
+                else None
             )
-            if needs_apply:
+            if identifier is not None:
+                identifiers_not_mentioned.discard(identifier)
+
+            # Track 1 -- bibliographic metadata. Hash-based dedup is reliable
+            # here (an Edition is only ever written through apply()). Circulation
+            # is stripped off and handled separately below so that an unchanged
+            # title does not force a metadata re-apply every sweep.
+            if bibliographic.needs_apply(self._session):
+                metadata = bibliographic.model_copy(update={"circulation": None})
                 if synchronous:
-                    # Apply in-band (mirrors the apply.bibliographic_apply task body)
-                    # so the caller sees the updated availability in its own session.
-                    edition, _ = bibliographic.edition(self._session)
-                    bibliographic.apply(
+                    edition, _ = metadata.edition(self._session)
+                    metadata.apply(
                         self._session,
                         edition,
                         self._collection,
@@ -249,22 +254,69 @@ class BibliothecaCirculationUpdater(LoggerMixin):
                     )
                 else:
                     apply.bibliographic_apply.delay(
-                        bibliographic,
+                        metadata,
                         collection_id=self._collection.id,
                         replace=ReplacementPolicy.from_license_source(),
                     )
 
+            # Track 2 -- circulation/availability. Reconcile against the pool's
+            # LIVE columns rather than its updated_at_data_hash (see this method's
+            # docstring): the hash drifts from the columns because the event
+            # importer and loan/hold operations mutate licenses_* without updating
+            # it. When the snapshot differs from the columns we force the apply
+            # past the (possibly stale) hash with even_if_not_apparently_updated.
+            circulation = bibliographic.circulation
+            if identifier is not None and circulation is not None:
+                pool = self._license_pool_for(identifier)
+                if pool is None or not self._availability_matches_pool(
+                    circulation, pool
+                ):
+                    replace = ReplacementPolicy.from_license_source(
+                        even_if_not_apparently_updated=True
+                    )
+                    if synchronous:
+                        circulation.apply(self._session, self._collection, replace)
+                    else:
+                        apply.circulation_apply.delay(
+                            circulation,
+                            collection_id=self._collection.id,
+                            replace=replace,
+                        )
+
         now = utc_now()
         for identifier in identifiers_not_mentioned:
-            pools = [
-                lp
-                for lp in identifier.licensed_through
-                if lp.data_source.name == DataSourceConstants.BIBLIOTHECA
-                and lp.collection == self._collection
-            ]
-            if not pools:
+            pool = self._license_pool_for(identifier)
+            if pool is None:
                 continue
-            [pool] = pools
             if pool.licenses_owned > 0:
                 self.log.warning("Removing %s from circulation.", identifier.identifier)
             pool.update_availability(0, 0, 0, 0, as_of=now)
+
+    def _license_pool_for(self, identifier: Identifier) -> LicensePool | None:
+        """Return this collection's Bibliotheca ``LicensePool`` for ``identifier``, if any."""
+        pools = [
+            lp
+            for lp in identifier.licensed_through
+            if lp.data_source.name == DataSourceConstants.BIBLIOTHECA
+            and lp.collection == self._collection
+        ]
+        return pools[0] if pools else None
+
+    @staticmethod
+    def _availability_matches_pool(
+        circulation: CirculationData, pool: LicensePool
+    ) -> bool:
+        """Whether ``circulation`` already matches the pool's live availability columns.
+
+        Compared against the actual ``licenses_*`` / ``status`` columns rather than
+        :attr:`~palace.manager.sqlalchemy.model.licensing.LicensePool.updated_at_data_hash`,
+        which is not a reliable proxy for the current column values (see
+        :meth:`_process_batch`).
+        """
+        return (
+            circulation.licenses_owned == pool.licenses_owned
+            and circulation.licenses_available == pool.licenses_available
+            and circulation.licenses_reserved == pool.licenses_reserved
+            and circulation.patrons_in_hold_queue == pool.patrons_in_hold_queue
+            and (circulation.status is None or circulation.status == pool.status)
+        )

--- a/tests/manager/integration/license/test_bibliotheca_circulation_updater.py
+++ b/tests/manager/integration/license/test_bibliotheca_circulation_updater.py
@@ -21,7 +21,7 @@ from palace.manager.sqlalchemy.constants import DataSourceConstants
 from palace.manager.sqlalchemy.model.coverage import Timestamp
 from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.sqlalchemy.model.identifier import Identifier
-from palace.manager.sqlalchemy.model.licensing import LicensePool
+from palace.manager.sqlalchemy.model.licensing import LicensePool, LicensePoolStatus
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.mocks.bibliotheca import MockBibliothecaAPI
 
@@ -45,11 +45,19 @@ def _make_bib(
     reserved: int = 0,
     holds: int = 0,
     title: str = "Unchanging Title",
+    status: LicensePoolStatus | None = None,
 ) -> BibliographicData:
-    """Build a BibliographicData (with embedded circulation) for a Bibliotheca title."""
+    """Build a BibliographicData (with embedded circulation) for a Bibliotheca title.
+
+    ``status`` defaults to the production-shaped value (``ACTIVE`` when any copies are
+    owned, else ``EXHAUSTED``), matching ``ItemListParser._make_circulation_data`` so
+    the embedded circulation always carries a status the way real Bibliotheca data does.
+    """
     identifier_data = IdentifierData(
         type=Identifier.BIBLIOTHECA_ID, identifier=bibliotheca_id
     )
+    if status is None:
+        status = LicensePoolStatus.ACTIVE if owned > 0 else LicensePoolStatus.EXHAUSTED
     return BibliographicData(
         data_source_name=DataSourceConstants.BIBLIOTHECA,
         primary_identifier_data=identifier_data,
@@ -62,6 +70,7 @@ def _make_bib(
             licenses_available=available,
             licenses_reserved=reserved,
             patrons_in_hold_queue=holds,
+            status=status,
         ),
     )
 
@@ -391,27 +400,47 @@ class TestBibliothecaCirculationUpdaterUpdateBatch:
         mock_bib_apply.delay.assert_not_called()
         mock_circ_apply.delay.assert_not_called()
 
-    def test_availability_matches_pool_compares_live_columns(
+
+class TestBibliothecaCirculationUpdaterAvailabilityMatchesPool:
+    def test_compares_live_columns_and_status(
         self, db: DatabaseTransactionFixture
     ) -> None:
-        """_availability_matches_pool compares the snapshot against the pool columns."""
-        updater, _ = _make_updater(db)
-        pool = self._seed_imported_title(updater, db, 5, 3, title="Title A")
-        bibliotheca_id = pool.identifier.identifier
+        """_availability_matches_pool compares counts AND status against the live pool row."""
+        updater, mock_api = _make_updater(db)
+        ident = db.identifier(
+            identifier_type=Identifier.BIBLIOTHECA_ID, foreign_id="matcher"
+        )
+        pool, _ = LicensePool.for_foreign_id(
+            db.session,
+            mock_api.data_source,
+            Identifier.BIBLIOTHECA_ID,
+            ident.identifier,
+            collection=mock_api.collection,
+        )
+        pool.licenses_owned = 5
+        pool.licenses_available = 3
+        pool.licenses_reserved = 0
+        pool.patrons_in_hold_queue = 0
+        pool.status = LicensePoolStatus.ACTIVE
+        db.session.flush()
 
-        matching = _make_bib(bibliotheca_id, 5, 3).circulation
+        # All counts and status match the live row.
+        matching = _make_bib(ident.identifier, 5, 3).circulation
         assert matching is not None
         assert updater._availability_matches_pool(matching, pool) is True
 
-        for owned, available, reserved, holds in (
-            (4, 3, 0, 0),
-            (5, 2, 0, 0),
-            (5, 3, 1, 0),
-            (5, 3, 0, 1),
-        ):
-            differing = _make_bib(
-                bibliotheca_id, owned, available, reserved=reserved, holds=holds
-            ).circulation
+        # Each case differs from the pool in exactly one field -- including the
+        # status leg, which production Bibliotheca data always populates.
+        differing_circulations = [
+            _make_bib(ident.identifier, 4, 3).circulation,
+            _make_bib(ident.identifier, 5, 2).circulation,
+            _make_bib(ident.identifier, 5, 3, reserved=1).circulation,
+            _make_bib(ident.identifier, 5, 3, holds=1).circulation,
+            _make_bib(
+                ident.identifier, 5, 3, status=LicensePoolStatus.EXHAUSTED
+            ).circulation,
+        ]
+        for differing in differing_circulations:
             assert differing is not None
             assert updater._availability_matches_pool(differing, pool) is False
 

--- a/tests/manager/integration/license/test_bibliotheca_circulation_updater.py
+++ b/tests/manager/integration/license/test_bibliotheca_circulation_updater.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -35,6 +35,35 @@ def _make_updater(
     mock_api = api or MockBibliothecaAPI(db.session, collection)
     updater = BibliothecaCirculationUpdater(db.session, collection, api=mock_api)
     return updater, mock_api
+
+
+def _make_bib(
+    bibliotheca_id: str,
+    owned: int,
+    available: int,
+    *,
+    reserved: int = 0,
+    holds: int = 0,
+    title: str = "Unchanging Title",
+) -> BibliographicData:
+    """Build a BibliographicData (with embedded circulation) for a Bibliotheca title."""
+    identifier_data = IdentifierData(
+        type=Identifier.BIBLIOTHECA_ID, identifier=bibliotheca_id
+    )
+    return BibliographicData(
+        data_source_name=DataSourceConstants.BIBLIOTHECA,
+        primary_identifier_data=identifier_data,
+        title=title,
+        medium=Edition.BOOK_MEDIUM,
+        circulation=CirculationData(
+            data_source_name=DataSourceConstants.BIBLIOTHECA,
+            primary_identifier_data=identifier_data,
+            licenses_owned=owned,
+            licenses_available=available,
+            licenses_reserved=reserved,
+            patrons_in_hold_queue=holds,
+        ),
+    )
 
 
 class TestBibliothecaCirculationUpdaterGetOffset:
@@ -271,112 +300,120 @@ class TestBibliothecaCirculationUpdaterUpdateBatch:
         assert pool.licenses_owned == 5
         assert pool.licenses_available == 3
 
-    def test_needs_apply_true_queues_bibliographic_apply(
+    def _seed_imported_title(
+        self,
+        updater: BibliothecaCirculationUpdater,
+        db: DatabaseTransactionFixture,
+        owned: int,
+        available: int,
+        *,
+        title: str = "Unchanging Title",
+    ) -> LicensePool:
+        """Import a title to a known state (edition hash + pool columns established)."""
+        edition, pool = db.edition(
+            identifier_type=Identifier.BIBLIOTHECA_ID,
+            data_source_name=DataSourceConstants.BIBLIOTHECA,
+            with_license_pool=True,
+            collection=updater._collection,
+        )
+        seed = _make_bib(pool.identifier.identifier, owned, available, title=title)
+        with patch.object(BibliothecaAPI, "bibliographic_lookup", return_value=[seed]):
+            updater.process_identifiers([pool.identifier])
+        return pool
+
+    def test_metadata_change_queues_bibliographic_apply_only(
         self, db: DatabaseTransactionFixture
     ) -> None:
-        """bibliographic_apply is queued when needs_apply() returns True."""
-        updater, mock_api = _make_updater(db)
-        collection = mock_api.collection
+        """A metadata-only change queues bibliographic_apply (circulation stripped)."""
+        updater, _ = _make_updater(db)
+        pool = self._seed_imported_title(updater, db, 5, 5, title="Title A")
+        bibliotheca_id = pool.identifier.identifier
 
-        ident = db.identifier(
-            identifier_type=Identifier.BIBLIOTHECA_ID, foreign_id="applytest"
-        )
-        LicensePool.for_foreign_id(
-            db.session,
-            mock_api.data_source,
-            Identifier.BIBLIOTHECA_ID,
-            ident.identifier,
-            collection=collection,
-        )
-        db.session.flush()
-
-        mock_bib = MagicMock()
-        mock_bib.needs_apply.return_value = True
-        mock_bib.primary_identifier_data.identifier = ident.identifier
-
+        # Metadata changes; availability is identical to the live columns.
+        changed = _make_bib(bibliotheca_id, 5, 5, title="Title B")
         with (
             patch.object(
-                BibliothecaAPI, "bibliographic_lookup", return_value=[mock_bib]
+                BibliothecaAPI, "bibliographic_lookup", return_value=[changed]
             ),
-            patch.object(apply, "bibliographic_apply") as mock_apply,
+            patch.object(apply, "bibliographic_apply") as mock_bib_apply,
+            patch.object(apply, "circulation_apply") as mock_circ_apply,
         ):
             updater.update_batch(0)
 
-        mock_apply.delay.assert_called_once()
+        mock_bib_apply.delay.assert_called_once()
+        # Circulation is handled on its own track, so it is stripped from the
+        # bibliographic payload to avoid a redundant (hash-gated) apply.
+        dispatched = mock_bib_apply.delay.call_args.args[0]
+        assert dispatched.circulation is None
+        mock_circ_apply.delay.assert_not_called()
 
-    def test_no_changes_does_not_queue_bibliographic_apply(
+    def test_availability_change_queues_circulation_apply_only(
         self, db: DatabaseTransactionFixture
     ) -> None:
-        """Nothing is queued when neither bibliographic nor circulation data changed."""
-        updater, mock_api = _make_updater(db)
-        collection = mock_api.collection
+        """An availability change queues circulation_apply with a force-apply policy."""
+        updater, _ = _make_updater(db)
+        pool = self._seed_imported_title(updater, db, 5, 5, title="Title A")
+        bibliotheca_id = pool.identifier.identifier
 
-        ident = db.identifier(
-            identifier_type=Identifier.BIBLIOTHECA_ID, foreign_id="noapply"
-        )
-        LicensePool.for_foreign_id(
-            db.session,
-            mock_api.data_source,
-            Identifier.BIBLIOTHECA_ID,
-            ident.identifier,
-            collection=collection,
-        )
-        db.session.flush()
-
-        mock_bib = MagicMock()
-        mock_bib.needs_apply.return_value = False
-        mock_bib.circulation.needs_apply.return_value = False
-        mock_bib.primary_identifier_data.identifier = ident.identifier
-
+        # Availability changes; metadata is identical.
+        changed = _make_bib(bibliotheca_id, 5, 2, title="Title A")
         with (
             patch.object(
-                BibliothecaAPI, "bibliographic_lookup", return_value=[mock_bib]
+                BibliothecaAPI, "bibliographic_lookup", return_value=[changed]
             ),
-            patch.object(apply, "bibliographic_apply") as mock_apply,
+            patch.object(apply, "bibliographic_apply") as mock_bib_apply,
+            patch.object(apply, "circulation_apply") as mock_circ_apply,
         ):
             updater.update_batch(0)
 
-        mock_apply.delay.assert_not_called()
+        mock_bib_apply.delay.assert_not_called()
+        mock_circ_apply.delay.assert_called_once()
+        dispatched_circ = mock_circ_apply.delay.call_args.args[0]
+        assert dispatched_circ.licenses_available == 2
+        # The apply is forced so the (possibly stale) pool hash cannot block it.
+        replace = mock_circ_apply.delay.call_args.kwargs["replace"]
+        assert replace.even_if_not_apparently_updated is True
 
-    def test_circulation_change_queues_bibliographic_apply(
-        self, db: DatabaseTransactionFixture
-    ) -> None:
-        """A circulation-only change is queued even when metadata is unchanged.
+    def test_no_change_queues_nothing(self, db: DatabaseTransactionFixture) -> None:
+        """Nothing is queued when both metadata and availability match the pool."""
+        updater, _ = _make_updater(db)
+        pool = self._seed_imported_title(updater, db, 5, 5, title="Title A")
+        bibliotheca_id = pool.identifier.identifier
 
-        Regression test: ``BibliographicData.needs_apply()`` excludes circulation
-        from its hash, so an availability-only change leaves it ``False``.  The
-        sweep must still dispatch, keyed on ``CirculationData.needs_apply()``.
-        """
-        updater, mock_api = _make_updater(db)
-        collection = mock_api.collection
-
-        ident = db.identifier(
-            identifier_type=Identifier.BIBLIOTHECA_ID, foreign_id="circchanged"
-        )
-        LicensePool.for_foreign_id(
-            db.session,
-            mock_api.data_source,
-            Identifier.BIBLIOTHECA_ID,
-            ident.identifier,
-            collection=collection,
-        )
-        db.session.flush()
-
-        mock_bib = MagicMock()
-        mock_bib.needs_apply.return_value = False
-        mock_bib.circulation.needs_apply.return_value = True
-        mock_bib.primary_identifier_data.identifier = ident.identifier
-
+        same = _make_bib(bibliotheca_id, 5, 5, title="Title A")
         with (
-            patch.object(
-                BibliothecaAPI, "bibliographic_lookup", return_value=[mock_bib]
-            ),
-            patch.object(apply, "bibliographic_apply") as mock_apply,
+            patch.object(BibliothecaAPI, "bibliographic_lookup", return_value=[same]),
+            patch.object(apply, "bibliographic_apply") as mock_bib_apply,
+            patch.object(apply, "circulation_apply") as mock_circ_apply,
         ):
             updater.update_batch(0)
 
-        mock_apply.delay.assert_called_once()
-        mock_bib.circulation.needs_apply.assert_called_once_with(db.session, collection)
+        mock_bib_apply.delay.assert_not_called()
+        mock_circ_apply.delay.assert_not_called()
+
+    def test_availability_matches_pool_compares_live_columns(
+        self, db: DatabaseTransactionFixture
+    ) -> None:
+        """_availability_matches_pool compares the snapshot against the pool columns."""
+        updater, _ = _make_updater(db)
+        pool = self._seed_imported_title(updater, db, 5, 3, title="Title A")
+        bibliotheca_id = pool.identifier.identifier
+
+        matching = _make_bib(bibliotheca_id, 5, 3).circulation
+        assert matching is not None
+        assert updater._availability_matches_pool(matching, pool) is True
+
+        for owned, available, reserved, holds in (
+            (4, 3, 0, 0),
+            (5, 2, 0, 0),
+            (5, 3, 1, 0),
+            (5, 3, 0, 1),
+        ):
+            differing = _make_bib(
+                bibliotheca_id, owned, available, reserved=reserved, holds=holds
+            ).circulation
+            assert differing is not None
+            assert updater._availability_matches_pool(differing, pool) is False
 
 
 class TestBibliothecaCirculationUpdaterProcessIdentifiers:
@@ -408,78 +445,90 @@ class TestBibliothecaCirculationUpdaterProcessIdentifiers:
         )
         assert ts is None
 
-    def test_changed_title_applied_synchronously(
+    def test_changed_metadata_applied_synchronously(
         self, db: DatabaseTransactionFixture
     ) -> None:
-        """On the on-demand path, a changed title is applied in-band, not queued."""
-        updater, mock_api = _make_updater(db)
-        collection = mock_api.collection
-
-        ident = db.identifier(
-            identifier_type=Identifier.BIBLIOTHECA_ID, foreign_id="syncapply"
+        """On the on-demand path, a metadata change is applied in-band, not queued."""
+        updater, _ = _make_updater(db)
+        edition, pool = db.edition(
+            identifier_type=Identifier.BIBLIOTHECA_ID,
+            data_source_name=DataSourceConstants.BIBLIOTHECA,
+            with_license_pool=True,
+            collection=updater._collection,
         )
-        LicensePool.for_foreign_id(
-            db.session,
-            mock_api.data_source,
-            Identifier.BIBLIOTHECA_ID,
-            ident.identifier,
-            collection=collection,
-        )
-        db.session.flush()
+        bibliotheca_id = pool.identifier.identifier
 
-        mock_bib = MagicMock()
-        mock_bib.needs_apply.return_value = True
-        mock_bib.primary_identifier_data.identifier = ident.identifier
-        mock_bib.edition.return_value = (MagicMock(), False)
-
+        changed = _make_bib(bibliotheca_id, 5, 5, title="A Brand New Title")
         with (
             patch.object(
-                BibliothecaAPI, "bibliographic_lookup", return_value=[mock_bib]
+                BibliothecaAPI, "bibliographic_lookup", return_value=[changed]
             ),
-            patch.object(apply, "bibliographic_apply") as mock_apply,
+            patch.object(apply, "bibliographic_apply") as mock_bib_apply,
+            patch.object(apply, "circulation_apply") as mock_circ_apply,
         ):
-            updater.process_identifiers([ident])
+            updater.process_identifiers([pool.identifier])
 
-        # The change was applied synchronously, not dispatched to a worker.
-        mock_bib.apply.assert_called_once()
-        assert mock_bib.apply.call_args.kwargs["create_coverage_record"] is False
-        mock_apply.delay.assert_not_called()
+        # Applied in-band: the edition reflects the new title and no task was queued.
+        assert edition.title == "A Brand New Title"
+        assert pool.licenses_available == 5
+        mock_bib_apply.delay.assert_not_called()
+        mock_circ_apply.delay.assert_not_called()
 
-    def test_unchanged_title_and_circulation_is_not_applied(
+    def test_sweep_reconciles_drift_when_hash_is_stale(
         self, db: DatabaseTransactionFixture
     ) -> None:
-        """On the synchronous path, nothing is applied when neither bibliographic
-        nor circulation data changed."""
+        """Regression: the sweep corrects availability even when the pool's
+        ``updated_at_data_hash`` already matches the snapshot.
+
+        The event importer and loan/hold operations mutate ``licenses_*`` via
+        ``update_availability`` *without* updating ``updated_at_data_hash``, so the
+        hash can match the distributor snapshot while the columns have drifted. A
+        hash-based dedup (the previous behaviour) would skip; the sweep must instead
+        reconcile against the live columns.
+        """
         updater, mock_api = _make_updater(db)
         collection = mock_api.collection
-
-        ident = db.identifier(
-            identifier_type=Identifier.BIBLIOTHECA_ID, foreign_id="syncnoapply"
-        )
-        LicensePool.for_foreign_id(
-            db.session,
-            mock_api.data_source,
-            Identifier.BIBLIOTHECA_ID,
-            ident.identifier,
+        edition, pool = db.edition(
+            identifier_type=Identifier.BIBLIOTHECA_ID,
+            data_source_name=DataSourceConstants.BIBLIOTHECA,
+            with_license_pool=True,
             collection=collection,
         )
-        db.session.flush()
+        bibliotheca_id = pool.identifier.identifier
 
-        mock_bib = MagicMock()
-        mock_bib.needs_apply.return_value = False
-        mock_bib.circulation.needs_apply.return_value = False
-        mock_bib.primary_identifier_data.identifier = ident.identifier
-
-        with (
-            patch.object(
-                BibliothecaAPI, "bibliographic_lookup", return_value=[mock_bib]
-            ),
-            patch.object(apply, "bibliographic_apply") as mock_apply,
+        # Seed: apply the snapshot (5, 5). Columns and updated_at_data_hash now
+        # both reflect (5, 5).
+        with patch.object(
+            BibliothecaAPI,
+            "bibliographic_lookup",
+            return_value=[_make_bib(bibliotheca_id, 5, 5)],
         ):
-            updater.process_identifiers([ident])
+            updater.process_identifiers([pool.identifier])
+        assert pool.licenses_available == 5
+        stale_hash = pool.updated_at_data_hash
+        assert stale_hash is not None
 
-        mock_bib.apply.assert_not_called()
-        mock_apply.delay.assert_not_called()
+        # Simulate event-importer drift: a checkout changes the columns via
+        # update_availability, which does NOT touch updated_at_data_hash.
+        pool.update_availability(5, 2, 0, 0)
+        db.session.flush()
+        assert pool.licenses_available == 2
+        assert pool.updated_at_data_hash == stale_hash  # hash is now stale
+
+        # Bibliotheca's authoritative snapshot is (5, 5) again. Its circulation
+        # hash equals the stored (stale) hash, so the old hash-based check would
+        # NOT fire -- assert that precondition explicitly.
+        reconcile = _make_bib(bibliotheca_id, 5, 5)
+        assert reconcile.circulation is not None
+        assert reconcile.circulation.needs_apply(db.session, collection) is False
+
+        with patch.object(
+            BibliothecaAPI, "bibliographic_lookup", return_value=[reconcile]
+        ):
+            updater.process_identifiers([pool.identifier])
+
+        # Reconciled against the live columns: availability is restored.
+        assert pool.licenses_available == 5
 
     def test_circulation_applied_when_metadata_unchanged(
         self, db: DatabaseTransactionFixture
@@ -493,46 +542,27 @@ class TestBibliothecaCirculationUpdaterProcessIdentifiers:
         circulation, ``needs_apply()`` is ``False`` for the second lookup -- yet
         the pool must still reflect the new availability.
         """
-        updater, mock_api = _make_updater(db)
-        collection = mock_api.collection
-
+        updater, _ = _make_updater(db)
         edition, pool = db.edition(
             identifier_type=Identifier.BIBLIOTHECA_ID,
             data_source_name=DataSourceConstants.BIBLIOTHECA,
             with_license_pool=True,
-            collection=collection,
+            collection=updater._collection,
         )
         bibliotheca_id = pool.identifier.identifier
 
-        def make_bib(owned: int, available: int) -> BibliographicData:
-            identifier_data = IdentifierData(
-                type=Identifier.BIBLIOTHECA_ID, identifier=bibliotheca_id
-            )
-            return BibliographicData(
-                data_source_name=DataSourceConstants.BIBLIOTHECA,
-                primary_identifier_data=identifier_data,
-                title="Unchanging Title",
-                medium=Edition.BOOK_MEDIUM,
-                circulation=CirculationData(
-                    data_source_name=DataSourceConstants.BIBLIOTHECA,
-                    primary_identifier_data=identifier_data,
-                    licenses_owned=owned,
-                    licenses_available=available,
-                    licenses_reserved=0,
-                    patrons_in_hold_queue=0,
-                ),
-            )
-
         # First sweep: establishes the bibliographic hash and seeds availability.
         with patch.object(
-            BibliothecaAPI, "bibliographic_lookup", return_value=[make_bib(5, 5)]
+            BibliothecaAPI,
+            "bibliographic_lookup",
+            return_value=[_make_bib(bibliotheca_id, 5, 5)],
         ):
             updater.process_identifiers([pool.identifier])
         assert pool.licenses_owned == 5
         assert pool.licenses_available == 5
 
         # Second sweep: identical metadata, so the bibliographic hash is unchanged...
-        second = make_bib(5, 0)
+        second = _make_bib(bibliotheca_id, 5, 0)
         assert second.needs_apply(db.session) is False
 
         # ...but the availability change must still be applied.


### PR DESCRIPTION
## Description

The Bibliotheca circulation sweep decided whether to write a `LicensePool`'s availability by
comparing the incoming snapshot's hash against the pool's stored `updated_at_data_hash`. That
hash is **not** a reliable proxy for the live availability columns, so the sweep skipped real
updates and Bibliotheca availability stopped syncing.

This change makes the sweep reconcile **circulation against the pool's live column values**
(`licenses_owned/available/reserved`, `patrons_in_hold_queue`, `status`) rather than the hash,
and forces the apply past the (possibly stale) hash with `even_if_not_apparently_updated=True`.
Bibliographic **metadata** keeps its hash-based dedup (that hash *is* reliable — an `Edition` is
only ever written through `apply()`), dispatched separately so unchanged metadata is not
re-applied every sweep.

This is a follow-up to #3510 (PP-4666), which was necessary but not sufficient — see below.

## Motivation and Context
JIRA (PP-4691)
### Symptom

Bibliotheca availability was not updating from the circulation sweep. Identifiers were processed
25 at a time with no errors, but copy/hold counts never changed. The only workaround was manually
setting `license_pools.updated_at_data_hash = NULL` for Bibliotheca pools before running the sweep.

### Root cause: the hash drifts away from the columns

`LicensePool.updated_at_data_hash` is written in exactly **one** place — `CirculationData.apply()`.
But the availability **columns** are also mutated out of band, without touching the hash, by:

- the **Bibliotheca event importer** (runs every few minutes), which applies checkout/checkin/hold
  events via `LicensePool.update_availability_from_delta()` → `update_availability()`, and
- **loan/hold** operations via `update_availability()`.

So the hash freezes at the last full-snapshot apply while the columns keep moving. When
Bibliotheca's current snapshot hashes equal to that frozen value — common — `should_apply_to(pool)`
returns `False` and the sweep skips, even though the columns have drifted. Nulling the hash is
exactly the escape hatch, which is why the manual workaround worked.

Note this is *by design* for the deltas: the event importer's own docstring says its data is
"unlikely to be completely accurate." The sweep's whole purpose is to reconcile that drift against
Bibliotheca's authoritative snapshot — and the stale hash was blinding it to the very drift it
exists to fix.

### Why #3510 didn't fully fix it

#3510 added a circulation gate to the sweep, but keyed it on `CirculationData.needs_apply()` —
which *is* that same hash comparison. It only helped when the hash differed; it did not help the
common case where the hash matches but the columns have drifted.

### Why Bibliotheca specifically (and not OPDS/ODL)

The bug needs three ingredients together: (1) an out-of-band writer of the availability columns
that doesn't stamp the hash, (2) that writer being *approximate* so a correction pass is genuinely
needed, and (3) the correction being a hash-gated reconciliation against a remote snapshot. Only
Bibliotheca has all three.

- **Pure OPDS** lacks (1): `OPDSAPI.update_availability` is a no-op; only the feed import writes
  availability, and it stamps the hash. One writer ⟹ the hash can't desync.
- **ODL** has out-of-band writers (loans/holds/expiration via `update_availability_from_licenses`)
  but lacks (2)/(3): those writes compute the *authoritative* counts from local license/hold state,
  ODL counts never come from a remote snapshot (the feed sets `licenses_owned/available = None`),
  and the OPDS importer already refuses to trust the hash for ODL circulation
  ("license expiry is time-dependent and undetectable by hashing").

In other words, the codebase's existing answer to "availability can change out of band" is *don't
gate it on the hash* — ODL already does this. This PR brings Bibliotheca's sweep in line with that
stance.

## Alternatives considered

**A. Reconcile against the live columns (this PR).** Compare the snapshot to the actual columns;
apply (forced) only when they differ. Localized to the Bibliotheca updater; needs no migration
(it ignores the stale hash entirely, so the next sweep self-heals); precise (skips net-zero churn).

**B. Recompute the hash whenever `update_availability(_from_delta)` changes the columns.** This
would also be correct, but it computes the same "did availability change?" decision indirectly, and
the recompute is fragile: the stored hash is a hash of the incoming `CirculationData` *wire object*
(counts **plus** `formats`, `status`, `type`, `default_rights_uri`, identifier, …), not of the pool.
To produce a *matching* hash, the delta path would have to rebuild that exact object from DB state
and serialize it byte-identically — there is no `CirculationData.from_license_pool()`, the delta
path doesn't have the source's `formats`, and `update_availability` is a generic method shared by
every distributor (each with a differently-shaped `CirculationData`). Getting any field wrong flips
the failure from "skips too much" (visible) to "re-applies everything every run" (silent).

**C. Invalidate (null) the hash on any out-of-band column change.** The tractable cousin of B — no
reconstruction needed. But it touches the shared hot path for *all* distributors, re-applies every
active title every sweep (even net-zero churn that A skips), and still requires the one-time
"null all existing hashes" migration to fix already-drifted pools.

**D. Canonical-state dedup refactor.** Compute the circulation dedup hash from the pool's canonical
state instead of the wire object, uniformly across distributors. This is the "right" long-term shape
if we want one mechanism everywhere, but it's a deliberate, separately-tested refactor with a
migration — not a hotfix.

### Rationale for choosing A

A and B/D make the **same** apply/skip decision (apply ⟺ the snapshot differs from the columns); A
just computes it directly instead of through a maintained-hash detour. Given that, A wins on every
axis that matters for this fix:

- **Blast radius**: touches only the Bibliotheca updater, not `update_availability`'s ~20 call
  sites across every distributor.
- **No migration**: it never consults the stale hash, so existing drift self-heals on the next
  sweep — nothing to reset.
- **Precision**: skips titles whose net availability is unchanged, which C would re-apply.
- **Consistency**: matches ODL's existing "don't trust the hash for availability" stance.

The cost is a narrow completeness gap — A compares counts + status, not the other hashed fields
(`formats`, `type`, …) — which is effectively moot for Bibliotheca (no circulation links/licenses,
`type` always METERED, `status` is compared, EPUB/EPUB3 formats collapse to identical `FormatData`)
and can be widened later if needed.

We are deliberately **deferring** the broader canonical-state refactor (D). It's the cleaner uniform
solution, but it's a larger, migration-bearing change that should be done on its own, not folded into
this fix.

## How Has This Been Tested?

- Added `test_sweep_reconciles_drift_when_hash_is_stale`, an end-to-end regression for the exact
  reported scenario: apply (5,5), drift the columns to (5,2) via `update_availability` (no hash
  change), then feed the authoritative (5,5) snapshot whose hash *matches* the stored one. It
  asserts the precondition (`needs_apply(...) is False`) and that the sweep still restores the
  columns. **Fails on the hash-gate, passes now.**
- Converted the dispatch tests to real data and added coverage for the two-track behaviour
  (metadata-only → `bibliographic_apply`; availability-only → `circulation_apply` with the
  force-apply policy; no-change → nothing) and for `_availability_matches_pool`.
- Full local runs (throwaway Postgres/Redis): the updater suite plus `test_bibliotheca.py` and the
  Bibliotheca Celery task tests pass. `mypy` and pre-commit clean.
- On minotaur I updated the Biblotheca licensepools.licenses_available to 0 and then ran the bibliotheca_circulation_update script.  I verified that the count went from 0 to the expected 71.
## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
