### PR TITLE
Drop deprecated lanes.size columns (PP-4506)

### DIFF
--- a/alembic/versions/20260715_de6ae4bbf4a5_drop_deprecated_lanes_size_columns.py
+++ b/alembic/versions/20260715_de6ae4bbf4a5_drop_deprecated_lanes_size_columns.py
@@ -1,0 +1,49 @@
+"""Drop deprecated lanes.size columns
+
+Revision ID: de6ae4bbf4a5
+Revises: dbeb42224c1b
+Create Date: 2026-07-15 14:08:25.692742+00:00
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "de6ae4bbf4a5"
+down_revision = "dbeb42224c1b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop the deprecated lane-size cache columns. They are no longer read or
+    # written by the current code (release 1 marked them ``deferred`` and moved
+    # ``size``'s default into the database), so no running release references
+    # them. See the online-migration two-release sequence in CLAUDE.md.
+    op.drop_column("lanes", "size_by_entrypoint")
+    op.drop_column("lanes", "size")
+
+
+def downgrade() -> None:
+    # Recreate the columns in the state they had after release 1: ``size`` is
+    # NOT NULL with a server_default of 0 (so existing rows are backfilled),
+    # ``size_by_entrypoint`` is nullable JSON.
+    op.add_column(
+        "lanes",
+        sa.Column(
+            "size",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "lanes",
+        sa.Column(
+            "size_by_entrypoint",
+            postgresql.JSON(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )

--- a/src/palace/manager/sqlalchemy/model/lane.py
+++ b/src/palace/manager/sqlalchemy/model/lane.py
@@ -13,13 +13,11 @@ from sqlalchemy import (
     Unicode,
     UniqueConstraint,
     or_,
-    text,
 )
-from sqlalchemy.dialects.postgresql import ARRAY, INT4RANGE, JSON
+from sqlalchemy.dialects.postgresql import ARRAY, INT4RANGE
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import (
     Mapped,
-    deferred,
     relationship,
 )
 from sqlalchemy.orm.session import Session
@@ -112,14 +110,6 @@ class Lane(Base, DatabaseBackedWorkList, HierarchyWorkList):
     )
 
     priority: Mapped[int] = Column(Integer, index=True, nullable=False, default=0)
-
-    # Deprecated: these cached size estimates are no longer populated or read.
-    # The code that maintained them (update_size and the lane-size Celery tasks)
-    # has been removed; the columns remain mapped only so the model continues to
-    # match the database schema, and will be dropped in a follow-up migration.
-    # TODO: Drop these next release when it is safe to do so.
-    size = deferred(Column(Integer, nullable=False, server_default=text("0")))
-    size_by_entrypoint = deferred(Column(JSON, nullable=True))
 
     # A lane may have one parent lane and many sublanes.
     sublanes: Mapped[list[Lane]] = relationship(


### PR DESCRIPTION
## Description

Release-2 (the drop) of the online-migration sequence for removing the deprecated lane-size cache columns. Stacked on the release-1 PR #3619, which stops all reads of `size` / `size_by_entrypoint` (they were already made write-safe via `server_default` in #3481). This PR removes the columns from the `Lane` model and drops them from the schema.

**Do not merge until a release containing #3619 has shipped.** Until then the still-running previous release reads `lanes.size` and dropping the column would break it — so this is left in draft. Note that the CI `Backwards compatibility test` on this PR is *expected to fail* until then: that job runs the latest published release's suite, which still reads the columns; it will pass once a release containing #3619 becomes the baseline.

## Motivation and Context

JIRA: PP-4506

Completes the two-release removal. The read-side fix in #3619 was validated against this exact drop locally with the backwards-compatibility check's new local mode (#3618): the release-1 branch's `pytest -m db` suite passes against this dropped schema.

## How Has This Been Tested?

- `tests/migration/test_alembic_builtin_tests.py` passes, including `test_model_definitions_match_ddl` (model matches the migrated schema after the drop) and the up/down migration round-trip.
- Backwards-compatibility check (local mode) with the #3619 branch as the previous side: **3341 passed, 0 failed** against this dropped schema (vs. 20 failures before #3619).

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
