### PR TITLE
Run the backwards-compatibility check locally against any git ref (PP-4506)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,28 @@ the removal isn't forgotten later:
 Pushing both PRs up front is deliberate: it makes the follow-up cleanup visible and prevents the second step from
 being lost.
 
+**Verifying backwards compatibility.** CI runs a `Backwards compatibility test`
+(`docker/ci/test_backwards_compatibility.sh`): it builds the schema from the current code, then runs the **latest**
+**published release's** database test suite (`pytest -m db`, external-schema mode) against it. A failure there means
+the migration would break the still-running previous release. It most often means a release-1 "stop using" change
+did not actually stop using the object — e.g. a `deferred()` column still re-selected by `Query.count()` /
+`from_self()`, or a Python-side `default=` still emitted on `INSERT`.
+
+Because that gate tests against a *published release*, it can only catch such a mistake **after** release-1 has
+shipped — a full release cycle after the bug was written. To get the same signal locally in minutes, pass a **git**
+**ref** to the script; it then builds both sides from git (previous side from the ref, current side from your working
+tree) instead of pulling a release:
+
+```bash
+# Prove that <release-1 commit> still works against the schema in your working tree
+# (e.g. the stacked release-2 drop). Green here means the "stop using" change is real.
+./docker/ci/test_backwards_compatibility.sh <release-1-commit-or-HEAD~1>
+```
+
+Run this before merging any release-1 "stop using" PR: check out the drop in your working tree, point the script at
+the release-1 commit, and confirm it passes. CI still tests against the real previous release; this is a local
+pre-flight so a broken "stop using" change never reaches a release. (Requires Docker and a pullable base image.)
+
 ## Contributing Guidelines
 
 - All new features require corresponding tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,11 +184,10 @@ being lost.
 (`docker/ci/test_backwards_compatibility.sh`): it builds the schema from the current code, then runs the **latest**
 **published release's** database test suite (`pytest -m db`, external-schema mode) against it. A failure there means
 the migration would break the still-running previous release. It most often means a release-1 "stop using" change
-did not actually stop using the object — e.g. a `deferred()` column still re-selected by `Query.count()` /
-`from_self()`, or a Python-side `default=` still emitted on `INSERT`.
+did not actually stop using the object — a lingering read or write slipped past the rules above.
 
 Because that gate tests against a *published release*, it can only catch such a mistake **after** release-1 has
-shipped — a full release cycle after the bug was written. To get the same signal locally in minutes, pass a **git**
+shipped — a full release cycle after the bug was written. To get the same signal locally, pass a **git**
 **ref** to the script; it then builds both sides from git (previous side from the ref, current side from your working
 tree) instead of pulling a release:
 
@@ -198,9 +197,8 @@ tree) instead of pulling a release:
 ./docker/ci/test_backwards_compatibility.sh <release-1-commit-or-HEAD~1>
 ```
 
-Run this before merging any release-1 "stop using" PR: check out the drop in your working tree, point the script at
-the release-1 commit, and confirm it passes. CI still tests against the real previous release; this is a local
-pre-flight so a broken "stop using" change never reaches a release. (Requires Docker and a pullable base image.)
+**Run this before you open the PR, not after it merges.** Check out the release-2 drop in your working tree, point the
+script at the release-1 commit, and confirm it passes.
 
 ## Contributing Guidelines
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,10 +74,15 @@ services:
       POSTGRES_PASSWORD: test
       POSTGRES_DB: circ
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U palace -d circ"]
+      # -h 127.0.0.1 forces a TCP check: during initdb the entrypoint runs a temporary
+      # socket-only server, and a socketless pg_isready would report healthy before Postgres
+      # is actually listening on 5432.
+      test: ["CMD-SHELL", "pg_isready -U palace -d circ -h 127.0.0.1"]
       interval: 30s
       timeout: 30s
       retries: 3
+      start_period: 60s
+      start_interval: 2s
 
   minio:
     build:
@@ -97,6 +102,8 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
+      start_period: 60s
+      start_interval: 2s
 
   os:
     build:
@@ -110,10 +117,14 @@ services:
       OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
       DISABLE_INSTALL_DEMO_CONFIG: "true"
     healthcheck:
-      test: curl --silent http://localhost:9200 >/dev/null; if [[ $$? == 52 ]]; then echo 0; else echo 1; fi
+      # Gate on cluster readiness (yellow+ within 1s), not merely the HTTP transport binding,
+      # so index creation in initialize_instance does not race a not-yet-ready cluster.
+      test: ["CMD", "curl", "--silent", "--show-error", "--fail", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s"]
       interval: 30s
       timeout: 10s
       retries: 5
+      start_period: 90s
+      start_interval: 2s
 
   valkey:
     image: "valkey/valkey:9.0"
@@ -122,3 +133,5 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
+      start_period: 60s
+      start_interval: 2s

--- a/docker/ci/test_backwards_compatibility.sh
+++ b/docker/ci/test_backwards_compatibility.sh
@@ -16,8 +16,9 @@
 #      compatible.
 #
 # The current image is provided via the WEBAPP_IMAGE environment variable (as in the other
-# docker CI jobs). The previous release image can be overridden via PREV_RELEASE_IMAGE
-# (useful for running this script locally).
+# docker CI jobs). The previous release image can be overridden via PREV_RELEASE_IMAGE (useful
+# for running this script locally); it is ignored in local mode, where the previous image is
+# always built from the ref.
 #
 # Local mode (PREV_RELEASE_REF): pass a git ref as the first argument, or set
 # PREV_RELEASE_REF, to test against that ref instead of the latest published release. Both
@@ -32,8 +33,9 @@
 
 set -uo pipefail
 
-# Optional git ref for local mode (see header): accept it as $1 or via PREV_RELEASE_REF.
-PREV_RELEASE_REF="${PREV_RELEASE_REF:-${1:-}}"
+# Optional git ref for local mode (see header): accept it as $1, falling back to
+# PREV_RELEASE_REF.
+PREV_RELEASE_REF="${1:-${PREV_RELEASE_REF:-}}"
 
 COMPOSE_FILES=(-f docker-compose.yml -f docker/ci/test_backwards_compatibility.yml)
 
@@ -42,7 +44,10 @@ compose_cmd() {
   docker compose "${COMPOSE_FILES[@]}" --progress quiet "$@"
 }
 
-# Run a command in a container with the palace virtualenv activated.
+# Run a command in a container with the palace virtualenv activated. compose run builds a missing
+# image from its build: context, so webapp-prev -- which inherits webapp's build: via extends --
+# must have its previous image ensured upstream (its --load/pull steps are || fail-guarded), or a
+# missing one would silently test the working tree against itself instead of failing.
 run_in_container() {
   local container="$1"
   shift
@@ -58,33 +63,45 @@ fail() {
   exit "${2:-1}"
 }
 
+# Reject bad arguments early: only one git ref is meaningful. Too many (e.g. mistaking it for a
+# ref range) or an empty one (e.g. ./...sh "$UNSET_VAR") would otherwise silently test the wrong
+# thing -- the first ref, or a fall-through to the latest release -- and report a confident result.
+[[ $# -gt 1 ]] && fail "Too many arguments; expected at most one git ref, got $#."
+[[ $# -eq 1 && -z "${1:-}" ]] && fail "Empty git ref argument; pass a ref, or no argument to test against the latest release."
+
 # (0) Local mode: when a git ref is given, build both sides from git instead of pulling the
 # latest release, so a "stop using" change can be validated before it ships. Skipped in CI,
 # which leaves PREV_RELEASE_REF unset and tests against the published previous release.
 if [[ -n "${PREV_RELEASE_REF}" ]]; then
   git rev-parse --verify --quiet "${PREV_RELEASE_REF}^{commit}" >/dev/null \
     || fail "PREV_RELEASE_REF='${PREV_RELEASE_REF}' is not a valid git ref."
-  prev_sha="$(git rev-parse --short "${PREV_RELEASE_REF}")"
-  base_image="${BUILD_BASE_IMAGE:-ghcr.io/thepalaceproject/circ-baseimage:latest}"
+  prev_sha="$(git rev-parse --short "${PREV_RELEASE_REF}^{commit}")"
+  base_image="${BUILD_BASE_IMAGE-ghcr.io/thepalaceproject/circ-baseimage:latest}"
 
-  # Previous side: build from the ref's committed tree. git archive streams that tree as the
-  # build context, so uncommitted changes are excluded (this is exactly the ref's code) and
-  # the working tree is never touched -- no checkout or worktree needed.
-  PREV_RELEASE_IMAGE="circ-webapp:backcompat-prev-${prev_sha}"
+  # Previous side: build the ref's committed tree, streamed as the build context via git archive
+  # so the working tree is untouched -- no checkout or worktree needed. Export (not just set) so
+  # `compose_cmd build webapp` below sees it, else compose warns webapp-prev's image is unset.
+  export PREV_RELEASE_IMAGE="circ-webapp:backcompat-prev-${prev_sha}"
   echo "Building previous image from ${PREV_RELEASE_REF} (${prev_sha}) ..."
-  git archive --format=tar "${PREV_RELEASE_REF}" \
-    | docker build -f docker/Dockerfile --target webapp \
-        --build-arg "BASE_IMAGE=${base_image}" \
-        --cache-from ghcr.io/thepalaceproject/circ-webapp:main \
-        -t "${PREV_RELEASE_IMAGE}" - \
+  # --load: else a container-driver buildx builder leaves the tag only in its cache, not the image store.
+  prev_build=(docker buildx build -f docker/Dockerfile --target webapp --load
+    --build-arg "BASE_IMAGE=${base_image}" -t "${PREV_RELEASE_IMAGE}")
+  # cache_from / --platform: mirror docker-compose.yml so both sides build alike (empty cache_from is skipped;
+  # a BUILD_PLATFORM mismatch would otherwise surface as a bogus "not backwards compatible" on webapp-prev).
+  cache_from="${BUILD_CACHE_FROM-ghcr.io/thepalaceproject/circ-webapp:main}"
+  [[ -n "${cache_from}" ]] && prev_build+=(--cache-from "${cache_from}")
+  [[ -n "${BUILD_PLATFORM:-}" ]] && prev_build+=(--platform "${BUILD_PLATFORM}")
+  prev_build+=(-)
+  git archive --format=tar "${PREV_RELEASE_REF}" | "${prev_build[@]}" \
     || fail "Could not build the previous image from ${PREV_RELEASE_REF}."
 
   # Current side: build from the working tree (including uncommitted changes) so the schema
-  # under test is whatever you are working on right now.
+  # under test is whatever you are working on right now. Use plain progress (not compose_cmd's
+  # --progress quiet) so this build -- the longest step in local mode -- streams output.
   if [[ -z "${WEBAPP_IMAGE:-}" ]]; then
     export WEBAPP_IMAGE="circ-webapp:backcompat-current-local"
     echo "Building current image from the working tree ..."
-    compose_cmd build webapp \
+    docker compose "${COMPOSE_FILES[@]}" --progress plain build webapp \
       || fail "Could not build the current image from the working tree."
   fi
 fi
@@ -119,6 +136,9 @@ echo "Previous release image: ${PREV_RELEASE_IMAGE}"
 if [[ -z "${WEBAPP_IMAGE:-}" ]]; then
   fail "WEBAPP_IMAGE is not set; it must point at the current build's webapp image."
 fi
+# Echo the current image too, so a stale/exported WEBAPP_IMAGE (which skips the working-tree
+# build in local mode) is visible rather than producing a confidently wrong result.
+echo "Current image: ${WEBAPP_IMAGE}"
 
 trap cleanup EXIT
 
@@ -126,7 +146,14 @@ trap cleanup EXIT
 # --wait blocks until the services report healthy: initialize_instance is run with
 # `compose run --no-deps` (below), which bypasses the webapp service's depends_on health
 # gating, so without --wait it can race a still-starting OpenSearch/Postgres and fail.
-compose_cmd up -d --wait pg os minio valkey || fail "Could not start service containers."
+services=(pg os minio valkey)
+echo "Starting service containers and waiting for them to be healthy ..."
+compose_cmd up -d --wait "${services[@]}" || {
+  # cleanup (trap EXIT) tears these down on exit, so capture state and logs before failing.
+  compose_cmd ps -a
+  compose_cmd logs --no-color "${services[@]}"
+  fail "Could not start service containers."
+}
 run_in_container webapp "./bin/util/initialize_instance" \
   || fail "Failed to initialize the database with the current image."
 
@@ -136,6 +163,13 @@ run_in_container webapp "./bin/util/initialize_instance" \
 if [[ -z "${PREV_RELEASE_REF}" ]]; then
   compose_cmd pull --quiet webapp-prev || fail "Could not pull ${PREV_RELEASE_IMAGE}."
 fi
+# Assert the previous image is actually present before running it. compose pull does not reliably
+# fail for a service with a build: section (webapp-prev inherits webapp's via extends; it can fall
+# back to "must build"), and compose run would then rebuild the missing image from the working
+# tree -- a vacuous current-vs-current pass. This inspect fails loudly in both the pull (CI) and
+# --load (local) paths, so a missing previous image can never be silently rebuilt.
+docker image inspect "${PREV_RELEASE_IMAGE}" >/dev/null 2>&1 \
+  || fail "${PREV_RELEASE_IMAGE} is not present locally; the check would rebuild it from the working tree and pass vacuously."
 echo "Running the previous release's database tests against the current schema ..."
 if ! run_in_container webapp-prev \
   "uv sync --frozen --active && pytest --no-cov -n auto -m db --ignore=tests/migration tests"; then

--- a/docker/ci/test_backwards_compatibility.sh
+++ b/docker/ci/test_backwards_compatibility.sh
@@ -18,8 +18,22 @@
 # The current image is provided via the WEBAPP_IMAGE environment variable (as in the other
 # docker CI jobs). The previous release image can be overridden via PREV_RELEASE_IMAGE
 # (useful for running this script locally).
+#
+# Local mode (PREV_RELEASE_REF): pass a git ref as the first argument, or set
+# PREV_RELEASE_REF, to test against that ref instead of the latest published release. Both
+# images are then built from git -- the previous side from the ref's committed tree, the
+# current side from the working tree (WEBAPP_IMAGE, built if unset) -- so you can prove a
+# "stop using" change is backwards compatible locally, before it is released. Example:
+#
+#   ./docker/ci/test_backwards_compatibility.sh HEAD~1
+#
+# Requires that the build base image is pullable (docker login ghcr.io if needed). CI leaves
+# PREV_RELEASE_REF unset and keeps testing against the real previous release.
 
 set -uo pipefail
+
+# Optional git ref for local mode (see header): accept it as $1 or via PREV_RELEASE_REF.
+PREV_RELEASE_REF="${PREV_RELEASE_REF:-${1:-}}"
 
 COMPOSE_FILES=(-f docker-compose.yml -f docker/ci/test_backwards_compatibility.yml)
 
@@ -43,6 +57,37 @@ fail() {
   echo "::error::$1"
   exit "${2:-1}"
 }
+
+# (0) Local mode: when a git ref is given, build both sides from git instead of pulling the
+# latest release, so a "stop using" change can be validated before it ships. Skipped in CI,
+# which leaves PREV_RELEASE_REF unset and tests against the published previous release.
+if [[ -n "${PREV_RELEASE_REF}" ]]; then
+  git rev-parse --verify --quiet "${PREV_RELEASE_REF}^{commit}" >/dev/null \
+    || fail "PREV_RELEASE_REF='${PREV_RELEASE_REF}' is not a valid git ref."
+  prev_sha="$(git rev-parse --short "${PREV_RELEASE_REF}")"
+  base_image="${BUILD_BASE_IMAGE:-ghcr.io/thepalaceproject/circ-baseimage:latest}"
+
+  # Previous side: build from the ref's committed tree. git archive streams that tree as the
+  # build context, so uncommitted changes are excluded (this is exactly the ref's code) and
+  # the working tree is never touched -- no checkout or worktree needed.
+  PREV_RELEASE_IMAGE="circ-webapp:backcompat-prev-${prev_sha}"
+  echo "Building previous image from ${PREV_RELEASE_REF} (${prev_sha}) ..."
+  git archive --format=tar "${PREV_RELEASE_REF}" \
+    | docker build -f docker/Dockerfile --target webapp \
+        --build-arg "BASE_IMAGE=${base_image}" \
+        --cache-from ghcr.io/thepalaceproject/circ-webapp:main \
+        -t "${PREV_RELEASE_IMAGE}" - \
+    || fail "Could not build the previous image from ${PREV_RELEASE_REF}."
+
+  # Current side: build from the working tree (including uncommitted changes) so the schema
+  # under test is whatever you are working on right now.
+  if [[ -z "${WEBAPP_IMAGE:-}" ]]; then
+    export WEBAPP_IMAGE="circ-webapp:backcompat-current-local"
+    echo "Building current image from the working tree ..."
+    compose_cmd build webapp \
+      || fail "Could not build the current image from the working tree."
+  fi
+fi
 
 # (1) Resolve the previous release image.
 if [[ -z "${PREV_RELEASE_IMAGE:-}" ]]; then
@@ -78,14 +123,19 @@ fi
 trap cleanup EXIT
 
 # (2) Build the current schema by initializing a fresh database with the current image.
-compose_cmd up -d pg os minio valkey || fail "Could not start service containers."
+# --wait blocks until the services report healthy: initialize_instance is run with
+# `compose run --no-deps` (below), which bypasses the webapp service's depends_on health
+# gating, so without --wait it can race a still-starting OpenSearch/Postgres and fail.
+compose_cmd up -d --wait pg os minio valkey || fail "Could not start service containers."
 run_in_container webapp "./bin/util/initialize_instance" \
   || fail "Failed to initialize the database with the current image."
 
 # (3) Run the previous release's database tests against the new schema. In external-schema
 # mode each xdist worker clones the freshly-built schema into its own database, so the suite
-# runs in parallel (-n auto).
-compose_cmd pull --quiet webapp-prev || fail "Could not pull ${PREV_RELEASE_IMAGE}."
+# runs in parallel (-n auto). In local mode the previous image was built above, not pulled.
+if [[ -z "${PREV_RELEASE_REF}" ]]; then
+  compose_cmd pull --quiet webapp-prev || fail "Could not pull ${PREV_RELEASE_IMAGE}."
+fi
 echo "Running the previous release's database tests against the current schema ..."
 if ! run_in_container webapp-prev \
   "uv sync --frozen --active && pytest --no-cov -n auto -m db --ignore=tests/migration tests"; then


### PR DESCRIPTION
## Description

The `Backwards compatibility test` CI job (`docker/ci/test_backwards_compatibility.sh`) runs the previous *release's* database test suite against the schema built from the current code. Because it resolves the previous release from the latest published GitHub release, it can only catch a broken online-migration change *after* that release has shipped — a full release cycle after the mistake was written.

This adds an opt-in **local mode**: pass a git ref as the first argument (or set `PREV_RELEASE_REF`) and the script builds both images from git instead of pulling a release — the previous side from the ref's committed tree (via `git archive | docker build`), the current side from the working tree — so a "stop using" change can be validated against the eventual drop before either is released:

```
./docker/ci/test_backwards_compatibility.sh <release-1-commit-or-HEAD~1>
```

CI leaves `PREV_RELEASE_REF` unset and continues to test against the real previous release; that path is unchanged.

This also hardens the shared step-2 startup with `--wait`. `initialize_instance` runs via `compose run --no-deps`, which bypasses the `webapp` service's `depends_on` health gating, so without `--wait` it can race a still-starting OpenSearch/Postgres and fail — a latent flake in the CI job as well, not just locally.

For that `--wait` to actually gate OpenSearch, this also fixes the `os` healthcheck in `docker-compose.yml`, which was effectively a no-op. Its test command ended in `if [[ ... ]]; then echo 0; else echo 1; fi`; Docker decides health from the command's **exit code**, not its output, and an `if` block exits with its taken branch's status — both branches are `echo`, which always exits `0` — so the container reported healthy on its first check regardless of OpenSearch's state. It is now a real `curl --fail` check with a `start_period` grace for OpenSearch's boot. This healthcheck is shared by every job that uses this compose file.

The workflow is documented in `CLAUDE.md`.

## Motivation and Context

JIRA: PP-4506

While completing the lane-size column removal we hit exactly this gap: #3481 shipped in v45.1.0 but did not fully stop reading the columns, and nothing surfaced it until the #3563's backcompat gate failed — a release cycle later. This gives that signal locally in minutes. This is helpful, since there are many edge cases to take into account when dropping a column, as we are seeing.

## How Has This Been Tested?

- Ran `./docker/ci/test_backwards_compatibility.sh <ref>` locally end-to-end against the stacked lane-size work: it builds the previous side from the ref, builds the current side from the working tree, and runs the previous side's `pytest -m db` suite against the freshly-built schema.
- Exercised both directions as a control: against an incomplete "stop using" commit it fails (6 failing db tests), and against the completed one it passes (3341 passed, 0 failed).
- Confirmed the CI path is unaffected: with `PREV_RELEASE_REF` unset the script still resolves and pulls the latest release image.
- Re-verified after the `os` healthcheck fix: `os` reaches `healthy` under `compose up --wait`, and a full local run stays green (3341 passed).

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
