### PR TITLE
Reconcile circulation against live pool columns in the shared data layer (PP-4703)

### DIFF
--- a/src/palace/manager/data_layer/circulation.py
+++ b/src/palace/manager/data_layer/circulation.py
@@ -11,6 +11,7 @@ from palace.manager.data_layer.license import LicenseData
 from palace.manager.data_layer.link import LinkData
 from palace.manager.data_layer.policy.replacement import ReplacementPolicy
 from palace.manager.sqlalchemy.model.collection import Collection
+from palace.manager.sqlalchemy.model.edition import Edition
 from palace.manager.sqlalchemy.model.licensing import (
     DeliveryMechanism,
     LicensePool,
@@ -402,3 +403,76 @@ class CirculationData(BaseMutableData):
         """
         pool, _ = self.license_pool(session, collection, autocreate=False)
         return self.should_apply_to(pool)
+
+    def fields_excluded_from_hash(self) -> set[str]:
+        """Exclude the volatile availability counts from the dedup hash.
+
+        ``licenses_owned``/``licenses_available``/``licenses_reserved`` and
+        ``patrons_in_hold_queue`` are mutated **out of band** — by the event
+        importer, loan/hold operations, and the circulation dispatcher via
+        :meth:`~palace.manager.sqlalchemy.model.licensing.LicensePool.update_availability`
+        (and ``update_availability_from_delta`` / ``update_availability_from_licenses``)
+        — which never restamp ``updated_at_data_hash``.  The hash therefore cannot
+        track them, so they are excluded from it and compared against the pool's live
+        columns in :meth:`should_apply_to` instead.  Every other field is only ever
+        written by :meth:`apply`, so the hash stays a reliable change-signal for it.
+        """
+        return super().fields_excluded_from_hash() | {
+            "licenses_owned",
+            "licenses_available",
+            "licenses_reserved",
+            "patrons_in_hold_queue",
+        }
+
+    def should_apply_to(self, db_object: Edition | LicensePool | None = None) -> bool:
+        """Decide whether this circulation data should be applied to the pool.
+
+        Mirrors the base hash/timestamp logic, but additionally compares the volatile
+        availability counts against the pool's **live** columns — because those columns
+        drift from the hash (see :meth:`fields_excluded_from_hash`).  Apply when the
+        stable-field hash differs **or** the counts no longer match the columns.
+
+        Because both :meth:`needs_apply` (the importers' gate) and :meth:`apply`'s own
+        internal check go through this method, a dispatched ``circulation_apply`` is
+        never re-blocked, and an async apply that arrives after the columns already
+        match simply no-ops — no ``even_if_not_apparently_updated`` needed.
+        """
+        if not isinstance(db_object, LicensePool):
+            # No stored pool to compare against (None, or not a pool) -> apply.
+            return True
+        pool = db_object
+        if pool.updated_at is None or pool.updated_at_data_hash is None:
+            # Never applied before -> apply.
+            return True
+        if self.as_of_timestamp < pool.updated_at:
+            # Incoming data is older than what is stored; don't overwrite newer state.
+            return False
+        return (
+            self.calculate_hash() != pool.updated_at_data_hash
+            or not self._availability_matches(pool)
+        )
+
+    def _availability_matches(self, pool: LicensePool) -> bool:
+        """Whether this snapshot's availability already matches the pool's live columns.
+
+        Compares the volatile count fields (the ones excluded from the dedup hash)
+        against the actual columns.  A field left unset (``None``) is treated as "no
+        assertion" and never forces an apply, mirroring
+        :meth:`~palace.manager.sqlalchemy.model.licensing.LicensePool.update_availability`,
+        which skips ``None`` values rather than writing them.
+        """
+        return (
+            (self.licenses_owned is None or self.licenses_owned == pool.licenses_owned)
+            and (
+                self.licenses_available is None
+                or self.licenses_available == pool.licenses_available
+            )
+            and (
+                self.licenses_reserved is None
+                or self.licenses_reserved == pool.licenses_reserved
+            )
+            and (
+                self.patrons_in_hold_queue is None
+                or self.patrons_in_hold_queue == pool.patrons_in_hold_queue
+            )
+        )

--- a/src/palace/manager/data_layer/circulation.py
+++ b/src/palace/manager/data_layer/circulation.py
@@ -304,8 +304,9 @@ class CirculationData(BaseMutableData):
         changed_availability = False
         changed_lp_type = False
         changed_lp_status = False
-        # The early return above already filtered out pools whose content hash has
-        # not changed. If we reach this point with a pool, we know we need to apply the availability data.
+        # The early return above (should_apply_to) only let this pool through because
+        # either its stable-field hash changed or its live availability columns drifted
+        # from the incoming snapshot. Either way, we need to apply the availability data.
         if pool:
             # Update availability information. This may result in
             # the issuance of additional circulation events.
@@ -395,7 +396,7 @@ class CirculationData(BaseMutableData):
 
         Looks up the existing :class:`~palace.manager.sqlalchemy.model.licensing.LicensePool`
         for this object's primary identifier in *collection* and delegates to
-        :meth:`~palace.manager.data_layer.base.mutable.BaseMutableData.should_apply_to`.
+        :meth:`should_apply_to`.
 
         :param session: Active database session used to look up the pool.
         :param collection: The collection the pool belongs to.
@@ -407,15 +408,13 @@ class CirculationData(BaseMutableData):
     def fields_excluded_from_hash(self) -> set[str]:
         """Exclude the volatile availability counts from the dedup hash.
 
-        ``licenses_owned``/``licenses_available``/``licenses_reserved`` and
-        ``patrons_in_hold_queue`` are mutated **out of band** — by the event
-        importer, loan/hold operations, and the circulation dispatcher via
-        :meth:`~palace.manager.sqlalchemy.model.licensing.LicensePool.update_availability`
-        (and ``update_availability_from_delta`` / ``update_availability_from_licenses``)
-        — which never restamp ``updated_at_data_hash``.  The hash therefore cannot
-        track them, so they are excluded from it and compared against the pool's live
-        columns in :meth:`should_apply_to` instead.  Every other field is only ever
-        written by :meth:`apply`, so the hash stays a reliable change-signal for it.
+        Rule for any field added to :class:`CirculationData`: it may ride the dedup
+        hash only if it is *exclusively* written by :meth:`apply` — then the stored
+        hash (the data as of the last apply) still reflects the live row, so
+        "incoming hash != stored hash" is a sound change-signal. A field that the
+        database can mutate independently of :meth:`apply` will drift from the hash;
+        exclude it here and live-compare it in :meth:`should_apply_to` instead (as the
+        availability counts below are).
         """
         return super().fields_excluded_from_hash() | {
             "licenses_owned",

--- a/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
+++ b/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
@@ -12,7 +12,6 @@ from palace.util.datetime_helpers import utc_now
 from palace.util.log import LoggerMixin
 
 from palace.manager.celery.tasks import apply
-from palace.manager.data_layer.circulation import CirculationData
 from palace.manager.data_layer.policy.replacement import ReplacementPolicy
 from palace.manager.integration.license.bibliotheca import BibliothecaAPI
 from palace.manager.sqlalchemy.constants import DataSourceConstants
@@ -182,29 +181,18 @@ class BibliothecaCirculationUpdater(LoggerMixin):
     ) -> None:
         """Look up availability from Bibliotheca, apply changes, and zero out removed titles.
 
-        Each returned record is reconciled along two independent tracks:
-
-        - **Bibliographic metadata** is deduplicated with
-          :meth:`~palace.manager.data_layer.bibliographic.BibliographicData.needs_apply`
-          (hash based).  This is reliable because an ``Edition``'s content is only
-          ever written through ``apply``, so its stored hash stays in sync with it.
-          Unchanged metadata is skipped.
-
-        - **Circulation/availability** is reconciled against the ``LicensePool``'s
-          *live* column values — not its
-          :attr:`~palace.manager.sqlalchemy.model.licensing.LicensePool.updated_at_data_hash`.
-          That hash is only maintained by
-          :meth:`~palace.manager.data_layer.circulation.CirculationData.apply`,
-          whereas ``licenses_*`` are also mutated out of band — by the event
-          importer and by loan/hold operations via
-          :meth:`~palace.manager.sqlalchemy.model.licensing.LicensePool.update_availability`
-          and :meth:`~palace.manager.sqlalchemy.model.licensing.LicensePool.update_availability_from_delta`,
-          neither of which touches the hash.  A matching hash therefore does **not**
-          mean the columns are correct, and gating the sweep on it makes it skip the
-          very drift it exists to reconcile.  So we compare the snapshot to the
-          actual columns and, when they differ, apply with
-          ``even_if_not_apparently_updated=True`` to bypass the stale hash;
-          ``update_availability`` still writes and logs only genuine differences.
+        Reconciles each returned record along two tracks (the same shape as the OPDS
+        importer): bibliographic **metadata** is hash-deduplicated via
+        :meth:`~palace.manager.data_layer.bibliographic.BibliographicData.needs_apply`,
+        and otherwise **circulation** is gated on
+        :meth:`~palace.manager.data_layer.circulation.CirculationData.needs_apply`.
+        The circulation check is reliable for availability because
+        :meth:`~palace.manager.data_layer.circulation.CirculationData.should_apply_to`
+        compares the snapshot against the pool's *live* columns — the availability
+        counts are excluded from the dedup hash, which they would otherwise drift from
+        (the event importer and loan/hold operations mutate ``licenses_*`` via
+        :meth:`~palace.manager.sqlalchemy.model.licensing.LicensePool.update_availability`
+        without restamping the hash).
 
         When ``synchronous`` is ``False`` (the sweep) applies are queued as
         ``bibliographic_apply`` / ``circulation_apply`` Celery tasks; when ``True``
@@ -238,15 +226,20 @@ class BibliothecaCirculationUpdater(LoggerMixin):
             if identifier is not None:
                 identifiers_not_mentioned.discard(identifier)
 
-            # Track 1 -- bibliographic metadata. Hash-based dedup is reliable
-            # here (an Edition is only ever written through apply()). Circulation
-            # is stripped off and handled separately below so that an unchanged
-            # title does not force a metadata re-apply every sweep.
+            # Two-track reconciliation (same shape as the OPDS importer): apply
+            # bibliographic metadata when its hash changed; otherwise apply
+            # circulation when CirculationData.needs_apply() says so. The latter is
+            # reliable for availability because CirculationData.should_apply_to()
+            # compares the pool's live columns (the availability counts are excluded
+            # from the dedup hash, which they would otherwise drift from -- the event
+            # importer and loan/hold operations mutate licenses_* without restamping
+            # it). When metadata changed, its embedded circulation rides along and is
+            # reconciled by CirculationData.apply's own should_apply_to.
+            circulation = bibliographic.circulation
             if bibliographic.needs_apply(self._session):
-                metadata = bibliographic.model_copy(update={"circulation": None})
                 if synchronous:
-                    edition, _ = metadata.edition(self._session)
-                    metadata.apply(
+                    edition, _ = bibliographic.edition(self._session)
+                    bibliographic.apply(
                         self._session,
                         edition,
                         self._collection,
@@ -255,34 +248,25 @@ class BibliothecaCirculationUpdater(LoggerMixin):
                     )
                 else:
                     apply.bibliographic_apply.delay(
-                        metadata,
+                        bibliographic,
                         collection_id=self._collection.id,
                         replace=ReplacementPolicy.from_license_source(),
                     )
-
-            # Track 2 -- circulation/availability. Reconcile against the pool's
-            # LIVE columns rather than its updated_at_data_hash (see this method's
-            # docstring): the hash drifts from the columns because the event
-            # importer and loan/hold operations mutate licenses_* without updating
-            # it. When the snapshot differs from the columns we force the apply
-            # past the (possibly stale) hash with even_if_not_apparently_updated.
-            circulation = bibliographic.circulation
-            if identifier is not None and circulation is not None:
-                pool = self._license_pool_for(identifier)
-                if pool is None or not self._availability_matches_pool(
-                    circulation, pool
-                ):
-                    replace = ReplacementPolicy.from_license_source(
-                        even_if_not_apparently_updated=True
+            elif circulation is not None and circulation.needs_apply(
+                self._session, self._collection
+            ):
+                if synchronous:
+                    circulation.apply(
+                        self._session,
+                        self._collection,
+                        ReplacementPolicy.from_license_source(),
                     )
-                    if synchronous:
-                        circulation.apply(self._session, self._collection, replace)
-                    else:
-                        apply.circulation_apply.delay(
-                            circulation,
-                            collection_id=self._collection.id,
-                            replace=replace,
-                        )
+                else:
+                    apply.circulation_apply.delay(
+                        circulation,
+                        collection_id=self._collection.id,
+                        replace=ReplacementPolicy.from_license_source(),
+                    )
 
         now = utc_now()
         for identifier in identifiers_not_mentioned:
@@ -302,40 +286,3 @@ class BibliothecaCirculationUpdater(LoggerMixin):
             and lp.collection == self._collection
         ]
         return pools[0] if pools else None
-
-    @staticmethod
-    def _availability_matches_pool(
-        circulation: CirculationData, pool: LicensePool
-    ) -> bool:
-        """Whether ``circulation`` already matches the pool's live availability columns.
-
-        Compared against the actual ``licenses_*`` / ``status`` columns rather than
-        :attr:`~palace.manager.sqlalchemy.model.licensing.LicensePool.updated_at_data_hash`,
-        which is not a reliable proxy for the current column values (see
-        :meth:`_process_batch`).
-
-        A field the snapshot leaves unset (``None``) is treated as "no assertion" and
-        does not, on its own, count as a mismatch — mirroring
-        :meth:`~palace.manager.sqlalchemy.model.licensing.LicensePool.update_availability`,
-        which skips ``None`` values rather than writing them. (Bibliotheca always
-        populates every count and ``status``, so this only matters defensively.)
-        """
-        return (
-            (
-                circulation.licenses_owned is None
-                or circulation.licenses_owned == pool.licenses_owned
-            )
-            and (
-                circulation.licenses_available is None
-                or circulation.licenses_available == pool.licenses_available
-            )
-            and (
-                circulation.licenses_reserved is None
-                or circulation.licenses_reserved == pool.licenses_reserved
-            )
-            and (
-                circulation.patrons_in_hold_queue is None
-                or circulation.patrons_in_hold_queue == pool.patrons_in_hold_queue
-            )
-            and (circulation.status is None or circulation.status == pool.status)
-        )

--- a/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
+++ b/src/palace/manager/integration/license/bibliotheca_circulation_updater.py
@@ -226,15 +226,15 @@ class BibliothecaCirculationUpdater(LoggerMixin):
             if identifier is not None:
                 identifiers_not_mentioned.discard(identifier)
 
-            # Two-track reconciliation (same shape as the OPDS importer): apply
-            # bibliographic metadata when its hash changed; otherwise apply
-            # circulation when CirculationData.needs_apply() says so. The latter is
-            # reliable for availability because CirculationData.should_apply_to()
-            # compares the pool's live columns (the availability counts are excluded
-            # from the dedup hash, which they would otherwise drift from -- the event
-            # importer and loan/hold operations mutate licenses_* without restamping
-            # it). When metadata changed, its embedded circulation rides along and is
-            # reconciled by CirculationData.apply's own should_apply_to.
+            # Two-track reconciliation: apply bibliographic metadata when its hash
+            # changed; otherwise apply circulation when CirculationData.needs_apply()
+            # says so. The latter is reliable for availability because
+            # CirculationData.should_apply_to() compares the pool's live columns (the
+            # availability counts are excluded from the dedup hash, which they would
+            # otherwise drift from -- the event importer and loan/hold operations
+            # mutate licenses_* without restamping it). When metadata changed, its
+            # embedded circulation rides along and is reconciled by
+            # CirculationData.apply's own should_apply_to.
             circulation = bibliographic.circulation
             if bibliographic.needs_apply(self._session):
                 if synchronous:

--- a/src/palace/manager/integration/license/boundless/importer.py
+++ b/src/palace/manager/integration/license/boundless/importer.py
@@ -113,6 +113,7 @@ class BoundlessImporter(LoggerMixin):
         self,
         active_title_ids: list[str],
         apply_bibliographic: ApplyBibliographicCallable,
+        apply_circulation: ApplyCirculationCallable,
     ) -> None:
         policy = ReplacementPolicy(
             identifiers=False,
@@ -123,6 +124,7 @@ class BoundlessImporter(LoggerMixin):
         )
 
         bibliographic_updated = 0
+        circulation_updated = 0
         no_changes = 0
 
         for chunk in chunks(
@@ -137,6 +139,16 @@ class BoundlessImporter(LoggerMixin):
                         bibliographic, collection_id=self._collection.id, replace=policy
                     )
                     bibliographic_updated += 1
+                elif circulation.needs_apply(self._db, self._collection):
+                    # The bibliographic metadata is unchanged, but the
+                    # availability has changed. BibliographicData.needs_apply()
+                    # cannot detect this because its hash deliberately excludes
+                    # circulation, so apply the circulation update on its own.
+                    # Otherwise availability-only changes -- the common case for
+                    # an already-imported title, and exactly what put this title
+                    # in the modified-since feed -- would be silently dropped.
+                    apply_circulation(circulation, collection_id=self._collection.id)
+                    circulation_updated += 1
                 else:
                     no_changes += 1
 
@@ -144,6 +156,7 @@ class BoundlessImporter(LoggerMixin):
             self.log.info(
                 f"Processed {len(active_title_ids)} active titles: "
                 f"{bibliographic_updated} bibliographic updates, "
+                f"{circulation_updated} circulation-only updates, "
                 f"{no_changes} unchanged."
             )
 
@@ -166,7 +179,9 @@ class BoundlessImporter(LoggerMixin):
         :param apply_bibliographic: Callable to queue bibliographic data for processing.
             Called for each active title that has changed or when import_all is True.
         :param apply_circulation: Callable to queue circulation data for processing.
-            Called for inactive titles to mark them as unavailable.
+            Called for inactive titles to mark them as unavailable, and for active
+            titles whose availability changed but whose bibliographic metadata did
+            not (so the availability update is not dropped).
         :param page: The page number to fetch from the API (1-indexed).
         :param modified_since: Only fetch titles modified after this datetime.
         :return: FeedImportResult containing pagination info, counts of titles processed,
@@ -185,7 +200,9 @@ class BoundlessImporter(LoggerMixin):
         active_title_ids = [
             title.title_id for title in title_response.titles if title.active is True
         ]
-        self._import_active_titles(active_title_ids, apply_bibliographic)
+        self._import_active_titles(
+            active_title_ids, apply_bibliographic, apply_circulation
+        )
 
         inactive_title_ids = [
             title.title_id for title in title_response.titles if title.active is False

--- a/src/palace/manager/sqlalchemy/model/licensing.py
+++ b/src/palace/manager/sqlalchemy/model/licensing.py
@@ -330,7 +330,10 @@ class LicensePool(Base):
     created_at = Column(DateTime(timezone=True), default=None)
     updated_at = Column(DateTime(timezone=True), default=None)
 
-    # Hash of the CirculationData last used to create/update this LicensePool.
+    # Hash of the stable CirculationData fields last used to create/update this
+    # LicensePool. The volatile availability counts are deliberately excluded (they
+    # are mutated out of band and would drift from the hash); see
+    # CirculationData.fields_excluded_from_hash for the exact set and the reasoning.
     updated_at_data_hash = Column(String, default=None)
 
     # A LicensePool that seemingly looks fine may be manually suppressed

--- a/tests/manager/data_layer/test_circulation.py
+++ b/tests/manager/data_layer/test_circulation.py
@@ -996,6 +996,122 @@ class TestCirculationData:
         pool.updated_at_data_hash = "stale-hash"
         assert circulation.needs_apply(db.session, collection) is True
 
+    def test_calculate_hash_excludes_availability_counts(
+        self, db: DatabaseTransactionFixture
+    ) -> None:
+        """The volatile availability counts are excluded from the dedup hash.
+
+        They drift out of band (``update_availability`` from the event importer,
+        loans/holds, the dispatcher) without restamping the hash, so they are compared
+        against the live columns in ``should_apply_to`` instead. Only the stable fields
+        contribute to the hash.
+        """
+        identifier = IdentifierData(type="test identifier", identifier="hash")
+
+        def circ(
+            owned: int,
+            available: int,
+            *,
+            reserved: int = 0,
+            holds: int = 0,
+            status: LicensePoolStatus | None = None,
+        ) -> CirculationData:
+            return CirculationData(
+                data_source_name="Test data source",
+                primary_identifier_data=identifier,
+                licenses_owned=owned,
+                licenses_available=available,
+                licenses_reserved=reserved,
+                patrons_in_hold_queue=holds,
+                status=status,
+            )
+
+        # Different counts, identical stable fields -> identical hash.
+        assert (
+            circ(5, 5).calculate_hash()
+            == circ(1, 0, reserved=2, holds=3).calculate_hash()
+        )
+        # A change to a stable field (status) DOES change the hash.
+        assert (
+            circ(5, 5, status=LicensePoolStatus.EXHAUSTED).calculate_hash()
+            != circ(5, 5).calculate_hash()
+        )
+
+    def test_needs_apply_compares_live_columns(
+        self, db: DatabaseTransactionFixture
+    ) -> None:
+        """Availability is reconciled against the pool's live columns, not the hash.
+
+        Because the counts are excluded from the hash, ``needs_apply`` must detect a
+        count difference even when the stable-field hash matches -- the drift bug the
+        Bibliotheca band-aids fixed locally, now fixed for every distributor here.
+        """
+        collection = db.collection()
+        identifier = IdentifierData(type="test identifier", identifier="drift")
+        one_day_ago = utc_now() - datetime.timedelta(days=1)
+
+        def circ(owned: int, available: int) -> CirculationData:
+            return CirculationData(
+                data_source_name="Test data source",
+                primary_identifier_data=identifier,
+                licenses_owned=owned,
+                licenses_available=available,
+                licenses_reserved=0,
+                patrons_in_hold_queue=0,
+            )
+
+        # Seed the pool to the "(5, 5) already applied" state.
+        pool, _ = circ(5, 5).license_pool(db.session, collection, autocreate=True)
+        pool.licenses_owned = 5
+        pool.licenses_available = 5
+        pool.licenses_reserved = 0
+        pool.patrons_in_hold_queue = 0
+        pool.updated_at = one_day_ago
+        pool.updated_at_data_hash = circ(5, 5).calculate_hash()
+
+        # Snapshot matches both the hash and the columns -> nothing to do.
+        assert circ(5, 5).needs_apply(db.session, collection) is False
+
+        # The columns drift out of band (e.g. the event importer) -- no hash restamp.
+        pool.licenses_available = 2
+
+        # The authoritative snapshot still reports (5, 5): the stable-field hash still
+        # matches, but the live columns no longer do -> apply.
+        assert circ(5, 5).needs_apply(db.session, collection) is True
+
+        # A snapshot that matches the (drifted) live columns needs no apply.
+        assert circ(5, 2).needs_apply(db.session, collection) is False
+
+    def test_needs_apply_skips_older_snapshot_even_when_counts_differ(
+        self, db: DatabaseTransactionFixture
+    ) -> None:
+        """An older snapshot is not applied even when its counts differ from the columns.
+
+        Preserves the base staleness rule so newer (e.g. loan-driven) column state is
+        not overwritten by stale data.
+        """
+        collection = db.collection()
+        identifier = IdentifierData(type="test identifier", identifier="stale")
+        today = utc_now()
+        two_days_ago = today - datetime.timedelta(days=2)
+
+        circulation = CirculationData(
+            data_source_name="Test data source",
+            primary_identifier_data=identifier,
+            licenses_owned=5,
+            licenses_available=5,
+            licenses_reserved=0,
+            patrons_in_hold_queue=0,
+            updated_at=two_days_ago,  # the snapshot is old
+        )
+        pool, _ = circulation.license_pool(db.session, collection, autocreate=True)
+        pool.licenses_available = 0  # live columns differ from the snapshot
+        pool.updated_at = today  # the pool is newer than the snapshot
+        pool.updated_at_data_hash = circulation.calculate_hash()
+
+        # as_of (two_days_ago) < pool.updated_at (today) -> skip despite the difference.
+        assert circulation.needs_apply(db.session, collection) is False
+
     @pytest.mark.parametrize(
         "initial_type,new_type,expected_type",
         [

--- a/tests/manager/integration/license/boundless/test_importer.py
+++ b/tests/manager/integration/license/boundless/test_importer.py
@@ -1,5 +1,5 @@
 from functools import partial
-from unittest.mock import MagicMock, create_autospec
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
@@ -10,6 +10,8 @@ from palace.manager.celery.tasks.apply import (
     ApplyBibliographicCallable,
     ApplyCirculationCallable,
 )
+from palace.manager.data_layer.bibliographic import BibliographicData
+from palace.manager.data_layer.circulation import CirculationData
 from palace.manager.integration.license.boundless.api import BoundlessApi
 from palace.manager.integration.license.boundless.importer import BoundlessImporter
 from palace.manager.sqlalchemy.model.licensing import LicensePoolStatus
@@ -27,12 +29,15 @@ class TestBoundlessImporter:
         boundless.http_client.queue_response(200, content=data)
         importer = boundless.create_importer()
 
-        # Mock the apply callable
+        # Mock the apply callables
         apply_bibliographic = create_autospec(ApplyBibliographicCallable)
+        apply_circulation = create_autospec(ApplyCirculationCallable)
 
         # Import two active titles
         active_title_ids = ["0003642860", "0012164897"]
-        importer._import_active_titles(active_title_ids, apply_bibliographic)
+        importer._import_active_titles(
+            active_title_ids, apply_bibliographic, apply_circulation
+        )
 
         # We made a request to the correct URL.
         assert "/availability/v2" in boundless.http_client.requests[1]
@@ -41,8 +46,10 @@ class TestBoundlessImporter:
             "titleIds": "0003642860,0012164897",
         }
 
-        # Both titles should have been processed
+        # Both titles are new, so both go through the bibliographic apply path
+        # (which carries their embedded circulation); no circulation-only applies.
         assert apply_bibliographic.call_count == 2
+        apply_circulation.assert_not_called()
 
         # Make sure the circulation data is correct
         calls = apply_bibliographic.call_args_list
@@ -75,12 +82,15 @@ class TestBoundlessImporter:
 
         importer = boundless.create_importer()
         apply_bibliographic = MagicMock()
+        apply_circulation = MagicMock()
 
         # Create a list of title IDs that exceeds the chunk size
         chunk_size = importer._AVAILABILITY_CALL_MAXIMUM_IDENTIFIERS
         active_title_ids = [f"{i:010d}" for i in range(chunk_size + 10)]
 
-        importer._import_active_titles(active_title_ids, apply_bibliographic)
+        importer._import_active_titles(
+            active_title_ids, apply_bibliographic, apply_circulation
+        )
 
         # We should have made two requests (one for each chunk)
         # Request 0 is the token request, requests 1 and 2 are the availability calls
@@ -102,6 +112,69 @@ class TestBoundlessImporter:
         title_ids_2 = params2["titleIds"]
         assert isinstance(title_ids_2, str)
         assert len(title_ids_2.split(",")) == 10
+
+    def test__import_active_titles_applies_circulation_only_change(
+        self, boundless: BoundlessFixture, db: DatabaseTransactionFixture
+    ):
+        """Regression: an availability-only change is applied on its own.
+
+        ``BibliographicData.needs_apply()`` excludes circulation from its hash,
+        so when a title's metadata is unchanged but its availability changed,
+        ``needs_apply()`` is ``False``.  The importer must fall back to
+        ``CirculationData.needs_apply()`` and dispatch the circulation update --
+        otherwise the change that put the title in the modified-since feed in the
+        first place is silently dropped.
+        """
+        data = boundless.files.sample_data("tiny_collection.xml")
+        boundless.http_client.queue_response(200, content=data)
+        importer = boundless.create_importer()
+
+        apply_bibliographic = create_autospec(ApplyBibliographicCallable)
+        apply_circulation = create_autospec(ApplyCirculationCallable)
+
+        active_title_ids = ["0003642860", "0012164897"]
+        # Metadata unchanged (needs_apply False) but availability changed
+        # (circulation needs_apply True).
+        with (
+            patch.object(BibliographicData, "needs_apply", return_value=False),
+            patch.object(CirculationData, "needs_apply", return_value=True),
+        ):
+            importer._import_active_titles(
+                active_title_ids, apply_bibliographic, apply_circulation
+            )
+
+        # No bibliographic apply, but a circulation apply per title.
+        apply_bibliographic.assert_not_called()
+        assert apply_circulation.call_count == 2
+        applied_ids = {
+            call.args[0].primary_identifier_data.identifier
+            for call in apply_circulation.call_args_list
+        }
+        assert applied_ids == {"0003642860", "0012164897"}
+        for call in apply_circulation.call_args_list:
+            assert call.kwargs["collection_id"] == importer._collection.id
+
+    def test__import_active_titles_skips_when_nothing_changed(
+        self, boundless: BoundlessFixture, db: DatabaseTransactionFixture
+    ):
+        """Neither callable fires when both metadata and circulation are unchanged."""
+        data = boundless.files.sample_data("tiny_collection.xml")
+        boundless.http_client.queue_response(200, content=data)
+        importer = boundless.create_importer()
+
+        apply_bibliographic = create_autospec(ApplyBibliographicCallable)
+        apply_circulation = create_autospec(ApplyCirculationCallable)
+
+        with (
+            patch.object(BibliographicData, "needs_apply", return_value=False),
+            patch.object(CirculationData, "needs_apply", return_value=False),
+        ):
+            importer._import_active_titles(
+                ["0003642860", "0012164897"], apply_bibliographic, apply_circulation
+            )
+
+        apply_bibliographic.assert_not_called()
+        apply_circulation.assert_not_called()
 
     def test_incorrect_collection_protocol(
         self, db: DatabaseTransactionFixture, boundless: BoundlessFixture

--- a/tests/manager/integration/license/test_bibliotheca_circulation_updater.py
+++ b/tests/manager/integration/license/test_bibliotheca_circulation_updater.py
@@ -330,10 +330,10 @@ class TestBibliothecaCirculationUpdaterUpdateBatch:
             updater.process_identifiers([pool.identifier])
         return pool
 
-    def test_metadata_change_queues_bibliographic_apply_only(
+    def test_metadata_change_queues_bibliographic_apply(
         self, db: DatabaseTransactionFixture
     ) -> None:
-        """A metadata-only change queues bibliographic_apply (circulation stripped)."""
+        """A metadata change queues bibliographic_apply (carrying its circulation)."""
         updater, _ = _make_updater(db)
         pool = self._seed_imported_title(updater, db, 5, 5, title="Title A")
         bibliotheca_id = pool.identifier.identifier
@@ -349,17 +349,17 @@ class TestBibliothecaCirculationUpdaterUpdateBatch:
         ):
             updater.update_batch(0)
 
+        # Metadata changed -> bibliographic_apply; its embedded circulation rides
+        # along (reconciled by CirculationData.apply), so no separate circ apply.
         mock_bib_apply.delay.assert_called_once()
-        # Circulation is handled on its own track, so it is stripped from the
-        # bibliographic payload to avoid a redundant (hash-gated) apply.
         dispatched = mock_bib_apply.delay.call_args.args[0]
-        assert dispatched.circulation is None
+        assert dispatched.circulation is not None
         mock_circ_apply.delay.assert_not_called()
 
     def test_availability_change_queues_circulation_apply_only(
         self, db: DatabaseTransactionFixture
     ) -> None:
-        """An availability change queues circulation_apply with a force-apply policy."""
+        """An availability-only change queues circulation_apply, not bibliographic_apply."""
         updater, _ = _make_updater(db)
         pool = self._seed_imported_title(updater, db, 5, 5, title="Title A")
         bibliotheca_id = pool.identifier.identifier
@@ -379,9 +379,6 @@ class TestBibliothecaCirculationUpdaterUpdateBatch:
         mock_circ_apply.delay.assert_called_once()
         dispatched_circ = mock_circ_apply.delay.call_args.args[0]
         assert dispatched_circ.licenses_available == 2
-        # The apply is forced so the (possibly stale) pool hash cannot block it.
-        replace = mock_circ_apply.delay.call_args.kwargs["replace"]
-        assert replace.even_if_not_apparently_updated is True
 
     def test_no_change_queues_nothing(self, db: DatabaseTransactionFixture) -> None:
         """Nothing is queued when both metadata and availability match the pool."""
@@ -399,50 +396,6 @@ class TestBibliothecaCirculationUpdaterUpdateBatch:
 
         mock_bib_apply.delay.assert_not_called()
         mock_circ_apply.delay.assert_not_called()
-
-
-class TestBibliothecaCirculationUpdaterAvailabilityMatchesPool:
-    def test_compares_live_columns_and_status(
-        self, db: DatabaseTransactionFixture
-    ) -> None:
-        """_availability_matches_pool compares counts AND status against the live pool row."""
-        updater, mock_api = _make_updater(db)
-        ident = db.identifier(
-            identifier_type=Identifier.BIBLIOTHECA_ID, foreign_id="matcher"
-        )
-        pool, _ = LicensePool.for_foreign_id(
-            db.session,
-            mock_api.data_source,
-            Identifier.BIBLIOTHECA_ID,
-            ident.identifier,
-            collection=mock_api.collection,
-        )
-        pool.licenses_owned = 5
-        pool.licenses_available = 3
-        pool.licenses_reserved = 0
-        pool.patrons_in_hold_queue = 0
-        pool.status = LicensePoolStatus.ACTIVE
-        db.session.flush()
-
-        # All counts and status match the live row.
-        matching = _make_bib(ident.identifier, 5, 3).circulation
-        assert matching is not None
-        assert updater._availability_matches_pool(matching, pool) is True
-
-        # Each case differs from the pool in exactly one field -- including the
-        # status leg, which production Bibliotheca data always populates.
-        differing_circulations = [
-            _make_bib(ident.identifier, 4, 3).circulation,
-            _make_bib(ident.identifier, 5, 2).circulation,
-            _make_bib(ident.identifier, 5, 3, reserved=1).circulation,
-            _make_bib(ident.identifier, 5, 3, holds=1).circulation,
-            _make_bib(
-                ident.identifier, 5, 3, status=LicensePoolStatus.EXHAUSTED
-            ).circulation,
-        ]
-        for differing in differing_circulations:
-            assert differing is not None
-            assert updater._availability_matches_pool(differing, pool) is False
 
 
 class TestBibliothecaCirculationUpdaterProcessIdentifiers:
@@ -542,14 +495,17 @@ class TestBibliothecaCirculationUpdaterProcessIdentifiers:
         pool.update_availability(5, 2, 0, 0)
         db.session.flush()
         assert pool.licenses_available == 2
-        assert pool.updated_at_data_hash == stale_hash  # hash is now stale
+        # The hash is unchanged -- it only ever covered the stable fields, never the
+        # counts -- so it still matches the (5, 5) snapshot.
+        assert pool.updated_at_data_hash == stale_hash
 
-        # Bibliotheca's authoritative snapshot is (5, 5) again. Its circulation
-        # hash equals the stored (stale) hash, so the old hash-based check would
-        # NOT fire -- assert that precondition explicitly.
+        # Bibliotheca's authoritative snapshot is (5, 5) again: the stable-field hash
+        # matches, but the live columns have drifted to (5, 2), so the column-aware
+        # needs_apply correctly reports there is something to reconcile (a pure
+        # hash check -- the old behaviour -- would have skipped).
         reconcile = _make_bib(bibliotheca_id, 5, 5)
         assert reconcile.circulation is not None
-        assert reconcile.circulation.needs_apply(db.session, collection) is False
+        assert reconcile.circulation.needs_apply(db.session, collection) is True
 
         with patch.object(
             BibliothecaAPI, "bibliographic_lookup", return_value=[reconcile]


### PR DESCRIPTION
## Description

Generalizes the Bibliotheca live-column reconciliation from #3510/#3511 (PP-4666/PP-4691) into the
**shared data layer**, so circulation availability dedup is correct for **every** distributor, and
deletes the Bibliotheca-local band-aid. Also folds in the missing Boundless circulation gate.

The fix lives in `CirculationData`:

- **`fields_excluded_from_hash()`** now excludes the four availability count fields
  (`licenses_owned/available/reserved`, `patrons_in_hold_queue`). The dedup hash therefore covers only
  the *stable* fields (`formats`, `status`, `type`, `licenses`, …), which are only ever written by
  `apply()` and so remain reliable.
- **`should_apply_to(pool)`** compares those counts against the pool's **live columns** (in addition to
  the stable-field hash), while preserving the base `as_of_timestamp < pool.updated_at` staleness
  short-circuit. Both `needs_apply()` (the importers' gate) and `apply()`'s own internal check route
  through this method, so no `even_if_not_apparently_updated` is needed and an async apply that arrives
  after the columns already match simply no-ops.

Every importer that already gates circulation on `circulation.needs_apply()` (OPDS / OPDS2 /
for-distributors / ODL via the shared base, Overdrive, the Bibliotheca sweep) inherits the fix with no
logic change. The Bibliotheca sweep is simplified back to the OPDS-style two-track gate
(`bibliographic_apply` / `circulation_apply`), dropping `_availability_matches_pool` and the `even_if`
force. Boundless gets its missing circulation gate so it routes through the corrected dedup too.

## Motivation and Context
JIRA (PP-4703)
`LicensePool.updated_at_data_hash` is written only by `CirculationData.apply()`, but the availability
**columns** are mutated **out of band** — by the Bibliotheca event importer
(`update_availability_from_delta`), ODL loans/holds/expiration (`update_availability_from_licenses`), and
the circulation dispatcher (`update_availability`) — none of which restamp the hash. So the hash drifts
from the columns, and a hash-gated reconciliation skips real updates. This caused the Bibliotheca
availability-sync bug fixed locally in #3511; this PR removes the underlying drift class for all
distributors instead of per-distributor.

**ODL/aggregated pools are intentionally unaffected.** Their CirculationData carries `licenses` with the
counts as `None`, so the live-column compare is a no-op and they keep using the hash — matching the
existing `test_needs_apply_aggregated_pool_uses_hash` ("the hash check applies uniformly; license expiry
is handled by a dedicated Celery task"). License expiry remains the `license_expiration` task's job.

### Why this shape (and not the literal "canonical-state" refactor)

A *pure* canonical-state compare (and dropping `updated_at_data_hash`) is impractical: the stable fields
(`formats` ↔ delivery mechanisms, `links`, ODL `licenses`) don't round-trip from the pool and have no
reverse constructor. But the drift is confined to the **count columns**, and the hash is already reliable
for the stable fields — so we exclude the counts from the hash and compare them live, keeping the hash
for everything else. No migration is required: excluding the counts changes the hash value, so each pool
re-applies once on its next sweep/import and self-heals.

Considered and rejected: **dropping the column** (semantic comparators for the hard fields + an N-1
migration — much more code for marginal benefit) and **nulling the hash inside `update_availability`**
(touches a shared hot path for all distributors, re-applies every active title each run, and needs a
resync migration).

## How Has This Been Tested?

- **`tests/manager/data_layer/test_circulation.py`** (the core): added `test_calculate_hash_excludes_availability_counts`,
  `test_needs_apply_compares_live_columns` (the drift regression — a count change is detected while the
  stable-field hash matches), and `test_needs_apply_skips_older_snapshot_even_when_counts_differ`
  (staleness preserved). Existing `test_needs_apply` and `test_needs_apply_aggregated_pool_uses_hash`
  (ODL) continue to pass unchanged.
- **Bibliotheca updater tests** simplified to the two-track shape; the `_availability_matches_pool` unit
  tests are removed (logic now lives in `test_circulation.py`); the end-to-end drift regression is kept
  and its precondition updated (`needs_apply` now correctly reports the drift).
- **Boundless** importer gets the staged circulation-gate change and its tests.
- Full local runs (throwaway Postgres/Redis): **770** `integration/license/` + `data_layer/` tests and
  the apply / per-distributor Celery task tests pass. `mypy` and pre-commit clean. (The only non-passing
  Celery tests are pre-existing `test_search`/`test_marc` cases that require OpenSearch/S3, unrelated to
  this change.)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
