### PR TITLE
Index unclassified works with null fiction status (PP-4674)

### DIFF
--- a/src/palace/manager/sqlalchemy/model/work.py
+++ b/src/palace/manager/sqlalchemy/model/work.py
@@ -1692,8 +1692,15 @@ class Work(Base, LoggerMixin):
         result["work_id"] = getattr(doc, "id")
         result["summary"] = getattr(doc, "summary_text")
         result["suppressed_for"] = [int(l.id) for l in getattr(doc, "suppressed_for")]
+        # A work's fiction status is tri-state: True (fiction), False
+        # (nonfiction), or None (unknown/unclassified). Preserve that third
+        # state as None so an unclassified work is not silently indexed as
+        # nonfiction, which would make it match a nonfiction-only lane.
+        fiction_status = getattr(doc, "fiction")
         result["fiction"] = (
-            "fiction" if getattr(doc, "fiction") is True else "nonfiction"
+            None
+            if fiction_status is None
+            else ("fiction" if fiction_status else "nonfiction")
         )
         if result["audience"]:
             result["audience"] = result["audience"].replace(" ", "")

--- a/tests/manager/sqlalchemy/model/test_work.py
+++ b/tests/manager/sqlalchemy/model/test_work.py
@@ -1232,6 +1232,22 @@ class TestWork:
             "medium" not in search_doc["licensepools"][0]
         )  # No presentation edition means no medium
 
+    def test_to_search_doc_fiction_status(self, db: DatabaseTransactionFixture):
+        # The fiction status is tri-state, and the search document must
+        # preserve all three states. In particular, an unclassified work
+        # (fiction is None) must not be indexed as nonfiction, or it would
+        # incorrectly match a nonfiction-only lane.
+        work = db.work(with_license_pool=True)
+
+        work.fiction = True
+        assert work.to_search_document()["fiction"] == "fiction"
+
+        work.fiction = False
+        assert work.to_search_document()["fiction"] == "nonfiction"
+
+        work.fiction = None
+        assert work.to_search_document()["fiction"] is None
+
     def test_to_search_doc_datetime_cases(self, db: DatabaseTransactionFixture):
         # datetime.dates are tz unaware and converting to timestamps may cause errors
         # if the local timezone pushes it out of a valid date range (eg. year 0)


### PR DESCRIPTION
## Description

Works that have no fiction/non-fiction classification (`Work.fiction is None`) were being incorrectly indexed into OpenSearch as `"nonfiction"`, causing them to surface in non-fiction-only lanes. This fixes the search-document serialization so the unknown state is preserved.

## Motivation and Context

PP-4674

**The problem:** A book with no classification information — in particular, no fiction/non-fiction signal — was appearing in the Non-fiction lane, which should not happen. An unclassified work should match neither a fiction-only nor a non-fiction-only lane.

**The cause:** `Work.fiction` is tri-state: `True` (fiction), `False` (nonfiction), or `None` (unknown/unclassified). The classifier deliberately leaves `fiction` as `None` when there is no usable classification data rather than guessing. However, `Work.search_doc_as_dict` collapsed this tri-state value into a binary:

```python
result["fiction"] = (
    "fiction" if getattr(doc, "fiction") is True else "nonfiction"
)
```

Because the check was `is True`, any non-`True` value — including `None` — fell into the `else` branch and was indexed as `"nonfiction"`. The non-fiction lane filter (`Term(fiction="nonfiction")`) then matched these unclassified works.

**The resolution:** Preserve the third state as `None` in the search document, so an unclassified work is not indexed as nonfiction and matches neither lane. OpenSearch treats a null value as a missing field, so it correctly drops out of both the fiction and non-fiction term filters.

### Note on existing indexed works (automatic resolution)

This fix only affects newly generated search documents; works already in the index retain the stale `"nonfiction"` value until re-indexed. No manual backfill or one-time task is required: the nightly `full_search_reindex` job (`search_reindex`, scheduled daily at 12:10 AM) regenerates the search document for every presentation-ready work regardless of fiction state. As a result, all affected `fiction = None` works will self-heal within ~24 hours of this fix being deployed. Operators who want the correction applied immediately can trigger the existing search rebuild rather than waiting for the nightly run.

## How Has This Been Tested?

- Added `TestWork.test_to_search_doc_fiction_status` covering all three fiction states (`True` → `"fiction"`, `False` → `"nonfiction"`, `None` → `None`), with the `None` case as the regression guard.
- Ran the affected suite under `tox -e py312-docker -- tests/manager/sqlalchemy/model/test_work.py -k to_search_doc` (all passing).
- `mypy` clean on the changed module.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.