### PR TITLE
Start the valkey service in the backwards-compatibility check

### DIFF
--- a/docker/ci/test_backwards_compatibility.sh
+++ b/docker/ci/test_backwards_compatibility.sh
@@ -78,7 +78,7 @@ fi
 trap cleanup EXIT
 
 # (2) Build the current schema by initializing a fresh database with the current image.
-compose_cmd up -d pg os minio redis || fail "Could not start service containers."
+compose_cmd up -d pg os minio valkey || fail "Could not start service containers."
 run_in_container webapp "./bin/util/initialize_instance" \
   || fail "Failed to initialize the database with the current image."
 


### PR DESCRIPTION
## Description

Fixes the `backwards-compatibility-test` job, which has been failing on `main` since #3506 merged, with:

```
no such service: redis
##[error]Could not start service containers.
```

`docker/ci/test_backwards_compatibility.sh` asked docker compose to start a `redis` service. #3498 renamed that compose service to `valkey`. This renames the reference.

The service is still needed, so this is a rename rather than a removal: `initialize_instance` itself only takes a Postgres advisory lock, but the `webapp-prev` container inherits `PALACE_TEST_REDIS_URL: redis://valkey:6379/3` from the `webapp` service, so the container has to be up for the previous release's test run. The `redis://` URL scheme and the `PALACE_*REDIS*` variable names are deliberately left alone, consistent with #3498 — they name the protocol, not the instance.

## Motivation and Context

#3506 was branched off `main` before #3498 landed, and was never rebased. At #3506's head commit `docker-compose.yml` still defined a `redis` service, so the script was correct on the branch and the job passed there. The two PRs touch disjoint files, so git merged them without a textual conflict — the conflict was semantic, and nothing surfaced it until the job ran on `main`.

This also means the `push` job, which now depends on `backwards-compatibility-test`, is blocked on `main` until this lands.

## How Has This Been Tested?

Reproduced the failure and confirmed the fix locally with `docker compose ... up --dry-run`, which validates service names without starting containers:

- with the old `redis` argument: exit 1, `no such service: redis` — the identical message from the failing CI log.
- with the new `valkey` argument: exit 0.

Then started the service for real and confirmed it reaches `healthy` and that `valkey-cli ping` answers `PONG`.

I did not run the script end-to-end locally, since that requires pulling both the current and previous release images and running the full `pytest -m db` suite. Worth flagging for review: this fix unblocks a step that has never actually executed, because the previous release's test suite will now run against Valkey for the first time — on #3506's branch it only ever ran against `redis/redis-stack-server`. I expect that to be fine (Valkey is protocol-compatible, `main`'s own db suite already passes against `valkey:9.0` in the tox stack, and the previous release's Redis usage is core commands only), but this job is where that combination gets exercised first. The job runs on non-tag refs, so this PR's own CI is the real verification.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
