### PR TITLE
Make the blocking search rebuild actually run in this process (PP-4908)

### DIFF
--- a/src/palace/manager/scripts/search.py
+++ b/src/palace/manager/scripts/search.py
@@ -12,7 +12,7 @@ from palace.manager.celery.tasks.search import (
 from palace.manager.scripts.base import Script
 from palace.manager.search.external_search import ExternalSearchIndex
 from palace.manager.service.container import Services
-from palace.manager.service.redis.models.lock import TaskLock
+from palace.manager.service.redis.models.lock import LockError, TaskLock
 
 
 def _batch_size(value: str) -> int:
@@ -94,13 +94,17 @@ class RebuildSearchIndexScript(Script):
 
         `search_reindex` requeues itself once per batch, so its throughput is set by how
         long a trip through the `default` queue takes rather than by how long indexing
-        takes. On a manager whose queue carries a backlog that is minutes per batch, and
-        a full pass can run for days. Doing the same work in one process costs a couple
-        of hours instead, at the price of tying up whoever ran the script.
+        takes. On a manager whose queue carries a backlog that is minutes per batch, a
+        full pass can run for days. Doing the same work in one process costs a couple of
+        hours instead, at the price of tying up whoever ran the script.
 
         We take the task's own lock so the scheduled reindex can't run against the index
         at the same time, and extend it every batch, since nothing else will while we
         hold it.
+
+        Each batch ends its transaction, so a pass that runs for hours doesn't hold one
+        snapshot open for all of it and keep autovacuum off the tables the rest of the
+        application is writing to.
         """
         service = self.services.search.service()
         target_index = resolve_target_index(service)
@@ -115,7 +119,12 @@ class RebuildSearchIndexScript(Script):
                     self._db, self.batch_size, indexed
                 )
                 add_documents_to_index(self.log, self.search, documents)
-                lock.extend_timeout()
+                self._db.commit()
+                if not lock.extend_timeout():
+                    # Someone else can take the lock the moment ours expires, so carrying
+                    # on would mean indexing, and then publishing, alongside the very run
+                    # we took the lock to keep out.
+                    raise LockError(f"Lost the {lock.key} lock during the rebuild.")
                 indexed += len(documents)
                 if len(documents) < self.batch_size:
                     break

--- a/src/palace/manager/scripts/search.py
+++ b/src/palace/manager/scripts/search.py
@@ -15,6 +15,20 @@ from palace.manager.service.container import Services
 from palace.manager.service.redis.models.lock import TaskLock
 
 
+def _batch_size(value: str) -> int:
+    """
+    Parse a batch size, which has to be at least one work.
+
+    A batch of zero pages forever: the query comes back empty every time, so neither the
+    script's loop nor the task's requeue ever reaches the short batch that stops it, and
+    both go on holding the reindex lock.
+    """
+    batch_size = int(value)
+    if batch_size < 1:
+        raise argparse.ArgumentTypeError(f"must be at least 1, got {batch_size}")
+    return batch_size
+
+
 class RebuildSearchIndexScript(Script):
     """Completely delete the search index and recreate it."""
 
@@ -52,7 +66,7 @@ class RebuildSearchIndexScript(Script):
         )
         parser.add_argument(
             "--batch-size",
-            type=int,
+            type=_batch_size,
             default=500,
             help="How many works to index per batch. (default: %(default)s)",
         )

--- a/src/palace/manager/scripts/search.py
+++ b/src/palace/manager/scripts/search.py
@@ -82,14 +82,14 @@ class RebuildSearchIndexScript(Script):
         self.log.info("Rebuilding search index.")
 
         if self.blocking:
-            self.rebuild_in_process()
+            self.rebuild_locally()
         else:
             task = search_reindex.s(batch_size=self.batch_size).delay()
             self.log.info(
                 f"Search index rebuild started (Task ID: {task.id}). The reindex will run in the background."
             )
 
-    def rebuild_in_process(self) -> None:
+    def rebuild_locally(self) -> None:
         """
         Index every presentation-ready work here, rather than in a Celery worker.
 

--- a/src/palace/manager/scripts/search.py
+++ b/src/palace/manager/scripts/search.py
@@ -1,8 +1,13 @@
 import argparse
+import time
+from collections.abc import Sequence
+from typing import Any
 
+from opensearchpy import OpenSearchException
 from sqlalchemy.orm import Session
 
 from palace.manager.celery.tasks.search import (
+    FailedToIndex,
     add_documents_to_index,
     advance_read_pointer,
     get_presentation_ready_work_ids,
@@ -14,6 +19,7 @@ from palace.manager.search.external_search import ExternalSearchIndex
 from palace.manager.service.container import Services
 from palace.manager.service.redis.models.lock import LockError, TaskLock
 from palace.manager.sqlalchemy.model.work import Work
+from palace.manager.util.backoff import exponential_backoff
 
 
 def _batch_size(value: str) -> int:
@@ -32,6 +38,10 @@ def _batch_size(value: str) -> int:
 
 class RebuildSearchIndexScript(Script):
     """Completely delete the search index and recreate it."""
+
+    # As many attempts at a batch as search_reindex gets, for the same reason: a
+    # transient search failure shouldn't cost a pass that has been running for hours.
+    MAX_RETRIES = 4
 
     def __init__(
         self,
@@ -139,13 +149,9 @@ class RebuildSearchIndexScript(Script):
                     self._db, self.batch_size, offset
                 )
                 documents = Work.to_search_documents(self._db, work_ids)
-                add_documents_to_index(self.log, self.search, documents)
+                self.index_batch(documents, lock)
                 self._db.commit()
-                if not lock.extend_timeout():
-                    # Someone else can take the lock the moment ours expires, so carrying
-                    # on would mean indexing, and then publishing, alongside the very run
-                    # we took the lock to keep out.
-                    raise LockError(f"Lost the {lock.key} lock during the rebuild.")
+                self.extend_lock(lock)
                 offset += len(work_ids)
                 indexed += len(documents)
                 if len(work_ids) < self.batch_size:
@@ -156,6 +162,43 @@ class RebuildSearchIndexScript(Script):
 
             revision = self.services.search.revision_directory().highest()
             advance_read_pointer(self.log, service, revision, target_index)
+
+    def index_batch(self, documents: Sequence[dict[str, Any]], lock: TaskLock) -> None:
+        """
+        Submit a batch to the index, retrying a failure the way the task does.
+
+        search_reindex answers a transient search failure by retrying the batch, which
+        costs it one requeue. Here the same failure would cost the whole pass: there is
+        no offset to resume from, so a rebuild that has been running for hours would
+        start again from the first work.
+
+        :raises FailedToIndex: If the index kept rejecting documents.
+        :raises OpenSearchException: If the index kept rejecting the request.
+        """
+        for retries in range(self.MAX_RETRIES + 1):
+            try:
+                add_documents_to_index(self.log, self.search, documents)
+                return
+            except (FailedToIndex, OpenSearchException) as e:
+                if retries == self.MAX_RETRIES:
+                    raise
+                wait_time = exponential_backoff(retries)
+                self.log.exception(f"Batch failed ({e}). Retrying in {wait_time}s.")
+                time.sleep(wait_time)
+                # Waiting counts against the lock like anything else does, and a long
+                # enough run of failures would otherwise outlive it while we sleep.
+                self.extend_lock(lock)
+
+    def extend_lock(self, lock: TaskLock) -> None:
+        """
+        Keep holding the reindex lock, or stop.
+
+        :raises LockError: If the lock is no longer ours. Something else can take it the
+            moment it expires, so carrying on would mean indexing, and then publishing,
+            alongside the very run we took the lock to keep out.
+        """
+        if not lock.extend_timeout():
+            raise LockError(f"Lost the {lock.key} lock during the rebuild.")
 
     def take_lock(self, lock: TaskLock) -> None:
         """

--- a/src/palace/manager/scripts/search.py
+++ b/src/palace/manager/scripts/search.py
@@ -2,10 +2,17 @@ import argparse
 
 from sqlalchemy.orm import Session
 
-from palace.manager.celery.tasks.search import search_reindex
+from palace.manager.celery.tasks.search import (
+    add_documents_to_index,
+    advance_read_pointer,
+    get_work_search_documents,
+    resolve_target_index,
+    search_reindex,
+)
 from palace.manager.scripts.base import Script
 from palace.manager.search.external_search import ExternalSearchIndex
 from palace.manager.service.container import Services
+from palace.manager.service.redis.models.lock import TaskLock
 
 
 class RebuildSearchIndexScript(Script):
@@ -23,6 +30,7 @@ class RebuildSearchIndexScript(Script):
         args = self.parse_command_line(self._db, cmd_args=cmd_args)
         self.blocking: bool = args.blocking
         self.delete: bool = args.delete
+        self.batch_size: int = args.batch_size
 
     @classmethod
     def arg_parser(cls, _db: Session) -> argparse.ArgumentParser:
@@ -33,13 +41,20 @@ class RebuildSearchIndexScript(Script):
             "-b",
             "--blocking",
             action="store_true",
-            help="Block until the search index is rebuilt.",
+            help="Rebuild the index in this process, and wait for it to finish, "
+            "rather than handing the work to Celery.",
         )
         parser.add_argument(
             "-d",
             "--delete",
             action="store_true",
             help="Delete the search index before rebuilding.",
+        )
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=500,
+            help="How many works to index per batch. (default: %(default)s)",
         )
         return parser
 
@@ -51,12 +66,48 @@ class RebuildSearchIndexScript(Script):
 
         self.log.info("Rebuilding search index.")
 
-        rebuild_task = search_reindex.s()
-
         if self.blocking:
-            rebuild_task()
+            self.rebuild_in_process()
         else:
-            task = rebuild_task.delay()
+            task = search_reindex.s(batch_size=self.batch_size).delay()
             self.log.info(
                 f"Search index rebuild started (Task ID: {task.id}). The reindex will run in the background."
             )
+
+    def rebuild_in_process(self) -> None:
+        """
+        Index every presentation-ready work here, rather than in a Celery worker.
+
+        `search_reindex` requeues itself once per batch, so its throughput is set by how
+        long a trip through the `default` queue takes rather than by how long indexing
+        takes. On a manager whose queue carries a backlog that is minutes per batch, and
+        a full pass can run for days. Doing the same work in one process costs a couple
+        of hours instead, at the price of tying up whoever ran the script.
+
+        We take the task's own lock so the scheduled reindex can't run against the index
+        at the same time, and extend it every batch, since nothing else will while we
+        hold it.
+        """
+        service = self.services.search.service()
+        target_index = resolve_target_index(service)
+
+        lock = TaskLock(
+            redis_client=self.services.redis.client(), lock_name="search_reindex"
+        )
+        with lock.lock():
+            indexed = 0
+            while True:
+                documents = get_work_search_documents(
+                    self._db, self.batch_size, indexed
+                )
+                add_documents_to_index(self.log, self.search, documents)
+                lock.extend_timeout()
+                indexed += len(documents)
+                if len(documents) < self.batch_size:
+                    break
+                self.log.info(f"Indexed {indexed} works.")
+
+            self.log.info(f"Finished search reindex. Indexed {indexed} works.")
+
+            revision = self.services.search.revision_directory().highest()
+            advance_read_pointer(self.log, service, revision, target_index)

--- a/src/palace/manager/scripts/search.py
+++ b/src/palace/manager/scripts/search.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 from palace.manager.celery.tasks.search import (
     add_documents_to_index,
     advance_read_pointer,
-    get_work_search_documents,
+    get_presentation_ready_work_ids,
     resolve_target_index,
     search_reindex,
 )
@@ -13,6 +13,7 @@ from palace.manager.scripts.base import Script
 from palace.manager.search.external_search import ExternalSearchIndex
 from palace.manager.service.container import Services
 from palace.manager.service.redis.models.lock import LockError, TaskLock
+from palace.manager.sqlalchemy.model.work import Work
 
 
 def _batch_size(value: str) -> int:
@@ -113,11 +114,13 @@ class RebuildSearchIndexScript(Script):
             redis_client=self.services.redis.client(), lock_name="search_reindex"
         )
         with lock.lock():
+            offset = 0
             indexed = 0
             while True:
-                documents = get_work_search_documents(
-                    self._db, self.batch_size, indexed
+                work_ids = get_presentation_ready_work_ids(
+                    self._db, self.batch_size, offset
                 )
+                documents = Work.to_search_documents(self._db, work_ids)
                 add_documents_to_index(self.log, self.search, documents)
                 self._db.commit()
                 if not lock.extend_timeout():
@@ -125,10 +128,11 @@ class RebuildSearchIndexScript(Script):
                     # on would mean indexing, and then publishing, alongside the very run
                     # we took the lock to keep out.
                     raise LockError(f"Lost the {lock.key} lock during the rebuild.")
+                offset += len(work_ids)
                 indexed += len(documents)
-                if len(documents) < self.batch_size:
+                if len(work_ids) < self.batch_size:
                     break
-                self.log.info(f"Indexed {indexed} works.")
+                self.log.info(f"Indexed {indexed} of {offset} works.")
 
             self.log.info(f"Finished search reindex. Indexed {indexed} works.")
 

--- a/src/palace/manager/scripts/search.py
+++ b/src/palace/manager/scripts/search.py
@@ -99,19 +99,38 @@ class RebuildSearchIndexScript(Script):
 
     def do_run(self) -> None:
         """Delete all search documents, then rebuild the search index."""
-        if self.delete:
-            self.log.info("Deleting all search documents.")
-            self.search.clear_search_documents()
-
         self.log.info("Rebuilding search index.")
 
         if self.blocking:
             self.rebuild_locally()
         else:
-            task = search_reindex.s(batch_size=self.batch_size).delay()
-            self.log.info(
-                f"Search index rebuild started (Task ID: {task.id}). The reindex will run in the background."
-            )
+            self.queue_rebuild()
+
+    def reindex_lock(self) -> TaskLock:
+        """The lock search_reindex takes, so that we contend with it for the index."""
+        return TaskLock(
+            redis_client=self.services.redis.client(), lock_name="search_reindex"
+        )
+
+    def delete_documents(self) -> None:
+        """Empty the index. Only ever called holding the reindex lock."""
+        self.log.info("Deleting all search documents.")
+        self.search.clear_search_documents()
+
+    def queue_rebuild(self) -> None:
+        """Hand the rebuild to a Celery worker."""
+        if self.delete:
+            # Emptying the index gets in a running reindex's way as much as rebuilding
+            # does, so it waits for the same lock rather than pulling the index out from
+            # under one. We give the lock back before queueing, because the task we are
+            # queueing has to be able to take it.
+            with self.reindex_lock().lock():
+                self.delete_documents()
+
+        task = search_reindex.s(batch_size=self.batch_size).delay()
+        self.log.info(
+            f"Search index rebuild started (Task ID: {task.id}). The reindex will run in the background."
+        )
 
     def rebuild_locally(self) -> None:
         """
@@ -125,9 +144,11 @@ class RebuildSearchIndexScript(Script):
 
         We take the task's own lock so the scheduled reindex can't run against the index
         at the same time, and extend it every batch, since nothing else will while we
-        hold it. That means a reindex already running holds us off, which is the wrong
-        way round when a manager is down and the running reindex is the days-long one
-        we are trying to get ahead of: --force takes the lock from it instead.
+        hold it. --delete happens under that lock too, so a rebuild that cannot get the
+        lock leaves the index alone rather than emptying it and then stopping. That
+        means a reindex already running holds us off, which is the wrong way round when
+        a manager is down and the running reindex is the days-long one we are trying to
+        get ahead of: --force takes the lock from it instead.
 
         Each batch ends its transaction, so a pass that runs for hours doesn't hold one
         snapshot open for all of it and keep autovacuum off the tables the rest of the
@@ -136,12 +157,13 @@ class RebuildSearchIndexScript(Script):
         service = self.services.search.service()
         target_index = resolve_target_index(service)
 
-        lock = TaskLock(
-            redis_client=self.services.redis.client(), lock_name="search_reindex"
-        )
+        lock = self.reindex_lock()
         if self.force:
             self.take_lock(lock)
         with lock.lock():
+            if self.delete:
+                self.delete_documents()
+
             offset = 0
             indexed = 0
             while True:

--- a/src/palace/manager/scripts/search.py
+++ b/src/palace/manager/scripts/search.py
@@ -45,7 +45,14 @@ class RebuildSearchIndexScript(Script):
         args = self.parse_command_line(self._db, cmd_args=cmd_args)
         self.blocking: bool = args.blocking
         self.delete: bool = args.delete
+        self.force: bool = args.force
         self.batch_size: int = args.batch_size
+
+        if self.force and not self.blocking:
+            # A queued rebuild is the scheduled reindex, so there is nothing for it to
+            # take the lock from, and silently ignoring the flag would leave whoever is
+            # trying to take a manager back believing they had.
+            self.arg_parser(self._db).error("--force can only be used with --blocking.")
 
     @classmethod
     def arg_parser(cls, _db: Session) -> argparse.ArgumentParser:
@@ -64,6 +71,13 @@ class RebuildSearchIndexScript(Script):
             "--delete",
             action="store_true",
             help="Delete the search index before rebuilding.",
+        )
+        parser.add_argument(
+            "-f",
+            "--force",
+            action="store_true",
+            help="Take the reindex lock from whatever is holding it, stopping a running "
+            "reindex at its next batch. Only valid with --blocking.",
         )
         parser.add_argument(
             "--batch-size",
@@ -101,7 +115,9 @@ class RebuildSearchIndexScript(Script):
 
         We take the task's own lock so the scheduled reindex can't run against the index
         at the same time, and extend it every batch, since nothing else will while we
-        hold it.
+        hold it. That means a reindex already running holds us off, which is the wrong
+        way round when a manager is down and the running reindex is the days-long one
+        we are trying to get ahead of: --force takes the lock from it instead.
 
         Each batch ends its transaction, so a pass that runs for hours doesn't hold one
         snapshot open for all of it and keep autovacuum off the tables the rest of the
@@ -113,6 +129,8 @@ class RebuildSearchIndexScript(Script):
         lock = TaskLock(
             redis_client=self.services.redis.client(), lock_name="search_reindex"
         )
+        if self.force:
+            self.take_lock(lock)
         with lock.lock():
             offset = 0
             indexed = 0
@@ -138,3 +156,20 @@ class RebuildSearchIndexScript(Script):
 
             revision = self.services.search.revision_directory().highest()
             advance_read_pointer(self.log, service, revision, target_index)
+
+    def take_lock(self, lock: TaskLock) -> None:
+        """
+        Take the reindex lock away from a reindex that is already running.
+
+        The running reindex is not interrupted. It takes the lock once per batch, so it
+        stops when it comes back for the next one, and until then it is indexing the same
+        works into the same index as this rebuild - wasteful, but not harmful, since both
+        are writing the same documents.
+        """
+        held_by = lock.acquire_force()
+        if held_by is None:
+            self.log.info(f"Nothing was holding {lock.key}.")
+        else:
+            self.log.warning(
+                f"Took {lock.key} from {held_by}, which will stop at its next batch."
+            )

--- a/src/palace/manager/scripts/search.py
+++ b/src/palace/manager/scripts/search.py
@@ -135,24 +135,6 @@ class RebuildSearchIndexScript(Script):
     def rebuild_locally(self) -> None:
         """
         Index every presentation-ready work here, rather than in a Celery worker.
-
-        `search_reindex` requeues itself once per batch, so its throughput is set by how
-        long a trip through the `default` queue takes rather than by how long indexing
-        takes. On a manager whose queue carries a backlog that is minutes per batch, a
-        full pass can run for days. Doing the same work in one process costs a couple of
-        hours instead, at the price of tying up whoever ran the script.
-
-        We take the task's own lock so the scheduled reindex can't run against the index
-        at the same time, and extend it every batch, since nothing else will while we
-        hold it. --delete happens under that lock too, so a rebuild that cannot get the
-        lock leaves the index alone rather than emptying it and then stopping. That
-        means a reindex already running holds us off, which is the wrong way round when
-        a manager is down and the running reindex is the days-long one we are trying to
-        get ahead of: --force takes the lock from it instead.
-
-        Each batch ends its transaction, so a pass that runs for hours doesn't hold one
-        snapshot open for all of it and keep autovacuum off the tables the rest of the
-        application is writing to.
         """
         service = self.services.search.service()
         target_index = resolve_target_index(service)

--- a/src/palace/manager/service/redis/models/lock.py
+++ b/src/palace/manager/service/redis/models/lock.py
@@ -256,10 +256,7 @@ class TaskLock(RedisLock):
 
     `task` may be omitted, as long as `lock_name` and `redis_client` are given, so that
     code outside Celery can contend for the same lock as a task. That is for callers
-    doing a task's work themselves rather than merely touching the same resource - a
-    script reindexing in process, say - which need to hold off the scheduled task while
-    they do it. Those are the only two shapes: with a task, everything else can be
-    inferred; without one, both of the things it stands in for have to be supplied.
+    doing a task's work themselves rather than merely touching the same resource.
     """
 
     @overload

--- a/src/palace/manager/service/redis/models/lock.py
+++ b/src/palace/manager/service/redis/models/lock.py
@@ -5,7 +5,7 @@ from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from datetime import timedelta
 from functools import cached_property
-from typing import cast
+from typing import cast, overload
 from uuid import uuid4
 
 from palace.util.exceptions import BasePalaceException
@@ -258,8 +258,29 @@ class TaskLock(RedisLock):
     code outside Celery can contend for the same lock as a task. That is for callers
     doing a task's work themselves rather than merely touching the same resource - a
     script reindexing in process, say - which need to hold off the scheduled task while
-    they do it.
+    they do it. Those are the only two shapes: with a task, everything else can be
+    inferred; without one, both of the things it stands in for have to be supplied.
     """
+
+    @overload
+    def __init__(
+        self,
+        task: Task,
+        redis_client: Redis | None = None,
+        lock_name: str | None = None,
+        lock_timeout: timedelta | None = timedelta(minutes=5),
+        retry_delay: float = 0.2,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        redis_client: Redis,
+        lock_name: str,
+        lock_timeout: timedelta | None = timedelta(minutes=5),
+        retry_delay: float = 0.2,
+    ): ...
 
     def __init__(
         self,

--- a/src/palace/manager/service/redis/models/lock.py
+++ b/src/palace/manager/service/redis/models/lock.py
@@ -266,10 +266,10 @@ class TaskLock(RedisLock):
     def __init__(
         self,
         task: Task,
-        redis_client: Redis | None = None,
-        lock_name: str | None = None,
-        lock_timeout: timedelta | None = timedelta(minutes=5),
-        retry_delay: float = 0.2,
+        redis_client: Redis | None = ...,
+        lock_name: str | None = ...,
+        lock_timeout: timedelta | None = ...,
+        retry_delay: float = ...,
     ): ...
 
     @overload
@@ -278,8 +278,8 @@ class TaskLock(RedisLock):
         *,
         redis_client: Redis,
         lock_name: str,
-        lock_timeout: timedelta | None = timedelta(minutes=5),
-        retry_delay: float = 0.2,
+        lock_timeout: timedelta | None = ...,
+        retry_delay: float = ...,
     ): ...
 
     def __init__(

--- a/src/palace/manager/service/redis/models/lock.py
+++ b/src/palace/manager/service/redis/models/lock.py
@@ -233,23 +233,37 @@ class RedisLock(BaseRedisLock):
 
 
 class TaskLock(RedisLock):
+    """
+    The lock a task takes to keep a second copy of itself from running.
+
+    `task` may be omitted, as long as `lock_name` and `redis_client` are given, so that
+    code outside Celery can contend for the same lock as a task. That is for callers
+    doing a task's work themselves rather than merely touching the same resource - a
+    script reindexing in process, say - which need to hold off the scheduled task while
+    they do it.
+    """
+
     def __init__(
         self,
-        task: Task,
+        task: Task | None = None,
         redis_client: Redis | None = None,
         lock_name: str | None = None,
         lock_timeout: timedelta | None = timedelta(minutes=5),
         retry_delay: float = 0.2,
     ):
-        random_value = task.request.root_id or task.request.id
+        random_value = (task.request.root_id or task.request.id) if task else None
         if lock_name is None:
-            if task.name is None:
+            if task is None or task.name is None:
                 raise LockValueError(
-                    "Task.name must not be None if lock_name is not provided."
+                    "Task with a name must be provided if lock_name is not provided."
                 )
             name = ["Task", task.name]
         else:
             name = [lock_name]
         if redis_client is None:
+            if task is None:
+                raise LockValueError(
+                    "redis_client must be provided if task is not provided."
+                )
             redis_client = task.services.redis.client()
         super().__init__(redis_client, name, random_value, lock_timeout, retry_delay)

--- a/src/palace/manager/service/redis/models/lock.py
+++ b/src/palace/manager/service/redis/models/lock.py
@@ -188,6 +188,24 @@ class RedisLock(BaseRedisLock):
 
         return previous_value is None or previous_value == self._random_value
 
+    def acquire_force(self) -> str | None:
+        """
+        Take the lock, whether or not anything else is holding it.
+
+        Nothing tells the previous holder. It finds out the next time it tries to take
+        or extend the lock, so a holder that takes the lock once per unit of work carries
+        on until the end of the one it is doing, and both it and the caller are working
+        until then.
+
+        :return: What the previous holder had stored, or None if the lock was free.
+        """
+        return cast(
+            str | None,
+            self._redis_client.set(
+                self.key, self._random_value, px=self._lock_timeout, get=True
+            ),
+        )
+
     def acquire_blocking(self, timeout: float | int = -1) -> bool:
         """
         Acquire the lock. Blocks until the lock is acquired or the timeout is reached.

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -47,6 +47,16 @@ class TestRebuildSearchIndexScript:
         services_fixture.search_index.clear_search_documents.assert_called_once_with()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
 
+    def test_force_requires_blocking(
+        self,
+        db: DatabaseTransactionFixture,
+        services_fixture: ServicesFixture,
+    ):
+        # A queued rebuild has no lock of its own to take, so --force without --blocking
+        # would do nothing at all.
+        with pytest.raises(SystemExit):
+            RebuildSearchIndexScript(db.session, cmd_args=["--force"])
+
     @pytest.mark.parametrize("batch_size", ["0", "-1"])
     def test_batch_size_must_be_at_least_one(
         self,
@@ -162,6 +172,28 @@ class TestRebuildSearchIndexScript:
                 service.base_revision_name
             )
         )
+
+    def test_do_run_blocking_force_takes_the_lock_from_a_running_reindex(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        end_to_end_search_fixture: EndToEndSearchFixture,
+    ):
+        # When the running reindex is the days-long one we are trying to get ahead of,
+        # waiting for it is the wrong answer: --force takes the lock and rebuilds now.
+        work = db.work(with_open_access_download=True)
+        lock = TaskLock(redis_client=redis_fixture.client, lock_name="search_reindex")
+        assert lock.acquire() is True
+
+        RebuildSearchIndexScript(
+            db.session, cmd_args=["--blocking", "--force"]
+        ).do_run()
+
+        # The rebuild ran, and the reindex it took the lock from is not holding it any
+        # more, so it stops when it comes back for its next batch.
+        assert lock.extend_timeout() is False
+        end_to_end_search_fixture.external_search.write_client.indices.refresh()
+        end_to_end_search_fixture.expect_results([work], "", ordered=False)
 
     def test_do_run_blocking_takes_the_reindex_lock(
         self,

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -42,12 +42,41 @@ class TestRebuildSearchIndexScript:
         self,
         mock_search_reindex: MagicMock,
         db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
         services_fixture: ServicesFixture,
     ):
         # If we are called with the --delete argument, we clear the index before rebuilding.
         RebuildSearchIndexScript(db.session, cmd_args=["--delete"]).do_run()
         services_fixture.search_index.clear_search_documents.assert_called_once_with()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
+
+        # The lock is given back before the task is queued, since the task has to take it.
+        lock = TaskLock(redis_client=redis_fixture.client, lock_name="search_reindex")
+        assert lock.locked() is False
+
+    @pytest.mark.parametrize("blocking", [[], ["--blocking"]])
+    @patch("palace.manager.scripts.search.search_reindex")
+    def test_do_run_delete_leaves_the_index_alone_when_the_lock_is_held(
+        self,
+        mock_search_reindex: MagicMock,
+        blocking: list[str],
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        services_fixture: ServicesFixture,
+    ):
+        # Emptying the index under a running reindex would leave reads served from an
+        # empty index until that reindex finished refilling it, which is days away on the
+        # managers this script is for. Both ways of running it wait for the lock instead.
+        lock = TaskLock(redis_client=redis_fixture.client, lock_name="search_reindex")
+        assert lock.acquire() is True
+
+        with pytest.raises(LockNotAcquired):
+            RebuildSearchIndexScript(
+                db.session, cmd_args=["--delete", *blocking]
+            ).do_run()
+
+        services_fixture.search_index.clear_search_documents.assert_not_called()
+        mock_search_reindex.s.return_value.delay.assert_not_called()
 
     def test_force_requires_blocking(
         self,

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -5,9 +5,11 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from opensearchpy import OpenSearchException
 from sqlalchemy.orm import Session
 
 from palace.manager.scripts.search import RebuildSearchIndexScript
+from palace.manager.search.external_search import ExternalSearchIndex
 from palace.manager.service.redis.models.lock import (
     LockError,
     LockNotAcquired,
@@ -212,6 +214,50 @@ class TestRebuildSearchIndexScript:
 
         lock.release()
         script.do_run()
+
+    @patch("palace.manager.scripts.search.exponential_backoff")
+    def test_do_run_blocking_retries_a_failed_batch(
+        self,
+        mock_backoff: MagicMock,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        end_to_end_search_fixture: EndToEndSearchFixture,
+    ):
+        # A rebuild has no offset to resume from, so a transient search failure would
+        # cost the whole pass rather than the one batch it landed in.
+        mock_backoff.return_value = 0
+        work = db.work(with_open_access_download=True)
+
+        with patch.object(
+            ExternalSearchIndex, "add_documents", autospec=True
+        ) as add_documents:
+            # Rejected documents and a failed request are both worth another go.
+            add_documents.side_effect = [[work.id], OpenSearchException(), None]
+            RebuildSearchIndexScript(db.session, cmd_args=["--blocking"]).do_run()
+
+        assert add_documents.call_count == 3
+
+    @patch("palace.manager.scripts.search.exponential_backoff")
+    def test_do_run_blocking_gives_up_on_a_batch_that_keeps_failing(
+        self,
+        mock_backoff: MagicMock,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        end_to_end_search_fixture: EndToEndSearchFixture,
+    ):
+        # A search that is down rather than blipping ends the rebuild, with the failure
+        # it ended on rather than one of our own.
+        mock_backoff.return_value = 0
+        db.work(with_open_access_download=True)
+
+        with patch.object(
+            ExternalSearchIndex, "add_documents", autospec=True
+        ) as add_documents:
+            add_documents.side_effect = OpenSearchException()
+            with pytest.raises(OpenSearchException):
+                RebuildSearchIndexScript(db.session, cmd_args=["--blocking"]).do_run()
+
+        assert add_documents.call_count == 5
 
     def test_do_run_blocking_stops_if_it_loses_the_lock(
         self,

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -39,6 +39,20 @@ class TestRebuildSearchIndexScript:
         services_fixture.search_index.clear_search_documents.assert_called_once_with()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
 
+    @pytest.mark.parametrize("batch_size", ["0", "-1"])
+    def test_batch_size_must_be_at_least_one(
+        self,
+        batch_size: str,
+        db: DatabaseTransactionFixture,
+        services_fixture: ServicesFixture,
+    ):
+        # An empty batch never reaches the short batch that stops a rebuild, so both the
+        # blocking loop and the requeued task would page forever holding the lock.
+        with pytest.raises(SystemExit):
+            RebuildSearchIndexScript(
+                db.session, cmd_args=[f"--batch-size={batch_size}"]
+            )
+
     @pytest.mark.parametrize("batch_size", ["2", "3", "500"])
     def test_do_run_blocking(
         self,

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from palace.manager.scripts.search import RebuildSearchIndexScript
+from palace.manager.service.redis.models.lock import LockNotAcquired, TaskLock
 from tests.fixtures.database import DatabaseTransactionFixture
+from tests.fixtures.redis import RedisFixture
+from tests.fixtures.search import EndToEndSearchFixture
 from tests.fixtures.services import ServicesFixture
 
 
@@ -18,16 +23,9 @@ class TestRebuildSearchIndexScript:
         # If we are called with no arguments, we default to asynchronously rebuilding the search index.
         RebuildSearchIndexScript(db.session, cmd_args=[]).do_run()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
+        mock_search_reindex.s.assert_called_once_with(batch_size=500)
         # But we don't delete the index before rebuilding.
         services_fixture.search_index.clear_search_documents.assert_not_called()
-
-    @patch("palace.manager.scripts.search.search_reindex")
-    def test_do_run_blocking(
-        self, mock_search_reindex: MagicMock, db: DatabaseTransactionFixture
-    ):
-        # If we are called with the --blocking argument, we rebuild the search index synchronously.
-        RebuildSearchIndexScript(db.session, cmd_args=["--blocking"]).do_run()
-        mock_search_reindex.s.return_value.assert_called_once_with()
 
     @patch("palace.manager.scripts.search.search_reindex")
     def test_do_run_delete(
@@ -40,3 +38,54 @@ class TestRebuildSearchIndexScript:
         RebuildSearchIndexScript(db.session, cmd_args=["--delete"]).do_run()
         services_fixture.search_index.clear_search_documents.assert_called_once_with()
         mock_search_reindex.s.return_value.delay.assert_called_once_with()
+
+    @pytest.mark.parametrize("batch_size", ["2", "3", "500"])
+    def test_do_run_blocking(
+        self,
+        batch_size: str,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        end_to_end_search_fixture: EndToEndSearchFixture,
+    ):
+        # --blocking indexes everything in this process, rather than handing any of it
+        # to Celery. The batch size is varied to exercise pagination, including the case
+        # where a single batch covers every work.
+        work1 = db.work(with_open_access_download=True)
+        work2 = db.work(with_open_access_download=True)
+        db.work(with_open_access_download=False)
+        work4 = db.work(with_open_access_download=True)
+
+        client = end_to_end_search_fixture.external_search.write_client
+        client.indices.refresh()
+        end_to_end_search_fixture.expect_results([], "")
+
+        with patch("palace.manager.scripts.search.search_reindex") as mock_reindex:
+            RebuildSearchIndexScript(
+                db.session, cmd_args=["--blocking", "--batch-size", batch_size]
+            ).do_run()
+
+        # Nothing was queued.
+        mock_reindex.s.assert_not_called()
+
+        client.indices.refresh()
+        end_to_end_search_fixture.expect_results(
+            [work1, work2, work4], "", ordered=False
+        )
+
+    def test_do_run_blocking_takes_the_reindex_lock(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        end_to_end_search_fixture: EndToEndSearchFixture,
+    ):
+        # A blocking rebuild contends for the same lock as search_reindex, so it cannot
+        # run alongside the scheduled reindex.
+        lock = TaskLock(redis_client=redis_fixture.client, lock_name="search_reindex")
+        lock.acquire()
+
+        script = RebuildSearchIndexScript(db.session, cmd_args=["--blocking"])
+        with pytest.raises(LockNotAcquired):
+            script.do_run()
+
+        lock.release()
+        script.do_run()

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from palace.manager.scripts.search import RebuildSearchIndexScript
-from palace.manager.service.redis.models.lock import LockNotAcquired, TaskLock
+from palace.manager.service.redis.models.lock import (
+    LockError,
+    LockNotAcquired,
+    TaskLock,
+)
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.redis import RedisFixture
 from tests.fixtures.search import EndToEndSearchFixture
@@ -86,6 +90,40 @@ class TestRebuildSearchIndexScript:
             [work1, work2, work4], "", ordered=False
         )
 
+    def test_do_run_blocking_advances_the_read_pointer(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        end_to_end_search_fixture: EndToEndSearchFixture,
+    ):
+        # Having filled the index end to end, a blocking rebuild publishes it for reads,
+        # which is what makes it a repair for a manager whose reads are stuck on an
+        # older index.
+        service = end_to_end_search_fixture.external_search.service
+        client = end_to_end_search_fixture.external_search.write_client
+        db.work(with_open_access_download=True)
+
+        # Take the read pointer away, so reads are being served from nothing at all.
+        client.indices.update_aliases(
+            body={
+                "actions": [
+                    {"remove": {"index": "*", "alias": service.read_pointer_name()}}
+                ]
+            }
+        )
+        assert service.read_pointer() is None
+
+        RebuildSearchIndexScript(db.session, cmd_args=["--blocking"]).do_run()
+
+        read_pointer = service.read_pointer()
+        assert read_pointer is not None
+        assert (
+            read_pointer.index
+            == end_to_end_search_fixture.external_search.revision.name_for_index(
+                service.base_revision_name
+            )
+        )
+
     def test_do_run_blocking_takes_the_reindex_lock(
         self,
         db: DatabaseTransactionFixture,
@@ -103,3 +141,19 @@ class TestRebuildSearchIndexScript:
 
         lock.release()
         script.do_run()
+
+    def test_do_run_blocking_stops_if_it_loses_the_lock(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        end_to_end_search_fixture: EndToEndSearchFixture,
+    ):
+        # Once the lock is gone the scheduled reindex is free to start against the same
+        # index, so a rebuild that can no longer extend it stops rather than carry on
+        # indexing and publishing beside it.
+        db.work(with_open_access_download=True)
+        script = RebuildSearchIndexScript(db.session, cmd_args=["--blocking"])
+
+        with patch.object(TaskLock, "extend_timeout", return_value=False):
+            with pytest.raises(LockError, match="Lost the"):
+                script.do_run()

--- a/tests/manager/scripts/test_search.py
+++ b/tests/manager/scripts/test_search.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from sqlalchemy.orm import Session
 
 from palace.manager.scripts.search import RebuildSearchIndexScript
 from palace.manager.service.redis.models.lock import (
@@ -10,6 +13,7 @@ from palace.manager.service.redis.models.lock import (
     LockNotAcquired,
     TaskLock,
 )
+from palace.manager.sqlalchemy.model.work import Work
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.redis import RedisFixture
 from tests.fixtures.search import EndToEndSearchFixture
@@ -88,6 +92,41 @@ class TestRebuildSearchIndexScript:
         client.indices.refresh()
         end_to_end_search_fixture.expect_results(
             [work1, work2, work4], "", ordered=False
+        )
+
+    def test_do_run_blocking_indexes_the_works_after_one_that_cannot_be_indexed(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        end_to_end_search_fixture: EndToEndSearchFixture,
+    ):
+        # Work.to_search_documents drops a work whose document it cannot build, so a full
+        # batch of works arrives as a short batch of documents. The rebuild pages by the
+        # works it asked for, so it carries on to the works after the dropped one.
+        works = [db.work(with_open_access_download=True) for _ in range(4)]
+
+        to_search_documents = Work.to_search_documents
+        dropped: list[int] = []
+
+        def drop_one_document(
+            session: Session, work_ids: Sequence[int]
+        ) -> Sequence[dict[str, Any]]:
+            documents = to_search_documents(session, work_ids)
+            if not dropped and documents:
+                dropped.append(documents[0]["_id"])
+                return documents[1:]
+            return documents
+
+        # The document is lost from the first batch, so it cannot be the last one.
+        with patch.object(Work, "to_search_documents", drop_one_document):
+            RebuildSearchIndexScript(
+                db.session, cmd_args=["--blocking", "--batch-size", "2"]
+            ).do_run()
+
+        assert len(dropped) == 1
+        end_to_end_search_fixture.external_search.write_client.indices.refresh()
+        end_to_end_search_fixture.expect_results(
+            [work for work in works if work.id != dropped[0]], "", ordered=False
         )
 
     def test_do_run_blocking_advances_the_read_pointer(

--- a/tests/manager/service/redis/models/test_lock.py
+++ b/tests/manager/service/redis/models/test_lock.py
@@ -220,3 +220,25 @@ class TestTaskLock:
             mock_task, lock_name="test_lock", redis_client=redis_fixture.client
         )
         assert task_lock.key.endswith("::TaskLock::test_lock")
+
+    def test___init___without_task(self, redis_fixture: RedisFixture):
+        # A caller outside Celery can contend for a task's lock, as long as it supplies
+        # the two things the task would otherwise have provided.
+        task_lock = TaskLock(lock_name="test_lock", redis_client=redis_fixture.client)
+        assert task_lock.key.endswith("::TaskLock::test_lock")
+
+        # It gets the same key a task holding the same lock would, so the two contend.
+        mock_task = create_autospec(Task)
+        mock_task.name = "test_task"
+        assert (
+            TaskLock(
+                mock_task, lock_name="test_lock", redis_client=redis_fixture.client
+            ).key
+            == task_lock.key
+        )
+
+        # Without a task there is no name to fall back on, and no client to borrow.
+        with pytest.raises(LockValueError):
+            TaskLock(redis_client=redis_fixture.client)
+        with pytest.raises(LockValueError):
+            TaskLock(lock_name="test_lock")

--- a/tests/manager/service/redis/models/test_lock.py
+++ b/tests/manager/service/redis/models/test_lock.py
@@ -63,6 +63,25 @@ class TestRedisLock:
         assert not redis_lock_fixture.lock.acquire_blocking(timeout=0.1)
         assert redis_lock_fixture.lock.acquire_blocking(timeout=2)
 
+    def test_acquire_force(
+        self, redis_lock_fixture: RedisLockFixture, redis_fixture: RedisFixture
+    ):
+        # Taking a lock nothing holds reports that nothing held it.
+        assert redis_lock_fixture.lock.acquire_force() is None
+        assert redis_lock_fixture.lock.locked(by_us=True) is True
+
+        # Taking a lock someone else holds reports what they had stored, and hands the
+        # lock to us, timeout and all.
+        held_by = redis_lock_fixture.other_lock.acquire_force()
+        assert held_by == redis_lock_fixture.lock._random_value
+        assert redis_lock_fixture.other_lock.locked(by_us=True) is True
+        assert redis_fixture.client.ttl(redis_lock_fixture.other_lock.key) > 0
+
+        # The previous holder is not told, but it finds out: it can no longer extend the
+        # lock, or take it back, until we are done with it.
+        assert redis_lock_fixture.lock.extend_timeout() is False
+        assert redis_lock_fixture.lock.acquire() is False
+
     def test_release(
         self, redis_lock_fixture: RedisLockFixture, redis_fixture: RedisFixture
     ):

--- a/tests/manager/service/redis/models/test_lock.py
+++ b/tests/manager/service/redis/models/test_lock.py
@@ -256,8 +256,10 @@ class TestTaskLock:
             == task_lock.key
         )
 
-        # Without a task there is no name to fall back on, and no client to borrow.
+        # Without a task there is no name to fall back on, and no client to borrow. Both
+        # of these are rejected by the overloads too, hence the ignores: the checks are
+        # here for callers the type checker doesn't see.
         with pytest.raises(LockValueError):
-            TaskLock(redis_client=redis_fixture.client)
+            TaskLock(redis_client=redis_fixture.client)  # type: ignore[call-overload]
         with pytest.raises(LockValueError):
-            TaskLock(lock_name="test_lock")
+            TaskLock(lock_name="test_lock")  # type: ignore[call-overload]


### PR DESCRIPTION
> **Stacked on #3621** — Review that one first.

## Description

Gives `RebuildSearchIndexScript --blocking` its own batching loop, so it indexes everything in the calling process instead of handing the work to Celery.

- `--blocking` pages over `get_presentation_ready_work_ids`, building the documents and calling `add_documents_to_index` itself. Like the task, it pages by the works it asked for rather than the documents it managed to build, so a work `Work.to_search_documents` drops cannot end the pass early.
- A batch that fails to index is retried, with the attempts and the backoff the task uses. Losing a batch to a transient search failure costs the task one requeue; it would cost the rebuild everything, since there is no offset to resume from and a blip two hours in would send it back to the first work.
- It takes `search_reindex`'s own Redis lock for the duration, extending it each batch, so the scheduled reindex cannot run against the index at the same time. `TaskLock` grows an optional `task` argument to make that possible — callers outside Celery can now contend for the same key, as long as they supply `lock_name` and `redis_client`, and its two call shapes are declared as `@overload`s so that optionality doesn't cost the static check that one or the other was supplied. If an extension ever fails the rebuild stops, rather than carry on indexing and publishing beside whatever took the lock next.
- **`--delete` now waits for that lock too, on both paths.** It used to empty the index before anything took the lock, so a rebuild that then couldn't get the lock had already cleared it, and a reindex that was running had the index pulled out from under it — leaving reads on an empty index until the queued pass refilled it, which on these managers is days. `bin/repair/search_index --delete` will now fail with `LockNotAcquired` while a reindex is running, rather than clearing the index anyway. The queued path gives the lock back before queueing, since the task it queues has to take it.
- New `--force`, for when the reindex holding the lock is the days-long pass we are running the rebuild to get ahead of. `RedisLock.acquire_force` takes the key over atomically and logs what was holding it. The running reindex is not interrupted: it takes the lock once a batch, so it stops when it comes back for the next one, and until then it is indexing the same works into the same index we are. It is an error to ask for `--force` without `--blocking`, since the queued path has no lock of its own to take.
- On completing a pass it advances the read pointer by calling `advance_read_pointer`, so it publishes under exactly the conditions the task uses.
- New `--batch-size`, which a local run wants for tuning. It has to be at least 1: a batch of zero pages forever, in the loop here *and* in the task's requeue, holding the reindex lock the whole time.
- Each batch ends its transaction, so a pass that runs for hours doesn't hold one snapshot open for all of it and keep autovacuum off the tables the rest of the application is writing to. The task gets this for free by taking a session per batch; the script has one session, so it commits.

## Motivation and Context

JIRA: PP-4908

`--blocking` did not really block and run in the local process as expected. It called the task signature directly, which runs the task body in-process but `raise task.replace(...)`, still queues the next round into celery. So `--blocking` indexed the first batch locally, published the second to the broker.

That left no way to reindex a manager without going through the queue — which matters because **the task's throughput is set by queue latency, not by indexing**. Measured on `nj-newjersey`: a batch is ~4.6s of work (3.4s building documents, 1.1s indexing), but the next batch lands a median of **328 seconds** later, because the `default` queue carries a persistent ~120-deep backlog. A full pass there needs 1,343 batches.

| | per batch | full pass (nj-newjersey) |
|---|---|---|
| via the queue | ~328s | **4–5 days** |
| in process | ~6s | **~2 hours** |

This backlog is its own issue I want to fix, but I think having a script can run off-queue is also important, as a backup in case this situation arises in the future.

## How Has This Been Tested?

- Added a number of new tests.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

