### PR TITLE
Support monospace font hint for admin UI settings fields (PP-4734)

### DIFF
--- a/src/palace/manager/integration/settings.py
+++ b/src/palace/manager/integration/settings.py
@@ -118,6 +118,11 @@ class FormMetadata(LoggerMixin):
     # If set to True, the Admin UI will be directed to hide this field.
     hidden: bool = False
 
+    # If set to True, hints the Admin UI that it should render the field's input in a
+    # monospace font. Useful for fields whose values are easier to read in monospace
+    # (e.g. structured data, code).
+    use_monospace_font: bool = False
+
     # If set to True, this field is eligible to be included in the patron auth filter
     # expression context. Fields that contain credentials (e.g., private keys, client
     # secrets) or large blobs (e.g., XML metadata) should leave this False.
@@ -179,6 +184,8 @@ class FormMetadata(LoggerMixin):
             ]
         if self.format is not None:
             form_entry["format"] = self.format
+        if self.use_monospace_font:
+            form_entry["use_monospace_font"] = True
 
         return self.weight, form_entry
 

--- a/tests/manager/integration/test_settings.py
+++ b/tests/manager/integration/test_settings.py
@@ -549,6 +549,31 @@ class TestBaseSettings:
                 "a default value or factory and yet its required property is set to False"
             ) in caplog.text
 
+        @pytest.mark.parametrize(
+            "field_type, monospace, in_output",
+            [
+                pytest.param(FormFieldType.TEXTAREA, True, True, id="textarea-true"),
+                pytest.param(FormFieldType.JSON, True, True, id="json-true"),
+                pytest.param(FormFieldType.TEXT, True, True, id="text-true"),
+                pytest.param(FormFieldType.TEXT, False, False, id="text-false"),
+                pytest.param(FormFieldType.TEXT, None, False, id="text-default"),
+            ],
+        )
+        def test_monospace(
+            self,
+            field_type: FormFieldType,
+            monospace: bool | None,
+            in_output: bool,
+        ) -> None:
+            kwargs: dict[str, Any] = {"label": "Test", "type": field_type}
+            if monospace is not None:
+                kwargs["use_monospace_font"] = monospace
+            _, entry = FormMetadata(**kwargs).to_dict(MagicMock(), "test", False)
+            if in_output:
+                assert entry["use_monospace_font"] is True
+            else:
+                assert "use_monospace_font" not in entry
+
     def test_get_form_field_label_by_alias(
         self, base_settings_fixture: BaseSettingsFixture
     ) -> None:


### PR DESCRIPTION
## Description

Adds a `use_monospace_font` boolean hint to `FormMetadata` for integration settings fields. When set to `True`, the flag is included in the serialized form entry sent to the Admin UI, signaling that the field's input should be rendered in a monospace font. The flag defaults to `False` and is omitted from the output when false to keep the payload minimal.

## Motivation and Context

Some settings fields (structured data, filter code snippets) are easier to read and edit in a monospace font. The Admin UI needs a backend-supplied hint to know when to apply that treatment. This is the backend half of the work, with the frontend side tracked on ThePalaceProject/circulation-admin#307. It is safe to merge them independently.

[Jira PP-4734]

## How Has This Been Tested?

- Manual testing in local dev environment with frontend dev-server.
- New tests for this functionality.
- All tests pass locally.
- [CI tests](https://github.com/ThePalaceProject/circulation/actions/runs/28827880245) pass.

## Checklist

- N/A - I have updated the documentation accordingly.
- [x] All new and existing tests passed.
