### PR TITLE
Keep one bad custom list from blowing up the entries sweep (PP-4787)

### DIFF
--- a/src/palace/manager/celery/tasks/custom_lists.py
+++ b/src/palace/manager/celery/tasks/custom_lists.py
@@ -11,7 +11,8 @@ Pipeline (orchestrated via a chord):
    and reconciles the list's cached ``size``.  Uses ``task.replace()`` to spread
    pagination over multiple short task invocations.
 3. ``finalize_custom_list_entries_sweep``  — chord callback: releases the sweep-level
-   Redis lock after every per-list task has finished.
+   Redis lock after every per-list task has finished.  Registered as both the chord's
+   body and its error callback, so the lock is released even when a per-list task fails.
 """
 
 from __future__ import annotations
@@ -31,6 +32,7 @@ from palace.manager.celery.task import Task
 from palace.manager.celery.utils import ModelNotFoundError, load_from_id, signature_with
 from palace.manager.core.query.customlist import CustomListQueries
 from palace.manager.search.external_search import ExternalSearchIndex
+from palace.manager.search.query import QueryParseException
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.redis.models.lock import RedisLock
 from palace.manager.service.redis.redis import Redis
@@ -109,7 +111,9 @@ def update_custom_list_entries_sweep(task: Task) -> None:
     A sweep-level Redis lock prevents a second beat-triggered run from
     overlapping with a sweep already in progress.  The lock is acquired here
     and released by ``finalize_custom_list_entries_sweep`` at the end of the
-    chord — so it genuinely covers the full fan-out.
+    chord — so it genuinely covers the full fan-out.  ``finalize`` is wired up
+    as both the chord's body and its error callback, so the lock is released
+    whether or not the per-list tasks all succeed.
     """
     redis = task.services.redis.client()
     lock_value = str(uuid4())
@@ -139,9 +143,19 @@ def update_custom_list_entries_sweep(task: Task) -> None:
         finalize_custom_list_entries_sweep.delay(lock_value=lock_value)
         return
 
+    # Celery runs a chord's body only if *every* header task succeeded. Attaching
+    # finalize as the body's error callback as well means the sweep lock is released
+    # on both paths: without it, one per-list task failing (a database outage, an
+    # OpenSearch transport error -- anything the per-list handler deliberately lets
+    # propagate) would leave the lock held for its full 2-hour TTL, silently skipping
+    # the next hourly sweeps for every list. Exactly one of the two runs, so the lock
+    # is released exactly once.
+    finalize = finalize_custom_list_entries_sweep.si(lock_value=lock_value)
+    finalize.on_error(finalize_custom_list_entries_sweep.si(lock_value=lock_value))
+
     chord(
         group([update_custom_list_entries.si(list_id) for list_id in list_ids]),
-        finalize_custom_list_entries_sweep.si(lock_value=lock_value),
+        finalize,
     ).delay()
 
 
@@ -350,18 +364,23 @@ def update_custom_list_entries(
                 f"Custom list {custom_list_id} not found; it may have been deleted. "
                 "Skipping."
             )
-        except RequestError:
+        except (RequestError, QueryParseException):
             # This task is a chord header, so an unhandled error aborts the whole
-            # sweep chord. A RequestError (OpenSearch 400) means *this* list's
-            # auto_update_query is malformed -- a list-specific problem, not an
-            # infrastructure failure -- so we skip it rather than let one bad query
-            # block the rest of the sweep.
+            # sweep chord. Both of these mean *this* list's auto_update_query is
+            # malformed -- a list-specific problem, not an infrastructure failure --
+            # so we skip it rather than let one bad query block the rest of the sweep.
             #
-            # A malformed query should not be reachable through normal use: the
-            # admin UI and circulation API validate queries before saving. Seeing
-            # one here therefore points to an upstream validation bug, so we log it
-            # as an exception (with traceback) to make it visible -- but we do not
-            # escalate to a task failure, since a single bad list shouldn't take
+            # The two arrive from different layers, and catching only one of them
+            # leaves the other to abort the sweep:
+            #   * QueryParseException is raised by our own JSONQuery parser, before
+            #     any request reaches OpenSearch (e.g. a `published` value that isn't
+            #     YYYY-MM-DD).
+            #   * RequestError is an OpenSearch 400, for a query that parses here but
+            #     that OpenSearch rejects.
+            #
+            # Either way the list is unusable until an admin fixes its query, so we
+            # log it as an exception (with traceback) to make it visible -- but we do
+            # not escalate to a task failure, since a single bad list shouldn't take
             # down the sweep.
             #
             # Infrastructure failures are deliberately NOT caught here: a
@@ -389,6 +408,10 @@ def finalize_custom_list_entries_sweep(
     Chord callback from ``update_custom_list_entries_sweep``.  It exists solely
     to release the sweep lock after every per-list ``update_custom_list_entries``
     task has finished, so the lock truly covers the full fan-out.
+
+    ``update_custom_list_entries_sweep`` registers this task as both the chord's
+    body and the body's error callback, since Celery skips the body entirely when
+    a header task fails.  Exactly one of the two invocations happens per sweep.
 
     :param lock_value: Sweep-lock random value from
         ``update_custom_list_entries_sweep``.  When provided, releases the lock.

--- a/tests/manager/celery/tasks/test_custom_lists.py
+++ b/tests/manager/celery/tasks/test_custom_lists.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import time
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -16,6 +17,7 @@ from palace.manager.celery.tasks.custom_lists import (
     _entry_update_lock,
     _sweep_lock,
 )
+from palace.manager.search.query import QueryParseException
 from palace.manager.sqlalchemy.model.customlist import CustomList, CustomListEntry
 from tests.fixtures.celery import CeleryFixture
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -41,6 +43,24 @@ def _make_auto_updating_list(
     if last_update is not None:
         custom_list.auto_update_last_update = last_update
     return custom_list
+
+
+def _wait_for_sweep_lock_release(
+    redis_fixture: RedisFixture, timeout: float = 10.0
+) -> None:
+    """Block until the sweep lock is free, or fail the test after ``timeout``.
+
+    The chord body (or its error callback) releases the lock on a worker thread,
+    after the sweep task that queued it has already returned.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        lock = _sweep_lock(redis_fixture.client, str(uuid4()))
+        if lock.acquire() is not False:
+            lock.release()
+            return
+        time.sleep(0.05)
+    pytest.fail(f"Sweep lock was not released within {timeout} seconds.")
 
 
 # ---------------------------------------------------------------------------
@@ -123,6 +143,61 @@ class TestUpdateCustomListEntriesSweep:
         # The chord callback signature must carry lock_value.
         chord_callback = mock_chord.call_args[0][1]
         assert chord_callback.kwargs.get("lock_value") is not None
+
+    def test_finalize_registered_as_chord_error_callback(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+    ):
+        """finalize is wired up as the chord body's error callback too.
+
+        Celery skips a chord's body when any header task fails, so without an
+        error callback a single failing per-list task would strand the sweep lock
+        until its 2-hour TTL expired.
+        """
+        _make_auto_updating_list(db)
+
+        with (
+            patch.object(custom_lists, "update_custom_list_entries"),
+            patch("palace.manager.celery.tasks.custom_lists.chord") as mock_chord,
+            patch("palace.manager.celery.tasks.custom_lists.group"),
+        ):
+            custom_lists.update_custom_list_entries_sweep.delay().wait()
+
+        chord_callback = mock_chord.call_args[0][1]
+        (errback,) = chord_callback.options["link_error"]
+        assert errback.task == custom_lists.finalize_custom_list_entries_sweep.name
+        # The errback must release the same lock the body would have released.
+        assert errback.kwargs["lock_value"] == chord_callback.kwargs["lock_value"]
+
+    def test_failing_per_list_task_still_releases_sweep_lock(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """End-to-end: a per-list task that fails must not strand the sweep lock.
+
+        Infrastructure errors are deliberately allowed to propagate out of
+        update_custom_list_entries so they trigger the unhandled-error alarm. That
+        failure aborts the chord body, so the lock has to come back via the error
+        callback instead.
+        """
+        _make_auto_updating_list(db, status=CustomList.INIT)
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            mock_queries.populate_query_pages.side_effect = SQLAlchemyError(
+                "database is down"
+            )
+            custom_lists.update_custom_list_entries_sweep.delay().wait()
+
+            # The chord header and its error callback run asynchronously, after the
+            # sweep task itself has returned. Poll until the lock comes back.
+            _wait_for_sweep_lock_release(redis_fixture)
 
     def test_sweep_lock_prevents_concurrent_sweeps(
         self,
@@ -399,28 +474,46 @@ class TestUpdateCustomListEntries:
         # Should not raise.
         custom_lists.update_custom_list_entries.delay(nonexistent_id).wait()
 
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(
+                RequestError(400, "parsing_exception", {"error": "malformed query"}),
+                id="opensearch-400",
+            ),
+            pytest.param(
+                QueryParseException(
+                    detail="Could not parse 'published' value '2025>01>01'."
+                ),
+                id="json-query-parse",
+            ),
+        ],
+    )
     def test_malformed_query_logged_and_swallowed(
         self,
+        error: Exception,
         db: DatabaseTransactionFixture,
         redis_fixture: RedisFixture,
         celery_fixture: CeleryFixture,
         services_fixture: ServicesFixture,
     ):
-        """A RequestError (this list's query is malformed) is logged and skipped.
+        """A malformed auto_update_query for this list is logged and skipped.
 
         Because this task is a chord header, a propagated error would abort the
         whole sweep chord and hold the sweep lock until its TTL. A malformed
         query is a list-specific config problem, so the task must instead succeed
         (the chord proceeds and the per-list lock is released).
+
+        Both flavors must be caught: OpenSearch rejects some queries with a 400
+        (RequestError), while others are rejected by our own JSONQuery parser
+        before a request is ever sent (QueryParseException).
         """
         custom_list = _make_auto_updating_list(db, status=CustomList.INIT)
 
         with patch(
             "palace.manager.celery.tasks.custom_lists.CustomListQueries"
         ) as mock_queries:
-            mock_queries.populate_query_pages.side_effect = RequestError(
-                400, "parsing_exception", {"error": "malformed query"}
-            )
+            mock_queries.populate_query_pages.side_effect = error
             # Should not raise -- the error is caught, logged, and swallowed.
             custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
 

--- a/tests/manager/celery/tasks/test_custom_lists.py
+++ b/tests/manager/celery/tasks/test_custom_lists.py
@@ -288,6 +288,53 @@ class TestUpdateCustomListEntries:
         )
         assert remaining == 0
 
+    def test_repopulate_parse_error_rolls_back_the_delete(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        celery_fixture: CeleryFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """A parse error after the REPOPULATE delete must leave the list intact.
+
+        In REPOPULATE mode the existing entries are bulk-deleted *before*
+        populate_query_pages parses and runs the query. A malformed query is
+        caught and swallowed so it does not abort the sweep -- but that swallow
+        must not commit the half-done work. This is safe only because the handler
+        sits outside the ``with task.transaction()`` block, so the exception
+        propagates out and rolls the transaction (delete included) back before
+        being caught. This test pins that invariant: move the catch inside the
+        transaction and the delete would commit, silently emptying the list.
+        """
+        custom_list = _make_auto_updating_list(db, status=CustomList.REPOPULATE)
+        work1 = db.work()
+        work2 = db.work()
+        custom_list.add_entry(work1.presentation_edition)
+        custom_list.add_entry(work2.presentation_edition)
+        db.session.flush()
+
+        with patch(
+            "palace.manager.celery.tasks.custom_lists.CustomListQueries"
+        ) as mock_queries:
+            mock_queries.populate_query_pages.side_effect = QueryParseException(
+                detail="Could not parse 'published' value '2025>01>01'."
+            )
+            # Swallowed, not raised -- one bad list must not abort the sweep.
+            custom_lists.update_custom_list_entries.delay(custom_list.id).wait()
+
+        db.session.expire_all()
+        remaining = (
+            db.session.query(CustomListEntry)
+            .filter(CustomListEntry.list_id == custom_list.id)
+            .count()
+        )
+        # The delete was rolled back: the last good entries survive ...
+        assert remaining == 2
+        # ... and the list stays in REPOPULATE so it retries once the query is fixed.
+        refreshed = db.session.get(CustomList, custom_list.id)
+        assert refreshed is not None
+        assert refreshed.auto_update_status == CustomList.REPOPULATE
+
     def test_updated_mode_injects_time_filter(
         self,
         db: DatabaseTransactionFixture,


### PR DESCRIPTION
## Description

Two fixes to `update_custom_list_entries`, both aimed at the same failure: a single custom list with a malformed `auto_update_query` currently takes down the entire custom-list entries sweep.

**1. Catch `QueryParseException` alongside `RequestError`.**

The per-list task already intends to log-and-skip a list whose query is malformed, so that one bad list doesn't abort the sweep chord. But it only caught `RequestError` (an OpenSearch 400). A query can also be rejected by our own `JSONQuery` parser, *before* any request reaches OpenSearch — that raises `QueryParseException`, which sailed straight past the handler and failed the task.

This restores the behavior of the `CustomListUpdateEntriesScript` this pipeline replaced, which wrapped each list in a bare `except Exception: self.log.exception(...)`.

One other note here:  even though we are validating custom list queries when they are entered by users, it is still possible that query validation logic could tighten down the road causing existing queries to start failing.   That is why I believe it is worth in submitting this PR along with #3551. 

**2. Release the sweep lock when a per-list task fails.**

`update_custom_list_entries` is a chord header, and Celery runs a chord's body only if every header task succeeded. The body is `finalize_custom_list_entries_sweep`, which is what releases the sweep-level Redis lock — so any header failure left that lock held for its full 2-hour TTL. The sweep is beat-scheduled hourly, so the next one or two ticks would skip with "another sweep is already in progress," and then the same thing would happen again.

`finalize` is now registered as the chord body's error callback as well as its body. Exactly one of the two runs, so the lock is released exactly once. Infrastructure errors (database down, OpenSearch transport failure) still propagate and alarm as before — they just no longer strand the lock on their way out.

## Motivation and Context

Seen in production (PP-4787). A list's stored query contained a `published` value of `2025>01>01` — someone typed `2025.01.01` with the shift key held down. Every sweep, that list raised:

```
palace.manager.search.query.QueryParseException: Could not parse 'published' value '2025>01>01'. Only use 'YYYY-MM-DD'
```

which failed the task, skipped the chord body, and left the sweep lock held. The net effect was that **no** custom list updated for any library, on a permanent, self-renewing cycle — from one bad row.

A follow-up PR (stacked on this one) adds validation of `auto_update_query` at save time in the admin controller, so a query that can't be parsed can't be stored in the first place.

The error was occurring on a single custom list in the California collection.  I manually fixed the production issue via one off database write  so we are not longer seeing the aforementioned error in production. 

## How Has This Been Tested?

`tox -e py312-docker -- tests/manager/celery/tasks/test_custom_lists.py` (24 passed).

- `test_malformed_query_logged_and_swallowed` is now parametrized over both `RequestError` and `QueryParseException`.
- `test_finalize_registered_as_chord_error_callback` asserts the error callback is wired up and carries the same `lock_value` as the body.
- `test_failing_per_list_task_still_releases_sweep_lock` is end-to-end: it runs a real sweep whose per-list task raises `SQLAlchemyError`, then polls until the sweep lock comes back. I confirmed this test is not vacuous by reverting the `on_error` line and watching it fail with "Sweep lock was not released within 10.0 seconds."

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)