### PR TITLE
Improve logging for OIDC patron ID extraction & SAML/OIDC filtering

### DIFF
--- a/src/palace/manager/integration/patron_auth/oidc/credential.py
+++ b/src/palace/manager/integration/patron_auth/oidc/credential.py
@@ -332,7 +332,11 @@ class OIDCCredentialManager(LoggerMixin):
             # If no expiry provided, keep existing expiry logic
             self.log.warning("Refreshed token has no expiry information")
 
-        self.log.info(f"Successfully refreshed credential {credential.id}")
+        self.log.info(
+            "Successfully refreshed credential %s, claims: %s",
+            credential.id,
+            new_id_token_claims,
+        )
         return credential
 
     def lookup_patron_by_identifier(

--- a/src/palace/manager/integration/patron_auth/oidc/provider.py
+++ b/src/palace/manager/integration/patron_auth/oidc/provider.py
@@ -23,7 +23,10 @@ from palace.manager.api.authenticator import BaseOIDCAuthenticationProvider
 from palace.manager.integration.patron_auth.constants import (
     LOGOUT_REDIRECT_QUERY_PARAM,
 )
-from palace.manager.integration.patron_auth.oidc.auth import OIDCAuthenticationManager
+from palace.manager.integration.patron_auth.oidc.auth import (
+    OIDCAuthenticationManager,
+    OIDCRefreshTokenError,
+)
 from palace.manager.integration.patron_auth.oidc.configuration.model import (
     OIDCAuthLibrarySettings,
     OIDCAuthSettings,
@@ -263,8 +266,14 @@ class OIDCAuthenticationProvider(
                 db, credential, auth_manager
             )
             return refreshed_credential.patron
-        except Exception as e:
-            self.log.warning(f"Failed to refresh OIDC token: {e}")
+        except OIDCRefreshTokenError as e:
+            library = self.library(db)
+            lib_label = (
+                f"{library.name} ({library.short_name})"
+                if library
+                else f"library_id={self.library_id}"
+            )
+            self.log.warning("Failed to refresh OIDC token for %s: %s", lib_label, e)
             return OIDC_TOKEN_EXPIRED
 
     def get_authentication_manager(self) -> OIDCAuthenticationManager:
@@ -293,7 +302,7 @@ class OIDCAuthenticationProvider(
         return self._auth_manager
 
     def remote_patron_lookup_from_oidc_claims(
-        self, id_token_claims: dict[str, str]
+        self, id_token_claims: dict[str, Any]
     ) -> PatronData:
         """Create PatronData from ID token claims.
 
@@ -302,9 +311,15 @@ class OIDCAuthenticationProvider(
         :raises: ProblemDetailException if patron cannot be determined
         """
         patron_id_claim = self._settings.patron_id_claim
+        id_token_claim_names = list(id_token_claims.keys())
         raw_patron_id = id_token_claims.get(patron_id_claim)
 
         if not raw_patron_id:
+            self.log.error(
+                "Failed to extract patron ID: claim '%s' not found; token claims: %s",
+                patron_id_claim,
+                id_token_claim_names,
+            )
             raise ProblemDetailException(problem_detail=OIDC_CANNOT_DETERMINE_PATRON)
 
         if self._settings.patron_id_regular_expression:
@@ -312,6 +327,12 @@ class OIDCAuthenticationProvider(
                 str(raw_patron_id)
             )
             if not match or "patron_id" not in match.groupdict():
+                # raw_patron_id is intentionally included to aid regex debugging.
+                self.log.warning(
+                    "Failed to extract patron ID: value %r for claim '%s' did not match pattern",
+                    raw_patron_id,
+                    patron_id_claim,
+                )
                 raise ProblemDetailException(
                     problem_detail=OIDC_CANNOT_DETERMINE_PATRON
                 )
@@ -319,6 +340,12 @@ class OIDCAuthenticationProvider(
         else:
             patron_id = str(raw_patron_id)
 
+        self.log.info(
+            "Extracted patron ID '%s' from claim '%s'; token claims: %s",
+            patron_id,
+            patron_id_claim,
+            id_token_claim_names,
+        )
         return PatronData(
             permanent_id=patron_id,
             authorization_identifier=patron_id,
@@ -350,24 +377,34 @@ class OIDCAuthenticationProvider(
         ``patron_auth_filter_context=True``, including ``extra_data``),
         and ``library`` (``id``, ``name``, ``short_name``).
 
+        All configured expressions are always evaluated so that a single log entry
+        can report every failing level at once.
+
         :param db: Database session
         :param id_token_claims: Validated ID token claims from the OIDC provider
         :raises ProblemDetailException: if the patron is denied access or an expression errors
         """
-        expressions = [
-            e
-            for e in (
-                self._settings.filter_expression,
-                self._library_settings.filter_expression,
+        labeled_expressions = [
+            (label, e)
+            for label, e in (
+                ("integration", self._settings.filter_expression),
+                ("library", self._library_settings.filter_expression),
             )
             if e is not None
         ]
-        if not expressions:
+        if not labeled_expressions:
             return
 
+        id_token_claim_names = list(id_token_claims.keys())
         library = self.library(db)
         if library is None:
             raise ProblemDetailException(problem_detail=OIDC_LIBRARY_NOT_FOUND)
+        self.log.debug(
+            "Evaluating filter expression for library %s (%s) with claims: %s",
+            library.name,
+            library.short_name,
+            id_token_claim_names,
+        )
         context = {
             "claims": id_token_claims,
             "integration": self._settings.filter_context_dump(),
@@ -378,20 +415,52 @@ class OIDCAuthenticationProvider(
             },
         }
 
-        for expression in expressions:
+        failing: list[str] = []
+        eval_errors: list[FilterExpressionError] = []
+        for label, expression in labeled_expressions:
             try:
                 result = FilterExpression(expression).evaluate(context)
             except FilterExpressionError as exc:
-                raise ProblemDetailException(
-                    problem_detail=OIDC_FILTER_EVALUATION_ERROR.detailed(str(exc))
-                ) from exc
+                self.log.error(
+                    "Filter [%s] evaluation error for library %s (%s): %s",
+                    label,
+                    library.name,
+                    library.short_name,
+                    exc,
+                )
+                failing.append(label)
+                eval_errors.append(exc)
+                continue
+            self.log.info(
+                "Filter [%s] %s for library %s (%s)",
+                label,
+                "passed" if result else "failed",
+                library.name,
+                library.short_name,
+            )
             if not result:
-                raise ProblemDetailException(problem_detail=OIDC_NO_ACCESS_ERROR)
+                failing.append(label)
+
+        if failing:
+            self.log.warning(
+                "Access denied for library %s (%s): filter(s) failed: %s; claim names=%s",
+                library.name,
+                library.short_name,
+                ", ".join(failing),
+                id_token_claim_names,
+            )
+            if eval_errors:
+                raise ProblemDetailException(
+                    problem_detail=OIDC_FILTER_EVALUATION_ERROR.detailed(
+                        "; ".join(str(e) for e in eval_errors)
+                    )
+                ) from eval_errors[0]
+            raise ProblemDetailException(problem_detail=OIDC_NO_ACCESS_ERROR)
 
     def oidc_callback(
         self,
         db: Session,
-        id_token_claims: dict[str, str],
+        id_token_claims: dict[str, Any],
         access_token: str,
         refresh_token: str | None = None,
         expires_in: int | None = None,
@@ -424,6 +493,16 @@ class OIDCAuthenticationProvider(
             expires_in,
             self._settings.session_lifetime,
             id_token,
+        )
+
+        library = self.library(db)
+        lib_name = library.name if library else str(self.library_id)
+        lib_short = library.short_name if library else "unknown"
+        self.log.info(
+            "OIDC patron access granted for library %s (%s): patron=%s",
+            lib_name,
+            lib_short,
+            patron_data.authorization_identifier,
         )
 
         return credential, patron, patron_data

--- a/src/palace/manager/integration/patron_auth/saml/provider.py
+++ b/src/palace/manager/integration/patron_auth/saml/provider.py
@@ -436,19 +436,22 @@ class SAMLWebSSOAuthenticationProvider(
         integration settings marked with ``patron_auth_filter_context=True``, including
         ``extra_data``), and ``library`` (``id``, ``name``, ``short_name``).
 
+        All configured expressions are always evaluated so that a single log entry
+        can report every failing level at once.
+
         :param db: Database session
         :param subject: Authenticated SAML subject to authorize
         :raises ProblemDetailException: if the subject is denied access or an expression errors
         """
-        expressions = [
-            e
-            for e in (
-                self._settings.filter_expression,
-                self._library_settings.filter_expression,
+        labeled_expressions = [
+            (label, e)
+            for label, e in (
+                ("integration", self._settings.filter_expression),
+                ("library", self._library_settings.filter_expression),
             )
-            if e
+            if e is not None
         ]
-        if not expressions:
+        if not labeled_expressions:
             return
 
         library = self.library(db)
@@ -456,6 +459,12 @@ class SAMLWebSSOAuthenticationProvider(
             raise ProblemDetailException(
                 problem_detail=SAML_GENERIC_ERROR.detailed("Library not found")
             )
+        self.log.debug(
+            "Evaluating filter expression for library %s (%s) with subject: %s",
+            library.name,
+            library.short_name,
+            subject,
+        )
         context = {
             "subject": subject,
             "integration": self._settings.filter_context_dump(),
@@ -466,23 +475,55 @@ class SAMLWebSSOAuthenticationProvider(
             },
         }
 
-        for expression in expressions:
+        failing: list[str] = []
+        eval_errors: list[FilterExpressionError] = []
+        for label, expression in labeled_expressions:
             try:
                 result = FilterExpression(
                     expression,
                     extra_safe_types=_SAML_FILTER_SAFE_TYPES,
                 ).evaluate(context)
             except FilterExpressionError as exc:
-                raise ProblemDetailException(
-                    problem_detail=SAML_GENERIC_ERROR.detailed(str(exc))
-                ) from exc
+                self.log.error(
+                    "Filter [%s] evaluation error for library %s (%s): %s",
+                    label,
+                    library.name,
+                    library.short_name,
+                    exc,
+                )
+                failing.append(label)
+                eval_errors.append(exc)
+                continue
+            self.log.info(
+                "Filter [%s] %s for library %s (%s)",
+                label,
+                "passed" if result else "failed",
+                library.name,
+                library.short_name,
+            )
             if not result:
-                raise ProblemDetailException(problem_detail=SAML_NO_ACCESS_ERROR)
+                failing.append(label)
+
+        if failing:
+            self.log.warning(
+                "Access denied for library %s (%s): filter(s) failed: %s; subject=%s",
+                library.name,
+                library.short_name,
+                ", ".join(failing),
+                subject,
+            )
+            if eval_errors:
+                raise ProblemDetailException(
+                    problem_detail=SAML_GENERIC_ERROR.detailed(
+                        "; ".join(str(e) for e in eval_errors)
+                    )
+                ) from eval_errors[0]
+            raise ProblemDetailException(problem_detail=SAML_NO_ACCESS_ERROR)
 
     def saml_callback(
         self, db: Session, subject: SAMLSubject
     ) -> tuple[Credential, Patron, PatronData]:
-        """Verifies the SAML subject, generates a Bearer token in the case of successful authentication and returns it
+        """Verify the SAML subject, generate a Bearer token on successful authentication, and return it.
 
         :param db: Database session
         :param subject: Subject object containing SAML Subject and AttributeStatement
@@ -506,6 +547,16 @@ class SAMLWebSSOAuthenticationProvider(
         # Create a credential for the Patron
         credential = self._credential_manager.create_saml_token(
             db, patron, subject, self._settings.session_lifetime
+        )
+
+        library = self.library(db)
+        lib_name = library.name if library else str(self.library_id)
+        lib_short = library.short_name if library else "unknown"
+        self.log.info(
+            "SAML patron access granted for library %s (%s): patron=%s",
+            lib_name,
+            lib_short,
+            patron_data.authorization_identifier,
         )
 
         return credential, patron, patron_data

--- a/tests/manager/integration/patron_auth/oidc/test_credential.py
+++ b/tests/manager/integration/patron_auth/oidc/test_credential.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import logging
 from unittest.mock import Mock
 
 import pytest
@@ -420,8 +421,10 @@ class TestOIDCCredentialManager:
         db: DatabaseTransactionFixture,
         mock_patron,
         sample_id_token_claims,
+        caplog: pytest.LogCaptureFixture,
     ):
         """Test refresh_token_if_needed when token is expired."""
+        caplog.set_level(logging.INFO)
         credential = manager.create_oidc_token(
             db.session,
             mock_patron,
@@ -457,6 +460,8 @@ class TestOIDCCredentialManager:
         expected_expiry = utc_now() + datetime.timedelta(seconds=3600)
         assert refreshed_credential.expires is not None
         assert abs((refreshed_credential.expires - expected_expiry).total_seconds()) < 5
+        assert "Successfully refreshed" in caplog.text
+        assert sample_id_token_claims["sub"] in caplog.text
 
     def test_refresh_token_if_needed_expiring_soon(
         self,

--- a/tests/manager/integration/patron_auth/oidc/test_provider.py
+++ b/tests/manager/integration/patron_auth/oidc/test_provider.py
@@ -16,6 +16,7 @@ from palace.manager.api.authentication.base import PatronData, PatronLookupNotSu
 from palace.manager.integration.patron_auth.constants import (
     LOGOUT_REDIRECT_QUERY_PARAM,
 )
+from palace.manager.integration.patron_auth.oidc.auth import OIDCRefreshTokenError
 from palace.manager.integration.patron_auth.oidc.configuration.model import (
     OIDCAuthLibrarySettings,
     OIDCAuthSettings,
@@ -398,8 +399,13 @@ class TestOIDCAuthenticationProvider:
         assert result == patron
 
     def test_authenticated_patron_with_refresh_failure(
-        self, db: DatabaseTransactionFixture, oidc_provider
+        self,
+        db: DatabaseTransactionFixture,
+        oidc_provider: OIDCAuthenticationProvider,
+        caplog: pytest.LogCaptureFixture,
     ):
+        caplog.set_level(logging.WARNING)
+        library = db.default_library()
         patron = db.patron()
         patron.authorization_identifier = "test-user"
 
@@ -425,18 +431,27 @@ class TestOIDCAuthenticationProvider:
         )
         db.session.commit()
 
+        assert credential.credential is not None
         with patch.object(
             oidc_provider._credential_manager,
             "refresh_token_if_needed",
-            side_effect=Exception("Refresh failed"),
+            side_effect=OIDCRefreshTokenError("Refresh failed"),
         ):
             result = oidc_provider.authenticated_patron(
                 db.session, credential.credential
             )
 
         assert result == OIDC_TOKEN_EXPIRED
+        assert "Failed to refresh" in caplog.text
+        assert library.name is not None and library.name in caplog.text
+        assert library.short_name is not None and library.short_name in caplog.text
 
-    def test_remote_patron_lookup_from_oidc_claims_success(self, oidc_provider):
+    def test_remote_patron_lookup_from_oidc_claims_success(
+        self,
+        oidc_provider: OIDCAuthenticationProvider,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        caplog.set_level(logging.INFO)
         id_token_claims = {
             "sub": "test-user-123",
             "email": "test@example.com",
@@ -450,18 +465,27 @@ class TestOIDCAuthenticationProvider:
         assert patron_data.authorization_identifier == "test-user-123"
         assert patron_data.external_type == "A"
         assert patron_data.complete is True
+        assert "Extracted patron ID" in caplog.text
+        assert "test-user-123" in caplog.text
 
     def test_remote_patron_lookup_from_oidc_claims_missing_patron_id(
-        self, oidc_provider
+        self,
+        oidc_provider: OIDCAuthenticationProvider,
+        caplog: pytest.LogCaptureFixture,
     ):
+        caplog.set_level(logging.ERROR)
         id_token_claims = {"email": "test@example.com"}
 
         with pytest.raises(ProblemDetailException) as exc_info:
             oidc_provider.remote_patron_lookup_from_oidc_claims(id_token_claims)
 
         assert exc_info.value.problem_detail == OIDC_CANNOT_DETERMINE_PATRON
+        assert "Failed to extract patron ID" in caplog.text
 
-    def test_remote_patron_lookup_from_oidc_claims_with_regex(self):
+    def test_remote_patron_lookup_from_oidc_claims_with_regex(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        caplog.set_level(logging.INFO)
         settings = OIDCAuthSettings(
             issuer_url="https://idp.example.com",
             client_id="test-client-id",
@@ -485,8 +509,13 @@ class TestOIDCAuthenticationProvider:
 
         assert patron_data.permanent_id == "user123"
         assert patron_data.authorization_identifier == "user123"
+        assert "Extracted patron ID" in caplog.text
+        assert "user123" in caplog.text
 
-    def test_remote_patron_lookup_from_oidc_claims_regex_no_match(self):
+    def test_remote_patron_lookup_from_oidc_claims_regex_no_match(
+        self, caplog: pytest.LogCaptureFixture
+    ):
+        caplog.set_level(logging.WARNING)
         settings = OIDCAuthSettings(
             issuer_url="https://idp.example.com",
             client_id="test-client-id",
@@ -510,13 +539,21 @@ class TestOIDCAuthenticationProvider:
             provider.remote_patron_lookup_from_oidc_claims(id_token_claims)
 
         assert exc_info.value.problem_detail == OIDC_CANNOT_DETERMINE_PATRON
+        assert "Failed to extract patron ID" in caplog.text
 
     def test_remote_patron_lookup_raises_not_supported(self, oidc_provider):
         with pytest.raises(PatronLookupNotSupported):
             oidc_provider.remote_patron_lookup(PatronData(permanent_id="test"))
 
-    def test_oidc_callback(self, db: DatabaseTransactionFixture, oidc_provider):
+    def test_oidc_callback(
+        self,
+        db: DatabaseTransactionFixture,
+        oidc_provider: OIDCAuthenticationProvider,
+        caplog: pytest.LogCaptureFixture,
+    ):
         DataSource.lookup(db.session, "OIDC", autocreate=True)
+        caplog.set_level(logging.INFO)
+        library = db.default_library()
 
         id_token_claims = {
             "sub": "test-user-456",
@@ -539,6 +576,10 @@ class TestOIDCAuthenticationProvider:
         assert patron_data.permanent_id == "test-user-456"
         assert credential.credential is not None
         assert credential.patron == patron
+        assert "OIDC patron access granted" in caplog.text
+        assert library.name is not None and library.name in caplog.text
+        assert library.short_name is not None and library.short_name in caplog.text
+        assert "test-user-456" in caplog.text
 
     def test_get_authentication_manager(
         self, oidc_provider: OIDCAuthenticationProvider
@@ -662,9 +703,12 @@ class TestOIDCAuthenticationProvider:
         db: DatabaseTransactionFixture,
         create_oidc_settings: Callable[..., OIDCAuthSettings],
         create_oidc_provider: Callable[..., OIDCAuthenticationProvider],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """oidc_callback succeeds and returns (Credential, Patron, PatronData) when the filter passes."""
         DataSource.lookup(db.session, "OIDC", autocreate=True)
+        caplog.set_level(logging.INFO)
+        library = db.default_library()
         configuration = create_oidc_settings(
             filter_expression="claims['email'].endswith('@example.edu')"
         )
@@ -679,14 +723,19 @@ class TestOIDCAuthenticationProvider:
         assert isinstance(credential, Credential)
         assert isinstance(patron, Patron)
         assert isinstance(patron_data, PatronData)
+        assert "Filter [integration] passed" in caplog.text
+        assert library.name is not None and library.name in caplog.text
+        assert library.short_name is not None and library.short_name in caplog.text
 
     def test_oidc_callback_filter_evaluation_error(
         self,
         db: DatabaseTransactionFixture,
         create_oidc_settings: Callable[..., OIDCAuthSettings],
         create_oidc_provider: Callable[..., OIDCAuthenticationProvider],
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """oidc_callback raises OIDC_FILTER_EVALUATION_ERROR when the filter expression errors at evaluation."""
+        caplog.set_level(logging.ERROR)
         configuration = create_oidc_settings(
             # Syntactically valid, so the model validator accepts it;
             # claims.nonexistent raises AttributeDoesNotExist at evaluation time.
@@ -702,6 +751,34 @@ class TestOIDCAuthenticationProvider:
             )
 
         assert exc_info.value.problem_detail.uri == OIDC_FILTER_EVALUATION_ERROR.uri
+        assert "Filter [integration] evaluation error" in caplog.text
+
+    def test_filter_claims_both_levels_eval_error(
+        self,
+        db: DatabaseTransactionFixture,
+        create_oidc_settings: Callable[..., OIDCAuthSettings],
+        create_oidc_provider: Callable[..., OIDCAuthenticationProvider],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """When both filter levels raise FilterExpressionError, both messages appear in the detail."""
+        caplog.set_level(logging.ERROR)
+        configuration = create_oidc_settings(
+            filter_expression="claims.no_such_attr == 'x'"
+        )
+        provider = create_oidc_provider(
+            settings=configuration,
+            library_settings=OIDCAuthLibrarySettings(
+                filter_expression="claims.also_missing == 'x'"
+            ),
+        )
+
+        with pytest.raises(ProblemDetailException) as exc_info:
+            provider._filter_claims(db.session, self._FILTER_CLAIMS)
+
+        assert exc_info.value.problem_detail.uri == OIDC_FILTER_EVALUATION_ERROR.uri
+        detail = str(exc_info.value.problem_detail.detail)
+        assert "; " in detail
+        assert len([r for r in caplog.records if r.levelno == logging.ERROR]) == 2
 
     def test_filter_claims_library_not_found(
         self,
@@ -836,8 +913,10 @@ class TestOIDCAuthenticationProvider:
         library_expression: str | None,
         extra_data: object,
         expect_no_access: bool,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Integration and library filter expressions are ANDed; both must pass."""
+        caplog.set_level(logging.WARNING)
         configuration = create_oidc_settings(
             filter_expression=integration_expression,
             extra_data=extra_data,
@@ -857,3 +936,11 @@ class TestOIDCAuthenticationProvider:
 
         if expect_no_access:
             assert exc_info.value.problem_detail.uri == OIDC_NO_ACCESS_ERROR.uri
+            # All failures are collected into a single warning regardless of how many filters fail.
+            warning_records = [
+                r for r in caplog.records if r.levelno == logging.WARNING
+            ]
+            assert len(warning_records) == 1
+            assert (
+                str(list(self._FILTER_CLAIMS.keys())) in warning_records[0].getMessage()
+            )

--- a/tests/manager/integration/patron_auth/saml/test_provider.py
+++ b/tests/manager/integration/patron_auth/saml/test_provider.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 from collections.abc import Callable
 from contextlib import nullcontext
 from unittest.mock import MagicMock, create_autospec, patch
@@ -1222,8 +1223,11 @@ class TestSAMLWebSSOAuthenticationProvider:
         controller_fixture: ControllerFixture,
         create_saml_configuration: Callable[..., SAMLWebSSOAuthSettings],
         create_saml_provider: Callable[..., SAMLWebSSOAuthenticationProvider],
+        caplog: pytest.LogCaptureFixture,
     ):
         """saml_callback succeeds and returns (Credential, Patron, PatronData) when the filter passes."""
+        caplog.set_level(logging.INFO)
+        library = controller_fixture.db.default_library()
         subject = SAMLSubject(
             "http://idp.example.com",
             None,
@@ -1248,6 +1252,40 @@ class TestSAMLWebSSOAuthenticationProvider:
         assert isinstance(credential, Credential)
         assert isinstance(patron, Patron)
         assert isinstance(patron_data, PatronData)
+        assert "Filter [integration] passed" in caplog.text
+        assert "SAML patron access granted" in caplog.text
+        assert library.name is not None and library.name in caplog.text
+        assert library.short_name is not None and library.short_name in caplog.text
+
+    def test_filter_subject_both_levels_eval_error(
+        self,
+        controller_fixture: ControllerFixture,
+        create_saml_configuration: Callable[..., SAMLWebSSOAuthSettings],
+        create_saml_provider: Callable[..., SAMLWebSSOAuthenticationProvider],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """When both filter levels raise FilterExpressionError, both messages appear in the detail."""
+        caplog.set_level(logging.ERROR)
+        configuration = create_saml_configuration(
+            filter_expression="subject.no_such_attr == 'x'"
+        )
+        provider = create_saml_provider(
+            settings=configuration,
+            library_settings=SAMLWebSSOAuthLibrarySettings(
+                filter_expression="subject.also_missing == 'x'"
+            ),
+        )
+
+        with pytest.raises(ProblemDetailException) as exc_info:
+            provider._filter_subject(
+                controller_fixture.db.session,
+                SAMLSubject("http://idp.example.com", None, None),
+            )
+
+        assert exc_info.value.problem_detail.uri == SAML_GENERIC_ERROR.uri
+        detail = str(exc_info.value.problem_detail.detail)
+        assert "; " in detail
+        assert len([r for r in caplog.records if r.levelno == logging.ERROR]) == 2
 
     def test_filter_subject_library_not_found(
         self,
@@ -1388,8 +1426,10 @@ class TestSAMLWebSSOAuthenticationProvider:
         library_expression: str | None,
         extra_data: object,
         expect_no_access: bool,
+        caplog: pytest.LogCaptureFixture,
     ):
         """Integration and library filter expressions are ANDed; both must pass."""
+        caplog.set_level(logging.WARNING)
         configuration = create_saml_configuration(
             filter_expression=integration_expression,
             extra_data=extra_data,
@@ -1412,3 +1452,9 @@ class TestSAMLWebSSOAuthenticationProvider:
 
         if expect_no_access:
             assert exc_info.value.problem_detail.uri == SAML_NO_ACCESS_ERROR.uri
+            # All failures are collected into a single warning regardless of how many filters fail.
+            warning_records = [
+                r for r in caplog.records if r.levelno == logging.WARNING
+            ]
+            assert len(warning_records) == 1
+            assert "idp.example.com" in warning_records[0].getMessage()


### PR DESCRIPTION
## Description

Adds structured logging throughout the OIDC and SAML patron authentication flows to make production debugging feasible:

- **Patron ID extraction (OIDC):** logs when a configured claim is missing, when a value fails to match the patron ID regex (at WARNING, value included intentionally for regex debugging), and on successful extraction — all using claim key names rather than full claim values to limit PII exposure.
- **Filter evaluation (OIDC & SAML):** changes from fail-fast to batch evaluation — all configured filter expressions are always evaluated, failures are collected, and a single WARNING entry names every failing level. Individual INFO entries record pass/fail per expression.
- **Authentication success (OIDC & SAML):** adds an INFO entry at the end of each callback confirming which library and patron were granted access.
- **Token refresh failure (OIDC):** includes library name/short-name in the existing warning, and narrows the caught exception from `Exception` to `OIDCRefreshTokenError`.

## Motivation and Context

Diagnosing OIDC/SAML authentication failures in production was difficult because the logs gave little indication of which filter level rejected a patron, whether patron ID extraction succeeded, or which library was involved. These additions provide the observability needed to distinguish misconfigured filters, missing claims, and regex mismatches without re-deploying.

## How Has This Been Tested?

- Unit tests were added or updated for every new log path:
	- Missing claim and regex no-match errors;
	- Filter pass, fail, and evaluation-error paths;
	- Token refresh failure with library context; and
	- Callback success messages.
- All assertions use `caplog` at the appropriate level and verify both message content and log level where it matters.
- Test / checks pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/28725864934) / checks pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
