### PR TITLE
Give the search reindex lock a timeout that outlives the queue wait (PP-4908)

### DIFF
--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -189,12 +189,6 @@ def search_reindex(
         advances the read pointer.
     """
     index = task.services.search.index()
-    # The lock is only extended when a batch actually runs, so its timeout has to
-    # cover the wait between batches, not just the work a batch does. On a busy
-    # `default` queue that wait is dominated by queue latency and can reach tens of
-    # minutes; if the lock lapses in that window a beat-scheduled reindex can start
-    # a second run, and whichever run next fails to reacquire the lock dies and
-    # loses all of its progress.
     task_lock = TaskLock(
         task, lock_name="search_reindex", lock_timeout=SEARCH_REINDEX_LOCK_TIMEOUT
     )

--- a/src/palace/manager/celery/tasks/search.py
+++ b/src/palace/manager/celery/tasks/search.py
@@ -157,6 +157,17 @@ def advance_read_pointer(
     set_read_pointer(log, service, revision)
 
 
+SEARCH_REINDEX_LOCK_TIMEOUT = timedelta(hours=1)
+"""
+How long the search reindex lock survives without being extended.
+
+A full reindex can span days, and the lock is extended once per batch, so this needs
+to exceed the longest realistic gap between two batches. The observed worst case in
+production is ~28 minutes on a circulation manager whose `default` queue runs a
+persistent backlog; an hour leaves roughly a 2x margin on that.
+"""
+
+
 @shared_task(
     queue=QueueNames.default, bind=True, max_retries=4, throws=(LockNotAcquired,)
 )
@@ -178,7 +189,15 @@ def search_reindex(
         advances the read pointer.
     """
     index = task.services.search.index()
-    task_lock = TaskLock(task, lock_name="search_reindex")
+    # The lock is only extended when a batch actually runs, so its timeout has to
+    # cover the wait between batches, not just the work a batch does. On a busy
+    # `default` queue that wait is dominated by queue latency and can reach tens of
+    # minutes; if the lock lapses in that window a beat-scheduled reindex can start
+    # a second run, and whichever run next fails to reacquire the lock dies and
+    # loses all of its progress.
+    task_lock = TaskLock(
+        task, lock_name="search_reindex", lock_timeout=SEARCH_REINDEX_LOCK_TIMEOUT
+    )
 
     with task_lock.lock(release_on_exit=False, ignored_exceptions=(Retry, Ignore)):
         try:

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -2,7 +2,6 @@ import json
 import math
 from collections import Counter
 from collections.abc import Sequence
-from datetime import timedelta
 from typing import Any
 from unittest.mock import MagicMock, call, patch
 
@@ -12,7 +11,6 @@ from opensearchpy import OpenSearchException
 from sqlalchemy.orm import Session
 
 from palace.manager.celery.tasks.search import (
-    SEARCH_REINDEX_LOCK_TIMEOUT,
     get_presentation_ready_work_ids,
     index_works,
     search_indexing,
@@ -188,36 +186,6 @@ def test_search_reindex_lock(
         search_reindex.delay().wait()
 
     assert "TaskLock::search_reindex could not be acquired" in str(exc_info.value)
-
-
-@patch("palace.manager.celery.tasks.search.random")
-def test_search_reindex_lock_timeout(
-    mock_random: MagicMock,
-    db: DatabaseTransactionFixture,
-    celery_fixture: CeleryFixture,
-    search_reindex_task_lock_fixture: SearchReindexTaskLockFixture,
-    end_to_end_search_fixture: EndToEndSearchFixture,
-) -> None:
-    mock_random.uniform.return_value = 0.0
-
-    # The lock is only extended once per batch, so it has to outlive the gap between
-    # batches rather than the work a single batch does.
-    redis_client = search_reindex_task_lock_fixture.redis_client
-    key = search_reindex_task_lock_fixture.task_lock.key
-
-    db.work(with_open_access_download=True)
-
-    with patch.object(TaskLock, "release"):
-        # `release` is patched out so the lock, and its TTL, survive the task finishing.
-        search_reindex.delay(batch_size=1).wait()
-
-    # The TTL is reset on every batch, so what is left is the full timeout less the
-    # time that batch took. Anything close to it means the run gets to keep the lock
-    # across a long wait for its next batch, rather than losing it to a beat-scheduled
-    # reindex partway through.
-    remaining = timedelta(milliseconds=redis_client.pttl(key))
-    assert SEARCH_REINDEX_LOCK_TIMEOUT - timedelta(minutes=1) < remaining
-    assert remaining <= SEARCH_REINDEX_LOCK_TIMEOUT
 
 
 def test_fiction_query_returns_results(

--- a/tests/manager/celery/tasks/test_search.py
+++ b/tests/manager/celery/tasks/test_search.py
@@ -2,6 +2,7 @@ import json
 import math
 from collections import Counter
 from collections.abc import Sequence
+from datetime import timedelta
 from typing import Any
 from unittest.mock import MagicMock, call, patch
 
@@ -11,6 +12,7 @@ from opensearchpy import OpenSearchException
 from sqlalchemy.orm import Session
 
 from palace.manager.celery.tasks.search import (
+    SEARCH_REINDEX_LOCK_TIMEOUT,
     get_presentation_ready_work_ids,
     index_works,
     search_indexing,
@@ -186,6 +188,36 @@ def test_search_reindex_lock(
         search_reindex.delay().wait()
 
     assert "TaskLock::search_reindex could not be acquired" in str(exc_info.value)
+
+
+@patch("palace.manager.celery.tasks.search.random")
+def test_search_reindex_lock_timeout(
+    mock_random: MagicMock,
+    db: DatabaseTransactionFixture,
+    celery_fixture: CeleryFixture,
+    search_reindex_task_lock_fixture: SearchReindexTaskLockFixture,
+    end_to_end_search_fixture: EndToEndSearchFixture,
+) -> None:
+    mock_random.uniform.return_value = 0.0
+
+    # The lock is only extended once per batch, so it has to outlive the gap between
+    # batches rather than the work a single batch does.
+    redis_client = search_reindex_task_lock_fixture.redis_client
+    key = search_reindex_task_lock_fixture.task_lock.key
+
+    db.work(with_open_access_download=True)
+
+    with patch.object(TaskLock, "release"):
+        # `release` is patched out so the lock, and its TTL, survive the task finishing.
+        search_reindex.delay(batch_size=1).wait()
+
+    # The TTL is reset on every batch, so what is left is the full timeout less the
+    # time that batch took. Anything close to it means the run gets to keep the lock
+    # across a long wait for its next batch, rather than losing it to a beat-scheduled
+    # reindex partway through.
+    remaining = timedelta(milliseconds=redis_client.pttl(key))
+    assert SEARCH_REINDEX_LOCK_TIMEOUT - timedelta(minutes=1) < remaining
+    assert remaining <= SEARCH_REINDEX_LOCK_TIMEOUT
 
 
 def test_fiction_query_returns_results(


### PR DESCRIPTION
## Description

Gives the `search_reindex` lock an explicit one-hour timeout instead of the `RedisLock` default of five minutes:

```python
SEARCH_REINDEX_LOCK_TIMEOUT = timedelta(hours=1)
```

Scoped to this one task, so the default is unchanged for the other `TaskLock` callers. There is precedent both directions already — `search_indexing` uses 15 minutes, `equivalent_identifiers_refresh` uses 2 hours.

## Motivation and Context

JIRA: PP-4908

`search_reindex` holds its lock across self-replacements (`release_on_exit=False`) and extends it once per batch, in `acquire()`. So the timeout has to cover the **gap between batches**, not the work a batch does — and that gap is dominated by `default` queue latency, not by indexing.

Measured on `nj-newjersey`: a batch does ~4.6s of work (3.4s DB query, 1.1s indexing), but the next batch lands a median of **328 seconds** later, because the queue carries a persistent ~120-deep backlog. Against a 5-minute TTL the lock is therefore expired for 20.6% of wall clock — and the exposure is worst exactly when it matters, because the 03:00-05:00 UTC nightly job wave that drives the queue deepest is also when `full_search_reindex` fires:

| UTC hour | median gap | lock expired |
|---|---|---|
| 02 | 270s | 15.6% |
| 03 | 503s | 43.2% |
| **04** (beat fires 04:10) | **518s** | **40.7%** |
| 11 | 202s | 6.7% |

When the beat lands in an open window it acquires the lock and starts a second run from offset 0, and whichever run next fails to reacquire raises `LockNotAcquired` and dies, discarding its progress. That happened on **twelve of twelve nights** between 07-22 and 08-03 on `nj-newjersey` — the incumbent lost 7 of them. A full pass there needs ~4.3 days, so a run has to win four consecutive nights to finish: exactly **1 of 12 runs** ever did.

`RebuildSearchIndexScript.reindex_lock()` contends for this same `search_reindex` key on `RedisLock`'s 5-minute default, while the task now holds it for an hour. That is deliberate — the script extends the lock between in-process batches with no queue wait to cover, which is the entire reason the task needs an hour, and a shorter TTL means a crashed script frees the key sooner. 

This change doesn't speed anything up. `nj-newjersey` still needs ~4-5 days per pass at a 462s median gap; this just stops that work being thrown away every night. I'm going to handle the queue backlog in a separate PR.

## How Has This Been Tested?

- No new tests needed, `TaskLock` is well covered already, this just changes the parameters passed to it.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

