### PR TITLE
Validate auto_update_query when a custom list is saved (PP-4506)

### DIFF
--- a/src/palace/manager/api/admin/controller/custom_lists.py
+++ b/src/palace/manager/api/admin/controller/custom_lists.py
@@ -34,6 +34,7 @@ from palace.manager.core.problem_details import INVALID_INPUT, METHOD_NOT_ALLOWE
 from palace.manager.core.query.customlist import CustomListQueries
 from palace.manager.feed.acquisition import OPDSAcquisitionFeed
 from palace.manager.feed.worklist.base import WorkList
+from palace.manager.search.query import JSONQuery, QueryParseException
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.customlist import CustomList
 from palace.manager.sqlalchemy.model.datasource import DataSource
@@ -129,7 +130,7 @@ class CustomListsController(
         deleted_entries: list[dict[str, Any]] | None = None,
         id: int | None = None,
         auto_update: bool | None = None,
-        auto_update_query: dict[str, str] | None = None,
+        auto_update_query: dict[str, Any] | None = None,
         auto_update_facets: dict[str, str] | None = None,
     ) -> ProblemDetail | Response:
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)
@@ -167,6 +168,21 @@ class CustomListsController(
                     raise ProblemDetailException(
                         INVALID_INPUT.detailed(
                             "auto_update_query is not JSON serializable"
+                        )
+                    )
+
+                # A query that is valid JSON may still be a query our search layer
+                # cannot parse (an unknown key, a bad operator, a `published` value
+                # that isn't YYYY-MM-DD, ...). Reject it here rather than storing it:
+                # the nightly entry-update task can only log and skip such a list, so
+                # an unvalidated query means a list that silently stops updating.
+                try:
+                    # Building the query is what validates it; the result is discarded.
+                    _ = JSONQuery(auto_update_query).search_query
+                except QueryParseException as exc:
+                    raise ProblemDetailException(
+                        INVALID_INPUT.detailed(
+                            f"auto_update_query is not a valid search query: {exc.detail}"
                         )
                     )
 

--- a/src/palace/manager/api/admin/controller/custom_lists.py
+++ b/src/palace/manager/api/admin/controller/custom_lists.py
@@ -34,7 +34,11 @@ from palace.manager.core.problem_details import INVALID_INPUT, METHOD_NOT_ALLOWE
 from palace.manager.core.query.customlist import CustomListQueries
 from palace.manager.feed.acquisition import OPDSAcquisitionFeed
 from palace.manager.feed.worklist.base import WorkList
-from palace.manager.search.query import JSONQuery, QueryParseException
+from palace.manager.search.query import (
+    JSONQuery,
+    JSONQueryDict,
+    QueryParseException,
+)
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.customlist import CustomList
 from palace.manager.sqlalchemy.model.datasource import DataSource
@@ -130,7 +134,7 @@ class CustomListsController(
         deleted_entries: list[dict[str, Any]] | None = None,
         id: int | None = None,
         auto_update: bool | None = None,
-        auto_update_query: dict[str, Any] | None = None,
+        auto_update_query: JSONQueryDict | None = None,
         auto_update_facets: dict[str, str] | None = None,
     ) -> ProblemDetail | Response:
         data_source = DataSource.lookup(self._db, DataSource.LIBRARY_STAFF)

--- a/src/palace/manager/search/query.py
+++ b/src/palace/manager/search/query.py
@@ -845,6 +845,17 @@ class JSONQuery(Query):
         if not query:
             return {}
 
+        # Every node must be an object. Without this guard a JSON-valid but
+        # ill-shaped node (e.g. a bare string from ``{"query": "foo"}``, or a
+        # string where ``and``/``or`` expects a list of sub-queries) would reach
+        # ``query.keys()`` below and raise a bare ``AttributeError`` — surfacing
+        # as a 500 instead of a "this query is invalid" 400.
+        if not isinstance(query, dict):
+            raise QueryParseException(
+                detail=f"Each query part must be an object, got "
+                f"{type(query).__name__}: {query!r}"
+            )
+
         # This is minimal set of leaf keys, op is optional
         leaves = {self.QueryLeaf.KEY, self.QueryLeaf.VALUE}
 
@@ -871,13 +882,37 @@ class JSONQuery(Query):
         old_key = query[self.QueryLeaf.KEY]
         value = query[self.QueryLeaf.VALUE]
 
-        # In case values need to be transformed
+        # ``key`` is used for dict lookups (VALUE_TRANSORMS, FIELD_MAPPING) and
+        # string concatenation below, so a non-string (e.g. a list) would raise
+        # ``TypeError: unhashable type`` rather than a validation error.
+        if not isinstance(old_key, str):
+            raise QueryParseException(
+                detail=f"Query 'key' must be a string, got "
+                f"{type(old_key).__name__}: {old_key!r}"
+            )
+
+        # In case values need to be transformed. Every transform expects a
+        # string (``published`` a date, ``language`` a name, etc.); a non-string
+        # would raise a bare ``AttributeError`` inside the transform. Numeric
+        # values remain legal for fields without a transform (e.g. a range
+        # filter on ``licensepools.availability_time``), so this only constrains
+        # the transformed keys.
         if old_key in self.VALUE_TRANSORMS:
+            if not isinstance(value, str):
+                raise QueryParseException(
+                    detail=f"Value for '{old_key}' must be a string, got "
+                    f"{type(value).__name__}: {value!r}"
+                )
             value = self.VALUE_TRANSORMS[old_key](value)
 
         # The contains/regex operators are a regex match
         # So we must replace special operators where encountered
         if op in {self.Operators.CONTAINS, self.Operators.REGEX}:
+            if not isinstance(value, str):
+                raise QueryParseException(
+                    detail=f"The '{op}' operator requires a string value, got "
+                    f"{type(value).__name__}: {value!r}"
+                )
             value = value.translate(self.RESERVED_CHARS_MAP)
 
         key = self.FIELD_TRANSFORMS.get(
@@ -935,6 +970,14 @@ class JSONQuery(Query):
             )
 
         join = list(query.keys())[0]
+        # A conjunction joins a list of sub-queries. A non-list (e.g. a string)
+        # would otherwise be iterated element-wise — a string would be walked
+        # character by character — producing a confusing error; reject it here.
+        if not isinstance(query[join], list):
+            raise QueryParseException(
+                detail=f"'{join}' must be a list of sub-queries, got "
+                f"{type(query[join]).__name__}: {query[join]!r}"
+            )
         to_join = []
         for query_part in query[join]:
             q = self._parse_json_query(query_part)

--- a/src/palace/manager/search/query.py
+++ b/src/palace/manager/search/query.py
@@ -4,6 +4,8 @@ import datetime
 import json
 import re
 from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from typing import TypeAlias
 
 from attrs import define
 from opensearchpy.helpers.query import (
@@ -673,6 +675,20 @@ class Query(LoggerMixin):
         return hypotheses
 
 
+# A node in the JSON query language parsed by :class:`JSONQuery`. Recursive
+# because the tree nests arbitrarily deep, a node is one of:
+#   * the root wrapper ``{"query": <node>}``
+#   * a leaf ``{"key": str, "value": <scalar>, "op": str}`` — ``value`` is a
+#     string for most fields and numeric for range filters (see the numeric
+#     tower: ``float`` also admits ``int``/``bool``)
+#   * a conjunction ``{"and" | "or" | "not": [<node>, ...]}``
+# ``Mapping``/``Sequence`` (rather than ``dict``/``list``) are used so that the
+# covariant value type accepts narrower literals such as ``dict[str, str]``.
+JSONQueryDict: TypeAlias = Mapping[
+    str, "str | float | JSONQueryDict | Sequence[JSONQueryDict]"
+]
+
+
 class JSONQuery(Query):
     """An ES query created out of a JSON based query language
     Eg. { "query": { "and": [{"key": "title", "value": "book" }, {"key": "author", "value": "robert" }] } }
@@ -811,7 +827,7 @@ class JSONQuery(Query):
         "audience": ValueTransforms.audience,
     }
 
-    def __init__(self, query: str | dict, filter=None):
+    def __init__(self, query: str | JSONQueryDict, filter=None):
         if type(query) is str:
             try:
                 query = json.loads(query)
@@ -845,11 +861,10 @@ class JSONQuery(Query):
         if not query:
             return {}
 
-        # Every node must be an object. Without this guard a JSON-valid but
+        # Every query node must be a dict. Without this guard a JSON-valid but
         # ill-shaped node (e.g. a bare string from ``{"query": "foo"}``, or a
         # string where ``and``/``or`` expects a list of sub-queries) would reach
-        # ``query.keys()`` below and raise a bare ``AttributeError`` — surfacing
-        # as a 500 instead of a "this query is invalid" 400.
+        # ``query.keys()`` below.
         if not isinstance(query, dict):
             raise QueryParseException(
                 detail=f"Each query part must be an object, got "
@@ -875,6 +890,16 @@ class JSONQuery(Query):
     def _parse_json_leaf(self, query: dict) -> BaseQuery:
         """We have a leaf query, which means this becomes a keyword.term query"""
         op = query.get(self.QueryLeaf.OP, self.Operators.EQ)
+
+        # ``op not in self.Operators`` resolves through ``ValuesMeta.__contains__``,
+        # which tests membership against a ``set``. A non-hashable ``op`` (e.g. a
+        # JSON array or object) would raise a bare ``TypeError: unhashable type``
+        # rather than a validation error, so guard the type first.
+        if not isinstance(op, str):
+            raise QueryParseException(
+                detail=f"Query 'op' must be a string, got "
+                f"{type(op).__name__}: {op!r}"
+            )
 
         if op not in self.Operators:
             raise QueryParseException(detail=f"Unrecognized operator: {op}")

--- a/tests/manager/api/admin/controller/test_custom_lists.py
+++ b/tests/manager/api/admin/controller/test_custom_lists.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Literal
+from typing import Any, Literal
 from unittest import mock
 
 import feedparser
@@ -1127,12 +1127,15 @@ class TestCustomListsController:
         custom_list.library = admin_librarian_fixture.ctrl.db.default_library()
         custom_list.add_entry(w1)
         custom_list.auto_update_enabled = True
-        custom_list.auto_update_query = '{"query":"...."}'
+        custom_list.auto_update_query = json.dumps(
+            {"query": {"key": "title", "value": "old"}}
+        )
         custom_list.auto_update_status = CustomList.UPDATED
         admin_librarian_fixture.ctrl.db.session.commit()
 
         assert isinstance(custom_list.name, str)
         assert custom_list.library is not None
+        changed_query = {"query": {"key": "title", "value": "changed"}}
         response = admin_librarian_fixture.manager.admin_custom_lists_controller._create_or_update_list(
             custom_list.library,
             custom_list.name,
@@ -1141,11 +1144,11 @@ class TestCustomListsController:
             [],
             id=custom_list.id,
             auto_update=True,
-            auto_update_query={"query": "...changed"},
+            auto_update_query=changed_query,
         )
 
         assert response.status_code == 200
-        assert custom_list.auto_update_query == '{"query": "...changed"}'
+        assert custom_list.auto_update_query == json.dumps(changed_query)
         assert custom_list.auto_update_status == CustomList.REPOPULATE
         assert [e.work_id for e in custom_list.entries] == [w1.id]
 
@@ -1163,12 +1166,109 @@ class TestCustomListsController:
             [],
             id=None,
             auto_update=True,
-            auto_update_query={"foo": object()},  # type: ignore[dict-item]
+            auto_update_query={"foo": object()},
         )
 
         assert isinstance(response, ProblemDetail)
         assert response.status_code == 400
         assert response.detail == "auto_update_query is not JSON serializable"
+
+    @pytest.mark.parametrize(
+        "query,expected_reason",
+        [
+            pytest.param(
+                {"query": {"key": "published", "value": "2025>01>01"}},
+                "Could not parse 'published' value '2025>01>01'. Only use 'YYYY-MM-DD'",
+                id="unparseable-published-value",
+            ),
+            pytest.param(
+                {"query": {"key": "not_a_field", "value": "x"}},
+                "Unrecognized key: not_a_field",
+                id="unknown-key",
+            ),
+            pytest.param(
+                {"query": {"key": "title", "value": "x", "op": "sideways"}},
+                "Unrecognized operator: sideways",
+                id="unknown-operator",
+            ),
+            pytest.param(
+                {"not_query": {"key": "title", "value": "x"}},
+                "'query' key must be present as the root",
+                id="missing-query-root",
+            ),
+        ],
+    )
+    def test_auto_update_query_must_be_a_valid_search_query(
+        self,
+        query: dict[str, Any],
+        expected_reason: str,
+        admin_librarian_fixture: AdminLibrarianFixture,
+        db: DatabaseTransactionFixture,
+    ):
+        """A JSON-serializable query that the search layer cannot parse is rejected.
+
+        Storing one would produce a list that silently stops updating: the
+        entry-update task can only log and skip a list whose query fails to parse.
+        """
+        library = db.default_library()
+        response = admin_librarian_fixture.manager.admin_custom_lists_controller._create_or_update_list(
+            library,
+            "test list",
+            [],
+            [],
+            [],
+            id=None,
+            auto_update=True,
+            auto_update_query=query,
+        )
+
+        assert isinstance(response, ProblemDetail)
+        assert response.status_code == 400
+        assert response.detail is not None
+        assert "auto_update_query is not a valid search query" in response.detail
+        assert expected_reason in response.detail
+
+        # Nothing was persisted.
+        assert CustomList.find(db.session, "test list", library=library) is None
+
+    def test_auto_update_query_validated_on_edit(
+        self,
+        admin_librarian_fixture: AdminLibrarianFixture,
+    ):
+        """An existing list's query is validated too, not just a new list's.
+
+        Edits were the gap: creating a list incidentally exercised its query through
+        populate_query_pages, but an edit never parsed the query at all.
+        """
+        custom_list: CustomList
+        custom_list, _ = admin_librarian_fixture.ctrl.db.customlist(
+            data_source_name=DataSource.LIBRARY_STAFF, num_entries=0
+        )
+        custom_list.library = admin_librarian_fixture.ctrl.db.default_library()
+        custom_list.auto_update_enabled = True
+        good_query = json.dumps({"query": {"key": "title", "value": "good"}})
+        custom_list.auto_update_query = good_query
+        custom_list.auto_update_status = CustomList.UPDATED
+        admin_librarian_fixture.ctrl.db.session.commit()
+
+        assert isinstance(custom_list.name, str)
+        assert custom_list.library is not None
+        response = admin_librarian_fixture.manager.admin_custom_lists_controller._create_or_update_list(
+            custom_list.library,
+            custom_list.name,
+            [],
+            [],
+            [],
+            id=custom_list.id,
+            auto_update=True,
+            auto_update_query={"query": {"key": "published", "value": "2025>01>01"}},
+        )
+
+        assert isinstance(response, ProblemDetail)
+        assert response.status_code == 400
+        # The previously-good query is left untouched.
+        assert custom_list.auto_update_query == good_query
+        assert custom_list.auto_update_status == CustomList.UPDATED
 
     def test_auto_update_create_unable_to_serialize_facets(
         self,
@@ -1184,7 +1284,7 @@ class TestCustomListsController:
             [],
             id=None,
             auto_update=True,
-            auto_update_query={"query": "foo"},
+            auto_update_query={"query": {"key": "title", "value": "foo"}},
             auto_update_facets={"foo": object()},  # type: ignore[dict-item]
         )
 
@@ -1206,6 +1306,6 @@ class TestCustomListsController:
             [{}, {}],
             id=None,
             auto_update=True,
-            auto_update_query={"query": "foo"},
+            auto_update_query={"query": {"key": "title", "value": "foo"}},
         )
         assert response == AUTO_UPDATE_CUSTOM_LIST_CANNOT_HAVE_ENTRIES

--- a/tests/manager/api/admin/controller/test_custom_lists.py
+++ b/tests/manager/api/admin/controller/test_custom_lists.py
@@ -1166,7 +1166,10 @@ class TestCustomListsController:
             [],
             id=None,
             auto_update=True,
-            auto_update_query={"foo": object()},
+            # A bare ``object()`` is deliberately not JSON serializable — the
+            # point of this test is the runtime ``json.dumps`` guard, so the
+            # value intentionally violates the JSONQueryDict value type.
+            auto_update_query={"foo": object()},  # type: ignore[dict-item]
         )
 
         assert isinstance(response, ProblemDetail)

--- a/tests/manager/api/admin/controller/test_custom_lists.py
+++ b/tests/manager/api/admin/controller/test_custom_lists.py
@@ -1196,6 +1196,25 @@ class TestCustomListsController:
                 "'query' key must be present as the root",
                 id="missing-query-root",
             ),
+            # JSON-serializable but wrongly-typed inputs. These once reached the
+            # parser's string operations and raised AttributeError/TypeError,
+            # which escaped the QueryParseException catch as a 500. They must now
+            # come back as a clean 400 like any other invalid query.
+            pytest.param(
+                {"query": {"key": "language", "value": 5}},
+                "Value for 'language' must be a string",
+                id="non-string-value",
+            ),
+            pytest.param(
+                {"query": {"key": ["title"], "value": "x"}},
+                "Query 'key' must be a string",
+                id="non-string-key",
+            ),
+            pytest.param(
+                {"query": "just a string"},
+                "Each query part must be an object",
+                id="query-part-not-object",
+            ),
         ],
     )
     def test_auto_update_query_must_be_a_valid_search_query(

--- a/tests/manager/search/test_query.py
+++ b/tests/manager/search/test_query.py
@@ -1268,6 +1268,37 @@ class TestJSONQuery:
                 "Could not make sense of the query",
             ),
             ({"and": [], "or": []}, "A conjunction cannot have multiple parts"),
+            # Malformed but JSON-serializable shapes: before these were guarded
+            # they raised bare AttributeError/TypeError from deep in the parser,
+            # surfacing as a 500 rather than a validation error. See PP-4506.
+            pytest.param(
+                "foo", "Each query part must be an object", id="query-part-not-object"
+            ),
+            pytest.param(
+                {"and": "notalist"},
+                "'and' must be a list of sub-queries",
+                id="conjunction-not-a-list",
+            ),
+            pytest.param(
+                dict(key=["author"], value="name"),
+                "Query 'key' must be a string",
+                id="key-not-a-string",
+            ),
+            pytest.param(
+                dict(key="language", value=5),
+                "Value for 'language' must be a string",
+                id="transformed-value-not-a-string",
+            ),
+            pytest.param(
+                dict(key="published", value=20250101),
+                "Value for 'published' must be a string",
+                id="published-value-not-a-string",
+            ),
+            pytest.param(
+                dict(key="title", value=5, op="contains"),
+                "The 'contains' operator requires a string value",
+                id="contains-value-not-a-string",
+            ),
         ],
     )
     def test_errors(self, query, error_match):
@@ -1275,6 +1306,27 @@ class TestJSONQuery:
 
         with pytest.raises(QueryParseException, match=error_match):
             q.search_query  # fetch the property
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            # Numeric values remain legal for fields without a value transform;
+            # the type guards must not reject these. A range filter over a numeric
+            # field is how the custom-list entry sweep filters by availability.
+            pytest.param(
+                dict(key="target_age", value=18, op="gte"), id="numeric-range"
+            ),
+            pytest.param(
+                dict(
+                    key="licensepools.availability_time", value=1735689600.0, op="gte"
+                ),
+                id="float-timestamp-range",
+            ),
+        ],
+    )
+    def test_numeric_values_are_not_rejected(self, query):
+        # search_query must build without raising; the exact DSL is covered elsewhere.
+        assert self._jq(query).search_query is not None
 
     def test_regex_query(self):
         q = self._jq(self._leaf("title", "book", op="regex"))

--- a/tests/manager/search/test_query.py
+++ b/tests/manager/search/test_query.py
@@ -1299,6 +1299,11 @@ class TestJSONQuery:
                 "The 'contains' operator requires a string value",
                 id="contains-value-not-a-string",
             ),
+            pytest.param(
+                dict(key="title", value="x", op=[]),
+                "Query 'op' must be a string",
+                id="op-not-a-string",
+            ),
         ],
     )
     def test_errors(self, query, error_match):


### PR DESCRIPTION
## Description

> [!NOTE]
> Companion to #3550, but independent — the two touch disjoint files (this one is the admin controller; #3550 is the Celery task), so this targets `main` and can merge in any order. #3550 makes the entry sweep resilient to a bad query at runtime; this stops a bad query being saved in the first place.

A custom list's `auto_update_query` was only checked for JSON *serializability* before being stored — never for whether the search layer could actually parse it. `CustomListsController._create_or_update_list` now builds a `JSONQuery` from the submitted query and returns `INVALID_INPUT` (400) if it can't be parsed, passing along the parser's own explanation of what's wrong.

Also corrects the `auto_update_query` parameter annotation, which claimed `dict[str, str]` even though a query's `value` is a nested dict. That's why the existing tests were able to pass placeholders like `{"query": "foo"}` without mypy complaining.

## Motivation and Context

Follow-up to #3550, which fixed the *symptom*: a list whose stored query contained a `published` value of `2025>01>01` failed its Celery task every sweep and (before that PR) wedged the sweep lock for every library.

This PR fixes how the bad value got in. Two gaps combined:

- **Creating** a list incidentally exercised its query, via the `populate_query_pages` call on the `is_new` path — but a `QueryParseException` there surfaced as an unhandled 500, not a validation error.
- **Editing** a list never parsed the query at all. So an invalid query could only ever be introduced — and never surfaced — through an edit.

Either way the result was a list that silently stopped updating, since the entry-update task can do nothing with an unparseable query but log it and skip. Rejecting the query at save time turns a silent, indefinitely-stalled list into an immediate 400 for the librarian who fat-fingered the date.

**Behavior change worth flagging in review:** a librarian editing an existing list whose stored query is *already* invalid will now get a 400 rather than a successful save, even if they only meant to change the list's name — the admin UI resubmits `auto_update_query` unchanged. That seems right to me (it forces the broken query to be fixed), but it is a real change, and it means any already-corrupted rows in production should be corrected before this ships. (At this time as far as I know there are no corrupted rows in production - I manually fixed the one issue that alerted us to the problem.)

## How Has This Been Tested?

`tox -e py312-docker -- tests/manager/api/admin/controller/test_custom_lists.py tests/manager/core/test_customlist_queries.py tests/manager/celery/tasks/test_custom_lists.py` (64 passed).

- `test_auto_update_query_must_be_a_valid_search_query` is parametrized over four ways to be invalid — the `2025>01>01` value from production, an unknown key, an unknown operator, and a missing `query` root — and asserts the parser's reason is surfaced in the problem detail and that nothing is persisted.
- `test_auto_update_query_validated_on_edit` covers the gap specifically: an existing list rejects a bad query on edit and keeps its previous good one.
- Three existing tests had to be updated. They passed placeholder queries (`{"query": "foo"}`, `{"query": "...changed"}`) that the new validation correctly rejects. They test facets serialization, entry handling, and the repopulate-on-query-change path, so they now pass a valid query. That they needed changing at all is a decent illustration of how little the old code cared what was in this column.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

