### PR TITLE
Fix SAML SP metadata model form field type

### DIFF
--- a/src/palace/manager/integration/patron_auth/saml/configuration/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/configuration/model.py
@@ -139,6 +139,7 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
                 "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST. "
                 "Leave empty to use environment configuration (PALACE_SAML_SP_METADATA or PALACE_SAML_SP_METADATA_FILE)."
             ),
+            type=FormFieldType.TEXTAREA,
         ),
     ] = None
     service_provider_private_key: Annotated[


### PR DESCRIPTION
## Description

Sets the form field type for the SAML Service Provider XML Metadata setting to `TEXTAREA`, so the admin UI renders it as a multi-line input instead of a single-line text box.

## Motivation and Context

The SP XML metadata field holds a multi-line XML document. Without an explicit `type`, `FormMetadata` defaults to `FormFieldType.TEXT` (single-line input), which makes the field impractical and annoying to edit. The adjacent `service_provider_private_key` and `non_federated_identity_provider_xml_metadata` fields already use `TEXTAREA`; this brings the SP metadata field into line with them.

## How Has This Been Tested?

This is a UI-metadata-only change with no logic impact. No new tests were added. The existing test suite covers the field's validation behavior and continues to pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
