### PR TITLE
Stop reading deprecated lanes.size columns via Query.count() (PP-4506)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,10 @@ mapped column in its default `SELECT`, and eagerly emits any column that has a P
 using it, and a later drop will break the still-running previous release. To fully stop using a column in
 release 1, before dropping it in release 2:
 
-- **Reads:** mark the column `deferred()` so it is excluded from the default `SELECT`.
+- **Reads:** mark the column `deferred()` so it is excluded from the default `SELECT`. Note that
+  `deferred()` alone is not always sufficient:
+  - `Query.count()` wraps its source in `SELECT count(*) FROM (<source>)`, and that inner subquery re-selects
+    every mapped column, deferred ones included.
 - **Writes:** remove any Python-side `default=`. If the column is `NOT NULL`, removing the Python default
   alone makes inserts fail the not-null constraint (SQLAlchemy sends no value and the database has none), so
   first move the default into the database with a `server_default`. A **nullable** column with no default

--- a/src/palace/manager/api/admin/controller/custom_lists.py
+++ b/src/palace/manager/api/admin/controller/custom_lists.py
@@ -466,7 +466,7 @@ class CustomListsController(
             return Response("", 204)
 
         shared_list_lanes = (
-            self._db.query(Lane)
+            self._db.query(Lane.id)
             .filter(
                 Lane.customlists.contains(customlist),
                 Lane.library_id != customlist.library_id,

--- a/src/palace/manager/sqlalchemy/model/library.py
+++ b/src/palace/manager/sqlalchemy/model/library.py
@@ -390,17 +390,12 @@ class Library(Base, HasSessionCache):
             from palace.manager.sqlalchemy.model.lane import Lane
 
             _db = Session.object_session(self)
-            # Query the id column rather than the Lane entity: Query.count() wraps its
-            # source in a subquery that re-selects every mapped column, including deferred
-            # ones. Selecting the whole entity here therefore still emits the deprecated
-            # lanes.size / size_by_entrypoint columns, which blocks dropping them. Selecting
-            # a single column avoids that.
-            root_lanes = (
+            root_lanes_count = (
                 _db.query(Lane.id)
                 .filter(Lane.library == self)
                 .filter(Lane.root_for_patron_type != None)
-            )
-            value = root_lanes.count() > 0
+            ).count()
+            value = root_lanes_count > 0
             Library._has_root_lane_cache[self.id] = value
         return value
 

--- a/src/palace/manager/sqlalchemy/model/library.py
+++ b/src/palace/manager/sqlalchemy/model/library.py
@@ -390,8 +390,13 @@ class Library(Base, HasSessionCache):
             from palace.manager.sqlalchemy.model.lane import Lane
 
             _db = Session.object_session(self)
+            # Query the id column rather than the Lane entity: Query.count() wraps its
+            # source in a subquery that re-selects every mapped column, including deferred
+            # ones. Selecting the whole entity here therefore still emits the deprecated
+            # lanes.size / size_by_entrypoint columns, which blocks dropping them. Selecting
+            # a single column avoids that.
             root_lanes = (
-                _db.query(Lane)
+                _db.query(Lane.id)
                 .filter(Lane.library == self)
                 .filter(Lane.root_for_patron_type != None)
             )

--- a/tests/manager/api/admin/controller/test_lanes.py
+++ b/tests/manager/api/admin/controller/test_lanes.py
@@ -417,7 +417,7 @@ class TestLanesController:
         lane.customlists += [list]
         assert (
             1
-            == alm_fixture.ctrl.db.session.query(Lane)
+            == alm_fixture.ctrl.db.session.query(Lane.id)
             .filter(Lane.library == library)
             .count()
         )
@@ -431,7 +431,7 @@ class TestLanesController:
             # The lane has been deleted.
             assert (
                 0
-                == alm_fixture.ctrl.db.session.query(Lane)
+                == alm_fixture.ctrl.db.session.query(Lane.id)
                 .filter(Lane.library == library)
                 .count()
             )
@@ -454,7 +454,7 @@ class TestLanesController:
         grandchild.customlists += [list]
         assert (
             3
-            == alm_fixture.ctrl.db.session.query(Lane)
+            == alm_fixture.ctrl.db.session.query(Lane.id)
             .filter(Lane.library == library)
             .count()
         )
@@ -468,7 +468,7 @@ class TestLanesController:
             # The lanes have all been deleted.
             assert (
                 0
-                == alm_fixture.ctrl.db.session.query(Lane)
+                == alm_fixture.ctrl.db.session.query(Lane.id)
                 .filter(Lane.library == library)
                 .count()
             )
@@ -574,7 +574,7 @@ class TestLanesController:
             # The old lane is gone.
             assert (
                 0
-                == alm_fixture.ctrl.db.session.query(Lane)
+                == alm_fixture.ctrl.db.session.query(Lane.id)
                 .filter(Lane.library == library)
                 .filter(Lane.id == old_lane.id)
                 .count()
@@ -583,7 +583,7 @@ class TestLanesController:
             # lanes were created.
             assert (
                 0
-                < alm_fixture.ctrl.db.session.query(Lane)
+                < alm_fixture.ctrl.db.session.query(Lane.id)
                 .filter(Lane.library == library)
                 .count()
             )

--- a/tests/manager/api/test_lanes.py
+++ b/tests/manager/api/test_lanes.py
@@ -210,7 +210,7 @@ class TestLaneCreation:
         priority = create_lane_for_small_collection(
             db.session, db.default_library(), parent, languages, priority=2
         )
-        lane = db.session.query(Lane).filter(Lane.parent == parent)
+        lane = db.session.query(Lane.id).filter(Lane.parent == parent)
         assert priority == 0
         assert lane.count() == 0
 
@@ -237,7 +237,7 @@ class TestLaneCreation:
             priority=3,
         )
         assert 0 == new_priority
-        lane = db.session.query(Lane).filter(Lane.parent == new_parent)
+        lane = db.session.query(Lane.id).filter(Lane.parent == new_parent)
         assert lane.count() == 0
 
     def test_create_default_lanes(

--- a/tests/manager/sqlalchemy/model/test_lane.py
+++ b/tests/manager/sqlalchemy/model/test_lane.py
@@ -166,12 +166,12 @@ class TestLane:
 
         # Not affected by any lists.
         for l in [l1, l2]:
-            assert 0 == Lane.affected_by_customlist(l1).count()
+            assert 0 == Lane.affected_by_customlist(l1).with_entities(Lane.id).count()
 
         # Add a lane to the list, and it becomes affected.
         lane.customlists.append(l1)
         assert [lane] == lane.affected_by_customlist(l1).all()
-        assert 0 == lane.affected_by_customlist(l2).count()
+        assert 0 == lane.affected_by_customlist(l2).with_entities(Lane.id).count()
         lane.customlists = []
 
         # A lane based on all lists with the GUTENBERG db source.
@@ -181,7 +181,7 @@ class TestLane:
         # It's affected by the GUTENBERG list but not the OVERDRIVE
         # list.
         assert [lane2] == Lane.affected_by_customlist(l1).all()
-        assert 0 == Lane.affected_by_customlist(l2).count()
+        assert 0 == Lane.affected_by_customlist(l2).with_entities(Lane.id).count()
 
     def test_inherited_value(self, db: DatabaseTransactionFixture):
         # Test WorkList.inherited_value.

--- a/tests/manager/sqlalchemy/model/test_lane.py
+++ b/tests/manager/sqlalchemy/model/test_lane.py
@@ -165,13 +165,13 @@ class TestLane:
         lane = db.lane()
 
         # Not affected by any lists.
-        for l in [l1, l2]:
-            assert 0 == Lane.affected_by_customlist(l1).with_entities(Lane.id).count()
+        for cl in [l1, l2]:
+            assert [] == Lane.affected_by_customlist(cl).all()
 
         # Add a lane to the list, and it becomes affected.
         lane.customlists.append(l1)
         assert [lane] == lane.affected_by_customlist(l1).all()
-        assert 0 == lane.affected_by_customlist(l2).with_entities(Lane.id).count()
+        assert [] == Lane.affected_by_customlist(l2).all()
         lane.customlists = []
 
         # A lane based on all lists with the GUTENBERG db source.
@@ -181,7 +181,7 @@ class TestLane:
         # It's affected by the GUTENBERG list but not the OVERDRIVE
         # list.
         assert [lane2] == Lane.affected_by_customlist(l1).all()
-        assert 0 == Lane.affected_by_customlist(l2).with_entities(Lane.id).count()
+        assert [] == Lane.affected_by_customlist(l2).all()
 
     def test_inherited_value(self, db: DatabaseTransactionFixture):
         # Test WorkList.inherited_value.


### PR DESCRIPTION
## Description

#3481 (shipped in v45.1.0) marked `lanes.size` / `size_by_entrypoint` as `deferred()` to stop reading them before a follow-up drop. That turns out to be insufficient: SQLAlchemy's `Query.count()` wraps its source in `SELECT count(*) FROM (<source>)`, and that inner subquery re-selects **every** mapped column, including deferred ones. So every `query(Lane).count()` still emitted the deprecated columns, and the previous release kept reading `lanes.size` — which is why the stacked drop PR's backwards-compatibility gate fails (#3563).

This completes the read-side "stop using" step by counting a single column instead of the whole entity everywhere `Lane` is counted:

- **Production:** `Library.has_root_lanes` and `CustomListsController.share_locally_DELETE` now count `query(Lane.id)`. These were the only two production paths that selected the deprecated columns — every other `query(Lane)` use is `.all()` / `.one()` / iteration, which `deferred()` already excludes from the SELECT.
- **Tests:** the lane-creation, admin lane delete/reset, and `affected_by_customlist` tests counted the `Lane` entity; they now follow the pattern used elsewhere and assert that `.all()` is `[]`.

After this, no code in this release — production or test — selects `lanes.size` / `size_by_entrypoint`, so the follow-up drop PR is backwards compatible.

## Motivation and Context

JIRA: PP-4506

First PR for the online-migration sequence to remove the deprecated lane-size columns; the column drop is #3563, stacked on this and held until this ships. Fixes the previous PR #3481, whose `deferred()`-only approach did not cover `Query.count()`. The columns were already made write-safe (`server_default`) in #3481.

## How Has This Been Tested?

- `mypy` clean; the full existing test suite passes.
- Ran the backwards-compatibility check locally with the new local mode (`docker/ci/test_backwards_compatibility.sh <this branch>`) against the stacked drop: the previous side (this branch) runs its full `pytest -m db` suite against the dropped schema with **0 failures** (3341 passed), where the previous, `deferred()`-only release fails 20. This new local mode was added in https://github.com/ThePalaceProject/circulation/pull/3618.
- Confirmed via the emitted SQL that `query(Lane.id).count()` no longer references the deprecated columns.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
