### PR TITLE
Advance the search read pointer from the reindex instead of a chain (PP-4908)

### DIFF
--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -120,6 +120,8 @@ def advance_read_pointer(task: Task, target_index: str | None) -> None:
     pass over that index publishes it. No caller has to remember to advance the pointer,
     and a run that dies partway through simply leaves the pointer where it was.
 
+    :param task: The task that completed the reindex, retried with a backoff if the
+        pointers cannot be read.
     :param target_index: The index the completed run was filling.
     """
     service = task.services.search.service()
@@ -161,7 +163,9 @@ def advance_read_pointer(task: Task, target_index: str | None) -> None:
     set_read_pointer(task, service, revision)
 
 
-@shared_task(queue=QueueNames.default, bind=True, max_retries=4)
+@shared_task(
+    queue=QueueNames.default, bind=True, max_retries=4, throws=(LockNotAcquired,)
+)
 def search_reindex(
     task: Task, offset: int = 0, batch_size: int = 500, target_index: str | None = None
 ) -> None:

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -26,13 +26,18 @@ from palace.manager.sqlalchemy.model.work import Work
 from palace.manager.util.backoff import exponential_backoff
 
 
-def get_work_search_documents(
+def get_presentation_ready_work_ids(
     session: Session, batch_size: int, offset: int
-) -> Sequence[dict[str, Any]]:
+) -> Sequence[int]:
     """
-    Get a batch of search documents for works that are presentation ready.
+    Get a batch of ids for works that are presentation ready.
+
+    A pass over the works pages by these ids rather than by the documents built from
+    them. `Work.to_search_documents` omits any work whose document it cannot build, so a
+    full batch of works can produce a short batch of documents, and a caller that treats
+    a short batch as the end of the works would stop there.
     """
-    works = [
+    return [
         w.id
         for w in session.execute(
             select(Work.id)
@@ -42,7 +47,6 @@ def get_work_search_documents(
             .offset(offset)
         )
     ]
-    return Work.to_search_documents(session, works)
 
 
 def add_documents_to_index(
@@ -193,11 +197,12 @@ def search_reindex(
                     skip_start=True,
                 ),
             ):
-                documents = get_work_search_documents(session, batch_size, offset)
+                work_ids = get_presentation_ready_work_ids(session, batch_size, offset)
+                documents = Work.to_search_documents(session, work_ids)
 
             add_documents_to_index(task.log, index, documents)
 
-            if len(documents) == batch_size:
+            if len(work_ids) == batch_size:
                 # This task is complete, but there are more works waiting to be indexed. Requeue ourselves
                 # to process the next batch. We add a random delay to avoid hammering the search service
                 # when this task is running in parallel on multiple workers.

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -241,11 +241,12 @@ def update_read_pointer(task: Task) -> None:
     an index that no single reindex run filled end to end, or one filled by a run that
     started before the revision it ended up writing to existed.
 
-    It has no CLI entry point, since the usual repair is another full reindex
-    (bin/repair/search_index), which publishes the index when it finishes. To publish an
-    already-filled index without reindexing, queue this task directly:
+    It has no CLI entry point, because the repair is normally just a completed reindex:
+    whichever run finishes a full pass publishes the index itself. To publish an index that
+    is already filled, without waiting for a pass to finish, queue this task by its
+    registered name (gen_task_name strips the module prefix, so it is not the import path):
 
-        celery -A "palace.manager.celery.app" call palace.manager.celery.tasks.search.update_read_pointer
+        celery -A "palace.manager.celery.app" call search.update_read_pointer
     """
     task.log.info("Updating read pointer.")
     service = task.services.search.service()

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -192,12 +192,11 @@ def search_reindex(
         advances the read pointer.
     """
     index = task.services.search.index()
-    service = task.services.search.service()
     task_lock = TaskLock(task, lock_name="search_reindex")
 
     with task_lock.lock(release_on_exit=False, ignored_exceptions=(Retry, Ignore)):
         if target_index is None and offset == 0:
-            target_index = resolve_target_index(task, service)
+            target_index = resolve_target_index(task, task.services.search.service())
 
         task.log.info(
             f"Running search reindex at offset {offset} with batch size {batch_size}."

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from datetime import timedelta
 from typing import Any
 
-from celery import chain, shared_task
+from celery import shared_task
 from celery.exceptions import Ignore, Retry
 from opensearchpy import OpenSearchException
 from sqlalchemy import select
@@ -17,6 +17,8 @@ from palace.util.log import elapsed_time_logging
 from palace.manager.celery.task import Task
 from palace.manager.celery.utils import signature_with
 from palace.manager.search.external_search import ExternalSearchIndex
+from palace.manager.search.revision import SearchSchemaRevision
+from palace.manager.search.service import SearchService
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.redis.models.lock import LockNotAcquired, TaskLock
 from palace.manager.service.redis.models.search import WaitingForIndexing
@@ -64,18 +66,88 @@ def add_documents_to_index(
 class FailedToIndex(BasePalaceException): ...
 
 
+def set_read_pointer(
+    task: Task, service: SearchService, revision: SearchSchemaRevision
+) -> None:
+    try:
+        service.read_pointer_set(revision)
+    except OpenSearchException as e:
+        wait_time = exponential_backoff(task.request.retries)
+        task.log.error(
+            f"Failed to update read pointer: {e}. Retrying in {wait_time} seconds."
+        )
+        raise task.retry(countdown=wait_time)
+    task.log.info(
+        f"Updated read pointer ({service.base_revision_name} v{revision.version})."
+    )
+
+
+def advance_read_pointer(task: Task, target_index: str | None) -> None:
+    """
+    Point reads at the index a completed reindex just filled, if reads are still being
+    served from an older one.
+
+    This is what makes a schema migration finish on its own: a new revision is created
+    with the write pointer aimed at it, and whichever reindex first completes a full
+    pass over that index publishes it. No caller has to remember to advance the pointer,
+    and a run that dies partway through simply leaves the pointer where it was.
+
+    :param target_index: The index the completed run was filling.
+    """
+    service = task.services.search.service()
+    revision = task.services.search.revision_directory().highest()
+    latest_index = revision.name_for_index(service.base_revision_name)
+
+    read_pointer = service.read_pointer()
+    if read_pointer is not None and read_pointer.version >= revision.version:
+        return
+
+    if target_index != latest_index:
+        task.log.warning(
+            f"Not advancing read pointer: this reindex filled {target_index}, "
+            f"but the latest revision is {latest_index}."
+        )
+        return
+
+    write_pointer = service.write_pointer()
+    if write_pointer is None or write_pointer.index != target_index:
+        # The write pointer moved partway through, so our documents are split across the
+        # old and new indexes and neither one received a complete pass.
+        task.log.warning(
+            f"Not advancing read pointer: the write pointer moved to "
+            f"{write_pointer.index if write_pointer is not None else None} "
+            f"while this reindex was filling {target_index}."
+        )
+        return
+
+    set_read_pointer(task, service, revision)
+
+
 @shared_task(queue=QueueNames.default, bind=True, max_retries=4)
-def search_reindex(task: Task, offset: int = 0, batch_size: int = 500) -> None:
+def search_reindex(
+    task: Task, offset: int = 0, batch_size: int = 500, target_index: str | None = None
+) -> None:
     """
     Submit all works that are presentation ready to the search index.
 
     This is done in batches, with the batch size determined by the batch_size parameter. This
-    task will do a batch, then requeue itself until all works have been indexed.
+    task will do a batch, then requeue itself until all works have been indexed. Once every
+    work has been indexed, the read pointer is advanced to the index we filled if it is still
+    behind. See advance_read_pointer.
+
+    :param target_index: The index this run is filling, carried across requeues so the final
+        batch can tell whether the write pointer moved partway through. Resolved from the write
+        pointer when the run starts; callers should not pass it.
     """
     index = task.services.search.index()
+    service = task.services.search.service()
     task_lock = TaskLock(task, lock_name="search_reindex")
 
     with task_lock.lock(release_on_exit=False, ignored_exceptions=(Retry, Ignore)):
+        if target_index is None:
+            write_pointer = service.write_pointer()
+            target_index = write_pointer.index if write_pointer is not None else None
+
         task.log.info(
             f"Running search reindex at offset {offset} with batch size {batch_size}."
         )
@@ -98,8 +170,12 @@ def search_reindex(task: Task, offset: int = 0, batch_size: int = 500) -> None:
             # when this task is running in parallel on multiple workers.
             delay = random.uniform(5, 15)
             raise task.replace(
-                signature_with(task, offset=offset + batch_size).set(countdown=delay)
+                signature_with(
+                    task, offset=offset + batch_size, target_index=target_index
+                ).set(countdown=delay)
             )
+
+        advance_read_pointer(task, target_index)
 
     task.log.info("Finished search reindex.")
     task_lock.release()
@@ -108,27 +184,18 @@ def search_reindex(task: Task, offset: int = 0, batch_size: int = 500) -> None:
 @shared_task(queue=QueueNames.default, bind=True, max_retries=4)
 def update_read_pointer(task: Task) -> None:
     """
-    Update the read pointer to the latest revision.
+    Update the read pointer to the latest revision, unconditionally.
 
-    This is used to indicate that the search index has been updated to a specific version. We
-    chain this task with search_reindex when doing a migration to ensure that the read pointer is
-    updated after all works have been indexed. See get_migrate_search_chain.
+    search_reindex advances the read pointer itself once it has filled the latest index, so
+    this is the manual override for the cases it deliberately declines to handle: publishing
+    an index that no single reindex run filled end to end, or one filled by a run that
+    started before the revision it ended up writing to existed.
     """
     task.log.info("Updating read pointer.")
     service = task.services.search.service()
     revision_directory = task.services.search.revision_directory()
     revision = revision_directory.highest()
-    try:
-        service.read_pointer_set(revision)
-    except OpenSearchException as e:
-        wait_time = exponential_backoff(task.request.retries)
-        task.log.error(
-            f"Failed to update read pointer: {e}. Retrying in {wait_time} seconds."
-        )
-        raise task.retry(countdown=wait_time)
-    task.log.info(
-        f"Updated read pointer ({service.base_revision_name} v{revision.version})."
-    )
+    set_read_pointer(task, service, revision)
 
 
 @shared_task(queue=QueueNames.default, bind=True, throws=(LockNotAcquired,))
@@ -176,10 +243,3 @@ def index_works(task: Task, works: Sequence[int]) -> None:
         documents = Work.to_search_documents(session, works)
 
     add_documents_to_index(task, index, documents)
-
-
-def get_migrate_search_chain() -> chain:
-    """
-    Get the chain of tasks to run when migrating the search index to a new schema.
-    """
-    return chain(search_reindex.si(), update_read_pointer.si())

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -52,6 +52,7 @@ def add_documents_to_index(
     Submit a batch of documents to the search index.
 
     :raises FailedToIndex: If the index rejected some of the documents.
+    :raises OpenSearchException: If the index rejected the request.
     """
     with elapsed_time_logging(
         log_method=log.info,
@@ -120,8 +121,6 @@ def advance_read_pointer(
     latest_index = revision.name_for_index(service.base_revision_name)
 
     read_pointer = service.read_pointer()
-    write_pointer = service.write_pointer()
-
     if read_pointer is not None and read_pointer.version >= revision.version:
         return
 
@@ -140,6 +139,7 @@ def advance_read_pointer(
         )
         return
 
+    write_pointer = service.write_pointer()
     if write_pointer is None or write_pointer.index != target_index:
         # The write pointer moved partway through, so our documents are split across the
         # old and new indexes and neither one received a complete pass.

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -137,14 +137,16 @@ def search_reindex(
 
     :param target_index: The index this run is filling, carried across requeues so the final
         batch can tell whether the write pointer moved partway through. Resolved from the write
-        pointer when the run starts; callers should not pass it.
+        pointer when a run starts from the beginning; callers should not pass it. A run started
+        at a non-zero offset skips the works before it, so it leaves this unset and never
+        advances the read pointer.
     """
     index = task.services.search.index()
     service = task.services.search.service()
     task_lock = TaskLock(task, lock_name="search_reindex")
 
     with task_lock.lock(release_on_exit=False, ignored_exceptions=(Retry, Ignore)):
-        if target_index is None:
+        if target_index is None and offset == 0:
             write_pointer = service.write_pointer()
             target_index = write_pointer.index if write_pointer is not None else None
 
@@ -190,6 +192,12 @@ def update_read_pointer(task: Task) -> None:
     this is the manual override for the cases it deliberately declines to handle: publishing
     an index that no single reindex run filled end to end, or one filled by a run that
     started before the revision it ended up writing to existed.
+
+    It has no CLI entry point, since the usual repair is another full reindex
+    (bin/repair/search_index), which publishes the index when it finishes. To publish an
+    already-filled index without reindexing, queue this task directly:
+
+        celery -A "palace.manager.celery.app" call palace.manager.celery.tasks.search.update_read_pointer
     """
     task.log.info("Updating read pointer.")
     service = task.services.search.service()

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -143,6 +143,14 @@ def advance_read_pointer(task: Task, target_index: str | None) -> None:
     if read_pointer is not None and read_pointer.version >= revision.version:
         return
 
+    if target_index is None:
+        # Either the run started partway through, or there was no write pointer for it to
+        # record when it started.
+        task.log.warning(
+            "Not advancing read pointer: this run did not record an index to fill."
+        )
+        return
+
     if target_index != latest_index:
         task.log.warning(
             f"Not advancing read pointer: this reindex filled {target_index}, "

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -48,19 +48,19 @@ def get_work_search_documents(
 def add_documents_to_index(
     task: Task, index: ExternalSearchIndex, documents: Sequence[dict[str, Any]]
 ) -> None:
-    try:
-        with elapsed_time_logging(
-            log_method=task.log.info,
-            message_prefix="Works added to index",
-            skip_start=True,
-        ):
-            failed_documents = index.add_documents(documents=documents)
-        if failed_documents:
-            raise FailedToIndex(f"Failed to index {len(failed_documents)} works.")
-    except (FailedToIndex, OpenSearchException) as e:
-        wait_time = exponential_backoff(task.request.retries)
-        task.log.error(f"{e}. Retrying in {wait_time} seconds.")
-        raise task.retry(countdown=wait_time)
+    """
+    Submit a batch of documents to the search index.
+
+    :raises FailedToIndex: If the index rejected some of the documents.
+    """
+    with elapsed_time_logging(
+        log_method=task.log.info,
+        message_prefix="Works added to index",
+        skip_start=True,
+    ):
+        failed_documents = index.add_documents(documents=documents)
+    if failed_documents:
+        raise FailedToIndex(f"Failed to index {len(failed_documents)} works.")
 
 
 class FailedToIndex(BasePalaceException): ...
@@ -72,41 +72,26 @@ def set_read_pointer(
     """
     Publish a revision's index for reads.
 
-    :param task: The task doing the update, retried with a backoff if OpenSearch rejects
-        the alias update.
+    :param task: The task doing the update, used for logging.
     :param service: The search service whose read pointer is being moved.
     :param revision: The revision whose index should serve reads.
+    :raises OpenSearchException: If OpenSearch rejects the alias update.
     """
-    try:
-        service.read_pointer_set(revision)
-    except OpenSearchException as e:
-        wait_time = exponential_backoff(task.request.retries)
-        task.log.error(
-            f"Failed to update read pointer: {e}. Retrying in {wait_time} seconds."
-        )
-        raise task.retry(countdown=wait_time)
+    service.read_pointer_set(revision)
     task.log.info(
         f"Updated read pointer ({service.base_revision_name} v{revision.version})."
     )
 
 
-def resolve_target_index(task: Task, service: SearchService) -> str | None:
+def resolve_target_index(service: SearchService) -> str | None:
     """
     Identify the index a reindex starting now is going to fill.
 
-    :param task: The task doing the reindex, retried with a backoff if OpenSearch cannot
-        be reached.
     :param service: The search service to read the write pointer from.
     :return: The index writes are currently going to, or None if there is no write pointer.
+    :raises OpenSearchException: If the write pointer cannot be read.
     """
-    try:
-        write_pointer = service.write_pointer()
-    except OpenSearchException as e:
-        wait_time = exponential_backoff(task.request.retries)
-        task.log.error(
-            f"Failed to read the write pointer: {e}. Retrying in {wait_time} seconds."
-        )
-        raise task.retry(countdown=wait_time)
+    write_pointer = service.write_pointer()
     return write_pointer.index if write_pointer is not None else None
 
 
@@ -120,25 +105,18 @@ def advance_read_pointer(task: Task, target_index: str | None) -> None:
     pass over that index publishes it. No caller has to remember to advance the pointer,
     and a run that dies partway through simply leaves the pointer where it was.
 
-    :param task: The task that completed the reindex, retried with a backoff if the
-        pointers cannot be read.
+    :param task: The task that completed the reindex, used for logging and to look up the
+        search service.
     :param target_index: The index the completed run was filling.
+    :raises OpenSearchException: If the pointers cannot be read, or the read pointer cannot
+        be updated.
     """
     service = task.services.search.service()
     revision = task.services.search.revision_directory().highest()
     latest_index = revision.name_for_index(service.base_revision_name)
 
-    try:
-        read_pointer = service.read_pointer()
-        write_pointer = service.write_pointer()
-    except OpenSearchException as e:
-        # A full pass takes days on a large collection, so a transient failure reading the
-        # pointers is worth retrying rather than discarding the run's work.
-        wait_time = exponential_backoff(task.request.retries)
-        task.log.error(
-            f"Failed to read search pointers: {e}. Retrying in {wait_time} seconds."
-        )
-        raise task.retry(countdown=wait_time)
+    read_pointer = service.read_pointer()
+    write_pointer = service.write_pointer()
 
     if read_pointer is not None and read_pointer.version >= revision.version:
         return
@@ -195,37 +173,47 @@ def search_reindex(
     task_lock = TaskLock(task, lock_name="search_reindex")
 
     with task_lock.lock(release_on_exit=False, ignored_exceptions=(Retry, Ignore)):
-        if target_index is None and offset == 0:
-            target_index = resolve_target_index(task, task.services.search.service())
+        try:
+            if target_index is None and offset == 0:
+                target_index = resolve_target_index(task.services.search.service())
 
-        task.log.info(
-            f"Running search reindex at offset {offset} with batch size {batch_size}."
-        )
-
-        with (
-            task.session() as session,
-            elapsed_time_logging(
-                log_method=task.log.info,
-                message_prefix="Works queried from database",
-                skip_start=True,
-            ),
-        ):
-            documents = get_work_search_documents(session, batch_size, offset)
-
-        add_documents_to_index(task, index, documents)
-
-        if len(documents) == batch_size:
-            # This task is complete, but there are more works waiting to be indexed. Requeue ourselves
-            # to process the next batch. We add a random delay to avoid hammering the search service
-            # when this task is running in parallel on multiple workers.
-            delay = random.uniform(5, 15)
-            raise task.replace(
-                signature_with(
-                    task, offset=offset + batch_size, target_index=target_index
-                ).set(countdown=delay)
+            task.log.info(
+                f"Running search reindex at offset {offset} with batch size {batch_size}."
             )
 
-        advance_read_pointer(task, target_index)
+            with (
+                task.session() as session,
+                elapsed_time_logging(
+                    log_method=task.log.info,
+                    message_prefix="Works queried from database",
+                    skip_start=True,
+                ),
+            ):
+                documents = get_work_search_documents(session, batch_size, offset)
+
+            add_documents_to_index(task, index, documents)
+
+            if len(documents) == batch_size:
+                # This task is complete, but there are more works waiting to be indexed. Requeue ourselves
+                # to process the next batch. We add a random delay to avoid hammering the search service
+                # when this task is running in parallel on multiple workers.
+                delay = random.uniform(5, 15)
+                raise task.replace(
+                    signature_with(
+                        task, offset=offset + batch_size, target_index=target_index
+                    ).set(countdown=delay)
+                )
+
+            advance_read_pointer(task, target_index)
+        except (FailedToIndex, OpenSearchException) as e:
+            # A full pass takes days on a large collection, so a transient search failure
+            # retries this batch rather than discarding the run's work. The retry happens
+            # here, inside the lock, so the run keeps the lock while it waits.
+            wait_time = exponential_backoff(task.request.retries)
+            task.log.exception(
+                f"Search reindex failed ({e}). Retrying in {wait_time} seconds."
+            )
+            raise task.retry(countdown=wait_time)
 
     task.log.info("Finished search reindex.")
     task_lock.release()
@@ -252,7 +240,15 @@ def update_read_pointer(task: Task) -> None:
     service = task.services.search.service()
     revision_directory = task.services.search.revision_directory()
     revision = revision_directory.highest()
-    set_read_pointer(task, service, revision)
+
+    try:
+        set_read_pointer(task, service, revision)
+    except OpenSearchException as e:
+        wait_time = exponential_backoff(task.request.retries)
+        task.log.exception(
+            f"Failed to update read pointer: {e}. Retrying in {wait_time} seconds."
+        )
+        raise task.retry(countdown=wait_time)
 
 
 @shared_task(queue=QueueNames.default, bind=True, throws=(LockNotAcquired,))
@@ -299,4 +295,9 @@ def index_works(task: Task, works: Sequence[int]) -> None:
     ):
         documents = Work.to_search_documents(session, works)
 
-    add_documents_to_index(task, index, documents)
+    try:
+        add_documents_to_index(task, index, documents)
+    except (FailedToIndex, OpenSearchException) as e:
+        wait_time = exponential_backoff(task.request.retries)
+        task.log.exception(f"{e}. Retrying in {wait_time} seconds.")
+        raise task.retry(countdown=wait_time)

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from palace.util.exceptions import BasePalaceException
-from palace.util.log import elapsed_time_logging
+from palace.util.log import LoggerType, elapsed_time_logging
 
 from palace.manager.celery.task import Task
 from palace.manager.celery.utils import signature_with
@@ -46,7 +46,7 @@ def get_work_search_documents(
 
 
 def add_documents_to_index(
-    task: Task, index: ExternalSearchIndex, documents: Sequence[dict[str, Any]]
+    log: LoggerType, index: ExternalSearchIndex, documents: Sequence[dict[str, Any]]
 ) -> None:
     """
     Submit a batch of documents to the search index.
@@ -54,7 +54,7 @@ def add_documents_to_index(
     :raises FailedToIndex: If the index rejected some of the documents.
     """
     with elapsed_time_logging(
-        log_method=task.log.info,
+        log_method=log.info,
         message_prefix="Works added to index",
         skip_start=True,
     ):
@@ -67,18 +67,18 @@ class FailedToIndex(BasePalaceException): ...
 
 
 def set_read_pointer(
-    task: Task, service: SearchService, revision: SearchSchemaRevision
+    log: LoggerType, service: SearchService, revision: SearchSchemaRevision
 ) -> None:
     """
     Publish a revision's index for reads.
 
-    :param task: The task doing the update, used for logging.
+    :param log: The logger of the task doing the update.
     :param service: The search service whose read pointer is being moved.
     :param revision: The revision whose index should serve reads.
     :raises OpenSearchException: If OpenSearch rejects the alias update.
     """
     service.read_pointer_set(revision)
-    task.log.info(
+    log.info(
         f"Updated read pointer ({service.base_revision_name} v{revision.version})."
     )
 
@@ -95,7 +95,12 @@ def resolve_target_index(service: SearchService) -> str | None:
     return write_pointer.index if write_pointer is not None else None
 
 
-def advance_read_pointer(task: Task, target_index: str | None) -> None:
+def advance_read_pointer(
+    log: LoggerType,
+    service: SearchService,
+    revision: SearchSchemaRevision,
+    target_index: str | None,
+) -> None:
     """
     Point reads at the index a completed reindex just filled, if reads are still being
     served from an older one.
@@ -105,14 +110,13 @@ def advance_read_pointer(task: Task, target_index: str | None) -> None:
     pass over that index publishes it. No caller has to remember to advance the pointer,
     and a run that dies partway through simply leaves the pointer where it was.
 
-    :param task: The task that completed the reindex, used for logging and to look up the
-        search service.
+    :param log: The logger of the task that completed the reindex.
+    :param service: The search service whose pointers are being read and moved.
+    :param revision: The latest revision, whose index is the one worth publishing.
     :param target_index: The index the completed run was filling.
     :raises OpenSearchException: If the pointers cannot be read, or the read pointer cannot
         be updated.
     """
-    service = task.services.search.service()
-    revision = task.services.search.revision_directory().highest()
     latest_index = revision.name_for_index(service.base_revision_name)
 
     read_pointer = service.read_pointer()
@@ -124,13 +128,13 @@ def advance_read_pointer(task: Task, target_index: str | None) -> None:
     if target_index is None:
         # Either the run started partway through, or there was no write pointer for it to
         # record when it started.
-        task.log.warning(
+        log.warning(
             "Not advancing read pointer: this run did not record an index to fill."
         )
         return
 
     if target_index != latest_index:
-        task.log.warning(
+        log.warning(
             f"Not advancing read pointer: this reindex filled {target_index}, "
             f"but the latest revision is {latest_index}."
         )
@@ -139,14 +143,14 @@ def advance_read_pointer(task: Task, target_index: str | None) -> None:
     if write_pointer is None or write_pointer.index != target_index:
         # The write pointer moved partway through, so our documents are split across the
         # old and new indexes and neither one received a complete pass.
-        task.log.warning(
+        log.warning(
             f"Not advancing read pointer: the write pointer moved to "
             f"{write_pointer.index if write_pointer is not None else None} "
             f"while this reindex was filling {target_index}."
         )
         return
 
-    set_read_pointer(task, service, revision)
+    set_read_pointer(log, service, revision)
 
 
 @shared_task(
@@ -191,7 +195,7 @@ def search_reindex(
             ):
                 documents = get_work_search_documents(session, batch_size, offset)
 
-            add_documents_to_index(task, index, documents)
+            add_documents_to_index(task.log, index, documents)
 
             if len(documents) == batch_size:
                 # This task is complete, but there are more works waiting to be indexed. Requeue ourselves
@@ -204,7 +208,12 @@ def search_reindex(
                     ).set(countdown=delay)
                 )
 
-            advance_read_pointer(task, target_index)
+            advance_read_pointer(
+                task.log,
+                task.services.search.service(),
+                task.services.search.revision_directory().highest(),
+                target_index,
+            )
         except (FailedToIndex, OpenSearchException) as e:
             # A full pass takes days on a large collection, so a transient search failure
             # retries this batch rather than discarding the run's work. The retry happens
@@ -242,7 +251,7 @@ def update_read_pointer(task: Task) -> None:
     revision = revision_directory.highest()
 
     try:
-        set_read_pointer(task, service, revision)
+        set_read_pointer(task.log, service, revision)
     except OpenSearchException as e:
         wait_time = exponential_backoff(task.request.retries)
         task.log.exception(
@@ -296,7 +305,7 @@ def index_works(task: Task, works: Sequence[int]) -> None:
         documents = Work.to_search_documents(session, works)
 
     try:
-        add_documents_to_index(task, index, documents)
+        add_documents_to_index(task.log, index, documents)
     except (FailedToIndex, OpenSearchException) as e:
         wait_time = exponential_backoff(task.request.retries)
         task.log.exception(f"{e}. Retrying in {wait_time} seconds.")

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -69,6 +69,14 @@ class FailedToIndex(BasePalaceException): ...
 def set_read_pointer(
     task: Task, service: SearchService, revision: SearchSchemaRevision
 ) -> None:
+    """
+    Publish a revision's index for reads.
+
+    :param task: The task doing the update, retried with a backoff if OpenSearch rejects
+        the alias update.
+    :param service: The search service whose read pointer is being moved.
+    :param revision: The revision whose index should serve reads.
+    """
     try:
         service.read_pointer_set(revision)
     except OpenSearchException as e:
@@ -98,7 +106,18 @@ def advance_read_pointer(task: Task, target_index: str | None) -> None:
     revision = task.services.search.revision_directory().highest()
     latest_index = revision.name_for_index(service.base_revision_name)
 
-    read_pointer = service.read_pointer()
+    try:
+        read_pointer = service.read_pointer()
+        write_pointer = service.write_pointer()
+    except OpenSearchException as e:
+        # A full pass takes days on a large collection, so a transient failure reading the
+        # pointers is worth retrying rather than discarding the run's work.
+        wait_time = exponential_backoff(task.request.retries)
+        task.log.error(
+            f"Failed to read search pointers: {e}. Retrying in {wait_time} seconds."
+        )
+        raise task.retry(countdown=wait_time)
+
     if read_pointer is not None and read_pointer.version >= revision.version:
         return
 
@@ -109,7 +128,6 @@ def advance_read_pointer(task: Task, target_index: str | None) -> None:
         )
         return
 
-    write_pointer = service.write_pointer()
     if write_pointer is None or write_pointer.index != target_index:
         # The write pointer moved partway through, so our documents are split across the
         # old and new indexes and neither one received a complete pass.

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -90,6 +90,26 @@ def set_read_pointer(
     )
 
 
+def resolve_target_index(task: Task, service: SearchService) -> str | None:
+    """
+    Identify the index a reindex starting now is going to fill.
+
+    :param task: The task doing the reindex, retried with a backoff if OpenSearch cannot
+        be reached.
+    :param service: The search service to read the write pointer from.
+    :return: The index writes are currently going to, or None if there is no write pointer.
+    """
+    try:
+        write_pointer = service.write_pointer()
+    except OpenSearchException as e:
+        wait_time = exponential_backoff(task.request.retries)
+        task.log.error(
+            f"Failed to read the write pointer: {e}. Retrying in {wait_time} seconds."
+        )
+        raise task.retry(countdown=wait_time)
+    return write_pointer.index if write_pointer is not None else None
+
+
 def advance_read_pointer(task: Task, target_index: str | None) -> None:
     """
     Point reads at the index a completed reindex just filled, if reads are still being
@@ -165,8 +185,7 @@ def search_reindex(
 
     with task_lock.lock(release_on_exit=False, ignored_exceptions=(Retry, Ignore)):
         if target_index is None and offset == 0:
-            write_pointer = service.write_pointer()
-            target_index = write_pointer.index if write_pointer is not None else None
+            target_index = resolve_target_index(task, service)
 
         task.log.info(
             f"Running search reindex at offset {offset} with batch size {batch_size}."

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -228,38 +228,6 @@ def search_reindex(
     task_lock.release()
 
 
-@shared_task(queue=QueueNames.default, bind=True, max_retries=4)
-def update_read_pointer(task: Task) -> None:
-    """
-    Update the read pointer to the latest revision, unconditionally.
-
-    search_reindex advances the read pointer itself once it has filled the latest index, so
-    this is the manual override for the cases it deliberately declines to handle: publishing
-    an index that no single reindex run filled end to end, or one filled by a run that
-    started before the revision it ended up writing to existed.
-
-    It has no CLI entry point, because the repair is normally just a completed reindex:
-    whichever run finishes a full pass publishes the index itself. To publish an index that
-    is already filled, without waiting for a pass to finish, queue this task by its
-    registered name (gen_task_name strips the module prefix, so it is not the import path):
-
-        celery -A "palace.manager.celery.app" call search.update_read_pointer
-    """
-    task.log.info("Updating read pointer.")
-    service = task.services.search.service()
-    revision_directory = task.services.search.revision_directory()
-    revision = revision_directory.highest()
-
-    try:
-        set_read_pointer(task.log, service, revision)
-    except OpenSearchException as e:
-        wait_time = exponential_backoff(task.request.retries)
-        task.log.exception(
-            f"Failed to update read pointer: {e}. Retrying in {wait_time} seconds."
-        )
-        raise task.retry(countdown=wait_time)
-
-
 @shared_task(queue=QueueNames.default, bind=True, throws=(LockNotAcquired,))
 def search_indexing(task: Task, batch_size: int = 500) -> None:
     redis_client = task.services.redis.client()

--- a/src/palace/manager/scripts/initialization.py
+++ b/src/palace/manager/scripts/initialization.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from palace.util.log import LoggerMixin
 
-from palace.manager.celery.tasks.search import get_migrate_search_chain
+from palace.manager.celery.tasks.search import search_reindex
 from palace.manager.scripts.startup import run_startup_tasks as _run_startup_tasks
 from palace.manager.search.revision import SearchSchemaRevision
 from palace.manager.search.service import SearchService
@@ -125,11 +125,12 @@ class InstanceInitializationScript(LoggerMixin):
         revision: SearchSchemaRevision,
     ) -> None:
         # The revision is not the most recent. We need to create a new index.
-        # and start reindexing our data into it asynchronously. When the reindex
-        # is complete, we will switch the read pointer to the new index.
+        # and start reindexing our data into it asynchronously. The reindex advances
+        # the read pointer itself once it has filled the new index, so a run that never
+        # finishes leaves reads on the old index rather than half-migrating.
         cls.logger().info(f"Creating a new index for revision (v{revision.version}).")
         cls.create_search_index(service, revision)
-        task = get_migrate_search_chain().apply_async()
+        task = search_reindex.apply_async()
         cls.logger().info(
             f"Task queued to index data into new search index (Task ID: {task.id})."
         )

--- a/src/palace/manager/scripts/initialization.py
+++ b/src/palace/manager/scripts/initialization.py
@@ -154,9 +154,9 @@ class InstanceInitializationScript(LoggerMixin):
             self.migrate_search(service, revision)
         elif read_pointer.version < revision.version:
             self.log.info(
-                f"Search read pointer is out-of-date (v{read_pointer.version}). Latest is v{revision.version}."
-                f"This likely means that the reindexing task is in progress. If there is no reindexing task "
-                f"running, you may need to repair the search index."
+                f"Search read pointer is out-of-date (v{read_pointer.version}). Latest is v{revision.version}. "
+                f"This likely means that the reindexing task is in progress. The first run to complete a "
+                f"full pass over the new index will publish it for reads."
             )
         elif (
             read_pointer.version > revision.version

--- a/src/palace/manager/scripts/initialization.py
+++ b/src/palace/manager/scripts/initialization.py
@@ -125,9 +125,9 @@ class InstanceInitializationScript(LoggerMixin):
         revision: SearchSchemaRevision,
     ) -> None:
         # The revision is not the most recent. We need to create a new index.
-        # and start reindexing our data into it asynchronously. The reindex advances
-        # the read pointer itself once it has filled the new index, so a run that never
-        # finishes leaves reads on the old index rather than half-migrating.
+        # and start reindexing our data into it asynchronously. When the reindex
+        # is complete, we will switch the read pointer to the new index. The normal
+        # search_reindex task handles this transition.
         cls.logger().info(f"Creating a new index for revision (v{revision.version}).")
         cls.create_search_index(service, revision)
         task = search_reindex.apply_async()

--- a/src/palace/manager/scripts/search.py
+++ b/src/palace/manager/scripts/search.py
@@ -2,7 +2,7 @@ import argparse
 
 from sqlalchemy.orm import Session
 
-from palace.manager.celery.tasks.search import get_migrate_search_chain, search_reindex
+from palace.manager.celery.tasks.search import search_reindex
 from palace.manager.scripts.base import Script
 from palace.manager.search.external_search import ExternalSearchIndex
 from palace.manager.service.container import Services
@@ -23,7 +23,6 @@ class RebuildSearchIndexScript(Script):
         args = self.parse_command_line(self._db, cmd_args=cmd_args)
         self.blocking: bool = args.blocking
         self.delete: bool = args.delete
-        self.migration: bool = args.migration
 
     @classmethod
     def arg_parser(cls, _db: Session) -> argparse.ArgumentParser:
@@ -42,12 +41,6 @@ class RebuildSearchIndexScript(Script):
             action="store_true",
             help="Delete the search index before rebuilding.",
         )
-        parser.add_argument(
-            "-m",
-            "--migration",
-            action="store_true",
-            help="Treat as a migration and update the read pointer after the rebuild is complete.",
-        )
         return parser
 
     def do_run(self) -> None:
@@ -58,10 +51,7 @@ class RebuildSearchIndexScript(Script):
 
         self.log.info("Rebuilding search index.")
 
-        if self.migration:
-            rebuild_task = get_migrate_search_chain()
-        else:
-            rebuild_task = search_reindex.s()
+        rebuild_task = search_reindex.s()
 
         if self.blocking:
             rebuild_task()

--- a/tests/fixtures/search.py
+++ b/tests/fixtures/search.py
@@ -11,7 +11,7 @@ from pydantic_settings import SettingsConfigDict
 
 from palace.util.log import LoggerMixin
 
-from palace.manager.celery.tasks.search import get_work_search_documents
+from palace.manager.celery.tasks.search import get_presentation_ready_work_ids
 from palace.manager.search.external_search import ExternalSearchIndex
 from palace.manager.search.revision import SearchSchemaRevision
 from palace.manager.search.service import SearchServiceOpensearch1
@@ -126,7 +126,8 @@ class EndToEndSearchFixture:
     def populate_search_index(self):
         """Populate the search index with a set of works. The given callback is passed this fixture instance."""
         # Add all the works created in the setup to the search index.
-        documents = get_work_search_documents(self.db.session, 1000, 0)
+        work_ids = get_presentation_ready_work_ids(self.db.session, 1000, 0)
+        documents = Work.to_search_documents(self.db.session, work_ids)
         self.external_search_index.add_documents(documents)
         self.external_search.write_client.indices.refresh()
 

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -1,14 +1,17 @@
 import json
 import math
 from collections import Counter
+from collections.abc import Sequence
+from typing import Any
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 from celery.exceptions import MaxRetriesExceededError
 from opensearchpy import OpenSearchException
+from sqlalchemy.orm import Session
 
 from palace.manager.celery.tasks.search import (
-    get_work_search_documents,
+    get_presentation_ready_work_ids,
     index_works,
     search_indexing,
     search_reindex,
@@ -19,6 +22,7 @@ from palace.manager.search.filter import Filter
 from palace.manager.search.service import SearchPointer
 from palace.manager.service.redis.models.lock import LockNotAcquired, TaskLock
 from palace.manager.service.redis.models.search import WaitingForIndexing
+from palace.manager.sqlalchemy.model.work import Work
 from tests.fixtures.celery import CeleryFixture
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.redis import RedisFixture
@@ -69,21 +73,19 @@ def mock_search_pointers(
     )
 
 
-def test_get_work_search_documents(db: DatabaseTransactionFixture) -> None:
+def test_get_presentation_ready_work_ids(db: DatabaseTransactionFixture) -> None:
     work1 = db.work(with_open_access_download=True)
     work2 = db.work(with_open_access_download=True)
     # This work is not presentation ready, because it has no open access download.
     work3 = db.work(with_open_access_download=False)
     work4 = db.work(with_open_access_download=True)
 
-    documents = get_work_search_documents(db.session, 2, 0)
-    assert {doc["_id"] for doc in documents} == {work1.id, work2.id}
-
-    documents = get_work_search_documents(db.session, 2, 2)
-    assert {doc["_id"] for doc in documents} == {work4.id}
-
-    documents = get_work_search_documents(db.session, 2, 4)
-    assert documents == []
+    assert set(get_presentation_ready_work_ids(db.session, 2, 0)) == {
+        work1.id,
+        work2.id,
+    }
+    assert set(get_presentation_ready_work_ids(db.session, 2, 2)) == {work4.id}
+    assert get_presentation_ready_work_ids(db.session, 2, 4) == []
 
 
 @pytest.mark.parametrize("batch_size", [2, 3, 500])
@@ -135,6 +137,43 @@ def test_search_reindex(
     end_to_end_search_fixture.expect_results([work1, work2, work4], "", ordered=False)
 
 
+@patch("palace.manager.celery.tasks.search.random")
+def test_search_reindex_indexes_the_works_after_one_that_cannot_be_indexed(
+    mock_random: MagicMock,
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+    search_reindex_task_lock_fixture: SearchReindexTaskLockFixture,
+    end_to_end_search_fixture: EndToEndSearchFixture,
+) -> None:
+    # Work.to_search_documents drops a work whose document it cannot build, so a full
+    # batch of works arrives as a short batch of documents. The run has to keep paging
+    # anyway: the works after the dropped one are the rest of the collection.
+    mock_random.uniform.return_value = 0.0
+    works = [db.work(with_open_access_download=True) for _ in range(4)]
+
+    to_search_documents = Work.to_search_documents
+    dropped: list[int] = []
+
+    def drop_one_document(
+        session: Session, work_ids: Sequence[int]
+    ) -> Sequence[dict[str, Any]]:
+        documents = to_search_documents(session, work_ids)
+        if not dropped and documents:
+            dropped.append(documents[0]["_id"])
+            return documents[1:]
+        return documents
+
+    # The first batch loses a document, so it has to be a batch that is not the last one.
+    with patch.object(Work, "to_search_documents", drop_one_document):
+        search_reindex.delay(batch_size=2).wait()
+
+    assert len(dropped) == 1
+    end_to_end_search_fixture.external_search.write_client.indices.refresh()
+    end_to_end_search_fixture.expect_results(
+        [work for work in works if work.id != dropped[0]], "", ordered=False
+    )
+
+
 def test_search_reindex_lock(
     db: DatabaseTransactionFixture,
     celery_fixture: CeleryFixture,
@@ -154,8 +193,10 @@ def test_fiction_query_returns_results(
 ) -> None:
     work1 = db.work(with_open_access_download=True, fiction=True)
     work2 = db.work(with_open_access_download=True, fiction=False)
-    documents = get_work_search_documents(db.session, 2, 0)
-    assert {doc["_id"] for doc in documents} == {work2.id, work1.id}
+    assert set(get_presentation_ready_work_ids(db.session, 2, 0)) == {
+        work2.id,
+        work1.id,
+    }
 
     end_to_end_search_fixture.populate_search_index()
     end_to_end_search_fixture.expect_results(
@@ -217,9 +258,9 @@ def test_search_reindex_failures(
 
 @patch("palace.manager.celery.tasks.search.random.uniform")
 @patch("palace.manager.celery.tasks.search.exponential_backoff")
-@patch("palace.manager.celery.tasks.search.get_work_search_documents")
+@patch("palace.manager.celery.tasks.search.get_presentation_ready_work_ids")
 def test_search_reindex_requeue_delay(
-    mock_get_work_search_documents: MagicMock,
+    mock_get_work_ids: MagicMock,
     mock_backoff: MagicMock,
     mock_random_uniform: MagicMock,
     celery_fixture: CeleryFixture,
@@ -232,10 +273,7 @@ def test_search_reindex_requeue_delay(
     mock_random_uniform.return_value = 0
 
     # Return a full batch to trigger requeueing, then an empty batch to stop
-    mock_get_work_search_documents.side_effect = [
-        [{"_id": 1}, {"_id": 2}],
-        [],
-    ]
+    mock_get_work_ids.side_effect = [[1, 2], []]
 
     # Ensure add_documents succeeds (returns no failed documents)
     services_fixture.search_index.add_documents.return_value = None
@@ -249,9 +287,9 @@ def test_search_reindex_requeue_delay(
 
 @patch("palace.manager.celery.tasks.search.random.uniform")
 @patch("palace.manager.celery.tasks.search.exponential_backoff")
-@patch("palace.manager.celery.tasks.search.get_work_search_documents")
+@patch("palace.manager.celery.tasks.search.get_presentation_ready_work_ids")
 def test_search_reindex_failures_multiple_batch(
-    mock_get_work_search_documents: MagicMock,
+    mock_get_work_ids: MagicMock,
     mock_backoff: MagicMock,
     mock_random_uniform: MagicMock,
     celery_fixture: CeleryFixture,
@@ -262,20 +300,10 @@ def test_search_reindex_failures_multiple_batch(
     # When a batch succeeds, the retry count is reset.
     mock_backoff.return_value = 0
     mock_random_uniform.return_value = 0
-    search_documents = [
-        {"_id": 1},
-        {"_id": 2},
-        {"_id": 3},
-        {"_id": 4},
-        {"_id": 5},
-        {"_id": 6},
-        {"_id": 7},
+    work_ids = [1, 2, 3, 4, 5, 6, 7]
+    mock_get_work_ids.side_effect = lambda session, batch_size, offset: work_ids[
+        offset : offset + batch_size
     ]
-    mock_get_work_search_documents.side_effect = (
-        lambda session, batch_size, offset: search_documents[
-            offset : offset + batch_size
-        ]
-    )
     add_documents_mock = services_fixture.search_index.add_documents
     add_documents_mock.side_effect = [
         # First batch

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -428,6 +428,32 @@ def test_search_reindex_advances_read_pointer(
     end_to_end_search_fixture.expect_results(fixture.works, "", ordered=False)
 
 
+@patch("palace.manager.celery.tasks.search.random.uniform")
+@patch("palace.manager.celery.tasks.search.exponential_backoff")
+def test_search_reindex_advances_read_pointer_after_a_retried_batch(
+    mock_backoff: MagicMock,
+    mock_random_uniform: MagicMock,
+    celery_fixture: CeleryFixture,
+    redis_fixture: RedisFixture,
+    search_migration_fixture: SearchMigrationFixture,
+):
+    fixture = search_migration_fixture
+    mock_backoff.return_value = 0
+    mock_random_uniform.return_value = 0
+
+    # The index a run is filling has to survive a retry of an already requeued batch, not
+    # just the requeue: a batch at a non-zero offset fails once, retries, and the run
+    # still knows what it filled when it reaches the end.
+    with patch.object(
+        ExternalSearchIndex, "add_documents", autospec=True
+    ) as add_documents:
+        add_documents.side_effect = [None, OpenSearchException(), None, None]
+        search_reindex.delay(batch_size=4).wait()
+
+    assert add_documents.call_count == 4
+    fixture.assert_pointers(read=fixture.new_index, write=fixture.new_index)
+
+
 def test_search_reindex_does_not_advance_read_pointer_for_another_index(
     celery_fixture: CeleryFixture,
     redis_fixture: RedisFixture,

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -402,18 +402,23 @@ def search_migration_fixture(
     return SearchMigrationFixture(db, end_to_end_search_fixture)
 
 
+@patch("palace.manager.celery.tasks.search.random.uniform")
 def test_search_reindex_advances_read_pointer(
+    mock_random_uniform: MagicMock,
     celery_fixture: CeleryFixture,
     redis_fixture: RedisFixture,
     search_migration_fixture: SearchMigrationFixture,
     end_to_end_search_fixture: EndToEndSearchFixture,
 ):
     fixture = search_migration_fixture
+    mock_random_uniform.return_value = 0.0
 
     # Creating the new index moves the write pointer but leaves reads on the old index.
     fixture.assert_pointers(read=fixture.old_index, write=fixture.new_index)
 
-    search_reindex.delay().wait()
+    # A real migration always takes more than one batch, so use a batch size that makes
+    # the run requeue itself: the index it is filling has to survive the requeues.
+    search_reindex.delay(batch_size=3).wait()
 
     # Having filled the new index end to end, the reindex publishes it. Nothing had to
     # chain a second task on to do it.
@@ -470,6 +475,28 @@ def test_search_reindex_does_not_advance_read_pointer_when_the_write_pointer_mov
 
     assert write_pointer.call_count == 2
     fixture.assert_pointers(read=fixture.old_index, write=fixture.new_index)
+
+
+@patch("palace.manager.celery.tasks.search.exponential_backoff")
+def test_search_reindex_retries_when_the_write_pointer_cannot_be_read(
+    mock_backoff: MagicMock,
+    celery_fixture: CeleryFixture,
+    redis_fixture: RedisFixture,
+    search_migration_fixture: SearchMigrationFixture,
+):
+    fixture = search_migration_fixture
+    mock_backoff.return_value = 0
+    started_on = fixture.service.write_pointer()
+
+    # The run can't tell which index it is filling until it reads the write pointer, so a
+    # transient failure there is retried rather than failing the run.
+    with patch.object(
+        type(fixture.service), "write_pointer", autospec=True
+    ) as write_pointer:
+        write_pointer.side_effect = [OpenSearchException(), started_on, started_on]
+        search_reindex.delay().wait()
+
+    fixture.assert_pointers(read=fixture.new_index, write=fixture.new_index)
 
 
 @patch("palace.manager.celery.tasks.search.exponential_backoff")

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -12,7 +12,6 @@ from palace.manager.celery.tasks.search import (
     index_works,
     search_indexing,
     search_reindex,
-    update_read_pointer,
 )
 from palace.manager.scripts.initialization import InstanceInitializationScript
 from palace.manager.search.external_search import ExternalSearchIndex
@@ -49,11 +48,8 @@ def search_reindex_task_lock_fixture(redis_fixture: RedisFixture):
 def mock_search_pointers(
     services_fixture: ServicesFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Point the mocked search service at a single index at the latest revision.
-
-    A reindex reads both pointers to decide whether to advance the read pointer, and an
-    unconfigured autospec hands back mocks that can neither be compared nor serialized
-    into the task's requeue.
+    """
+    Point the mocked search service at a single index at the latest revision.
     """
     base_name = "test_index"
     revision = MockSearchSchemaRevisionLatest(42)
@@ -301,54 +297,6 @@ def test_search_reindex_failures_multiple_batch(
     search_reindex.delay(batch_size=2).wait()
     assert add_documents_mock.call_count == 11
     assert search_reindex_task_lock_fixture.task_lock.locked() is False
-
-
-def test_update_read_pointer(
-    db: DatabaseTransactionFixture,
-    celery_fixture: CeleryFixture,
-    end_to_end_search_fixture: EndToEndSearchFixture,
-):
-    client = end_to_end_search_fixture.external_search.write_client
-    service = end_to_end_search_fixture.external_search.service
-
-    # Remove the read pointer
-    alias_name = service.read_pointer_name()
-    action = {
-        "actions": [
-            {"remove": {"index": "*", "alias": alias_name}},
-        ]
-    }
-    client.indices.update_aliases(body=action)
-
-    # Verify that the read pointer is gone
-    assert service.read_pointer() is None
-
-    # Update the read pointer
-    update_read_pointer.delay().wait()
-
-    # Verify that the read pointer is set
-    assert service.read_pointer() is not None
-
-
-@patch("palace.manager.celery.tasks.search.exponential_backoff")
-def test_update_read_pointer_failures(
-    mock_backoff: MagicMock,
-    celery_fixture: CeleryFixture,
-    services_fixture: ServicesFixture,
-):
-    # Make sure our backoff function doesn't delay the test.
-    mock_backoff.return_value = 0
-
-    read_pointer_set_mock = services_fixture.search_service.read_pointer_set
-    read_pointer_set_mock.side_effect = OpenSearchException()
-    with pytest.raises(MaxRetriesExceededError):
-        update_read_pointer.delay().wait()
-    assert read_pointer_set_mock.call_count == 5
-
-    read_pointer_set_mock.reset_mock()
-    read_pointer_set_mock.side_effect = [OpenSearchException(), None]
-    update_read_pointer.delay().wait()
-    assert read_pointer_set_mock.call_count == 2
 
 
 class SearchMigrationFixture:

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -437,6 +437,63 @@ def test_search_reindex_does_not_advance_read_pointer_for_another_index(
     fixture.assert_pointers(read=fixture.old_index, write=fixture.new_index)
 
 
+@pytest.mark.parametrize("write_pointer_removed", [False, True])
+def test_search_reindex_does_not_advance_read_pointer_when_the_write_pointer_moves(
+    celery_fixture: CeleryFixture,
+    redis_fixture: RedisFixture,
+    search_migration_fixture: SearchMigrationFixture,
+    write_pointer_removed: bool,
+):
+    fixture = search_migration_fixture
+    started_on = fixture.service.write_pointer()
+
+    # An instance running a newer revision deploys partway through and aims writes at an
+    # index this run never touched, so the works are split across two indexes and neither
+    # got a complete pass.
+    later_revision = MockSearchSchemaRevisionLatest(1010102)
+    moved_to = (
+        None
+        if write_pointer_removed
+        else SearchPointer(
+            alias=fixture.service.write_pointer_name(),
+            index=later_revision.name_for_index(fixture.service.base_revision_name),
+            version=later_revision.version,
+        )
+    )
+
+    # The run reads the write pointer once on the way in and once at the end.
+    with patch.object(
+        type(fixture.service), "write_pointer", autospec=True
+    ) as write_pointer:
+        write_pointer.side_effect = [started_on, moved_to]
+        search_reindex.delay().wait()
+
+    assert write_pointer.call_count == 2
+    fixture.assert_pointers(read=fixture.old_index, write=fixture.new_index)
+
+
+@patch("palace.manager.celery.tasks.search.exponential_backoff")
+def test_search_reindex_retries_when_the_pointers_cannot_be_read(
+    mock_backoff: MagicMock,
+    celery_fixture: CeleryFixture,
+    redis_fixture: RedisFixture,
+    search_migration_fixture: SearchMigrationFixture,
+):
+    fixture = search_migration_fixture
+    mock_backoff.return_value = 0
+    current_read_pointer = fixture.service.read_pointer()
+
+    # Reading the pointers is the last thing a pass does, after days of work on a large
+    # collection, so a transient failure there is retried rather than losing the run.
+    with patch.object(
+        type(fixture.service), "read_pointer", autospec=True
+    ) as read_pointer:
+        read_pointer.side_effect = [OpenSearchException(), current_read_pointer]
+        search_reindex.delay().wait()
+
+    fixture.assert_pointers(read=fixture.new_index, write=fixture.new_index)
+
+
 @patch("palace.manager.celery.tasks.search.random.uniform")
 @patch("palace.manager.celery.tasks.search.exponential_backoff")
 def test_search_reindex_does_not_advance_read_pointer_when_it_fails(

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -18,6 +18,7 @@ from palace.manager.celery.tasks.search import (
 )
 from palace.manager.scripts.initialization import InstanceInitializationScript
 from palace.manager.search.filter import Filter
+from palace.manager.search.service import SearchPointer
 from palace.manager.service.redis.models.lock import LockNotAcquired, TaskLock
 from palace.manager.service.redis.models.search import WaitingForIndexing
 from tests.fixtures.celery import CeleryFixture
@@ -43,6 +44,34 @@ class SearchReindexTaskLockFixture:
 @pytest.fixture
 def search_reindex_task_lock_fixture(redis_fixture: RedisFixture):
     return SearchReindexTaskLockFixture(redis_fixture)
+
+
+@pytest.fixture
+def mock_search_pointers(
+    services_fixture: ServicesFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Point the mocked search service at a single index at the latest revision.
+
+    A reindex reads both pointers to decide whether to advance the read pointer, and an
+    unconfigured autospec hands back mocks that can neither be compared nor serialized
+    into the task's requeue.
+    """
+    base_name = "test_index"
+    revision = MockSearchSchemaRevisionLatest(42)
+    index = revision.name_for_index(base_name)
+
+    # The services fixture resets return values between tests, but not attributes we
+    # assign directly, so base_revision_name is set through monkeypatch.
+    monkeypatch.setattr(
+        services_fixture.search_service, "base_revision_name", base_name
+    )
+    services_fixture.search_revision_directory.highest.return_value = revision
+    services_fixture.search_service.read_pointer.return_value = SearchPointer(
+        alias=f"{base_name}-search-read", index=index, version=revision.version
+    )
+    services_fixture.search_service.write_pointer.return_value = SearchPointer(
+        alias=f"{base_name}-search-write", index=index, version=revision.version
+    )
 
 
 def test_get_work_search_documents(db: DatabaseTransactionFixture) -> None:
@@ -161,6 +190,7 @@ def test_search_reindex_failures(
     celery_fixture: CeleryFixture,
     search_reindex_task_lock_fixture: SearchReindexTaskLockFixture,
     services_fixture: ServicesFixture,
+    mock_search_pointers: None,
 ):
     # Make sure our backoff function doesn't delay the test.
     mock_backoff.return_value = 0
@@ -200,6 +230,7 @@ def test_search_reindex_requeue_delay(
     celery_fixture: CeleryFixture,
     search_reindex_task_lock_fixture: SearchReindexTaskLockFixture,
     services_fixture: ServicesFixture,
+    mock_search_pointers: None,
 ) -> None:
     """Verify that the task requeues with a random delay to avoid hammering the search service."""
     mock_backoff.return_value = 0
@@ -231,6 +262,7 @@ def test_search_reindex_failures_multiple_batch(
     celery_fixture: CeleryFixture,
     search_reindex_task_lock_fixture: SearchReindexTaskLockFixture,
     services_fixture: ServicesFixture,
+    mock_search_pointers: None,
 ):
     # When a batch succeeds, the retry count is reset.
     mock_backoff.return_value = 0
@@ -373,6 +405,7 @@ def search_migration_fixture(
 
 def test_search_reindex_advances_read_pointer(
     celery_fixture: CeleryFixture,
+    redis_fixture: RedisFixture,
     search_migration_fixture: SearchMigrationFixture,
     end_to_end_search_fixture: EndToEndSearchFixture,
 ):
@@ -393,6 +426,7 @@ def test_search_reindex_advances_read_pointer(
 
 def test_search_reindex_does_not_advance_read_pointer_for_another_index(
     celery_fixture: CeleryFixture,
+    redis_fixture: RedisFixture,
     search_migration_fixture: SearchMigrationFixture,
 ):
     fixture = search_migration_fixture
@@ -423,6 +457,7 @@ def test_search_reindex_does_not_advance_read_pointer_when_it_fails(
 def test_search_reindex_leaves_current_read_pointer_alone(
     db: DatabaseTransactionFixture,
     celery_fixture: CeleryFixture,
+    redis_fixture: RedisFixture,
     end_to_end_search_fixture: EndToEndSearchFixture,
 ):
     # Outside a migration the read pointer is already at the latest revision, so a

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -363,6 +363,22 @@ class SearchMigrationFixture:
             self.service, self.new_revision
         )
 
+    def remove_read_pointer(self) -> None:
+        """Leave the index with no read pointer at all, serving no reads."""
+        self.client.indices.update_aliases(
+            body={
+                "actions": [
+                    {
+                        "remove": {
+                            "index": "*",
+                            "alias": self.service.read_pointer_name(),
+                        }
+                    }
+                ]
+            }
+        )
+        assert self.service.read_pointer() is None
+
     def assert_pointers(self, read: str, write: str) -> None:
         read_pointer = self.service.read_pointer()
         write_pointer = self.service.write_pointer()
@@ -402,6 +418,22 @@ def test_search_reindex_advances_read_pointer(
 
     fixture.client.indices.refresh()
     end_to_end_search_fixture.expect_results(fixture.works, "", ordered=False)
+
+
+def test_search_reindex_advances_read_pointer_when_there_is_none(
+    celery_fixture: CeleryFixture,
+    redis_fixture: RedisFixture,
+    search_migration_fixture: SearchMigrationFixture,
+):
+    fixture = search_migration_fixture
+
+    # An index serving no reads at all is not "already current", so a completed pass
+    # publishes it rather than leaving search with nothing to read from.
+    fixture.remove_read_pointer()
+
+    search_reindex.delay().wait()
+
+    fixture.assert_pointers(read=fixture.new_index, write=fixture.new_index)
 
 
 @patch("palace.manager.celery.tasks.search.random.uniform")

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -10,7 +10,6 @@ from opensearchpy import OpenSearchException
 from palace.util.exceptions import BasePalaceException
 
 from palace.manager.celery.tasks.search import (
-    get_migrate_search_chain,
     get_work_search_documents,
     index_works,
     search_indexing,
@@ -321,69 +320,124 @@ def test_update_read_pointer_failures(
     assert read_pointer_set_mock.call_count == 2
 
 
-def test_get_migrate_search_chain(
+class SearchMigrationFixture:
+    """A search index mid-migration: a new revision exists and the write pointer has
+    moved to it, but the read pointer is still serving the old one."""
+
+    def __init__(
+        self,
+        db: DatabaseTransactionFixture,
+        end_to_end_search_fixture: EndToEndSearchFixture,
+    ):
+        container = end_to_end_search_fixture.external_search.search_container
+        self.client = container.write_client()
+        self.service = container.service()
+        revision_directory = container.revision_directory()
+
+        self.works = [
+            db.work(title=f"Work {x}", with_open_access_download=True)
+            for x in range(10)
+        ]
+        end_to_end_search_fixture.populate_search_index()
+
+        self.old_index = revision_directory.highest().name_for_index(
+            self.service.base_revision_name
+        )
+
+        self.new_revision = MockSearchSchemaRevisionLatest(1010101)
+        self.new_index = self.new_revision.name_for_index(
+            self.service.base_revision_name
+        )
+        available = dict(revision_directory.available)
+        available[self.new_revision.version] = self.new_revision
+        revision_directory._available = available
+
+        InstanceInitializationScript.create_search_index(
+            self.service, self.new_revision
+        )
+
+    def assert_pointers(self, read: str, write: str) -> None:
+        read_pointer = self.service.read_pointer()
+        write_pointer = self.service.write_pointer()
+        assert read_pointer is not None and read_pointer.index == read
+        assert write_pointer is not None and write_pointer.index == write
+
+
+@pytest.fixture
+def search_migration_fixture(
     db: DatabaseTransactionFixture,
-    celery_fixture: CeleryFixture,
-    search_reindex_task_lock_fixture: SearchReindexTaskLockFixture,
     end_to_end_search_fixture: EndToEndSearchFixture,
 ):
-    container = end_to_end_search_fixture.external_search.search_container
+    return SearchMigrationFixture(db, end_to_end_search_fixture)
 
-    client = container.write_client()
-    service = container.service()
-    revision_directory = container.revision_directory()
-    revision = revision_directory.highest()
 
-    works = [
-        db.work(title=f"Work {x}", with_open_access_download=True) for x in range(10)
-    ]
+def test_search_reindex_advances_read_pointer(
+    celery_fixture: CeleryFixture,
+    search_migration_fixture: SearchMigrationFixture,
+    end_to_end_search_fixture: EndToEndSearchFixture,
+):
+    fixture = search_migration_fixture
 
-    end_to_end_search_fixture.populate_search_index()
-    new_revision = MockSearchSchemaRevisionLatest(1010101)
-    new_revision_index_name = new_revision.name_for_index(service.base_revision_name)
-    available = dict(revision_directory.available)
-    available[new_revision.version] = new_revision
-    revision_directory._available = available
+    # Creating the new index moves the write pointer but leaves reads on the old index.
+    fixture.assert_pointers(read=fixture.old_index, write=fixture.new_index)
 
-    InstanceInitializationScript.create_search_index(service, new_revision)
+    search_reindex.delay().wait()
 
-    # The write pointer should point to the new revision
-    write_pointer = service.write_pointer()
-    assert write_pointer is not None
-    assert write_pointer.index == new_revision_index_name
-    assert write_pointer.version == new_revision.version
+    # Having filled the new index end to end, the reindex publishes it. Nothing had to
+    # chain a second task on to do it.
+    fixture.assert_pointers(read=fixture.new_index, write=fixture.new_index)
 
-    # The read pointer should still point to the old revision
-    read_pointer = service.read_pointer()
-    assert read_pointer is not None
-    assert read_pointer.index == revision.name_for_index(service.base_revision_name)
-    assert read_pointer.version == revision.version
+    fixture.client.indices.refresh()
+    end_to_end_search_fixture.expect_results(fixture.works, "", ordered=False)
 
-    # There is a lock on the search reindex task
+
+def test_search_reindex_does_not_advance_read_pointer_for_another_index(
+    celery_fixture: CeleryFixture,
+    search_migration_fixture: SearchMigrationFixture,
+):
+    fixture = search_migration_fixture
+
+    # A run that started before the new revision existed has been filling the old index,
+    # so the new one never received a complete pass and must not be published.
+    search_reindex.delay(target_index=fixture.old_index).wait()
+
+    fixture.assert_pointers(read=fixture.old_index, write=fixture.new_index)
+
+
+def test_search_reindex_does_not_advance_read_pointer_when_it_fails(
+    celery_fixture: CeleryFixture,
+    search_reindex_task_lock_fixture: SearchReindexTaskLockFixture,
+    search_migration_fixture: SearchMigrationFixture,
+):
+    fixture = search_migration_fixture
+
+    # A reindex that never reaches the end leaves reads where they were, rather than
+    # publishing a partially filled index.
     search_reindex_task_lock_fixture.task_lock.acquire()
-
-    # Run the migration task
     with pytest.raises(BasePalaceException):
-        get_migrate_search_chain().delay().wait()
+        search_reindex.delay().wait()
 
-    # The read pointer should still point to the old revision
-    read_pointer = service.read_pointer()
-    assert read_pointer is not None
-    assert read_pointer.index == revision.name_for_index(service.base_revision_name)
-    assert read_pointer.version == revision.version
+    fixture.assert_pointers(read=fixture.old_index, write=fixture.new_index)
 
-    # Release the lock and try again
-    search_reindex_task_lock_fixture.task_lock.release()
-    get_migrate_search_chain().delay().wait()
 
-    # The read pointer should now point to the new revision
-    read_pointer = service.read_pointer()
-    assert read_pointer is not None
-    assert read_pointer.index == new_revision_index_name
+def test_search_reindex_leaves_current_read_pointer_alone(
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+    end_to_end_search_fixture: EndToEndSearchFixture,
+):
+    # Outside a migration the read pointer is already at the latest revision, so a
+    # routine reindex has nothing to advance.
+    service = end_to_end_search_fixture.external_search.service
+    db.work(with_open_access_download=True)
+    before = service.read_pointer()
 
-    # And we should have all the works in the new index
-    client.indices.refresh()
-    end_to_end_search_fixture.expect_results(works, "", ordered=False)
+    with patch.object(
+        type(service), "read_pointer_set", autospec=True
+    ) as read_pointer_set:
+        search_reindex.delay().wait()
+
+    read_pointer_set.assert_not_called()
+    assert service.read_pointer() == before
 
 
 class SearchIndexingFixture:

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -7,8 +7,6 @@ import pytest
 from celery.exceptions import MaxRetriesExceededError
 from opensearchpy import OpenSearchException
 
-from palace.util.exceptions import BasePalaceException
-
 from palace.manager.celery.tasks.search import (
     get_work_search_documents,
     index_works,
@@ -17,6 +15,7 @@ from palace.manager.celery.tasks.search import (
     update_read_pointer,
 )
 from palace.manager.scripts.initialization import InstanceInitializationScript
+from palace.manager.search.external_search import ExternalSearchIndex
 from palace.manager.search.filter import Filter
 from palace.manager.search.service import SearchPointer
 from palace.manager.service.redis.models.lock import LockNotAcquired, TaskLock
@@ -438,18 +437,43 @@ def test_search_reindex_does_not_advance_read_pointer_for_another_index(
     fixture.assert_pointers(read=fixture.old_index, write=fixture.new_index)
 
 
+@patch("palace.manager.celery.tasks.search.random.uniform")
+@patch("palace.manager.celery.tasks.search.exponential_backoff")
 def test_search_reindex_does_not_advance_read_pointer_when_it_fails(
+    mock_backoff: MagicMock,
+    mock_random_uniform: MagicMock,
     celery_fixture: CeleryFixture,
-    search_reindex_task_lock_fixture: SearchReindexTaskLockFixture,
+    redis_fixture: RedisFixture,
+    search_migration_fixture: SearchMigrationFixture,
+):
+    fixture = search_migration_fixture
+    mock_backoff.return_value = 0
+    mock_random_uniform.return_value = 0
+
+    # The first batch lands, then the second fails through every retry, so the reindex
+    # dies with the new index partly filled. Reads stay where they were rather than
+    # moving to an index missing half its works.
+    with patch.object(
+        ExternalSearchIndex, "add_documents", autospec=True
+    ) as add_documents:
+        add_documents.side_effect = [None, *([OpenSearchException()] * 5)]
+        with pytest.raises(MaxRetriesExceededError):
+            search_reindex.delay(batch_size=5).wait()
+
+    assert add_documents.call_count == 6
+    fixture.assert_pointers(read=fixture.old_index, write=fixture.new_index)
+
+
+def test_search_reindex_does_not_advance_read_pointer_from_a_resumed_run(
+    celery_fixture: CeleryFixture,
+    redis_fixture: RedisFixture,
     search_migration_fixture: SearchMigrationFixture,
 ):
     fixture = search_migration_fixture
 
-    # A reindex that never reaches the end leaves reads where they were, rather than
-    # publishing a partially filled index.
-    search_reindex_task_lock_fixture.task_lock.acquire()
-    with pytest.raises(BasePalaceException):
-        search_reindex.delay().wait()
+    # A run started partway through never indexes the works before its offset, so it has
+    # not filled the new index and must not publish it.
+    search_reindex.delay(offset=5).wait()
 
     fixture.assert_pointers(read=fixture.old_index, write=fixture.new_index)
 

--- a/tests/manager/scripts/test_initialization.py
+++ b/tests/manager/scripts/test_initialization.py
@@ -237,8 +237,8 @@ class TestInstanceInitializationScript:
         script.migrate_search = MagicMock(wraps=script.migrate_search)
         script._container.search.revision_directory.override(new_revision_directory)
         with patch(
-            "palace.manager.scripts.initialization.get_migrate_search_chain"
-        ) as get_migrate_search_chain:
+            "palace.manager.scripts.initialization.search_reindex"
+        ) as search_reindex:
             script.initialize_search()
 
         # We should have created the new search index, and started the migration
@@ -267,9 +267,8 @@ class TestInstanceInitializationScript:
         [indexed_work_1] = index.query_works("")
         assert indexed_work_1.work_id == work1.id
 
-        # The migration should have been queued
-        get_migrate_search_chain.assert_called_once()
-        get_migrate_search_chain.return_value.apply_async.assert_called_once()
+        # The reindex should have been queued
+        search_reindex.apply_async.assert_called_once()
 
         # If the initialization is run again, the migration should not be run again, but we do log a message
         # about the read pointer being out of date

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from palace.manager.scripts.search import RebuildSearchIndexScript
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.services import ServicesFixture
@@ -41,16 +43,10 @@ class TestRebuildSearchIndexScript:
         services_fixture.search_index.clear_search_documents.assert_called_once_with()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
 
-    @patch("palace.manager.scripts.search.get_migrate_search_chain")
-    def test_do_run_migration(
-        self, mock_get_migrate_search_chain: MagicMock, db: DatabaseTransactionFixture
+    def test_do_run_migration_flag_removed(
+        self, db: DatabaseTransactionFixture, services_fixture: ServicesFixture
     ):
-        # If we are called with the --migration argument, we treat the reindex as completing a migration.
-        RebuildSearchIndexScript(db.session, cmd_args=["--migration"]).do_run()
-        mock_get_migrate_search_chain.return_value.delay.assert_called_once_with()
-
-        # We can also combine --blocking and --migration.
-        RebuildSearchIndexScript(
-            db.session, cmd_args=["--migration", "--blocking"]
-        ).do_run()
-        mock_get_migrate_search_chain.return_value.assert_called_once_with()
+        # search_reindex advances the read pointer itself, so there is no longer a
+        # separate migration mode to opt into.
+        with pytest.raises(SystemExit):
+            RebuildSearchIndexScript(db.session, cmd_args=["--migration"])

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from palace.manager.scripts.search import RebuildSearchIndexScript
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.services import ServicesFixture
@@ -42,11 +40,3 @@ class TestRebuildSearchIndexScript:
         RebuildSearchIndexScript(db.session, cmd_args=["--delete"]).do_run()
         services_fixture.search_index.clear_search_documents.assert_called_once_with()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
-
-    def test_do_run_migration_flag_removed(
-        self, db: DatabaseTransactionFixture, services_fixture: ServicesFixture
-    ):
-        # search_reindex advances the read pointer itself, so there is no longer a
-        # separate migration mode to opt into.
-        with pytest.raises(SystemExit):
-            RebuildSearchIndexScript(db.session, cmd_args=["--migration"])


### PR DESCRIPTION
## Description

Folds the search read-pointer advance into the end of `search_reindex`, and deletes both `get_migrate_search_chain()` and the `update_read_pointer` task.

A schema migration used to create the new index, point writes at it, and queue `chain(search_reindex.si(), update_read_pointer.si())`. Now `search_reindex` advances the read pointer itself once it has completed a full pass, so whichever run first fills the latest index publishes it.

To make that safe, `search_reindex` records the index it started filling (`target_index`, resolved from the write pointer at offset 0) and carries it across requeues via `signature_with`. The pointer only advances when that index is both the latest revision *and* still the write pointer at the end. If the write pointer moved partway through — a deploy landing mid-run — the documents are split across two indexes and neither received a complete pass, so the pointer is left alone.

**A running search reindex that happens during a deploy will error out due to this added kwarg**, but this is fine, its a one time thing during deploy and a new reindex will be rescheduled the next night anyway. I think this is better trade-off then dealing with the complexity of a task that can handle this kwarg or not.

- `InstanceInitializationScript.migrate_search` and `RebuildSearchIndexScript` now queue a bare `search_reindex`.
- `RebuildSearchIndexScript` loses its `--migration` flag, which no longer distinguishes anything.
- `update_read_pointer` is deleted. It was the chain's second link and had no other caller — no beat entry, no CLI — and the only thing it could still do was publish an index that no single run filled end to end, which means serving reads from an index nobody verified is complete. The repair for that is a reindex that finishes, and #3623 makes `RebuildSearchIndexScript --blocking` run a real pass in-process, in hours rather than the days a queued pass takes.
- Retries moved out of the helpers and into the task bodies. `task.retry` reschedules the whole task, so a retry raised from inside a helper reads as if only that helper is retried; the helpers now raise and each task decides what to retry. `search_reindex` retries inside its lock, so a run that is waiting to retry keeps holding it.
- The helpers take a `LoggerType` rather than a `Task`, so nothing outside a task body touches `Task`. Passing `task.log` keeps the per-task logger name that `LoggerMixin` derives from the task class.
- A pass now pages by works rather than by the documents built from them. `Work.to_search_documents` omits any work whose document it cannot build, so a full batch of works can come back as a short batch of documents — which the reindex read as the end of the works, stopping the pass there. That was survivable when a short pass just meant an incomplete index; now that a completed pass publishes the index, one work with a broken presentation edition would have published a truncated one. `get_work_search_documents` is split into `get_presentation_ready_work_ids` plus a `Work.to_search_documents` call, so the batch that decides whether there is more to do is the batch of works we asked for.
- The startup message for a read pointer behind the write pointer no longer tells operators they may need to repair the index by hand. That was right when nothing advanced the pointer on its own; now the first reindex to complete a full pass publishes it.

## Motivation and Context

JIRA: PP-4908

Three production circulation managers — `ca-california`, `ct-connecticut`, `nj-newjersey` — have been serving search from the v7 index since v45.1.0 rolled out on 2026-07-20, two weeks ago. Writes go to v8, reads come from v7, and nothing is repairing it.

A chain only reaches its second link if the first one succeeds. `search_reindex` raises `LockNotAcquired` when a reindex is already running, and on these managers a full pass takes 3-5 days against a daily `full_search_reindex` beat, so a run is almost always already in flight. At deploy time the migration chain lost that race and died at the first link:

```
2026-07-20 23:33:35 ca-california ERROR Task search.search_reindex[a8a683da…] raised unexpected:
  LockNotAcquired('Lock ca-california::TaskLock::search_reindex could not be acquired')
2026-07-20 23:36:27 nj-newjersey ERROR Task search.search_reindex[3d6005b2…] raised unexpected:
  LockNotAcquired('Lock nj-newjersey::TaskLock::search_reindex could not be acquired')
```

The chain's second link was never received for any of the three (it ran and succeeded for `ks-kansas` and `wa-washington`, whose nightly reindex had already finished and so left the lock free).

Nothing recovers from that. The nightly beat queues a bare `search_reindex` with no second link, so the reindex has since completed several times — `nj-newjersey` 07-21, `ct-connecticut` 07-23 / 07-29 / 08-02, `ca-california` 07-27 — with zero read-pointer updates in two weeks of logs. The `ca-california` and `ct-connecticut` v8 indexes are now fully populated and still unpublished.

With this change, any one of those completed runs would have finished the migration on its own.

The failure also degrades in the right direction: a run that dies partway through leaves the pointer where it was, so a stalled migration means "reads stay on the old index" rather than a half-migrated one.

## How Has This Been Tested?

Eleven new tests in `tests/manager/celery/tasks/test_search.py`, most built on a new `SearchMigrationFixture` (new revision created, write pointer moved, read pointer still on the old index). Two of them cover states nothing else reaches: a batch whose documents come back short of its works still pages to the end, and an index with no read pointer at all gets published rather than treated as current.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

