### PR TITLE
Remove the orphaned v5/v6/v7 search indexes

### DIFF
--- a/src/palace/manager/search/service.py
+++ b/src/palace/manager/search/service.py
@@ -363,7 +363,10 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
         if not self._write_client.indices.exists(index=name):
             return False
         self.log.info(f"removing index {name}")
-        self._write_client.indices.delete(index=name)
+        # ignore=[404] covers the small window where the index is dropped between
+        # the exists() check and here, so a concurrent delete is a no-op rather
+        # than a NotFoundError.
+        self._write_client.indices.delete(index=name, ignore=[404])
         return True
 
 

--- a/src/palace/manager/search/service.py
+++ b/src/palace/manager/search/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
@@ -160,6 +161,14 @@ class SearchService(ABC):
     @abstractmethod
     def index_remove_document(self, doc_id: int) -> None:
         """Remove a specific document from the given index."""
+
+    @abstractmethod
+    def index_remove(self, name: str) -> bool:
+        """Delete the index with the given *name* if it exists.
+
+        :return: True if the index existed and was removed, False if there was
+            no such index.
+        """
 
 
 class SearchServiceOpensearch1(SearchService, LoggerMixin):
@@ -349,3 +358,57 @@ class SearchServiceOpensearch1(SearchService, LoggerMixin):
 
     def index_remove_document(self, doc_id: int) -> None:
         self._write_client.delete(index=self.write_pointer_name(), id=doc_id)
+
+    def index_remove(self, name: str) -> bool:
+        if not self._write_client.indices.exists(index=name):
+            return False
+        self.log.info(f"removing index {name}")
+        self._write_client.indices.delete(index=name)
+        return True
+
+
+def remove_search_indices(
+    service: SearchService,
+    versions: Sequence[int],
+    *,
+    log: logging.Logger,
+) -> list[str]:
+    """Remove the search indexes for the given old schema *versions*.
+
+    When the search schema migrates to a new revision the read and write aliases
+    are re-pointed at the new index, but the index they replaced is left in
+    place, so retired revisions leave orphaned ``{base}-v{n}`` indexes behind in
+    the cluster. This deletes the named versions if they are still present.
+
+    As a safety guard it never deletes an index that a read or write alias still
+    points at, so it cannot remove the live index even if it is asked to.
+
+    :param service: The search service to operate on.
+    :param versions: The schema versions whose indexes should be removed.
+    :param log: The logger to report progress to.
+    :return: The names of the indexes that were removed.
+    """
+    base = service.base_revision_name
+
+    # Never delete an index an alias still points at -- that would break reads or
+    # writes. In the expected post-migration state both aliases are on the
+    # current revision, so none of the old versions are protected.
+    protected = {
+        pointer.index
+        for pointer in (service.read_pointer(), service.write_pointer())
+        if pointer is not None
+    }
+
+    removed: list[str] = []
+    for version in versions:
+        name = f"{base}-v{version}"
+        if name in protected:
+            log.warning(
+                f"Not removing search index {name}: an alias still points at it."
+            )
+        elif service.index_remove(name):
+            log.info(f"Removed old search index {name}.")
+            removed.append(name)
+        else:
+            log.info(f"Old search index {name} not found; nothing to remove.")
+    return removed

--- a/startup_tasks/2026_06_30_remove_old_search_indexes.py
+++ b/startup_tasks/2026_06_30_remove_old_search_indexes.py
@@ -1,0 +1,26 @@
+"""Remove the orphaned v5, v6 and v7 search indexes.
+
+The v5-v7 search schema revisions were removed once production moved to the
+self-contained v8 schema. Earlier reindex migrations re-pointed the search
+read/write aliases at each new index but never deleted the index they replaced,
+so ``circulation-works-v5``, ``-v6`` and ``-v7`` linger in the cluster consuming
+shards and disk. This removes them if they are still present, skipping any index
+an alias still points at.
+
+TODO: Remove this task once it has run on all deployments.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from celery.canvas import Signature
+from sqlalchemy.orm import Session
+
+from palace.manager.search.service import remove_search_indices
+from palace.manager.service.container import Services
+
+
+def run(services: Services, session: Session, log: logging.Logger) -> Signature | None:
+    remove_search_indices(services.search.service(), [5, 6, 7], log=log)
+    return None

--- a/startup_tasks/2026_06_30_remove_old_search_indexes.py
+++ b/startup_tasks/2026_06_30_remove_old_search_indexes.py
@@ -6,8 +6,6 @@ read/write aliases at each new index but never deleted the index they replaced,
 so ``circulation-works-v5``, ``-v6`` and ``-v7`` linger in the cluster consuming
 shards and disk. This removes them if they are still present, skipping any index
 an alias still points at.
-
-TODO: Remove this task once it has run on all deployments.
 """
 
 from __future__ import annotations
@@ -22,5 +20,8 @@ from palace.manager.service.container import Services
 
 
 def run(services: Services, session: Session, log: logging.Logger) -> Signature | None:
+    # Removing a handful of indexes is a fast metadata operation, so we run it
+    # directly here rather than dispatching a Celery task. If OpenSearch is
+    # briefly unavailable this raises and the task runs again on the next boot.
     remove_search_indices(services.search.service(), [5, 6, 7], log=log)
     return None

--- a/tests/manager/search/test_service.py
+++ b/tests/manager/search/test_service.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,6 +8,7 @@ from palace.manager.search.service import (
     SearchDocument,
     SearchPointer,
     SearchServiceOpensearch1,
+    remove_search_indices,
 )
 from tests.fixtures.search import ExternalSearchFixture
 from tests.mocks.search import MockSearchSchemaRevision
@@ -83,6 +85,23 @@ class TestService:
         assert indices.exists(
             index=revision.name_for_index(external_search_fixture.index_prefix)
         )
+
+    def test_index_remove(self, external_search_fixture: ExternalSearchFixture):
+        """index_remove deletes an existing index and is a no-op if it's absent."""
+        service = external_search_fixture.service
+        revision = MockSearchSchemaRevision(23)
+        service.index_create(revision)
+
+        name = revision.name_for_index(external_search_fixture.index_prefix)
+        indices = external_search_fixture.write_client.indices
+        assert indices.exists(index=name)
+
+        # Removing an existing index reports True and the index is gone.
+        assert service.index_remove(name) is True
+        assert not indices.exists(index=name)
+
+        # Removing a missing index is a no-op that reports False.
+        assert service.index_remove(name) is False
 
     def test_read_pointer_none(self, external_search_fixture: ExternalSearchFixture):
         """The read pointer is initially unset."""
@@ -199,3 +218,55 @@ class TestService:
         pointer = service._get_pointer("base-search-read")
         assert pointer is None
         mock_client.indices.get_alias.assert_called_once_with(name="base-search-read")
+
+
+class TestRemoveSearchIndices:
+    def test_removes_old_indices(self, external_search_fixture: ExternalSearchFixture):
+        service = external_search_fixture.service
+        base = external_search_fixture.index_prefix
+        indices = external_search_fixture.write_client.indices
+
+        # A current index that both aliases point at, plus old leftovers.
+        current = MockSearchSchemaRevision(8)
+        service.index_create(current)
+        service.read_pointer_set(current)
+        service.write_pointer_set(current)
+        for version in (5, 6, 7):
+            service.index_create(MockSearchSchemaRevision(version))
+
+        removed = remove_search_indices(
+            service, [5, 6, 7], log=logging.getLogger("test")
+        )
+
+        assert set(removed) == {f"{base}-v{version}" for version in (5, 6, 7)}
+        for version in (5, 6, 7):
+            assert not indices.exists(index=f"{base}-v{version}")
+        # The live index is untouched.
+        assert indices.exists(index=f"{base}-v8")
+
+    def test_skips_aliased_index(self, external_search_fixture: ExternalSearchFixture):
+        """An index a read or write alias still points at is never removed."""
+        service = external_search_fixture.service
+        base = external_search_fixture.index_prefix
+        indices = external_search_fixture.write_client.indices
+
+        # Point the read alias at an "old" version, as if a migration were still
+        # in progress and the read pointer had not yet moved on.
+        old = MockSearchSchemaRevision(5)
+        service.index_create(old)
+        service.read_pointer_set(old)
+
+        removed = remove_search_indices(service, [5], log=logging.getLogger("test"))
+
+        assert removed == []
+        assert indices.exists(index=f"{base}-v5")
+
+    def test_missing_index_is_noop(
+        self, external_search_fixture: ExternalSearchFixture
+    ):
+        """Removing versions whose indexes don't exist is a harmless no-op."""
+        service = external_search_fixture.service
+        removed = remove_search_indices(
+            service, [5, 6, 7], log=logging.getLogger("test")
+        )
+        assert removed == []

--- a/tests/mocks/search.py
+++ b/tests/mocks/search.py
@@ -39,6 +39,7 @@ class SearchServiceFake(SearchService):
         self._documents_by_index = defaultdict(list)
         self._read_pointer: SearchPointer | None = None
         self._write_pointer: SearchPointer | None = None
+        self._created_indices: set[str] = set()
         self._search_client = Search(using=MagicMock())
         self._multi_search_client = MultiSearch(using=MagicMock())
         self._document_submission_attempts = []
@@ -99,6 +100,7 @@ class SearchServiceFake(SearchService):
 
     def index_create(self, revision: SearchSchemaRevision) -> None:
         self._fail_if_necessary()
+        self._created_indices.add(revision.name_for_index(self.base_name))
         return None
 
     def index_set_mapping(self, revision: SearchSchemaRevision) -> None:
@@ -181,6 +183,13 @@ class SearchServiceFake(SearchService):
         to_remove = [item for item in items if item.get("_id") == doc_id]
         for item in to_remove:
             items.remove(item)
+
+    def index_remove(self, name: str) -> bool:
+        self._fail_if_necessary()
+        if name in self._created_indices:
+            self._created_indices.discard(name)
+            return True
+        return False
 
 
 def fake_hits(works: list[Work]):


### PR DESCRIPTION
## Description

Stacked on top of #3523. Cleans up the orphaned `circulation-works-v5`, `-v6` and `-v7` OpenSearch indexes that earlier schema revisions left behind in the cluster.

When the search schema migrates to a new revision, the reindex flow creates the new index and re-points the read/write aliases at it, but it never deletes the index it replaced — so every retired revision leaves an orphaned `{base}-v{n}` index sitting in the cluster, consuming shards and disk. Nothing in the codebase has ever removed them. #3523 removes the v5–v7 revision *code*; this PR removes the leftover *indexes*.

This adds:

- **`SearchService.index_remove(name)`** — deletes an index if it exists and reports whether it did. The service had no delete-index capability before.
- **`remove_search_indices(service, versions, *, log)` helper** — deletes the named old versions, with a safety guard that **never deletes an index a read or write alias still points at**, so it cannot drop the live index even if asked to. It's idempotent (delete-if-exists) and returns the names it removed.
- **A one-shot startup task** (`startup_tasks/2026_06_30_remove_old_search_indexes.py`) that calls the helper inline for versions `[5, 6, 7]` on the next boot.

Removing a handful of indexes is a fast metadata operation, so this runs inline in the startup task rather than via a background job. If OpenSearch is briefly unavailable the helper raises, the startup runner declines to record the task as done, and it simply retries on the next boot.

## Motivation and Context

Removing the v5–v7 revision modules (#3523) stops the code from referencing those schemas, but the actual indexes remain in the cluster forever because the migration flow only swaps aliases and never drops the old index. This reclaims that cluster state (shards, disk) as the final step of retiring those revisions.

## How Has This Been Tested?

New tests, all passing under the docker tox environment:

- `tests/manager/search/test_service.py::TestService::test_index_remove` — `index_remove` deletes a real index and is a no-op (returns `False`) when it's absent.
- `tests/manager/search/test_service.py::TestRemoveSearchIndices` — three cases against the real OpenSearch fixture: the happy path (old indexes removed, the live index preserved), the alias guard (an index a read alias points at is skipped), and a no-op when the indexes don't exist.

Also ran the startup-task and initialization suites to confirm the new task file is discovered and the boot wiring is unaffected.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
