### PR TITLE
Use monospace font for some settings in admin UI

### DIFF
--- a/src/palace/manager/integration/patron_auth/oidc/configuration/model.py
+++ b/src/palace/manager/integration/patron_auth/oidc/configuration/model.py
@@ -277,6 +277,7 @@ class OIDCAuthSettings(AuthProviderSettings, LoggerMixin):
                 "<pre>(?P&lt;patron_id&gt;[^@]+)@example\\.edu</pre>"
                 "Leave empty to use the full claim value."
             ),
+            use_monospace_font=True,
         ),
     ] = None
 
@@ -316,6 +317,7 @@ class OIDCAuthSettings(AuthProviderSettings, LoggerMixin):
                 "<pre>claims['email'].endswith('@example.edu')</pre>"
             ),
             type=FormFieldType.TEXTAREA,
+            use_monospace_font=True,
         ),
     ] = None
 
@@ -334,6 +336,7 @@ class OIDCAuthSettings(AuthProviderSettings, LoggerMixin):
             ),
             type=FormFieldType.JSON,
             patron_auth_filter_context=True,
+            use_monospace_font=True,
         ),
     ] = None
 
@@ -584,6 +587,7 @@ class OIDCAuthLibrarySettings(AuthProviderLibrarySettings):
                 " syntax and available context variables."
             ),
             type=FormFieldType.TEXTAREA,
+            use_monospace_font=True,
         ),
     ] = None
 

--- a/src/palace/manager/integration/patron_auth/saml/configuration/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/configuration/model.py
@@ -140,6 +140,7 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
                 "Leave empty to use environment configuration (PALACE_SAML_SP_METADATA or PALACE_SAML_SP_METADATA_FILE)."
             ),
             type=FormFieldType.TEXTAREA,
+            use_monospace_font=True,
         ),
     ] = None
     service_provider_private_key: Annotated[
@@ -149,6 +150,7 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
             description="Private key used for encrypting SAML requests. "
             "Leave empty to use environment configuration (PALACE_SAML_SP_PRIVATE_KEY or PALACE_SAML_SP_PRIVATE_KEY_FILE).",
             type=FormFieldType.TEXTAREA,
+            use_monospace_font=True,
         ),
     ] = None
     federated_identity_provider_entity_ids: Annotated[
@@ -216,6 +218,7 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
                 "The expression will extract the <b>patron_id</b> from the first SAML attribute that matches "
                 "or NameID if it matches the expression."
             ),
+            use_monospace_font=True,
         ),
     ] = None
     non_federated_identity_provider_xml_metadata: Annotated[
@@ -229,6 +232,7 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
                 "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect."
             ),
             type=FormFieldType.TEXTAREA,
+            use_monospace_font=True,
         ),
     ] = None
     session_lifetime: Annotated[
@@ -278,6 +282,7 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
                 "</pre>"
             ),
             type=FormFieldType.TEXTAREA,
+            use_monospace_font=True,
         ),
     ] = None
     # Note: the key-ordering caveat in the description below is a JSONB storage
@@ -295,6 +300,7 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
             ),
             type=FormFieldType.JSON,
             patron_auth_filter_context=True,
+            use_monospace_font=True,
         ),
     ] = None
     service_provider_strict_mode: Annotated[
@@ -484,6 +490,7 @@ class SAMLWebSSOAuthLibrarySettings(AuthProviderLibrarySettings):
                 " syntax and examples."
             ),
             type=FormFieldType.TEXTAREA,
+            use_monospace_font=True,
         ),
     ] = None
 


### PR DESCRIPTION
## Description

Enable monospace font rendering for form fields in the OIDC and SAML patron authentication configuration models that contain code-like content — regular expressions, filter expressions, JSON, and XML/PEM blobs.

## Motivation and Context

Fields holding structured or code-like values (regex patterns, Python expressions, XML metadata, JSON objects, private keys) are easier to read and edit in a monospace font. This sets `use_monospace_font=True` on those fields in the admin UI so their content renders as expected.

## How Has This Been Tested?

- Manual testing in local dev environment to verify that fields display with correct font family.
- No logic changes, so existing tests should continue to pass.


## Checklist

- N/A - I have updated the documentation accordingly.
- N/A - All new and existing tests passed.
