### PR TITLE
Support parallel test runs in external-schema mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,11 +778,13 @@ to create and drop databases, the tests will fail. You can disable this behavior
 `PALACE_TEST_DATABASE_CREATE_DATABASE` environment variable to `false`.
 
 Setting `PALACE_TEST_DATABASE_EXTERNAL_SCHEMA` to `true` tells the tests that the schema has already
-been applied to the provided database, so the fixtures use it as-is, without dropping and recreating the
-schema from the current models. Because the database is used as-is, you must also set
-`PALACE_TEST_DATABASE_CREATE_DATABASE` to `false` — the two settings must agree, or the tests will raise
-an error — which also means the tests must be run serially. This is used by the backwards-compatibility
-CI check, which runs a previous release's tests against a schema built by the current code.
+been applied to the provided database (by the current code), so the fixtures use that schema as-is,
+without dropping and recreating it from the current models. With database creation left enabled (the
+default), each worker clones the provided database as a template into its own per-worker database, so
+the suite can still run in parallel. If you additionally set `PALACE_TEST_DATABASE_CREATE_DATABASE` to
+`false`, the provided database is used directly, which requires the tests to be run serially. This is
+used by the backwards-compatibility CI check, which runs a previous release's tests against a schema
+built by the current code.
 
 ### Override `pytest` Arguments
 

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -220,6 +220,17 @@ class DatabaseCreationFixture:
                 "This is not supported. Please enable database creation or run tests in serial mode."
             )
         self._config_url = make_url(config.url)
+        # In external-schema mode each worker clones the configured database as a template
+        # (see _create_db), so the URL must name a database to clone from.
+        if (
+            self.external_schema
+            and self.create_database
+            and self._config_url.database is None
+        ):
+            raise BasePalaceException(
+                "External schema mode requires the configured database URL to name a "
+                "database to use as the clone template."
+            )
 
     @cached_property
     def database_name(self) -> str:

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -180,11 +180,14 @@ def function_test_id(worker_id: str) -> IdFixture:
 class DatabaseTestConfiguration(FixtureTestUrlConfiguration):
     url: PostgresDsn
     create_database: bool = True
-    # When set, the database schema is assumed to have been applied
-    # externally before the tests run, so the fixtures use the database as-is instead of
-    # dropping and recreating the schema from the current models. This is used by the
-    # backwards-compatibility CI check, which runs a previous release's test suite against a
-    # schema built by the current code.
+    # When set, the schema is assumed to have been built externally (by the current code) in
+    # the configured database before the tests run. The fixtures then use that schema as-is
+    # rather than dropping and recreating it from the current models. With create_database
+    # enabled (the default), each worker clones the configured database as a template into
+    # its own per-worker database, so the suite can still run in parallel; with
+    # create_database disabled, the configured database is used directly and the suite must
+    # run serially. This is used by the backwards-compatibility CI check, which runs a
+    # previous release's test suite against a schema built by the current code.
     external_schema: bool = False
     model_config = SettingsConfigDict(env_prefix="PALACE_TEST_DATABASE_")
 
@@ -207,14 +210,10 @@ class DatabaseCreationFixture:
         config = DatabaseTestConfiguration.from_env()
         self.external_schema = config.external_schema
         self.create_database = config.create_database
-        # External-schema mode uses the provided database and its schema as-is, so it is
-        # incompatible with creating a fresh database. Require the two settings to agree
-        # explicitly rather than silently overriding create_database.
-        if self.external_schema and self.create_database:
-            raise BasePalaceException(
-                "External schema mode (PALACE_TEST_DATABASE_EXTERNAL_SCHEMA) cannot create a "
-                "database. Set PALACE_TEST_DATABASE_CREATE_DATABASE=false to use the database as-is."
-            )
+        # When database creation is disabled the configured database is used directly, so
+        # every worker would share it -- that only works serially. (External-schema mode with
+        # database creation enabled avoids this by cloning the configured database into a
+        # per-worker database; see _create_db.)
         if not self.create_database and self.test_id.parallel:
             raise BasePalaceException(
                 "Database creation is disabled, but tests are running in parallel mode. "
@@ -251,13 +250,17 @@ class DatabaseCreationFixture:
     def _db_connection(self) -> Generator[Connection]:
         """
         Databases need to be created and dropped outside a transaction. This method
-        provides a connection to database URL provided in the configuration that is not
-        wrapped in a transaction.
+        provides a connection to the server's maintenance database that is not wrapped in a
+        transaction.
+
+        We connect to the maintenance database (``postgres``) rather than the configured
+        database because ``CREATE DATABASE ... TEMPLATE`` requires that nothing is connected
+        to the template, and CREATE/DROP DATABASE are cluster-level commands that work from
+        any database.
         """
 
-        engine = create_engine(
-            self._config_url, isolation_level="AUTOCOMMIT", future=True
-        )
+        admin_url = self._config_url.set(database="postgres")
+        engine = create_engine(admin_url, isolation_level="AUTOCOMMIT", future=True)
         connection = engine.connect()
         try:
             yield connection
@@ -271,7 +274,19 @@ class DatabaseCreationFixture:
 
         with self._db_connection() as connection, connection.begin():
             user = self._config_url.username
-            connection.execute(text(f"CREATE DATABASE {self.database_name}"))
+            if self.external_schema:
+                # Clone the externally-built schema (and seed data) into this worker's
+                # database, using the configured database as a template. This lets the tests
+                # run against the schema the current code produced while still giving each
+                # worker its own isolated database, so the suite can run in parallel.
+                connection.execute(
+                    text(
+                        f"CREATE DATABASE {self.database_name} "
+                        f"TEMPLATE {self._config_url.database}"
+                    )
+                )
+            else:
+                connection.execute(text(f"CREATE DATABASE {self.database_name}"))
             connection.execute(
                 text(f"GRANT ALL PRIVILEGES ON DATABASE {self.database_name} TO {user}")
             )

--- a/tests/fixtures/database.py
+++ b/tests/fixtures/database.py
@@ -179,15 +179,16 @@ def function_test_id(worker_id: str) -> IdFixture:
 
 class DatabaseTestConfiguration(FixtureTestUrlConfiguration):
     url: PostgresDsn
+    # Create a separate database for each worker in a test run. When external schema is
+    # false, each worker's database is initialized from the database models; when external
+    # schema is true, each worker instead clones the configured database (used as a
+    # template) into its own database.
     create_database: bool = True
-    # When set, the schema is assumed to have been built externally (by the current code) in
-    # the configured database before the tests run. The fixtures then use that schema as-is
-    # rather than dropping and recreating it from the current models. With create_database
-    # enabled (the default), each worker clones the configured database as a template into
-    # its own per-worker database, so the suite can still run in parallel; with
-    # create_database disabled, the configured database is used directly and the suite must
-    # run serially. This is used by the backwards-compatibility CI check, which runs a
-    # previous release's test suite against a schema built by the current code.
+    # When set, the database schema is assumed to have been applied externally before the
+    # tests run, so the fixtures use the database as-is instead of dropping and recreating
+    # the schema from the current models. This is used by the backwards-compatibility CI
+    # check, which runs a previous release's test suite against a schema built by the
+    # current code.
     external_schema: bool = False
     model_config = SettingsConfigDict(env_prefix="PALACE_TEST_DATABASE_")
 


### PR DESCRIPTION
## Description

Makes the test suite's external-schema mode parallel-capable. When database creation is enabled (the default), each xdist worker now provisions its own database by cloning the configured database as a Postgres template (`CREATE DATABASE ... TEMPLATE`), instead of all workers sharing the one configured database. The previous release's tests still run against the schema the current code produced, but each worker gets an isolated database, so the suite can run under xdist.

Admin (`CREATE`/`DROP DATABASE`) operations now connect to the `postgres` maintenance database rather than the configured one, since you cannot clone a template you are connected to; these are cluster-level commands that work from any database, and this path is exercised by the normal suite on every run.

The single-shared-database serial mode (external schema with database creation disabled) is preserved for local debugging.

## Motivation and Context

The backwards-compatibility CI check runs a previous release's `-m db` test suite against a schema built by the current code, using external-schema mode. Until now that mode used the one configured database as-is and forbade xdist, so the suite ran serially (`-n0`) and took ~13 minutes. Its not really feasible for this check to take so long, so I'm adding this option to speed it up. 

This will have to be merged and go into a release, before I can test it in the workflow in https://github.com/ThePalaceProject/circulation/pull/3506

## How Has This Been Tested?

Because the backwards-compatibility job won't exercise this for real until the next release, it was proven locally:

- Parallel external clone mode against a real Postgres: a db-test slice ran green under `-n auto` with `PALACE_TEST_DATABASE_EXTERNAL_SCHEMA=true` / `PALACE_TEST_DATABASE_CREATE_DATABASE=true`; per-worker `session_gw*` clones were created from the template and dropped at teardown.
- Negative control: dropping a table from the template made the same parallel run fail with `UndefinedTable`, confirming the check still catches backwards-incompatible schemas under parallelism.
- Normal-mode regression: the standard parallel suite (which now routes admin DDL through the `postgres` maintenance database on every run) passed via `tox -e py312-docker`.
- Full end-to-end against a locally built image using the real backwards-compatibility compose overlay (`-n auto`, clone-per-worker): 3,269 db tests passed in 3:47 on a 4-worker runner, versus ~13 minutes serial.
- `mypy` clean.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.