### PR TITLE
Update circulation-admin to 1.43.0

### DIFF
--- a/src/palace/manager/api/admin/config.py
+++ b/src/palace/manager/api/admin/config.py
@@ -86,7 +86,7 @@ class OperationalMode(str, Enum):
 class Configuration(LoggerMixin):
     APP_NAME = "Palace Collection Manager"
     PACKAGE_NAME = "@thepalaceproject/circulation-admin"
-    PACKAGE_VERSION = "1.42.2"
+    PACKAGE_VERSION = "1.43.0"
 
     STATIC_ASSETS = {
         "admin_js": "circulation-admin.js",


### PR DESCRIPTION
## Description

Bump the bundled `@thepalaceproject/circulation-admin` package version from `1.42.2` to `1.43.0` in `Configuration.PACKAGE_VERSION`.

## Motivation and Context

Keeps the admin web dashboard assets served by Palace Manager up to date with the latest `circulation-admin` release.

## How Has This Been Tested?

Ran pre-commit on the changed file. This is a version-string bump only; the admin assets are loaded from the CDN at the configured version.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
