### PR TITLE
Add circ-celery container image to replace circ-scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
       scripts-meta: ${{ steps.meta-scripts.outputs.json }}
       exec-repo: ${{ steps.ghcr-repo.outputs.exec }}
       exec-meta: ${{ steps.meta-exec.outputs.json }}
+      celery-repo: ${{ steps.ghcr-repo.outputs.celery }}
+      celery-meta: ${{ steps.meta-celery.outputs.json }}
 
     # https://docs.docker.com/build/ci/github-actions/local-registry/
     services:
@@ -74,6 +76,7 @@ jobs:
           webapp="ghcr.io/$repo/circ-webapp"
           scripts="ghcr.io/$repo/circ-scripts"
           exec="ghcr.io/$repo/circ-exec"
+          celery="ghcr.io/$repo/circ-celery"
           baseimage="ghcr.io/$repo/circ-baseimage"
           echo "webapp=$webapp"
           echo "webapp=$webapp" >> "$GITHUB_OUTPUT"
@@ -81,6 +84,8 @@ jobs:
           echo "scripts=$scripts" >> "$GITHUB_OUTPUT"
           echo "exec=$exec"
           echo "exec=$exec" >> "$GITHUB_OUTPUT"
+          echo "celery=$celery"
+          echo "celery=$celery" >> "$GITHUB_OUTPUT"
           echo "baseimage=$baseimage"
           echo "baseimage=$baseimage" >> "$GITHUB_OUTPUT"
 
@@ -222,6 +227,29 @@ jobs:
           labels: ${{ steps.meta-exec.outputs.labels }}
           outputs: type=image,"name=${{ steps.ghcr-repo.outputs.exec }}",push-by-digest=true,name-canonical=true,push=true
 
+      - name: Generate tags for circ-celery
+        id: meta-celery
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ steps.ghcr-repo.outputs.celery }}
+          tags: |
+            type=semver,pattern={{major}}.{{minor}},priority=10
+            type=semver,pattern={{version}},priority=20
+            type=ref,event=branch,priority=30
+            type=sha,priority=40
+
+      - name: Build circ-celery image
+        id: build-celery
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          target: celery
+          build-args: |
+            BASE_IMAGE=${{ steps.baseimage.outputs.tag }}
+          labels: ${{ steps.meta-celery.outputs.labels }}
+          outputs: type=image,"name=${{ steps.ghcr-repo.outputs.celery }}",push-by-digest=true,name-canonical=true,push=true
+
       - name: Export digests
         run: |
           mkdir -p ${{ runner.temp }}/digests/webapp
@@ -236,6 +264,10 @@ jobs:
           exec_digest="${{ steps.build-exec.outputs.digest }}"
           touch "${{ runner.temp }}/digests/exec/${exec_digest#sha256:}"
           echo "EXEC_DIGEST=$exec_digest"
+          mkdir -p ${{ runner.temp }}/digests/celery
+          celery_digest="${{ steps.build-celery.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/celery/${celery_digest#sha256:}"
+          echo "CELERY_DIGEST=$celery_digest"
 
       - name: Upload digests
         uses: actions/upload-artifact@v7
@@ -292,6 +324,15 @@ jobs:
           echo "$IMAGE"
           echo "WEBAPP_IMAGE=$IMAGE" >> $GITHUB_ENV
 
+      # This sets the environment variable referenced in the docker-compose file
+      # for the celery containers to the digest of the image built in the build job.
+      - name: Set celery image
+        working-directory: ${{ runner.temp }}/digests/celery
+        run: |
+          IMAGE="${{needs.build.outputs.celery-repo}}$(printf '@sha256:%s' *)"
+          echo "$IMAGE"
+          echo "CELERY_IMAGE=$IMAGE" >> $GITHUB_ENV
+
       # See comment here: https://github.com/actions/runner-images/issues/1187#issuecomment-686735760
       - name: Disable network offload
         run: sudo ethtool -K eth0 tx off rx off
@@ -307,6 +348,9 @@ jobs:
 
       - name: Run scripts image tests
         run: ./docker/ci/test_scripts.sh scripts
+
+      - name: Run celery image tests
+        run: ./docker/ci/test_celery.sh
 
       - name: Output logs
         if: failure()
@@ -516,3 +560,10 @@ jobs:
           docker buildx imagetools create
           $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ needs.build.outputs.exec-meta }}')
           $(printf '${{ needs.build.outputs.exec-repo }}@sha256:%s ' *)
+
+      - name: Create manifest & push circ-celery
+        working-directory: ${{ runner.temp }}/digests/celery
+        run: >
+          docker buildx imagetools create
+          $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ needs.build.outputs.celery-meta }}')
+          $(printf '${{ needs.build.outputs.celery-repo }}@sha256:%s ' *)

--- a/README.md
+++ b/README.md
@@ -251,10 +251,9 @@ the defaults should be sufficient. The full list of settings can be found in
 ##### `circ-celery` image
 
 The `circ-celery` image runs a single Celery process per container, so it can be deployed as the beat
-scheduler, one or more autoscaled worker pools, and the CloudWatch metrics camera — all from the same
-image. The role is chosen by the container command (`beat`, `worker`, or `cloudwatch`), and a few
-launch-time variables (read by the container's entrypoint, not by the application) configure the
-`worker` role:
+scheduler or one or more autoscaled worker pools — all from the same image. The role is chosen by the
+container command (`beat` or `worker`), and a few launch-time variables (read by the container's
+entrypoint, not by the application) configure the `worker` role:
 
 - `PALACE_CELERY_QUEUES`: Comma-separated list of queues a `worker` container should consume, e.g.
     `high,default` (**required for the `worker` role**). Each queue's tasks are defined by
@@ -265,11 +264,11 @@ launch-time variables (read by the container's entrypoint, not by the applicatio
     The default is `1` (optional).
 - `PALACE_CELERY_WORKER_HOSTNAME`: The Celery `--hostname` for a `worker` container. The default is
     `worker@%h` (optional).
-- `PALACE_CELERY_CLOUDWATCH_FLUSH_INTERVAL`: How often, in seconds, the `cloudwatch` role flushes queue
-    metrics. The default is `60` (optional).
 
-The `beat` and `cloudwatch` roles must each run as a single instance (a second beat would double-fire
-scheduled tasks); only the `worker` role should be scaled.
+The `beat` role must run as a single instance (a second beat would double-fire scheduled tasks); only
+the `worker` role should be scaled. The queue-depth metrics that drive worker autoscaling
+(`QueueWaiting` / `QueueOldestAge`, in the `Celery` CloudWatch namespace) are published every minute by
+the `publish_queue_stats` task on the beat schedule, so no always-on metrics process is required.
 
 #### Redis
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Docker images created from this code are available at:
 - [circ-webapp](https://github.com/ThePalaceProject/circulation/pkgs/container/circ-webapp)
 - [circ-scripts](https://github.com/ThePalaceProject/circulation/pkgs/container/circ-scripts)
 - [circ-exec](https://github.com/ThePalaceProject/circulation/pkgs/container/circ-exec)
+- [circ-celery](https://github.com/ThePalaceProject/circulation/pkgs/container/circ-celery)
 
 Docker images are the preferred way to deploy this code in a production environment.
 
@@ -246,6 +247,29 @@ pass a broker URL and a result backend URL to the application.
 We support overriding a number of other Celery settings via environment variables, but in most cases
 the defaults should be sufficient. The full list of settings can be found in
 [`service/celery/configuration.py`](src/palace/manager/service/celery/configuration.py).
+
+##### `circ-celery` image
+
+The `circ-celery` image runs a single Celery process per container, so it can be deployed as the beat
+scheduler, one or more autoscaled worker pools, and the CloudWatch metrics camera — all from the same
+image. The role is chosen by the container command (`beat`, `worker`, or `cloudwatch`), and a few
+launch-time variables (read by the container's entrypoint, not by the application) configure the
+`worker` role:
+
+- `PALACE_CELERY_QUEUES`: Comma-separated list of queues a `worker` container should consume, e.g.
+    `high,default` (**required for the `worker` role**). Each queue's tasks are defined by
+    [`QueueNames`](src/palace/manager/service/celery/celery.py).
+- `PALACE_CELERY_CONCURRENCY`: The number of child processes for a `worker` container. This is a single
+    pool shared across all of the queues that container consumes; to give a queue its own concurrency,
+    run a separate `worker` deployment with its own `PALACE_CELERY_QUEUES`/`PALACE_CELERY_CONCURRENCY`.
+    The default is `1` (optional).
+- `PALACE_CELERY_WORKER_HOSTNAME`: The Celery `--hostname` for a `worker` container. The default is
+    `worker@%h` (optional).
+- `PALACE_CELERY_CLOUDWATCH_FLUSH_INTERVAL`: How often, in seconds, the `cloudwatch` role flushes queue
+    metrics. The default is `60` (optional).
+
+The `beat` and `cloudwatch` roles must each run as a single instance (a second beat would double-fire
+scheduled tasks); only the `worker` role should be scaled.
 
 #### Redis
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,39 @@
 # Common CM setup
 # see: https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension
+
+# The shared environment is its own anchor so a service (e.g. the celery worker)
+# can merge it and add a few of its own variables without repeating the block.
+x-cm-environment: &cm-environment
+  SIMPLIFIED_PRODUCTION_DATABASE: "postgresql://palace:test@pg:5432/circ"
+  PALACE_SEARCH_URL: "http://os:9200"
+  PALACE_STORAGE_ACCESS_KEY: "palace"
+  PALACE_STORAGE_SECRET_KEY: "test123456789"
+  PALACE_STORAGE_ENDPOINT_URL: "http://minio:9000"
+  PALACE_STORAGE_PUBLIC_ACCESS_BUCKET: "public"
+  PALACE_STORAGE_ANALYTICS_BUCKET: "analytics"
+  PALACE_STORAGE_URL_TEMPLATE: "http://localhost:9000/{bucket}/{key}"
+  PALACE_REPORTING_NAME: "TEST CM"
+  PALACE_SECRET_KEY: "SECRET_KEY_USED_FOR_ADMIN_UI_COOKIES"
+  PALACE_PATRON_WEB_HOSTNAMES: "*"
+  PALACE_BASE_URL: "http://localhost:6500"
+  PALACE_CELERY_BROKER_URL: "redis://valkey:6379/0"
+  PALACE_CELERY_RESULT_BACKEND: "redis://valkey:6379/2"
+  PALACE_CELERY_BROKER_TRANSPORT_OPTIONS_GLOBAL_KEYPREFIX: "test"
+  PALACE_CELERY_CLOUDWATCH_STATISTICS_DRYRUN: "true"
+  PALACE_REDIS_URL: "redis://valkey:6379/1"
+  PALACE_GOOGLE_DRIVE_SERVICE_ACCOUNT_INFO_JSON: "${PALACE_GOOGLE_DRIVE_SERVICE_ACCOUNT_INFO_JSON-}"
+
+  # Set up the environment variables used for testing as well
+  PALACE_TEST_DATABASE_URL: "postgresql://palace:test@pg:5432/circ"
+  PALACE_TEST_SEARCH_URL: "http://os:9200"
+  PALACE_TEST_MINIO_URL: "http://minio:9000"
+  PALACE_TEST_MINIO_USER: "palace"
+  PALACE_TEST_MINIO_PASSWORD: "test123456789"
+  PALACE_TEST_REDIS_URL: "redis://valkey:6379/3"
+
 x-cm-variables: &cm
   platform: "${BUILD_PLATFORM-}"
-  environment:
-    SIMPLIFIED_PRODUCTION_DATABASE: "postgresql://palace:test@pg:5432/circ"
-    PALACE_SEARCH_URL: "http://os:9200"
-    PALACE_STORAGE_ACCESS_KEY: "palace"
-    PALACE_STORAGE_SECRET_KEY: "test123456789"
-    PALACE_STORAGE_ENDPOINT_URL: "http://minio:9000"
-    PALACE_STORAGE_PUBLIC_ACCESS_BUCKET: "public"
-    PALACE_STORAGE_ANALYTICS_BUCKET: "analytics"
-    PALACE_STORAGE_URL_TEMPLATE: "http://localhost:9000/{bucket}/{key}"
-    PALACE_REPORTING_NAME: "TEST CM"
-    PALACE_SECRET_KEY: "SECRET_KEY_USED_FOR_ADMIN_UI_COOKIES"
-    PALACE_PATRON_WEB_HOSTNAMES: "*"
-    PALACE_BASE_URL: "http://localhost:6500"
-    PALACE_CELERY_BROKER_URL: "redis://valkey:6379/0"
-    PALACE_CELERY_RESULT_BACKEND: "redis://valkey:6379/2"
-    PALACE_CELERY_BROKER_TRANSPORT_OPTIONS_GLOBAL_KEYPREFIX: "test"
-    PALACE_CELERY_CLOUDWATCH_STATISTICS_DRYRUN: "true"
-    PALACE_REDIS_URL: "redis://valkey:6379/1"
-    PALACE_GOOGLE_DRIVE_SERVICE_ACCOUNT_INFO_JSON: "${PALACE_GOOGLE_DRIVE_SERVICE_ACCOUNT_INFO_JSON-}"
-
-    # Set up the environment variables used for testing as well
-    PALACE_TEST_DATABASE_URL: "postgresql://palace:test@pg:5432/circ"
-    PALACE_TEST_SEARCH_URL: "http://os:9200"
-    PALACE_TEST_MINIO_URL: "http://minio:9000"
-    PALACE_TEST_MINIO_USER: "palace"
-    PALACE_TEST_MINIO_PASSWORD: "test123456789"
-    PALACE_TEST_REDIS_URL: "redis://valkey:6379/3"
+  environment: *cm-environment
 
   depends_on:
     pg:
@@ -66,6 +71,40 @@ services:
       <<: *cm-build
       target: scripts
     image: "${SCRIPTS_IMAGE-}"
+
+  # The celery-* services all run from the single circ-celery image; the role is
+  # the container command. In production these become the beat deployment (one
+  # replica), the autoscaled worker deployment(s), and the CloudWatch camera.
+  celery-beat:
+    <<: *cm
+    build:
+      <<: *cm-build
+      target: celery
+    image: "${CELERY_IMAGE-}"
+    command: ["beat"]
+
+  celery-worker:
+    <<: *cm
+    build:
+      <<: *cm-build
+      target: celery
+    image: "${CELERY_IMAGE-}"
+    command: ["worker"]
+    # A single dev/test worker consumes every queue. In production each queue
+    # (or group) is its own deployment with its own queues/concurrency so it can
+    # be autoscaled independently.
+    environment:
+      <<: *cm-environment
+      PALACE_CELERY_QUEUES: "high,default,apply"
+      PALACE_CELERY_CONCURRENCY: "2"
+
+  celery-cloudwatch:
+    <<: *cm
+    build:
+      <<: *cm-build
+      target: celery
+    image: "${CELERY_IMAGE-}"
+    command: ["cloudwatch"]
 
   pg:
     image: "postgres:16"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,9 @@ services:
 
   # The celery-* services all run from the single circ-celery image; the role is
   # the container command. In production these become the beat deployment (one
-  # replica), the autoscaled worker deployment(s), and the CloudWatch camera.
+  # replica) and the autoscaled worker deployment(s). Queue-depth metrics are
+  # published by the beat-scheduled publish_queue_stats task, so there is no
+  # separate metrics container.
   celery-beat:
     <<: *cm
     build:
@@ -97,14 +99,6 @@ services:
       <<: *cm-environment
       PALACE_CELERY_QUEUES: "high,default,apply"
       PALACE_CELERY_CONCURRENCY: "2"
-
-  celery-cloudwatch:
-    <<: *cm
-    build:
-      <<: *cm-build
-      target: celery
-    image: "${CELERY_IMAGE-}"
-    command: ["cloudwatch"]
 
   pg:
     image: "postgres:16"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,6 +64,34 @@ WORKDIR /home/palace/circulation/bin
 CMD ["/sbin/my_init"]
 
 ###############################################################################
+## Circ-celery Image
+##
+## A single image that runs one Celery process per container. The role is
+## selected by the first argument to the entrypoint (beat|worker|cloudwatch),
+## so one image backs the beat scheduler, every autoscaled worker pool, and the
+## CloudWatch metrics camera. Unlike the scripts image, it does NOT use runit to
+## supervise several processes -- one process per container is what lets the
+## worker pools be scaled horizontally, and the beat scheduler be pinned to a
+## single instance.
+###############################################################################
+
+FROM common AS celery
+
+# Set the local timezone so log timestamps line up with the other images. Beat's
+# own schedule is driven by the Celery `timezone` setting, not this.
+ENV TZ=US/Eastern
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
+
+COPY --chmod=755 docker/celery-entrypoint.sh /celery-entrypoint.sh
+
+WORKDIR /var/www/circulation
+
+# The role is provided as the container command, e.g. `docker run circ-celery
+# worker`, with PALACE_CELERY_QUEUES / PALACE_CELERY_CONCURRENCY set for worker
+# pools. See docker/celery-entrypoint.sh for the supported roles and env vars.
+ENTRYPOINT ["/celery-entrypoint.sh"]
+
+###############################################################################
 ## Circ-webapp Image
 ###############################################################################
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,6 +81,14 @@ FROM common AS celery
 ENV TZ=US/Eastern
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
 
+# The entrypoint runs as root and drops to the `palace` user via `celery --uid`,
+# which does not reset HOME. Without this the worker would inherit root's
+# HOME=/root, and libpq (psycopg2) -- probing $HOME/.postgresql/postgresql.crt on
+# connect -- would hit EACCES on /root (mode 700), abort the SSL handshake, and
+# fall back to a plaintext connection that an SSL-required Postgres rejects. The
+# phusion-based images get this from my_init; here we set it explicitly.
+ENV HOME=/home/palace
+
 COPY --chmod=755 docker/celery-entrypoint.sh /celery-entrypoint.sh
 
 WORKDIR /var/www/circulation

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,12 +67,11 @@ CMD ["/sbin/my_init"]
 ## Circ-celery Image
 ##
 ## A single image that runs one Celery process per container. The role is
-## selected by the first argument to the entrypoint (beat|worker|cloudwatch),
-## so one image backs the beat scheduler, every autoscaled worker pool, and the
-## CloudWatch metrics camera. Unlike the scripts image, it does NOT use runit to
-## supervise several processes -- one process per container is what lets the
-## worker pools be scaled horizontally, and the beat scheduler be pinned to a
-## single instance.
+## selected by the first argument to the entrypoint (beat|worker), so one image
+## backs both the beat scheduler and every autoscaled worker pool. Unlike the
+## scripts image, it does NOT use runit to supervise several processes -- one
+## process per container is what lets the worker pools be scaled horizontally,
+## and the beat scheduler be pinned to a single instance.
 ###############################################################################
 
 FROM common AS celery

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,11 +67,19 @@ CMD ["/sbin/my_init"]
 ## Circ-celery Image
 ##
 ## A single image that runs one Celery process per container. The role is
-## selected by the first argument to the entrypoint (beat|worker), so one image
-## backs both the beat scheduler and every autoscaled worker pool. Unlike the
-## scripts image, it does NOT use runit to supervise several processes -- one
-## process per container is what lets the worker pools be scaled horizontally,
-## and the beat scheduler be pinned to a single instance.
+## selected by the container command (beat|worker), so one image backs both the
+## beat scheduler and every autoscaled worker pool. Unlike the scripts image, it
+## does NOT use runit to supervise several processes -- one process per container
+## is what lets the worker pools be scaled horizontally, and the beat scheduler
+## be pinned to a single instance.
+##
+## Like the webapp/scripts images it boots via my_init, so the shared
+## /etc/my_init.d startup scripts run first -- notably the advisory-locked
+## `initialize_instance` (alembic upgrade head) -- before the Celery role starts.
+## This keeps the migration path identical to the other images: every container
+## brings the schema to head on start, so no separate migration step is needed.
+## `--skip-runit` is used because this image has no runit services; the single
+## Celery process is my_init's main command instead.
 ###############################################################################
 
 FROM common AS celery
@@ -81,22 +89,25 @@ FROM common AS celery
 ENV TZ=US/Eastern
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
 
-# The entrypoint runs as root and drops to the `palace` user via `celery --uid`,
-# which does not reset HOME. Without this the worker would inherit root's
-# HOME=/root, and libpq (psycopg2) -- probing $HOME/.postgresql/postgresql.crt on
-# connect -- would hit EACCES on /root (mode 700), abort the SSL handshake, and
-# fall back to a plaintext connection that an SSL-required Postgres rejects. The
-# phusion-based images get this from my_init; here we set it explicitly.
+# The Celery process runs as the `palace` user via `celery --uid`, which does not
+# reset HOME. Without this it would inherit root's HOME=/root, and libpq
+# (psycopg2) -- probing $HOME/.postgresql/postgresql.crt on connect -- would hit
+# EACCES on /root (mode 700), abort the SSL handshake, and fall back to a
+# plaintext connection that an SSL-required Postgres rejects. my_init does not
+# override an inherited HOME, so setting it here covers the --uid drop.
 ENV HOME=/home/palace
 
 COPY --chmod=755 docker/celery-entrypoint.sh /celery-entrypoint.sh
 
+VOLUME /var/log
 WORKDIR /var/www/circulation
 
 # The role is provided as the container command, e.g. `docker run circ-celery
 # worker`, with PALACE_CELERY_QUEUES / PALACE_CELERY_CONCURRENCY set for worker
-# pools. See docker/celery-entrypoint.sh for the supported roles and env vars.
-ENTRYPOINT ["/celery-entrypoint.sh"]
+# pools. my_init runs the startup scripts (incl. the DB migration), then execs
+# the entrypoint with the role appended. See docker/celery-entrypoint.sh for the
+# supported roles and env vars.
+ENTRYPOINT ["/sbin/my_init", "--skip-runit", "--quiet", "--", "/celery-entrypoint.sh"]
 
 ###############################################################################
 ## Circ-webapp Image

--- a/docker/README.md
+++ b/docker/README.md
@@ -77,6 +77,37 @@ $ docker run --name search_index_refresh -it \
     ghcr.io/thepalaceproject/circ-exec:main
 ```
 
+### circ-celery
+
+This image runs a single Celery process per container. Unlike `circ-scripts`, which supervises the
+beat scheduler and every worker in one container with runit, `circ-celery` runs exactly one process,
+so each role can be deployed and (for workers) autoscaled independently. The role is chosen by the
+container command: `beat`, `worker`, or `cloudwatch`.
+
+```sh
+# The beat scheduler (run exactly one of these).
+$ docker run --name celery-beat -d \
+    -e PALACE_CELERY_BROKER_URL='redis://[host]:6379/0' \
+    -e PALACE_CELERY_RESULT_BACKEND='redis://[host]:6379/2' \
+    -e SIMPLIFIED_PRODUCTION_DATABASE='postgresql://[username]:[password]@[host]:[port]/[database_name]' \
+    ghcr.io/thepalaceproject/circ-celery:main beat
+
+# A worker pool (scale the replica count on queue depth). PALACE_CELERY_QUEUES is required.
+$ docker run --name celery-worker -d \
+    -e PALACE_CELERY_BROKER_URL='redis://[host]:6379/0' \
+    -e PALACE_CELERY_RESULT_BACKEND='redis://[host]:6379/2' \
+    -e SIMPLIFIED_PRODUCTION_DATABASE='postgresql://[username]:[password]@[host]:[port]/[database_name]' \
+    -e PALACE_CELERY_QUEUES='high,default' \
+    -e PALACE_CELERY_CONCURRENCY='8' \
+    ghcr.io/thepalaceproject/circ-celery:main worker
+```
+
+The `worker` launch variables (`PALACE_CELERY_QUEUES`, `PALACE_CELERY_CONCURRENCY`,
+`PALACE_CELERY_WORKER_HOSTNAME`) and the `cloudwatch` flush interval
+(`PALACE_CELERY_CLOUDWATCH_FLUSH_INTERVAL`) are documented in the top-level
+[`README.md`](../README.md). Logs are written to stdout/stderr rather than to files, so nothing is
+lost when an autoscaled worker is scaled away.
+
 ## Environment Variables
 
 Environment variables can be set with the `-e VARIABLE_KEY='variable_value'` option on the `docker run` command.

--- a/docker/README.md
+++ b/docker/README.md
@@ -82,7 +82,8 @@ $ docker run --name search_index_refresh -it \
 This image runs a single Celery process per container. Unlike `circ-scripts`, which supervises the
 beat scheduler and every worker in one container with runit, `circ-celery` runs exactly one process,
 so each role can be deployed and (for workers) autoscaled independently. The role is chosen by the
-container command: `beat`, `worker`, or `cloudwatch`.
+container command: `beat` or `worker`. Queue-depth metrics that drive autoscaling are published by the
+`publish_queue_stats` task on the beat schedule, so there is no separate always-on metrics container.
 
 ```sh
 # The beat scheduler (run exactly one of these).

--- a/docker/README.md
+++ b/docker/README.md
@@ -85,6 +85,10 @@ so each role can be deployed and (for workers) autoscaled independently. The rol
 container command: `beat` or `worker`. Queue-depth metrics that drive autoscaling are published by the
 `publish_queue_stats` task on the beat schedule, so there is no separate always-on metrics container.
 
+Like the other images, `circ-celery` boots via `my_init` and so initializes or migrates the database
+on startup (advisory-locked `alembic upgrade head`) before the Celery process starts. No separate
+migration step is required.
+
 ```sh
 # The beat scheduler (run exactly one of these).
 $ docker run --name celery-beat -d \

--- a/docker/celery-entrypoint.sh
+++ b/docker/celery-entrypoint.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# Entrypoint for the circ-celery image.
+#
+# A single image backs every Celery process we run; the role is chosen by the
+# first argument, so the same image can be deployed as the beat scheduler, any
+# number of autoscaled worker pools, or the CloudWatch metrics camera:
+#
+#   celery-entrypoint.sh beat
+#   celery-entrypoint.sh worker        (PALACE_CELERY_QUEUES required)
+#   celery-entrypoint.sh cloudwatch
+#
+# Exactly one Celery process runs per container (no runit supervision); that is
+# what lets the worker pools be scaled horizontally, one replica per unit of
+# queue depth. Logs are written to stdout/stderr (as JSON, via the application's
+# logging configuration) rather than to files, so nothing is lost when an
+# autoscaled worker is scaled away.
+
+set -euo pipefail
+
+APP="palace.manager.celery.app"
+CELERY="/var/www/circulation/env/bin/celery"
+
+cd /var/www/circulation
+
+role="${1:-}"
+if [[ -z "$role" ]]; then
+  echo "Usage: $(basename "$0") <beat|worker|cloudwatch> [extra celery args]" >&2
+  exit 64
+fi
+shift
+
+case "$role" in
+  beat)
+    # Beat MUST run as a singleton -- a second replica would double-fire every
+    # scheduled task. Never autoscale this role; pin it to a single instance.
+    schedule_dir="/var/run/celery"
+    mkdir -p "$schedule_dir"
+    chown palace:palace "$schedule_dir"
+    exec "$CELERY" -A "$APP" beat \
+      --uid palace --gid palace \
+      --schedule "$schedule_dir/beat-schedule" \
+      "$@"
+    ;;
+  worker)
+    # The queue set and concurrency are supplied per-deployment so one image can
+    # back every worker pool. Concurrency is a single pool of child processes
+    # shared across ALL queues this worker consumes -- to give a queue its own
+    # concurrency, run a separate deployment with its own PALACE_CELERY_QUEUES
+    # and PALACE_CELERY_CONCURRENCY.
+    queues="${PALACE_CELERY_QUEUES:-}"
+    if [[ -z "$queues" ]]; then
+      echo "PALACE_CELERY_QUEUES is required for the worker role (comma-separated queue names)." >&2
+      exit 64
+    fi
+    concurrency="${PALACE_CELERY_CONCURRENCY:-1}"
+    hostname="${PALACE_CELERY_WORKER_HOSTNAME:-worker@%h}"
+    exec "$CELERY" -A "$APP" worker \
+      --uid palace --gid palace \
+      --queues "$queues" \
+      --concurrency "$concurrency" \
+      --hostname "$hostname" \
+      "$@"
+    ;;
+  cloudwatch)
+    # Publishes the per-queue depth (QueueWaiting) and oldest-age
+    # (QueueOldestAge) metrics that drive worker autoscaling. A single replica
+    # snapshots the whole broker, so this is a singleton as well.
+    flush="${PALACE_CELERY_CLOUDWATCH_FLUSH_INTERVAL:-60}"
+    exec "$CELERY" -A "$APP" events \
+      -c "palace.manager.celery.monitoring.Cloudwatch" \
+      -F "$flush" \
+      --uid palace --gid palace \
+      "$@"
+    ;;
+  *)
+    echo "Unknown role '$role' (expected: beat, worker, or cloudwatch)." >&2
+    exit 64
+    ;;
+esac

--- a/docker/celery-entrypoint.sh
+++ b/docker/celery-entrypoint.sh
@@ -2,6 +2,11 @@
 #
 # Entrypoint for the circ-celery image.
 #
+# my_init runs this script as its main command (after the shared
+# /etc/my_init.d startup scripts, which apply the DB migration), so by the time
+# we exec Celery the schema is already at head -- the same path the webapp and
+# scripts images use.
+#
 # A single image backs every Celery process we run; the role is chosen by the
 # first argument, so the same image can be deployed as the beat scheduler or any
 # number of autoscaled worker pools:

--- a/docker/celery-entrypoint.sh
+++ b/docker/celery-entrypoint.sh
@@ -3,18 +3,21 @@
 # Entrypoint for the circ-celery image.
 #
 # A single image backs every Celery process we run; the role is chosen by the
-# first argument, so the same image can be deployed as the beat scheduler, any
-# number of autoscaled worker pools, or the CloudWatch metrics camera:
+# first argument, so the same image can be deployed as the beat scheduler or any
+# number of autoscaled worker pools:
 #
 #   celery-entrypoint.sh beat
 #   celery-entrypoint.sh worker        (PALACE_CELERY_QUEUES required)
-#   celery-entrypoint.sh cloudwatch
 #
 # Exactly one Celery process runs per container (no runit supervision); that is
 # what lets the worker pools be scaled horizontally, one replica per unit of
 # queue depth. Logs are written to stdout/stderr (as JSON, via the application's
 # logging configuration) rather than to files, so nothing is lost when an
 # autoscaled worker is scaled away.
+#
+# Queue-depth metrics (which drive worker autoscaling) are published by the
+# periodic publish_queue_stats task on the beat schedule, so there is no separate
+# always-on metrics process/role here.
 
 set -euo pipefail
 
@@ -25,7 +28,7 @@ cd /var/www/circulation
 
 role="${1:-}"
 if [[ -z "$role" ]]; then
-  echo "Usage: $(basename "$0") <beat|worker|cloudwatch> [extra celery args]" >&2
+  echo "Usage: $(basename "$0") <beat|worker> [extra celery args]" >&2
   exit 64
 fi
 shift
@@ -62,19 +65,8 @@ case "$role" in
       --hostname "$hostname" \
       "$@"
     ;;
-  cloudwatch)
-    # Publishes the per-queue depth (QueueWaiting) and oldest-age
-    # (QueueOldestAge) metrics that drive worker autoscaling. A single replica
-    # snapshots the whole broker, so this is a singleton as well.
-    flush="${PALACE_CELERY_CLOUDWATCH_FLUSH_INTERVAL:-60}"
-    exec "$CELERY" -A "$APP" events \
-      -c "palace.manager.celery.monitoring.Cloudwatch" \
-      -F "$flush" \
-      --uid palace --gid palace \
-      "$@"
-    ;;
   *)
-    echo "Unknown role '$role' (expected: beat, worker, or cloudwatch)." >&2
+    echo "Unknown role '$role' (expected: beat or worker)." >&2
     exit 64
     ;;
 esac

--- a/docker/ci/test_celery.sh
+++ b/docker/ci/test_celery.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Smoke test for the circ-celery image. Unlike the scripts image, circ-celery
+# runs a single Celery process per container (no runit), so we can't use the
+# `sv check` helpers. Instead we confirm the worker answers a ping over the
+# broker and that the beat and cloudwatch containers come up and stay running.
+
+set -ex
+
+CELERY="/var/www/circulation/env/bin/celery"
+APP="palace.manager.celery.app"
+
+# Assert a compose service's container is running (has not exited).
+function assert_running() {
+  service="$1"
+  cid=$(docker compose ps -q "$service")
+  if [[ -z "$cid" ]]; then
+    echo "  FAIL: $service has no container"
+    exit 1
+  fi
+  running=$(docker inspect -f '{{.State.Running}}' "$cid")
+  if [[ "$running" != "true" ]]; then
+    echo "  FAIL: $service is not running (State.Running=$running)"
+    docker compose logs "$service"
+    exit 1
+  fi
+  echo "  OK: $service is running"
+}
+
+# Output the version file for debugging.
+docker compose exec -T celery-worker cat /var/www/circulation/src/palace/manager/_version.py
+
+# Wait for the worker to come up and answer a ping over the broker. `inspect
+# ping` only returns successfully once a worker has connected and is ready, so
+# this exercises the whole path: image -> entrypoint -> celery -> broker.
+timeout 120s bash -c "
+  until docker compose exec -T celery-worker $CELERY -A $APP inspect ping --timeout 5; do
+    sleep 5
+  done
+"
+
+# Beat and the cloudwatch camera have no ping; confirm they started and are
+# still running (i.e. the entrypoint launched the right process and it did not
+# immediately exit).
+assert_running celery-beat
+assert_running celery-cloudwatch
+assert_running celery-worker
+
+# Confirm beat has actually started its scheduler loop.
+timeout 60s grep -q -e 'beat: Starting' -e 'Scheduler:' <(docker compose logs celery-beat -f 2>&1)
+
+exit 0

--- a/docker/ci/test_celery.sh
+++ b/docker/ci/test_celery.sh
@@ -3,7 +3,7 @@
 # Smoke test for the circ-celery image. Unlike the scripts image, circ-celery
 # runs a single Celery process per container (no runit), so we can't use the
 # `sv check` helpers. Instead we confirm the worker answers a ping over the
-# broker and that the beat and cloudwatch containers come up and stay running.
+# broker and that the beat container comes up and stays running.
 
 set -ex
 
@@ -39,11 +39,9 @@ timeout 120s bash -c "
   done
 "
 
-# Beat and the cloudwatch camera have no ping; confirm they started and are
-# still running (i.e. the entrypoint launched the right process and it did not
-# immediately exit).
+# Beat has no ping; confirm it started and is still running (i.e. the entrypoint
+# launched the right process and it did not immediately exit).
 assert_running celery-beat
-assert_running celery-cloudwatch
 assert_running celery-worker
 
 # Confirm beat has actually started its scheduler loop.

--- a/src/palace/manager/celery/monitoring.py
+++ b/src/palace/manager/celery/monitoring.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 import boto3
 from boto3.exceptions import Boto3Error
 from botocore.exceptions import BotoCoreError
+from celery import Celery
 from celery.events.snapshot import Polaroid
 from celery.events.state import State
 from kombu.transport.redis import PrefixedStrictRedis
@@ -96,37 +97,36 @@ class _PrefixedRedis(PrefixedStrictRedis):
     ]
 
 
-class Cloudwatch(Polaroid):
+class QueueStatsReporter:
     """
-    Implements a Celery custom camera that sends queue statistics to Cloudwatch.
+    Collects per-queue depth and oldest-message age from the broker Redis and
+    publishes them to Cloudwatch as the ``QueueWaiting`` / ``QueueOldestAge``
+    metrics.
 
-    See Celery documentation for more information on custom cameras:
-    https://docs.celeryq.dev/en/stable/userguide/monitoring.html#custom-camera
+    This is independent of Celery's event machinery, so it can be driven either by
+    the periodic ``publish_queue_stats`` task (see
+    :mod:`palace.manager.celery.tasks.monitoring`) or by the :class:`Cloudwatch`
+    events camera below. Both paths read the same config off the Celery app, so
+    they produce identical metrics (same namespace, ``Manager``/``QueueName``
+    dimensions).
     """
 
-    clear_after = True  # clear after flush (incl, state.event_count).
-
-    def __init__(
-        self,
-        *args: Any,
-        **kwargs: Any,
-    ):
-        super().__init__(*args, **kwargs)
+    def __init__(self, app: Celery):
         # We use logger_for_cls instead of just inheriting from LoggerMixin
-        # because the base class Polaroid already defines a logger attribute,
-        # which conflicts with the logger() method in LoggerMixin.
+        # because the Cloudwatch subclass's Polaroid base already defines a logger
+        # attribute, which conflicts with the logger() method in LoggerMixin.
         self.logger = logger_for_cls(self.__class__)
-        broker_url = self.app.conf.get("broker_url")
+        broker_url = app.conf.get("broker_url")
         broker_type = urlparse(broker_url).scheme if broker_url else None
         if broker_type != "redis":
             raise PalaceValueError(f"Broker type '{broker_type}' is not supported.")
 
-        region = self.app.conf.get("cloudwatch_statistics_region")
-        dryrun = self.app.conf.get("cloudwatch_statistics_dryrun")
+        region = app.conf.get("cloudwatch_statistics_region")
+        dryrun = app.conf.get("cloudwatch_statistics_dryrun")
         self.cloudwatch_client = (
             boto3.client("cloudwatch", region_name=region) if not dryrun else None
         )
-        broker_transport_options = self.app.conf.get("broker_transport_options", {})
+        broker_transport_options = app.conf.get("broker_transport_options", {})
         self.manager_name = broker_transport_options.get("global_keyprefix")
         self.redis_client = self.get_redis_client(
             broker_url,
@@ -135,9 +135,9 @@ class Cloudwatch(Polaroid):
             # value keeps health checks on rather than silently disabling them.
             broker_transport_options.get("health_check_interval", 30),
         )
-        self.namespace = self.app.conf.get("cloudwatch_statistics_namespace")
-        self.upload_size = self.app.conf.get("cloudwatch_statistics_upload_size")
-        self.queues = {queue.name for queue in self.app.conf.get("task_queues")}
+        self.namespace = app.conf.get("cloudwatch_statistics_namespace")
+        self.upload_size = app.conf.get("cloudwatch_statistics_upload_size")
+        self.queues = {queue.name for queue in app.conf.get("task_queues")}
 
     @classmethod
     def get_redis_client(
@@ -193,9 +193,9 @@ class Cloudwatch(Polaroid):
             for queue in self.queues
         }
 
-    def on_shutter(self, state: State) -> None:
-        timestamp = utc_now()
-        self.publish(self.get_queue_stats(), timestamp)
+    def run(self) -> None:
+        """Snapshot every queue and publish its metrics to Cloudwatch once."""
+        self.publish(self.get_queue_stats(), utc_now())
 
     def publish(
         self,
@@ -224,3 +224,26 @@ class Cloudwatch(Polaroid):
                 self.logger.info("Dry run enabled. Not sending metrics to Cloudwatch.")
                 for data in chunk:
                     self.logger.info(f"Data: {data}")
+
+
+class Cloudwatch(QueueStatsReporter, Polaroid):
+    """
+    A Celery custom camera that publishes queue statistics to Cloudwatch on the
+    events-snapshot interval.
+
+    This is retained for the ``celery events`` deployment used by the circ-scripts
+    container. New deployments publish the same metrics from the periodic
+    ``publish_queue_stats`` task instead, which does not require an always-on
+    events process. See Celery's custom-camera documentation:
+    https://docs.celeryq.dev/en/stable/userguide/monitoring.html#custom-camera
+    """
+
+    clear_after = True  # clear after flush (incl, state.event_count).
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        # Polaroid.__init__ sets self.app; QueueStatsReporter reads its config.
+        Polaroid.__init__(self, *args, **kwargs)
+        QueueStatsReporter.__init__(self, self.app)
+
+    def on_shutter(self, state: State) -> None:
+        self.run()

--- a/src/palace/manager/celery/tasks/monitoring.py
+++ b/src/palace/manager/celery/tasks/monitoring.py
@@ -1,0 +1,33 @@
+from celery import shared_task
+
+from palace.manager.celery.monitoring import QueueStatsReporter
+from palace.manager.celery.task import Task
+from palace.manager.service.celery.celery import QueueNames
+
+# The reporter opens a Redis connection pool and a boto3 Cloudwatch client, so we
+# build it once per worker process and reuse it across invocations (the task runs
+# every minute). This mirrors how Task caches its session maker.
+_reporter: QueueStatsReporter | None = None
+
+
+def _get_reporter(task: Task) -> QueueStatsReporter:
+    global _reporter
+    if _reporter is None:
+        _reporter = QueueStatsReporter(task.app)
+    return _reporter
+
+
+@shared_task(queue=QueueNames.high, bind=True)
+def publish_queue_stats(task: Task) -> None:
+    """Publish per-queue depth and oldest-message age to Cloudwatch.
+
+    Scheduled by beat every minute onto the ``high`` queue. ``high`` is the
+    always-staffed, time-sensitive queue, so the metric keeps flowing even while
+    the ``default`` / ``apply`` pools are saturated and being scaled -- which are
+    exactly the situations the autoscaler needs the metric for.
+
+    This replaces the always-on ``celery events`` Cloudwatch camera: the metric is
+    just a periodic Redis read plus a ``put_metric_data`` call, so it does not need
+    a dedicated long-running process.
+    """
+    _get_reporter(task).run()

--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -61,6 +61,7 @@ def beat_schedule() -> dict[str, Any]:
         equivalents,
         license_expiration,
         marc,
+        monitoring,
         notifications,
         novelist,
         nyt,
@@ -91,6 +92,10 @@ def beat_schedule() -> dict[str, Any]:
         },
         "search_indexing": {
             "task": search.search_indexing.name,
+            "schedule": crontab(minute="*"),  # Run every minute
+        },
+        "publish_queue_stats": {
+            "task": monitoring.publish_queue_stats.name,
             "schedule": crontab(minute="*"),  # Run every minute
         },
         "marc_export": {

--- a/tests/manager/celery/tasks/test_monitoring.py
+++ b/tests/manager/celery/tasks/test_monitoring.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+import pytest
+
+from palace.manager.celery.tasks import monitoring
+from palace.manager.celery.tasks.monitoring import publish_queue_stats
+from tests.fixtures.celery import CeleryFixture
+
+
+class TestPublishQueueStats:
+    def test_publishes_via_reporter(
+        self,
+        celery_fixture: CeleryFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        # The task builds a QueueStatsReporter from its app and runs it. We mock
+        # the reporter because the test app uses a memory:// broker, which the
+        # reporter (Redis-only) would reject.
+        monkeypatch.setattr(monitoring, "_reporter", None)
+        with patch.object(monitoring, "QueueStatsReporter") as mock_reporter_cls:
+            publish_queue_stats.delay().wait()
+
+        mock_reporter_cls.assert_called_once()
+        mock_reporter_cls.return_value.run.assert_called_once_with()

--- a/tests/manager/celery/test_monitoring.py
+++ b/tests/manager/celery/test_monitoring.py
@@ -9,7 +9,7 @@ from freezegun import freeze_time
 from palace.util.log import LogLevel
 
 from palace.manager.celery.celery import Celery
-from palace.manager.celery.monitoring import Cloudwatch, QueueStats
+from palace.manager.celery.monitoring import Cloudwatch, QueueStats, QueueStatsReporter
 
 
 class CloudwatchCameraFixture:
@@ -23,6 +23,11 @@ class CloudwatchCameraFixture:
         with patch.object(Cloudwatch, "get_redis_client") as mock_get_redis:
             self._mock_get_redis = mock_get_redis
             return Cloudwatch(state=MagicMock(), app=self.app)
+
+    def create_reporter(self):
+        with patch.object(QueueStatsReporter, "get_redis_client") as mock_get_redis:
+            self._mock_get_redis = mock_get_redis
+            return QueueStatsReporter(self.app)
 
     @property
     def mock_get_redis(self):
@@ -339,3 +344,35 @@ class TestCloudwatch:
         cloudwatch.publish(queues, timestamp)
         mock_put_metric_data.assert_not_called()
         assert "Dry run enabled. Not sending metrics to Cloudwatch." in caplog.text
+
+
+class TestQueueStatsReporter:
+    def test_logger_name(self, cloudwatch_camera: CloudwatchCameraFixture):
+        reporter = cloudwatch_camera.create_reporter()
+        assert (
+            reporter.logger.name
+            == "palace.manager.celery.monitoring.QueueStatsReporter"
+        )
+
+    def test_run(self, cloudwatch_camera: CloudwatchCameraFixture):
+        # The reporter can be driven directly (no events camera): run() snapshots
+        # every queue and publishes a QueueWaiting metric for each.
+        reporter = cloudwatch_camera.create_reporter()
+        cloudwatch_camera.mock_get_redis.return_value.llen.return_value = 3
+        cloudwatch_camera.mock_get_redis.return_value.lindex.return_value = None
+        put_metric_data = cloudwatch_camera.client.return_value.put_metric_data
+
+        with freeze_time("2021-01-01"):
+            reporter.run()
+
+        put_metric_data.assert_called_once()
+        metric_data = put_metric_data.call_args.kwargs["MetricData"]
+        assert {metric["MetricName"] for metric in metric_data} == {"QueueWaiting"}
+        assert all(metric["Value"] == 3 for metric in metric_data)
+        queue_dimensions = {
+            dimension["Value"]
+            for metric in metric_data
+            for dimension in metric["Dimensions"]
+            if dimension["Name"] == "QueueName"
+        }
+        assert queue_dimensions == {"queue1", "queue2"}


### PR DESCRIPTION
## Description

Introduces a single `circ-celery` Docker image that runs **one Celery process per container**, with the role selected by the container command (`beat` or `worker`). One image backs the beat scheduler and every worker pool.

Unlike `circ-scripts` — which supervises the beat scheduler and every worker in a single container with runit — `circ-celery` runs exactly one process, so each role can be deployed and (for workers) autoscaled independently. Running one process per container is what lets the worker pools be scaled horizontally per queue and the beat scheduler be pinned to a single instance.

Key points:
- **Boots via `my_init`** (like the `circ-webapp` / `circ-scripts` images), so the shared `/etc/my_init.d` startup scripts run before Celery — see "Database migration on startup" below. `--skip-runit` is used because this image has no runit services; the single Celery process is my_init's main command.
- **Role dispatch** via the container command (`beat` | `worker`), which my_init appends to the entrypoint (`docker/celery-entrypoint.sh`).
- **Env-driven workers** — queues and concurrency are supplied per-deployment via `PALACE_CELERY_QUEUES` / `PALACE_CELERY_CONCURRENCY`, so a single image covers every worker configuration. Concurrency is a single pool shared across all queues a worker consumes; per-queue concurrency = a separate deployment.
- **Logs to stdout/stderr** (as JSON, via the app's logging config) instead of files, so nothing is lost when an autoscaled worker is scaled away.
- `circ-scripts` is **left in place**; deployments can be cut over role-by-role and it can be dropped in a later change.

### Database migration on startup

Like `circ-webapp` and `circ-scripts`, `circ-celery` boots through `my_init`, so the shared `/etc/my_init.d` startup scripts run before the Celery role starts — most importantly the advisory-locked `initialize_instance` (`alembic upgrade head`). Every celery container therefore brings the schema to head on start, exactly like the other images, so **the migration system stays intact and no separate, bespoke migration step is needed on the deployment side** — a new worker/beat never starts against an un-migrated schema.

The `celery --uid palace` drop keeps `HOME=/home/palace` so that libpq (psycopg2) finds its `~/.postgresql` TLS material and negotiates SSL correctly against an SSL-required Postgres, rather than inheriting root's `HOME` and falling back to a rejected plaintext connection.

### Queue-depth metrics without an always-on process

The queue-depth metrics that drive worker autoscaling (`QueueWaiting` / `QueueOldestAge`, `Celery` CloudWatch namespace) are just a periodic Redis `LLEN`/`LINDEX` read plus `put_metric_data` — they don't need the always-on `celery events` camera. This PR publishes them from a new **`publish_queue_stats`** task on the **beat schedule** (every minute, routed to the `high` queue), so there's **no standalone metrics container** and no new artifact/deploy pipeline.

- The metric logic is extracted into a reusable `QueueStatsReporter`; the existing `Cloudwatch(Polaroid)` camera now composes it and still works for the `circ-scripts` `celery events` deployment.
- **Namespace, `Manager`/`QueueName` dimensions, and values are unchanged**, so the existing `hosting-playbook` CloudWatch alarms keep matching.
- Routing to `high` (the always-staffed, time-sensitive queue) keeps the metric flowing while the `default`/`apply` pools are saturated and scaling — exactly when the autoscaler needs it.

> **Draft:** opened for design review of the image/entrypoint structure and the metrics approach before the `hosting-playbook` side (deployments + autoscaling policy) is wired up.

## Motivation and Context

Replace the monolithic `circ-scripts` container with independently operable containers: a **beat** container (pinned to one instance) that kicks off scheduled tasks, and **worker** containers that autoscale on queue depth.

Because the image self-migrates on startup (via `my_init`, as above), the deployment can roll a new celery task definition the same way it rolls the web service and let the container migrate-then-start — no gated, out-of-band migration step. On the `hosting-playbook` side this is what lets the ECS task-service follow the same rollout pattern as the web service.

Autoscaling scale-down is safe with the existing Celery config: `task_acks_late`, `task_reject_on_worker_lost`, `worker_prefetch_multiplier=1`, and a 30-minute `task_time_limit` under the 1-hour broker visibility timeout together ensure a worker killed mid-task has its work redelivered rather than lost.

Deployment topology, replica counts, IAM (`cloudwatch:PutMetricData` moves from the scripts host to the worker pool), and the autoscaling policy live in `hosting-playbook` and are out of scope here.

## Alternatives Considered

**Image packaging — one configurable image vs. one image per role.** We considered building separate `circ-beat` / `circ-worker` (and originally `circ-cloudwatch`) images. Rejected: the image *contents* are identical across roles — only the launch command and a few env vars differ, which are runtime concerns. Separate images would mean N Dockerfile targets to build, scan, and keep version-locked for no isolation benefit. **Chosen:** a single `circ-celery` image, role selected by the container command.

**Database migration — self-migrate via `my_init` vs. a bespoke gated step.** An earlier iteration ran the Celery process directly (no `my_init`) and left migration to a separate, gated deployment step so new code never ran against an old schema. Rejected in favor of booting through `my_init` like the other images: the container self-migrates on start (advisory-locked, idempotent), which keeps the migration system intact, needs no new machinery, and lets the deployment roll celery exactly like it rolls the web service.

**Queue-depth metrics — how to publish `QueueWaiting` / `QueueOldestAge` without the always-on `celery events` camera.** The key realization is that these metrics are just a periodic Redis `LLEN`/`LINDEX` read plus `put_metric_data` — the camera's event-stream machinery is only being used as a 60s timer, so any scheduler can do the job. Three options:

1. **Keep the always-on camera as its own container.** Simplest, but it's a third always-on singleton. On today's EC2 + docker-compose hosts it's effectively free (co-located), so this is only worth eliminating if/when workers move to Fargate (where each always-on task has a cost floor). Rejected as the default because it doesn't advance the "avoid an always-on metrics process" goal.

2. **Scheduled Lambda (EventBridge, every minute).** Near-zero run cost and *fully decoupled* from the worker fleet — the strongest option for an autoscaling signal. Rejected for now because the delivery plumbing doesn't exist: circulation's CI publishes only to **GHCR** (images) and **PyPI**, and has **no AWS credentials at all**. A Lambda would require either granting circulation CI AWS access to push code, or publishing the zip as a versioned artifact that `hosting-playbook` fetches — plus VPC-attaching the function to reach the broker Redis. That's a non-trivial, net-new pipeline for a metric we already collect. Kept on the table as the natural choice *if* we later move to Fargate or otherwise want fleet-independent publishing.

3. **Custom beat `Scheduler` subclass that polls in the beat process.** Would give the camera's fleet-independence (beat is an unavoidable always-on singleton) with zero extra containers, but couples us to beat internals and is more code. Held as a future upgrade if the residual coupling below proves to matter.

**Chosen:** a **beat-scheduled task** (`publish_queue_stats`, every minute on the `high` queue). It ships inside the already-published `circ-celery` image, needs **no new artifact pipeline, no AWS creds in CI, and no Lambda/terraform**, and reuses the exact metric logic (`QueueStatsReporter`). Its one tradeoff is that the metric now rides on a worker running the task, rather than an independent process; routing to `high` (the always-staffed, time-sensitive queue) largely defuses this, since autoscaling the `default`/`apply` pools doesn't affect `high`, and a total fleet outage is a separate condition the depth metric can't act on anyway (the existing alarms use `treat_missing_data`).

## How Has This Been Tested?

- `pytest tests/manager/celery/test_monitoring.py tests/manager/celery/tasks/test_monitoring.py` — 18 passed (existing camera tests unchanged + new `QueueStatsReporter` and `publish_queue_stats` tests); `tests/manager/service/celery/` — 7 passed.
- `mypy` clean on all changed modules and tests.
- `docker buildx build --check --target celery` passes.
- `docker compose config` resolves the `beat` / `worker` services and confirms the worker receives both the shared environment and its `PALACE_CELERY_QUEUES` / `PALACE_CELERY_CONCURRENCY` launch vars.
- CI integration smoke test (`docker/ci/test_celery.sh`) brings up Postgres/OpenSearch and verifies the worker answers `celery inspect ping` over the broker and that beat starts and stays running — so the `my_init` startup migration runs before the role process, exercising the self-migration path.
- All pre-commit hooks pass (shell/YAML/workflow validation, black/isort/autoflake, markdown lint).

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.