### PR TITLE
Reap Overdrive collections by set difference instead of per-title polling (PP-4908)

### DIFF
--- a/src/palace/manager/celery/importer.py
+++ b/src/palace/manager/celery/importer.py
@@ -73,6 +73,17 @@ def import_workflow_lock(
     )
 
 
+def reap_key(collection_id: int, *additional: str) -> list[str]:
+    """
+    Generate a Redis key for a reap run's identifier set.
+    """
+    return [
+        "ReapCollection",
+        Collection.redis_key_from_id(collection_id),
+        *additional,
+    ]
+
+
 def reap_workflow_key(collection_id: int) -> list[str]:
     """
     Generate a Redis key for the reap workflow-level lock for the given collection.

--- a/src/palace/manager/celery/tasks/identifiers.py
+++ b/src/palace/manager/celery/tasks/identifiers.py
@@ -200,11 +200,26 @@ def mark_identifiers_unavailable(
 
     try:
         if not existing_identifiers.exists():
-            # Logged as an error because this discards a completed run: the active-side
-            # task did its work and there is now nothing to compare it against.
-            task.log.error(
-                "Existing identifiers set does not exist in Redis. No identifiers to mark as unavailable."
-            )
+            # An empty set is never materialised in Redis, so this is either a
+            # collection with nothing available to reap -- normal, and marking nothing
+            # is the right outcome -- or a set that expired before the other half of
+            # the chord finished, which throws away a completed run. Only the second
+            # is worth waking anyone up for.
+            with task.session() as session:
+                collection_has_identifiers = (
+                    session.execute(
+                        available_identifiers_query(collection_id).limit(1)
+                    ).first()
+                    is not None
+                )
+            message = "Existing identifiers set does not exist in Redis. No identifiers to mark as unavailable."
+            if collection_has_identifiers:
+                task.log.error(
+                    f"{message} The collection does have available identifiers, so a "
+                    f"completed run has been discarded."
+                )
+            else:
+                task.log.info(f"{message} The collection has none to mark.")
             return False
 
         if not active_identifiers.exists():

--- a/src/palace/manager/celery/tasks/identifiers.py
+++ b/src/palace/manager/celery/tasks/identifiers.py
@@ -227,8 +227,11 @@ def mark_identifiers_unavailable(
             # An empty set is never materialised in Redis, so this is either a
             # collection with nothing available to reap -- normal, and marking nothing
             # is the right outcome -- or a set that expired before the other half of
-            # the chord finished, which throws away a completed run. Only the second
-            # is worth waking anyone up for.
+            # the chord finished, which throws away a completed run. The database
+            # check below cannot tell those apart precisely: it runs when the chord
+            # body fires, which for a long crawl is hours after the set was (or was
+            # not) built, and a collection that was empty at the start may have
+            # gained identifiers from imports in between.
             with task.session() as session:
                 collection_has_identifiers = (
                     session.execute(
@@ -238,9 +241,10 @@ def mark_identifiers_unavailable(
                 )
             message = "Existing identifiers set does not exist in Redis. No identifiers to mark as unavailable."
             if collection_has_identifiers:
-                task.log.error(
-                    f"{message} The collection does have available identifiers, so a "
-                    f"completed run has been discarded."
+                task.log.warning(
+                    f"{message} The collection has available identifiers now, so "
+                    f"either a completed run outlived its set and was discarded, or "
+                    f"the collection gained identifiers while the run was underway."
                 )
             else:
                 task.log.info(f"{message} The collection has none to mark.")

--- a/src/palace/manager/celery/tasks/identifiers.py
+++ b/src/palace/manager/celery/tasks/identifiers.py
@@ -310,10 +310,13 @@ def create_mark_unavailable_chord(
 
     :return: A Celery chord signature that can be executed to perform the unavailable identifier marking process.
     """
-    # Both kwargs are omitted at their defaults so that the signatures a caller that
-    # wants neither produces still bind on a worker running the previous release. A
-    # rolling deploy has new code queueing work that old workers pick up, and a kwarg
-    # they have never heard of fails the whole reap rather than one page of it.
+    # Both kwargs are omitted at their defaults, so that a caller wanting neither
+    # produces signatures that still bind on a worker running the previous release: a
+    # rolling deploy has new code queueing work old workers pick up, and a kwarg they
+    # have never heard of fails the whole reap rather than one page of it. This covers
+    # the callers that pass neither, which is every OPDS reaper. A caller that wants
+    # one of them -- Overdrive wants both -- is exposed for the length of the deploy,
+    # though its chord body is queued hours later, when the crawl finishes.
     existing_identifiers_sig = existing_available_identifiers.s(
         collection_id,
         **({} if expire_time is None else {"expire_time": expire_time}),

--- a/src/palace/manager/celery/tasks/identifiers.py
+++ b/src/palace/manager/celery/tasks/identifiers.py
@@ -84,6 +84,7 @@ def mark_identifiers_unavailable(
     existing_and_active_identifier_sets: list[RedisSetKwargs | None],
     *,
     collection_id: int,
+    status: LicensePoolStatus = LicensePoolStatus.REMOVED,
 ) -> bool:
     """
     Takes a list of two RedisSetKwargs elements as the first positional argument. These are used to create
@@ -96,10 +97,14 @@ def mark_identifiers_unavailable(
 
     Any identifiers present in the existing set but not in the active set will be marked as unavailable in
     the collection. This is done by sending a circulation_apply task that creates CirculationData with
-    licenses_available and licenses_owned both set to 0, and status set to LicensePoolStatus.REMOVED.
+    licenses_available and licenses_owned both set to 0, and status set to `status`.
 
     This function is designed to be used as the body of a chord created by `create_mark_unavailable_chord`.
 
+    :param status: The status to record on the affected license pools. Defaults to
+        `LicensePoolStatus.REMOVED`, which revokes outstanding loans and holds. Distributors
+        whose feeds routinely drop titles that are merely out of circulation should pass
+        `LicensePoolStatus.EXHAUSTED` instead.
     :return: True if identifiers were successfully marked as unavailable, False if the operation was skipped.
     """
     redis_client = task.services.redis().client()
@@ -148,7 +153,7 @@ def mark_identifiers_unavailable(
             data_source_name=data_source_name,
             licenses_owned=0,
             licenses_available=0,
-            status=LicensePoolStatus.REMOVED,
+            status=status,
         )
         identifiers_to_mark = existing_identifiers - active_identifiers
         for identifier in identifiers_to_mark:
@@ -170,7 +175,10 @@ def mark_identifiers_unavailable(
 
 
 def create_mark_unavailable_chord(
-    collection_id: int, active_identifiers_sig: Signature
+    collection_id: int,
+    active_identifiers_sig: Signature,
+    *,
+    status: LicensePoolStatus = LicensePoolStatus.REMOVED,
 ) -> Signature:
     """
     Creates a Celery chord that identifies and marks as unavailable any identifiers that were not
@@ -190,11 +198,15 @@ def create_mark_unavailable_chord(
     :param active_identifiers_sig: A Celery signature that returns an IdentifierSet containing
         identifiers available in the distributor's feed. This task may requeue itself if needed, as
         long as it ultimately returns an IdentifierSet.
+    :param status: The status to record on the affected license pools. See
+        `mark_identifiers_unavailable`.
 
     :return: A Celery chord signature that can be executed to perform the unavailable identifier marking process.
     """
     existing_identifiers_sig = existing_available_identifiers.s(collection_id)
-    mark_identifiers_sig = mark_identifiers_unavailable.s(collection_id=collection_id)
+    mark_identifiers_sig = mark_identifiers_unavailable.s(
+        collection_id=collection_id, status=status
+    )
 
     chord_header = [existing_identifiers_sig, active_identifiers_sig]
 

--- a/src/palace/manager/celery/tasks/identifiers.py
+++ b/src/palace/manager/celery/tasks/identifiers.py
@@ -1,16 +1,21 @@
+from collections.abc import Iterable
 from functools import partial
+from logging import Logger
 
 from celery import shared_task
 from celery.canvas import Signature, chord
 from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import raiseload
+from sqlalchemy.sql import Select
 
 from palace.util.exceptions import PalaceValueError
+from palace.util.log import LoggerAdapterType
 
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks.apply import circulation_apply
 from palace.manager.celery.utils import load_from_id, validate_not_none
 from palace.manager.data_layer.circulation import CirculationData
+from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.redis.models.set import (
     IdentifierSet,
@@ -25,16 +30,86 @@ from palace.manager.sqlalchemy.model.licensing import (
 )
 
 
+def available_identifiers_query(collection_id: int) -> Select:
+    """
+    Select the identifiers in a collection whose license pools are currently available.
+
+    A pool is considered available if it is an UNLIMITED pool with ACTIVE status,
+    or a metered/aggregated pool with non-zero owned and available license counts.
+    UNLIMITED pools always have licenses_owned and licenses_available set to 0,
+    so they need to be matched on status instead.
+
+    Callers that only care about particular identifiers can narrow the returned
+    query further, which is how a distributor that reports its own removals checks
+    whether a title it has flagged is still available to us.
+
+    No relationships are loaded: callers want the identifiers themselves, and the
+    query is run over whole collections.
+    """
+    return (
+        select(Identifier)
+        .options(raiseload("*"))
+        .join(LicensePool)
+        .where(
+            LicensePool.collection_id == collection_id,
+            or_(
+                and_(
+                    LicensePool.type == LicensePoolType.UNLIMITED,
+                    LicensePool.status == LicensePoolStatus.ACTIVE,
+                ),
+                and_(
+                    LicensePool.type != LicensePoolType.UNLIMITED,
+                    LicensePool.licenses_available != 0,
+                    LicensePool.licenses_owned != 0,
+                ),
+            ),
+        )
+    )
+
+
+def queue_unavailable_updates(
+    identifiers: Iterable[IdentifierData],
+    *,
+    collection_id: int,
+    collection_name: str,
+    data_source_name: str,
+    status: LicensePoolStatus,
+    log: Logger | LoggerAdapterType,
+) -> int:
+    """
+    Queue a `circulation_apply` task for each identifier, zeroing out its licenses.
+
+    :param status: The status to record on the affected license pools.
+    :return: The number of tasks queued.
+    """
+    create_circulation_data = partial(
+        CirculationData,
+        data_source_name=data_source_name,
+        licenses_owned=0,
+        licenses_available=0,
+        status=status,
+    )
+    queued = 0
+    for identifier in identifiers:
+        log.info(
+            f"Marking identifier {identifier} as unavailable in collection "
+            f"{collection_name} ({collection_id})"
+        )
+        circulation_apply.delay(
+            circulation=create_circulation_data(primary_identifier_data=identifier),
+            collection_id=collection_id,
+        )
+        queued += 1
+    return queued
+
+
 @shared_task(queue=QueueNames.default, bind=True)
 def existing_available_identifiers(task: Task, collection_id: int) -> IdentifierSet:
     """
     Retrieves all identifiers in the specified collection whose license pools are
     currently available, returning them as a Redis IdentifierSet.
 
-    A pool is considered available if it is an UNLIMITED pool with ACTIVE status,
-    or a metered/aggregated pool with non-zero owned and available license counts.
-    UNLIMITED pools always have licenses_owned and licenses_available set to 0,
-    so they need to be matched on status instead.
+    See `available_identifiers_query` for what counts as available.
 
     This function is designed to be used as part of a chord operation that identifies and
     marks identifiers not present in a distributor's feed as unavailable.
@@ -47,25 +122,7 @@ def existing_available_identifiers(task: Task, collection_id: int) -> Identifier
 
     try:
         with task.session() as session:
-            identifiers_query = (
-                select(Identifier)
-                .join(LicensePool)
-                .where(
-                    LicensePool.collection_id == collection_id,
-                    or_(
-                        and_(
-                            LicensePool.type == LicensePoolType.UNLIMITED,
-                            LicensePool.status == LicensePoolStatus.ACTIVE,
-                        ),
-                        and_(
-                            LicensePool.type != LicensePoolType.UNLIMITED,
-                            LicensePool.licenses_available != 0,
-                            LicensePool.licenses_owned != 0,
-                        ),
-                    ),
-                )
-                .options(raiseload("*"))
-            )
+            identifiers_query = available_identifiers_query(collection_id)
 
             for identifiers in (
                 session.execute(identifiers_query).yield_per(100).scalars().partitions()
@@ -148,26 +205,16 @@ def mark_identifiers_unavailable(
             ).name
             collection_name = collection.name
 
-        create_circulation_data = partial(
-            CirculationData,
+        queued = queue_unavailable_updates(
+            existing_identifiers - active_identifiers,
+            collection_id=collection_id,
+            collection_name=collection_name,
             data_source_name=data_source_name,
-            licenses_owned=0,
-            licenses_available=0,
             status=status,
+            log=task.log,
         )
-        identifiers_to_mark = existing_identifiers - active_identifiers
-        for identifier in identifiers_to_mark:
-            task.log.info(
-                f"Marking identifier {identifier} as unavailable in collection {collection_name} ({collection_id})"
-            )
-            circulation_apply.delay(
-                circulation=create_circulation_data(primary_identifier_data=identifier),
-                collection_id=collection_id,
-            )
 
-        task.log.info(
-            f"Sent tasks to mark {len(identifiers_to_mark)} identifiers as unavailable"
-        )
+        task.log.info(f"Sent tasks to mark {queued} identifiers as unavailable")
         return True
     finally:
         existing_identifiers.delete()

--- a/src/palace/manager/celery/tasks/identifiers.py
+++ b/src/palace/manager/celery/tasks/identifiers.py
@@ -104,7 +104,9 @@ def queue_unavailable_updates(
 
 
 @shared_task(queue=QueueNames.default, bind=True)
-def existing_available_identifiers(task: Task, collection_id: int) -> IdentifierSet:
+def existing_available_identifiers(
+    task: Task, collection_id: int, *, expire_time: int | None = None
+) -> IdentifierSet:
     """
     Retrieves all identifiers in the specified collection whose license pools are
     currently available, returning them as a Redis IdentifierSet.
@@ -114,11 +116,23 @@ def existing_available_identifiers(task: Task, collection_id: int) -> Identifier
     This function is designed to be used as part of a chord operation that identifies and
     marks identifiers not present in a distributor's feed as unavailable.
 
+    :param expire_time: How long, in seconds, the set should outlive its creation.
+        This set is built once at the start of the chord and not touched again, so it
+        must outlast the other half of the chord however long that takes to run. The
+        default suits a feed that is walked in minutes; a distributor whose active-side
+        task runs for hours needs to say so.
+
     See: `create_mark_unavailable_chord`.
     """
 
     redis_client = task.services.redis().client()
-    identifier_set = IdentifierSet(redis_client, [task.name, task.request.id])
+    identifier_set = (
+        IdentifierSet(redis_client, [task.name, task.request.id])
+        if expire_time is None
+        else IdentifierSet(
+            redis_client, [task.name, task.request.id], expire_time=expire_time
+        )
+    )
 
     try:
         with task.session() as session:
@@ -186,7 +200,9 @@ def mark_identifiers_unavailable(
 
     try:
         if not existing_identifiers.exists():
-            task.log.warning(
+            # Logged as an error because this discards a completed run: the active-side
+            # task did its work and there is now nothing to compare it against.
+            task.log.error(
                 "Existing identifiers set does not exist in Redis. No identifiers to mark as unavailable."
             )
             return False
@@ -226,6 +242,7 @@ def create_mark_unavailable_chord(
     active_identifiers_sig: Signature,
     *,
     status: LicensePoolStatus = LicensePoolStatus.REMOVED,
+    expire_time: int | None = None,
 ) -> Signature:
     """
     Creates a Celery chord that identifies and marks as unavailable any identifiers that were not
@@ -247,10 +264,16 @@ def create_mark_unavailable_chord(
         long as it ultimately returns an IdentifierSet.
     :param status: The status to record on the affected license pools. See
         `mark_identifiers_unavailable`.
+    :param expire_time: How long, in seconds, the existing-identifier set should live.
+        The two halves of the chord start together but the existing side finishes
+        immediately, so this has to cover however long `active_identifiers_sig` runs
+        for. See `existing_available_identifiers`.
 
     :return: A Celery chord signature that can be executed to perform the unavailable identifier marking process.
     """
-    existing_identifiers_sig = existing_available_identifiers.s(collection_id)
+    existing_identifiers_sig = existing_available_identifiers.s(
+        collection_id, expire_time=expire_time
+    )
     mark_identifiers_sig = mark_identifiers_unavailable.s(
         collection_id=collection_id, status=status
     )

--- a/src/palace/manager/celery/tasks/identifiers.py
+++ b/src/palace/manager/celery/tasks/identifiers.py
@@ -67,6 +67,37 @@ def available_identifiers_query(collection_id: int) -> Select:
     )
 
 
+def held_identifiers_query(collection_id: int) -> Select:
+    """
+    Select the identifiers in a collection whose license pools still record copies.
+
+    Wider than `available_identifiers_query`, which additionally requires a copy to be
+    free to borrow. A metered pool whose copies are all checked out still says we hold
+    the title, and a distributor that reports its own removals has to be able to act on
+    one: a title can be withdrawn while every copy of it is out on loan.
+
+    No relationships are loaded, for the same reason as its sibling.
+    """
+    return (
+        select(Identifier)
+        .options(raiseload("*"))
+        .join(LicensePool)
+        .where(
+            LicensePool.collection_id == collection_id,
+            or_(
+                and_(
+                    LicensePool.type == LicensePoolType.UNLIMITED,
+                    LicensePool.status == LicensePoolStatus.ACTIVE,
+                ),
+                and_(
+                    LicensePool.type != LicensePoolType.UNLIMITED,
+                    LicensePool.licenses_owned != 0,
+                ),
+            ),
+        )
+    )
+
+
 def queue_unavailable_updates(
     identifiers: Iterable[IdentifierData],
     *,

--- a/src/palace/manager/celery/tasks/identifiers.py
+++ b/src/palace/manager/celery/tasks/identifiers.py
@@ -30,22 +30,27 @@ from palace.manager.sqlalchemy.model.licensing import (
 )
 
 
-def available_identifiers_query(collection_id: int) -> Select:
+def _identifiers_query(collection_id: int, *, borrowable: bool) -> Select:
     """
-    Select the identifiers in a collection whose license pools are currently available.
+    Select the identifiers in a collection whose license pools hold copies.
 
-    A pool is considered available if it is an UNLIMITED pool with ACTIVE status,
-    or a metered/aggregated pool with non-zero owned and available license counts.
-    UNLIMITED pools always have licenses_owned and licenses_available set to 0,
-    so they need to be matched on status instead.
-
-    Callers that only care about particular identifiers can narrow the returned
-    query further, which is how a distributor that reports its own removals checks
-    whether a title it has flagged is still available to us.
+    UNLIMITED pools always have licenses_owned and licenses_available set to 0, so
+    they are matched on status instead, and the distinction below does not apply to
+    them.
 
     No relationships are loaded: callers want the identifiers themselves, and the
     query is run over whole collections.
+
+    :param borrowable: Whether a metered pool must also have a copy free to borrow.
+        See the two callers below for why that distinction matters.
     """
+    metered = [
+        LicensePool.type != LicensePoolType.UNLIMITED,
+        LicensePool.licenses_owned != 0,
+    ]
+    if borrowable:
+        metered.append(LicensePool.licenses_available != 0)
+
     return (
         select(Identifier)
         .options(raiseload("*"))
@@ -57,14 +62,21 @@ def available_identifiers_query(collection_id: int) -> Select:
                     LicensePool.type == LicensePoolType.UNLIMITED,
                     LicensePool.status == LicensePoolStatus.ACTIVE,
                 ),
-                and_(
-                    LicensePool.type != LicensePoolType.UNLIMITED,
-                    LicensePool.licenses_available != 0,
-                    LicensePool.licenses_owned != 0,
-                ),
+                and_(*metered),
             ),
         )
     )
+
+
+def available_identifiers_query(collection_id: int) -> Select:
+    """
+    Select the identifiers in a collection that a patron could borrow right now.
+
+    This is the set a distributor's feed is compared against, so it is deliberately
+    the narrow one: a title with no copy free to borrow is already unavailable to
+    patrons, and marking it again would be a no-op.
+    """
+    return _identifiers_query(collection_id, borrowable=True)
 
 
 def held_identifiers_query(collection_id: int) -> Select:
@@ -75,27 +87,8 @@ def held_identifiers_query(collection_id: int) -> Select:
     free to borrow. A metered pool whose copies are all checked out still says we hold
     the title, and a distributor that reports its own removals has to be able to act on
     one: a title can be withdrawn while every copy of it is out on loan.
-
-    No relationships are loaded, for the same reason as its sibling.
     """
-    return (
-        select(Identifier)
-        .options(raiseload("*"))
-        .join(LicensePool)
-        .where(
-            LicensePool.collection_id == collection_id,
-            or_(
-                and_(
-                    LicensePool.type == LicensePoolType.UNLIMITED,
-                    LicensePool.status == LicensePoolStatus.ACTIVE,
-                ),
-                and_(
-                    LicensePool.type != LicensePoolType.UNLIMITED,
-                    LicensePool.licenses_owned != 0,
-                ),
-            ),
-        )
-    )
+    return _identifiers_query(collection_id, borrowable=False)
 
 
 def queue_unavailable_updates(
@@ -317,11 +310,17 @@ def create_mark_unavailable_chord(
 
     :return: A Celery chord signature that can be executed to perform the unavailable identifier marking process.
     """
+    # Both kwargs are omitted at their defaults so that the signatures a caller that
+    # wants neither produces still bind on a worker running the previous release. A
+    # rolling deploy has new code queueing work that old workers pick up, and a kwarg
+    # they have never heard of fails the whole reap rather than one page of it.
     existing_identifiers_sig = existing_available_identifiers.s(
-        collection_id, expire_time=expire_time
+        collection_id,
+        **({} if expire_time is None else {"expire_time": expire_time}),
     )
     mark_identifiers_sig = mark_identifiers_unavailable.s(
-        collection_id=collection_id, status=status
+        collection_id=collection_id,
+        **({} if status is LicensePoolStatus.REMOVED else {"status": status}),
     )
 
     chord_header = [existing_identifiers_sig, active_identifiers_sig]

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -3,7 +3,6 @@ from typing import Any, Literal, TypedDict, TypeGuard
 from uuid import uuid4
 
 from celery import chain, chord, group, shared_task
-from sqlalchemy import select
 
 from palace.util.datetime_helpers import utc_now
 
@@ -11,6 +10,7 @@ from palace.manager.celery.importer import (
     import_all as create_import_tasks,
     import_key,
     import_workflow_lock,
+    reap_key,
     reap_workflow_lock,
     workflow_lock_guard,
 )
@@ -25,8 +25,6 @@ from palace.manager.integration.license.overdrive.importer import OverdriveImpor
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.redis.models.set import IdentifierSet
 from palace.manager.sqlalchemy.model.collection import Collection
-from palace.manager.sqlalchemy.model.identifier import Identifier
-from palace.manager.sqlalchemy.model.licensing import LicensePool
 from palace.manager.util.http.exception import (
     BadResponseException,
     RemoteIntegrationException,
@@ -34,6 +32,13 @@ from palace.manager.util.http.exception import (
 )
 
 IMPORT_SKIPPED: str = "import_skipped"
+
+# How far a completed crawl may fall short of Overdrive's reported totalItems before
+# it is treated as incomplete. A crawl of a large collection runs for minutes while
+# titles are added and removed under it, so the count is expected to move a little;
+# the floor keeps small collections from being held to an unreachable standard.
+REAP_CRAWL_ALLOWANCE: float = 0.001
+REAP_CRAWL_ALLOWANCE_FLOOR: int = 10
 
 
 class ImportSkippedPayload(TypedDict):
@@ -469,7 +474,10 @@ def reap_all_collections(task: Task) -> None:
     Queue a reap task for every Overdrive collection.
 
     Includes both parent collections and Advantage (child) collections, since titles
-    can be removed from either independently.
+    can be removed from either independently. Each collection is reaped against its
+    own collection token, which is what keeps parent and Advantage collections
+    consistent: an Advantage token lists only the titles that account owns, exactly
+    the titles the importer wrote into that collection.
     """
     with task.session() as session:
         registry = task.services.integration_registry().license_providers()
@@ -478,7 +486,7 @@ def reap_all_collections(task: Task) -> None:
         )
         collections = session.scalars(collection_query).all()
     for collection in collections:
-        reap_collection.delay(collection.id)
+        OverdriveAPI.reap_task(collection.id).apply_async()
 
 
 @shared_task(
@@ -493,19 +501,36 @@ def reap_collection(
     task: Task,
     collection_id: int,
     *,
-    offset: int = 0,
-    batch_size: int = 50,
-) -> None:
+    page: str | None = None,
+    seen: int = 0,
+) -> IdentifierSet | None:
     """
-    Check for books that are in the local collection but have left our Overdrive collection.
+    Enumerate the titles an Overdrive collection currently holds.
 
-    Processes identifiers in batches, re-queuing itself via task.replace() until all
-    identifiers have been checked. Concurrency is governed by
+    Walks the collection's product list one page at a time, re-queuing itself via
+    ``task.replace()`` until the crawl is complete, and collects the identifiers into
+    a Redis set. Only ids are read -- no metadata or availability lookups -- so a
+    whole collection costs a handful of requests rather than one per title.
+
+    The returned set is the "active" half of
+    :func:`~palace.manager.celery.tasks.identifiers.create_mark_unavailable_chord`:
+    identifiers the collection holds locally but which are absent from this set have
+    left the Overdrive collection and are marked exhausted. Titles Overdrive still
+    lists but no longer owns are excluded by :meth:`OverdriveAPI.fetch_product_page`,
+    so they are reaped on the same footing.
+
+    Because reaping acts on the *absence* of an identifier, a partial crawl would
+    mark live titles as gone. The crawl is therefore checked against Overdrive's
+    ``totalItems`` before the set is handed on, and ``None`` is returned if it cannot
+    be shown to be complete -- which the chord body treats as a failed run and
+    aborts, marking nothing. Concurrency is governed by
     :func:`~palace.manager.celery.importer.workflow_lock_guard`.
 
     :param collection_id: The ID of the Overdrive collection to reap.
-    :param offset: The last Identifier.id processed; used to resume across batches.
-    :param batch_size: Number of identifiers to process per batch.
+    :param page: The product-list page to fetch, as a url. None starts a new crawl.
+    :param seen: Running count of products returned by previous pages.
+    :return: The identifiers the collection currently holds, or None if the crawl was
+        skipped, aborted, or could not be verified as complete.
     """
     with workflow_lock_guard(
         task,
@@ -514,54 +539,76 @@ def reap_collection(
         lock_factory=reap_workflow_lock,
     ) as proceed:
         if not proceed:
-            return
+            return None
 
-        new_offset = 0
-        processed_count = 0
-        collection_name = None
+        redis = task.services.redis().client()
+        identifier_set = IdentifierSet(redis, reap_key(collection_id, task.request.id))
 
         with task.transaction() as session:
             collection = load_from_id(session, Collection, collection_id)
             collection_name = collection.name
 
-            identifiers = (
-                session.execute(
-                    select(Identifier)
-                    .join(Identifier.licensed_through)
-                    .where(
-                        LicensePool.collection_id == collection_id,
-                        Identifier.id > offset,
-                    )
-                    .order_by(Identifier.id)
-                    .limit(batch_size)
+            if collection.marked_for_deletion:
+                task.log.warning(
+                    f"This collection is marked for deletion. "
+                    f"Skipping reap of '{collection_name}'."
                 )
-                .unique()
-                .scalars()
-                .all()
-            )
-
-            if not identifiers:
-                task.log.info(
-                    f"Overdrive reaper complete for collection '{collection_name}'."
-                )
-                return
+                identifier_set.delete()
+                return None
 
             api = OverdriveAPI(session, collection)
-            for identifier in identifiers:
-                api.update_licensepool(identifier.identifier)
+            endpoint = (
+                BookInfoEndpoint(page) if page else api.product_page_initial_endpoint()
+            )
+            result = api.fetch_product_page(endpoint)
 
-            new_offset = identifiers[-1].id
-            processed_count = len(identifiers)
+        identifier_set.add(*result.active)
+        seen += result.seen
+
+        if result.next_page is not None:
+            task.log.info(
+                f"Overdrive reaper crawling '{collection_name}': {seen} products seen "
+                f"of {result.total_items}."
+            )
+            raise task.replace(
+                signature_with(task, page=result.next_page.url, seen=seen)
+            )
+
+        if not _crawl_is_complete(task, collection_name, seen, result.total_items):
+            identifier_set.delete()
+            return None
 
         task.log.info(
-            f"Overdrive reaper: processed {processed_count} identifiers for "
-            f"collection '{collection_name}' (offset: {offset} -> {new_offset})."
+            f"Overdrive reaper crawl complete for collection '{collection_name}': "
+            f"{seen} products seen, {identifier_set.len()} still owned."
         )
+        return identifier_set
 
-        if processed_count == batch_size:
-            raise task.replace(
-                signature_with(
-                    task,
-                    offset=new_offset,
-                )
-            )
+
+def _crawl_is_complete(
+    task: Task, collection_name: str, seen: int, total_items: int | None
+) -> bool:
+    """Decide whether a finished crawl covered the whole collection.
+
+    A crawl runs for minutes against a collection that keeps changing underneath it,
+    so a small discrepancy against ``totalItems`` is expected -- titles added or
+    removed mid-crawl move the count. A large shortfall means pages were missed, and
+    reaping on that would mark live titles as gone.
+    """
+    if total_items is None:
+        task.log.error(
+            f"Overdrive reaper aborting for collection '{collection_name}': "
+            f"Overdrive did not report totalItems, so the crawl cannot be verified."
+        )
+        return False
+
+    allowance = max(REAP_CRAWL_ALLOWANCE_FLOOR, int(total_items * REAP_CRAWL_ALLOWANCE))
+    if seen + allowance < total_items:
+        task.log.error(
+            f"Overdrive reaper aborting for collection '{collection_name}': crawl saw "
+            f"{seen} products but Overdrive reports {total_items} "
+            f"(allowance {allowance}). Refusing to reap on an incomplete crawl."
+        )
+        return False
+
+    return True

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -513,7 +513,7 @@ def reap_collection(
     task: Task,
     collection_id: int,
     *,
-    page: str | None = None,
+    offset: int = 0,
     total_items: int | None = None,
 ) -> IdentifierSet | None:
     """
@@ -544,7 +544,9 @@ def reap_collection(
     governed by :func:`~palace.manager.celery.importer.workflow_lock_guard`.
 
     :param collection_id: The ID of the Overdrive collection to reap.
-    :param page: The product-list page to fetch, as a url. None starts a new crawl.
+    :param offset: Where in the product list to fetch the next page from. A crawl
+        starts at 0 and walks backwards from the end; see
+        :meth:`OverdriveAPI.next_product_offset`.
     :param total_items: Overdrive's collection size, as reported by the crawl's first
         page and carried across the remaining ones.
     :return: The identifiers the collection currently lists, or None if the crawl was
@@ -562,7 +564,10 @@ def reap_collection(
         redis = task.services.redis().client()
         identifier_set = IdentifierSet(redis, reap_key(collection_id, task.request.id))
 
-        with task.transaction() as session:
+        # The crawl reads the collection and queues apply tasks for what it finds. It
+        # writes nothing itself, so it does not hold a transaction open across the
+        # request for each page.
+        with task.session() as session:
             collection = load_from_id(session, Collection, collection_id)
             collection_name = collection.name
 
@@ -575,9 +580,8 @@ def reap_collection(
                 return None
 
             api = OverdriveAPI(session, collection)
-            endpoint = BookInfoEndpoint(page) if page else api.product_page_endpoint()
-            result = api.fetch_product_page(endpoint)
-            next_page = api.next_product_page(result)
+            result = api.fetch_product_page(api.product_page_endpoint(offset))
+            next_offset = api.next_product_offset(result, offset)
             marked = _mark_unowned_identifiers(
                 task, session, collection, result.unowned
             )
@@ -591,13 +595,13 @@ def reap_collection(
                 f"in collection '{collection_name}'."
             )
 
-        if next_page is not None:
+        if next_offset is not None:
             task.log.info(
                 f"Overdrive reaper crawling '{collection_name}': "
                 f"{identifier_set.len()} of {total_items} titles seen."
             )
             raise task.replace(
-                signature_with(task, page=next_page.url, total_items=total_items)
+                signature_with(task, offset=next_offset, total_items=total_items)
             )
 
         crawled = identifier_set.len()

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -523,7 +523,7 @@ def reap_collection(
     ``task.replace()`` until the crawl is complete, and collects the identifiers into
     a Redis set. Only ids and ownership are read -- no metadata or availability
     lookups -- so a whole collection costs a handful of requests rather than one per
-    title. See :meth:`OverdriveAPI.next_product_page` for how the crawl is paged.
+    title. See :meth:`OverdriveAPI.next_product_offset` for how the crawl is paged.
 
     Titles are removed from a collection in two ways, and this handles them
     differently:
@@ -589,6 +589,17 @@ def reap_collection(
         identifier_set.add(*result.listed)
         if total_items is None:
             total_items = result.total_items
+        if not result.pageable:
+            # The crawl stopped somewhere unknown rather than at the start of the
+            # list, so how much it covered is not a question the allowance for churn
+            # can answer.
+            task.log.error(
+                f"Overdrive reaper aborting for collection '{collection_name}': the "
+                f"page at offset {offset} carries no usable totalItems or page size, "
+                f"so the crawl cannot be continued or verified."
+            )
+            identifier_set.delete()
+            return None
         if marked:
             task.log.info(
                 f"Overdrive reaper marked {marked} title(s) Overdrive no longer owns "
@@ -605,7 +616,9 @@ def reap_collection(
             )
 
         crawled = identifier_set.len()
-        if not _crawl_is_complete(task, collection_name, crawled, total_items):
+        if not _crawl_is_complete(
+            task, collection_name, crawled, total_items, single_page=offset == 0
+        ):
             identifier_set.delete()
             return None
 
@@ -663,7 +676,12 @@ def _mark_unowned_identifiers(
 
 
 def _crawl_is_complete(
-    task: Task, collection_name: str, crawled: int, total_items: int | None
+    task: Task,
+    collection_name: str,
+    crawled: int,
+    total_items: int | None,
+    *,
+    single_page: bool,
 ) -> bool:
     """Decide whether a finished crawl covered the whole collection.
 
@@ -674,6 +692,10 @@ def _crawl_is_complete(
     small discrepancy against ``totalItems`` is expected -- titles added or removed
     mid-crawl move the count. A large shortfall means pages were missed, and reaping on
     that would mark live titles as gone.
+
+    :param single_page: Whether the whole collection arrived in one response. There is
+        no window for churn in that case -- the products and the count were produced
+        together -- so they are required to agree exactly.
     """
     if total_items is None:
         task.log.error(
@@ -682,9 +704,13 @@ def _crawl_is_complete(
         )
         return False
 
-    allowance = min(
-        REAP_CRAWL_ALLOWANCE_CAP,
-        max(REAP_CRAWL_ALLOWANCE_FLOOR, int(total_items * REAP_CRAWL_ALLOWANCE)),
+    allowance = (
+        0
+        if single_page
+        else min(
+            REAP_CRAWL_ALLOWANCE_CAP,
+            max(REAP_CRAWL_ALLOWANCE_FLOOR, int(total_items * REAP_CRAWL_ALLOWANCE)),
+        )
     )
     if crawled + allowance < total_items:
         task.log.error(

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -52,6 +52,11 @@ REAP_CRAWL_ALLOWANCE: float = 0.001
 REAP_CRAWL_ALLOWANCE_FLOOR: int = 10
 REAP_CRAWL_ALLOWANCE_CAP: int = 500
 
+# How long the reaper's identifier sets outlive their creation. Long enough that a
+# crawl of the largest collection cannot outlast the set it will be compared against,
+# and short enough that an abandoned run is cleaned up well before the next pass.
+REAP_IDENTIFIER_SET_LIFETIME: datetime.timedelta = datetime.timedelta(hours=36)
+
 
 class ImportSkippedPayload(TypedDict):
     """Payload returned when import is skipped (workflow lock already held)."""
@@ -562,12 +567,19 @@ def reap_collection(
             return None
 
         redis = task.services.redis().client()
-        identifier_set = IdentifierSet(redis, reap_key(collection_id, task.request.id))
+        identifier_set = IdentifierSet(
+            redis,
+            reap_key(collection_id, task.request.id),
+            # The crawl outlives the default expiry on a large collection, and its
+            # earlier pages have to still be there when the last one finishes. Matches
+            # the lifetime given to the set it will be compared against.
+            expire_time=REAP_IDENTIFIER_SET_LIFETIME,
+        )
 
-        # The crawl reads the collection and queues apply tasks for what it finds. It
-        # writes nothing itself, so it does not hold a transaction open across the
-        # request for each page.
-        with task.session() as session:
+        # Committed rather than read-only: resolving the collection token refreshes
+        # the cached library document, and a crawl that discarded that write would
+        # re-fetch it from Overdrive on every page.
+        with task.transaction() as session:
             collection = load_from_id(session, Collection, collection_id)
             collection_name = collection.name
 

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -27,6 +27,10 @@ from palace.manager.integration.license.overdrive.api import (
     BookInfoEndpoint,
     OverdriveAPI,
 )
+from palace.manager.integration.license.overdrive.crawl import (
+    CrawlCursor,
+    CrawlFault,
+)
 from palace.manager.integration.license.overdrive.importer import OverdriveImporter
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.redis.models.set import IdentifierSet
@@ -40,19 +44,6 @@ from palace.manager.util.http.exception import (
 )
 
 IMPORT_SKIPPED: str = "import_skipped"
-
-# How far a completed crawl may fall short of Overdrive's reported totalItems before
-# it is treated as incomplete. A crawl of a large collection runs for hours while
-# titles are added and removed under it, so the count is expected to move a little;
-# the floor keeps small collections from being held to an unreachable standard. The
-# shortfall being allowed for is churn during the crawl, which does not scale with
-# collection size, so the cap keeps the allowance below one page -- a crawl that lost
-# a whole page must never be excused.
-REAP_CRAWL_ALLOWANCE: float = 0.001
-REAP_CRAWL_ALLOWANCE_FLOOR: int = 10
-# Capped as a fraction of the page size the crawl is actually walking in, which is the
-# one Overdrive applied rather than the one asked for.
-REAP_CRAWL_ALLOWANCE_PAGE_FRACTION: float = 0.25
 
 # How long the reaper's identifier sets outlive their creation, between two bounds.
 # Long enough to outlast a crawl of the largest collection, since the set built at the
@@ -524,10 +515,8 @@ def reap_collection(
     task: Task,
     collection_id: int,
     *,
+    cursor: dict[str, Any] | None = None,
     offset: int = 0,
-    total_items: int | None = None,
-    previous_offset: int | None = None,
-    page_limit: int | None = None,
     batch_size: int | None = None,
 ) -> IdentifierSet | None:
     """
@@ -537,7 +526,9 @@ def reap_collection(
     ``task.replace()`` until the crawl is complete, and collects the identifiers into
     a Redis set. Only ids and ownership are read -- no metadata or availability
     lookups -- so a whole collection costs a handful of requests rather than one per
-    title. See :meth:`OverdriveAPI.next_product_offset` for how the crawl is paged.
+    title. The walk itself -- offsets, gap checks, and the completeness gate -- lives
+    in :class:`~palace.manager.integration.license.overdrive.crawl.CrawlCursor`; this
+    task only drives it and acts on what it decides.
 
     Titles are removed from a collection in two ways, and this handles them
     differently:
@@ -550,38 +541,31 @@ def reap_collection(
       :func:`~palace.manager.celery.tasks.identifiers.create_mark_unavailable_chord`,
       and identifiers held locally but missing from it are marked exhausted.
 
-    Because the second half acts on absence, a partial crawl would mark live titles as
-    gone. The crawl is therefore checked against Overdrive's ``totalItems`` before the
-    set is handed on, and ``None`` is returned if it cannot be shown to be complete --
-    which the chord body treats as a failed run and aborts. Titles flagged unowned are
-    still marked in that case, since nothing about them was inferred. Concurrency is
-    governed by :func:`~palace.manager.celery.importer.workflow_lock_guard`.
+    Because the second half acts on absence, any fault the cursor reports aborts the
+    run: ``None`` is returned, which the chord body treats as a failed run. Titles
+    flagged unowned are still marked in that case, since nothing about them was
+    inferred. Concurrency is governed by
+    :func:`~palace.manager.celery.importer.workflow_lock_guard`.
 
     :param collection_id: The ID of the Overdrive collection to reap.
-    :param offset: Where in the product list to fetch the next page from. A crawl
-        starts at 0 and walks backwards from the end; see
-        :meth:`OverdriveAPI.next_product_offset`.
-    :param total_items: Overdrive's collection size, as reported by the crawl's first
-        page and carried across the remaining ones.
-    :param previous_offset: Where the previous page of the backwards walk started, so
-        this one can be shown to reach it. None on the first page of a walk, which has
-        nothing above it to join up with.
-    :param page_limit: The page size Overdrive applied to the crawl's first page,
-        carried like ``total_items``. Every gap check is expressed in terms of it, so
-        the walk's arithmetic only holds while it stays the same.
+    :param cursor: The serialized
+        :class:`~palace.manager.integration.license.overdrive.crawl.CrawlCursor`
+        for the page this run should fetch. None starts a fresh crawl.
+    :param offset: Belonged to the previous per-title reaper, whose pages carried the
+        last ``Identifier.id`` processed. Accepted only so such a message still binds
+        after a deploy, and identifies one to discard; remove it once no such message
+        can be in flight.
     :param batch_size: Belonged to the previous per-title reaper and is ignored.
-        Accepted only so that a message carrying it still binds after a deploy; remove
-        it once no such message can be in flight.
+        Accepted for the same reason as ``offset``; remove it with ``offset``.
     :return: The identifiers the collection currently lists, or None if the crawl was
         skipped, aborted, or could not be verified as complete.
     """
-    if offset != 0 and total_items is None and page_limit is None:
-        # A page left over from the per-title reaper, whose `offset` was the last
-        # Identifier.id it had processed. Every page this reaper queues carries the
-        # crawl's totalItems and page size along with the offset, so their absence at
-        # a non-zero offset is what identifies one. Running it as a product-list
-        # offset would crawl from an arbitrary point, so the run is dropped and the
-        # next scheduled one starts clean.
+    if cursor is None and offset != 0:
+        # A page left over from the per-title reaper. Every page this reaper queues
+        # carries its crawl cursor, so a bare non-zero offset is what identifies one.
+        # Running it would treat an Identifier.id as a product-list offset and crawl
+        # from an arbitrary point, so the run is dropped and the next scheduled one
+        # starts clean.
         task.log.info(
             f"Discarding a reap page queued by the previous reaper implementation "
             f"for collection {collection_id}."
@@ -597,6 +581,9 @@ def reap_collection(
         if not proceed:
             return None
 
+        crawl_cursor = (
+            CrawlCursor.from_json(cursor) if cursor is not None else CrawlCursor()
+        )
         redis = task.services.redis().client()
         identifier_set = IdentifierSet(
             redis,
@@ -623,10 +610,12 @@ def reap_collection(
                 return None
 
             api = OverdriveAPI(session, collection)
-            result = api.fetch_product_page(api.product_page_endpoint(offset))
-            next_offset = api.next_product_offset(result, offset)
+            page = api.fetch_product_page(
+                api.product_page_endpoint(crawl_cursor.offset)
+            )
+            step = crawl_cursor.advance(page)
             unowned_to_mark = _unowned_identifiers_to_mark(
-                session, collection_id, result.unowned
+                session, collection_id, page.unowned
             )
             data_source_name = (
                 validate_not_none(
@@ -662,121 +651,36 @@ def reap_collection(
                 f"in collection '{collection_name}'."
             )
 
-        identifier_set.add(*result.listed)
-        if total_items is None:
-            total_items = result.total_items
-        if page_limit is None:
-            page_limit = result.limit
-        elif result.limit != page_limit:
-            # Where a page reaches, and so where the walk can stop, is measured in
-            # page sizes. Overdrive echoes the size it applied, and the crawl asks
-            # for the same one every time, so a change mid-crawl means the arithmetic
-            # the gap checks rely on no longer describes the list.
+        identifier_set.add(*page.listed)
+
+        if isinstance(step, CrawlFault):
             task.log.error(
-                f"Overdrive reaper aborting for collection '{collection_name}': the "
-                f"page at offset {offset} was returned with a page size of "
-                f"{result.limit}, but the crawl has been walking in steps of "
-                f"{page_limit}. Refusing to reap on a crawl whose paging changed "
-                f"underneath it."
+                f"Overdrive reaper aborting for collection '{collection_name}' "
+                f"after {crawl_cursor.elapsed}: {step.reason}"
             )
             identifier_set.delete()
             return None
 
-        if (
-            offset == 0
-            and total_items > result.limit
-            and len(result.listed) < result.limit
-        ):
-            # The walk finishes by stepping back into the region this page covered,
-            # and uses the page size to decide how far that reaches. A first page
-            # that came back short does not reach that far, leaving the strip between
-            # where it ended and where the walk stopped uncrawled.
-            task.log.error(
-                f"Overdrive reaper aborting for collection '{collection_name}': the "
-                f"first page returned {len(result.listed)} titles of a possible "
-                f"{result.limit}, so the walk cannot join back onto it. Refusing to "
-                f"reap across a gap."
-            )
-            identifier_set.delete()
-            return None
-
-        must_reach = min(result.total_items, total_items)
-        if (
-            previous_offset is None
-            and offset != 0
-            and offset + len(result.listed) < must_reach
-        ):
-            # The walk's first backwards page runs to the end of the list, and is the
-            # one page with nothing above it to be checked against. Its reach is
-            # exactly knowable for that same reason: it has to arrive at the end.
-            #
-            # Which end depends on what the collection did in between. Titles removed
-            # since the first page shorten the list, so the smaller count is the one
-            # to insist on; titles added lengthen it, and under dateAdded:asc they
-            # land beyond where this page starts, so they are not this page's to
-            # reach -- nor can they be falsely reaped, being absent from the snapshot
-            # the chord took of what we hold.
-            task.log.error(
-                f"Overdrive reaper aborting for collection '{collection_name}': the "
-                f"page at offset {offset} returned {len(result.listed)} titles and so "
-                f"stops short of the {must_reach} Overdrive reports. Refusing to reap "
-                f"across a gap."
-            )
-            identifier_set.delete()
-            return None
-
-        if (
-            previous_offset is not None
-            and offset + len(result.listed) < previous_offset
-        ):
-            # The walk steps back by a page size, but a page is free to return fewer
-            # titles than that. When one does, the step overshoots and leaves a strip
-            # of the list uncrawled -- which reaches the completeness check as a
-            # shortfall indistinguishable from titles removed mid-crawl. Pages are
-            # only legitimately short at the end of the list, so every other page is
-            # required to reach the one before it.
-            task.log.error(
-                f"Overdrive reaper aborting for collection '{collection_name}': the "
-                f"page at offset {offset} returned {len(result.listed)} titles and so "
-                f"stops short of the region already crawled at {previous_offset}. "
-                f"Refusing to reap across a gap."
-            )
-            identifier_set.delete()
-            return None
-
-        if next_offset is not None:
+        if isinstance(step, CrawlCursor):
             task.log.info(
                 f"Overdrive reaper crawling '{collection_name}': "
-                f"{identifier_set.len()} of {total_items} titles seen."
+                f"{identifier_set.len()} of {step.total_items} titles seen."
             )
-            raise task.replace(
-                signature_with(
-                    task,
-                    offset=next_offset,
-                    total_items=total_items,
-                    # The first page of a walk starts at 0 and is followed by a jump
-                    # to the end of the list, so the page after it has nothing to
-                    # join up with.
-                    previous_offset=offset or None,
-                    page_limit=page_limit,
-                )
-            )
+            raise task.replace(signature_with(task, cursor=step.__json__()))
 
         crawled = identifier_set.len()
-        if not _crawl_is_complete(
-            task,
-            collection_name,
-            crawled,
-            total_items,
-            single_page=offset == 0,
-            page_limit=page_limit,
-        ):
+        if (fault := step.completeness_fault(crawled)) is not None:
+            task.log.error(
+                f"Overdrive reaper aborting for collection '{collection_name}' "
+                f"after {step.elapsed}: {fault.reason}"
+            )
             identifier_set.delete()
             return None
 
         task.log.info(
-            f"Overdrive reaper crawl complete for collection '{collection_name}': "
-            f"{crawled} titles listed of {total_items} reported."
+            f"Overdrive reaper crawl complete for collection '{collection_name}' "
+            f"in {step.elapsed}: {crawled} titles listed of {step.total_items} "
+            f"reported."
         )
         return identifier_set
 
@@ -811,48 +715,3 @@ def _unowned_identifiers_to_mark(
         )
     ).all()
     return [IdentifierData.from_identifier(identifier) for identifier in identifiers]
-
-
-def _crawl_is_complete(
-    task: Task,
-    collection_name: str,
-    crawled: int,
-    total_items: int,
-    *,
-    single_page: bool,
-    page_limit: int,
-) -> bool:
-    """Decide whether a finished crawl covered the whole collection.
-
-    ``crawled`` counts *distinct* identifiers, so a title returned twice cannot paper
-    over one that was missed.
-
-    A crawl runs for hours against a collection that keeps changing underneath it, so a
-    small discrepancy against ``totalItems`` is expected -- titles added or removed
-    mid-crawl move the count. A large shortfall means pages were missed, and reaping on
-    that would mark live titles as gone.
-
-    :param single_page: Whether the whole collection arrived in one response. There is
-        no window for churn in that case -- the products and the count were produced
-        together -- so they are required to agree exactly.
-    :param page_limit: The page size the crawl walked in. The allowance is held below
-        it so that a lost page can never be mistaken for churn -- including the crawl's
-        first backwards page, which has nothing above it to be checked against.
-    """
-    allowance = (
-        0
-        if single_page
-        else min(
-            max(1, int(page_limit * REAP_CRAWL_ALLOWANCE_PAGE_FRACTION)),
-            max(REAP_CRAWL_ALLOWANCE_FLOOR, int(total_items * REAP_CRAWL_ALLOWANCE)),
-        )
-    )
-    if crawled + allowance < total_items:
-        task.log.error(
-            f"Overdrive reaper aborting for collection '{collection_name}': crawl saw "
-            f"{crawled} titles but Overdrive reports {total_items} "
-            f"(allowance {allowance}). Refusing to reap on an incomplete crawl."
-        )
-        return False
-
-    return True

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -616,9 +616,36 @@ def reap_collection(
             api = OverdriveAPI(session, collection)
             result = api.fetch_product_page(api.product_page_endpoint(offset))
             next_offset = api.next_product_offset(result, offset)
-            marked = _mark_unowned_identifiers(
-                task, session, collection, result.unowned
+            unowned_to_mark = _unowned_identifiers_to_mark(
+                session, collection_id, result.unowned
             )
+            data_source_name = (
+                validate_not_none(
+                    collection.data_source,
+                    message="Collection has no data source! (data_source is None).",
+                ).name
+                if unowned_to_mark
+                else None
+            )
+
+        # Queued outside the transaction, as `mark_identifiers_unavailable` does: a
+        # run of broker publishes should not be holding a write transaction open.
+        marked = (
+            queue_unavailable_updates(
+                unowned_to_mark,
+                collection_id=collection_id,
+                collection_name=collection_name,
+                data_source_name=data_source_name,
+                # Overdrive drops titles from a collection when a lease ends or a
+                # purchase is returned, not only when a title is withdrawn, so this
+                # means "no copies here now" rather than "revoke outstanding loans
+                # and holds".
+                status=LicensePoolStatus.EXHAUSTED,
+                log=task.log,
+            )
+            if unowned_to_mark and data_source_name is not None
+            else 0
+        )
 
         identifier_set.add(*result.listed)
         if total_items is None:
@@ -631,6 +658,25 @@ def reap_collection(
                 f"Overdrive reaper aborting for collection '{collection_name}': the "
                 f"page at offset {offset} carries no usable totalItems or page size, "
                 f"so the crawl cannot be continued or verified."
+            )
+            identifier_set.delete()
+            return None
+
+        if (
+            offset == 0
+            and total_items is not None
+            and total_items > result.limit
+            and len(result.listed) < result.limit
+        ):
+            # The walk finishes by stepping back into the region this page covered,
+            # and uses the page size to decide how far that reaches. A first page
+            # that came back short does not reach that far, leaving the strip between
+            # where it ended and where the walk stopped uncrawled.
+            task.log.error(
+                f"Overdrive reaper aborting for collection '{collection_name}': the "
+                f"first page returned {len(result.listed)} titles of a possible "
+                f"{result.limit}, so the walk cannot join back onto it. Refusing to "
+                f"reap across a gap."
             )
             identifier_set.delete()
             return None
@@ -690,50 +736,33 @@ def reap_collection(
         return identifier_set
 
 
-def _mark_unowned_identifiers(
-    task: Task,
+def _unowned_identifiers_to_mark(
     session: Session,
-    collection: Collection,
+    collection_id: int,
     unowned: tuple[IdentifierData, ...],
-) -> int:
-    """Mark the titles on a crawled page that Overdrive reports it no longer owns.
+) -> list[IdentifierData]:
+    """Which titles on a crawled page Overdrive has stopped owning, that we still hold.
 
     Overdrive keeps weeded and expired titles in the product list rather than dropping
     them, so this is a statement that a title is gone rather than an inference from its
-    absence -- which is why it does not wait on the crawl being shown complete.
+    absence -- which is why the caller acts on it without waiting for the crawl to be
+    shown complete.
 
-    Only titles we still record as available are marked, so the titles Overdrive keeps
+    Titles we already record as unavailable are left out, so the ones Overdrive keeps
     listing as unowned do not generate an apply task on every pass.
     """
     if not unowned:
-        return 0
+        return []
 
     identifiers = session.scalars(
-        available_identifiers_query(collection.id).where(
+        available_identifiers_query(collection_id).where(
             Identifier.type == Identifier.OVERDRIVE_ID,
             Identifier.identifier.in_(
                 [identifier.identifier for identifier in unowned]
             ),
         )
     ).all()
-    if not identifiers:
-        return 0
-
-    data_source = validate_not_none(
-        collection.data_source,
-        message="Collection has no data source! (data_source is None).",
-    )
-    return queue_unavailable_updates(
-        (IdentifierData.from_identifier(identifier) for identifier in identifiers),
-        collection_id=collection.id,
-        collection_name=collection.name,
-        data_source_name=data_source.name,
-        # Overdrive drops titles from a collection when a lease ends or a purchase is
-        # returned, not only when a title is withdrawn, so this means "no copies here
-        # now" rather than "revoke outstanding loans and holds".
-        status=LicensePoolStatus.EXHAUSTED,
-        log=task.log,
-    )
+    return [IdentifierData.from_identifier(identifier) for identifier in identifiers]
 
 
 def _crawl_is_complete(

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -50,7 +50,7 @@ IMPORT_SKIPPED: str = "import_skipped"
 # a whole page must never be excused.
 REAP_CRAWL_ALLOWANCE: float = 0.001
 REAP_CRAWL_ALLOWANCE_FLOOR: int = 10
-REAP_CRAWL_ALLOWANCE_CAP: int = 500
+REAP_CRAWL_ALLOWANCE_CAP: int = OverdriveAPI.PRODUCTS_PAGE_SIZE_LIMIT // 4
 
 # How long the reaper's identifier sets outlive their creation. A crawl of the largest
 # collection can span more than a day, and both halves of the comparison have to still
@@ -523,6 +523,7 @@ def reap_collection(
     offset: int = 0,
     total_items: int | None = None,
     previous_offset: int | None = None,
+    page_limit: int | None = None,
     batch_size: int | None = None,
 ) -> IdentifierSet | None:
     """
@@ -561,6 +562,9 @@ def reap_collection(
     :param previous_offset: Where the previous page of the backwards walk started, so
         this one can be shown to reach it. None on the first page of a walk, which has
         nothing above it to join up with.
+    :param page_limit: The page size Overdrive applied to the crawl's first page,
+        carried like ``total_items``. Every gap check is expressed in terms of it, so
+        the walk's arithmetic only holds while it stays the same.
     :param batch_size: Only ever set on a page queued by the previous per-title
         reaper, whose ``offset`` meant something else entirely. Accepted so those
         messages are discarded rather than failing to bind after a deploy; remove it
@@ -647,6 +651,12 @@ def reap_collection(
             else 0
         )
 
+        if marked:
+            task.log.info(
+                f"Overdrive reaper marked {marked} title(s) Overdrive no longer owns "
+                f"in collection '{collection_name}'."
+            )
+
         identifier_set.add(*result.listed)
         if total_items is None:
             total_items = result.total_items
@@ -658,6 +668,23 @@ def reap_collection(
                 f"Overdrive reaper aborting for collection '{collection_name}': the "
                 f"page at offset {offset} carries no usable totalItems or page size, "
                 f"so the crawl cannot be continued or verified."
+            )
+            identifier_set.delete()
+            return None
+
+        if page_limit is None:
+            page_limit = result.limit
+        elif result.limit != page_limit:
+            # Where a page reaches, and so where the walk can stop, is measured in
+            # page sizes. Overdrive echoes the size it applied, and the crawl asks
+            # for the same one every time, so a change mid-crawl means the arithmetic
+            # the gap checks rely on no longer describes the list.
+            task.log.error(
+                f"Overdrive reaper aborting for collection '{collection_name}': the "
+                f"page at offset {offset} was returned with a page size of "
+                f"{result.limit}, but the crawl has been walking in steps of "
+                f"{page_limit}. Refusing to reap on a crawl whose paging changed "
+                f"underneath it."
             )
             identifier_set.delete()
             return None
@@ -699,11 +726,6 @@ def reap_collection(
             )
             identifier_set.delete()
             return None
-        if marked:
-            task.log.info(
-                f"Overdrive reaper marked {marked} title(s) Overdrive no longer owns "
-                f"in collection '{collection_name}'."
-            )
 
         if next_offset is not None:
             task.log.info(
@@ -719,6 +741,7 @@ def reap_collection(
                     # to the end of the list, so the page after it has nothing to
                     # join up with.
                     previous_offset=offset or None,
+                    page_limit=page_limit,
                 )
             )
 

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -52,9 +52,11 @@ REAP_CRAWL_ALLOWANCE: float = 0.001
 REAP_CRAWL_ALLOWANCE_FLOOR: int = 10
 REAP_CRAWL_ALLOWANCE_CAP: int = 500
 
-# How long the reaper's identifier sets outlive their creation. Long enough that a
-# crawl of the largest collection cannot outlast the set it will be compared against,
-# and short enough that an abandoned run is cleaned up well before the next pass.
+# How long the reaper's identifier sets outlive their creation. A crawl of the largest
+# collection can span more than a day, and both halves of the comparison have to still
+# be there when it finishes. The sets are keyed on the run's task id, so an abandoned
+# run's keys cannot be picked up by the next pass -- they only take up space until they
+# expire.
 REAP_IDENTIFIER_SET_LIFETIME: datetime.timedelta = datetime.timedelta(hours=36)
 
 
@@ -520,6 +522,8 @@ def reap_collection(
     *,
     offset: int = 0,
     total_items: int | None = None,
+    previous_offset: int | None = None,
+    batch_size: int | None = None,
 ) -> IdentifierSet | None:
     """
     Enumerate the titles an Overdrive collection currently lists.
@@ -554,9 +558,27 @@ def reap_collection(
         :meth:`OverdriveAPI.next_product_offset`.
     :param total_items: Overdrive's collection size, as reported by the crawl's first
         page and carried across the remaining ones.
+    :param previous_offset: Where the previous page of the backwards walk started, so
+        this one can be shown to reach it. None on the first page of a walk, which has
+        nothing above it to join up with.
+    :param batch_size: Only ever set on a page queued by the previous per-title
+        reaper, whose ``offset`` meant something else entirely. Accepted so those
+        messages are discarded rather than failing to bind after a deploy; remove it
+        once no such message can still be in flight.
     :return: The identifiers the collection currently lists, or None if the crawl was
         skipped, aborted, or could not be verified as complete.
     """
+    if batch_size is not None:
+        # A page left over from the per-title reaper, whose `offset` was the last
+        # Identifier.id it processed. Running it as a product-list offset would crawl
+        # from an arbitrary point, so the run is dropped and the next scheduled one
+        # starts clean.
+        task.log.info(
+            f"Discarding a reap page queued by the previous reaper implementation "
+            f"for collection {collection_id}."
+        )
+        return None
+
     with workflow_lock_guard(
         task,
         collection_id,
@@ -612,6 +634,25 @@ def reap_collection(
             )
             identifier_set.delete()
             return None
+
+        if (
+            previous_offset is not None
+            and offset + len(result.listed) < previous_offset
+        ):
+            # The walk steps back by a page size, but a page is free to return fewer
+            # titles than that. When one does, the step overshoots and leaves a strip
+            # of the list uncrawled -- which reaches the completeness check as a
+            # shortfall indistinguishable from titles removed mid-crawl. Pages are
+            # only legitimately short at the end of the list, so every other page is
+            # required to reach the one before it.
+            task.log.error(
+                f"Overdrive reaper aborting for collection '{collection_name}': the "
+                f"page at offset {offset} returned {len(result.listed)} titles and so "
+                f"stops short of the region already crawled at {previous_offset}. "
+                f"Refusing to reap across a gap."
+            )
+            identifier_set.delete()
+            return None
         if marked:
             task.log.info(
                 f"Overdrive reaper marked {marked} title(s) Overdrive no longer owns "
@@ -624,7 +665,15 @@ def reap_collection(
                 f"{identifier_set.len()} of {total_items} titles seen."
             )
             raise task.replace(
-                signature_with(task, offset=next_offset, total_items=total_items)
+                signature_with(
+                    task,
+                    offset=next_offset,
+                    total_items=total_items,
+                    # The first page of a walk starts at 0 and is followed by a jump
+                    # to the end of the list, so the page after it has nothing to
+                    # join up with.
+                    previous_offset=offset or None,
+                )
             )
 
         crawled = identifier_set.len()

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -677,6 +677,19 @@ def reap_collection(
             identifier_set.delete()
             return None
 
+        if crawled == 0:
+            # Overdrive lists nothing for this collection, so there is no set for
+            # the chord to act on -- an empty set is never materialised in Redis.
+            # The chord body deliberately refuses to reap a whole collection from a
+            # missing set, so hand it the documented "skipped" result instead of a
+            # set that reads as an error.
+            task.log.info(
+                f"Overdrive lists no titles for collection '{collection_name}'; "
+                f"skipping the set-difference reap."
+            )
+            identifier_set.delete()
+            return None
+
         task.log.info(
             f"Overdrive reaper crawl complete for collection '{collection_name}' "
             f"in {step.elapsed}: {crawled} titles listed of {step.total_items} "

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -663,18 +663,6 @@ def reap_collection(
         identifier_set.add(*result.listed)
         if total_items is None:
             total_items = result.total_items
-        if not result.pageable:
-            # The crawl stopped somewhere unknown rather than at the start of the
-            # list, so how much it covered is not a question the allowance for churn
-            # can answer.
-            task.log.error(
-                f"Overdrive reaper aborting for collection '{collection_name}': the "
-                f"page at offset {offset} carries no usable totalItems or page size, "
-                f"so the crawl cannot be continued or verified."
-            )
-            identifier_set.delete()
-            return None
-
         if page_limit is None:
             page_limit = result.limit
         elif result.limit != page_limit:
@@ -707,6 +695,25 @@ def reap_collection(
                 f"first page returned {len(result.listed)} titles of a possible "
                 f"{result.limit}, so the walk cannot join back onto it. Refusing to "
                 f"reap across a gap."
+            )
+            identifier_set.delete()
+            return None
+
+        if (
+            previous_offset is None
+            and offset != 0
+            and offset + len(result.listed) < result.total_items
+        ):
+            # The walk's first backwards page runs to the end of the list, and is the
+            # one page with nothing above it to be checked against. Its reach is
+            # exactly knowable for that same reason: it has to arrive at the end.
+            # Measured against the count this page reports rather than the one the
+            # crawl started with, so a collection that shrank mid-crawl still passes.
+            task.log.error(
+                f"Overdrive reaper aborting for collection '{collection_name}': the "
+                f"page at offset {offset} returned {len(result.listed)} titles and so "
+                f"stops short of the {result.total_items} Overdrive reports. Refusing "
+                f"to reap across a gap."
             )
             identifier_set.delete()
             return None

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -54,6 +54,12 @@ IMPORT_SKIPPED: str = "import_skipped"
 # per run.
 REAP_IDENTIFIER_SET_LIFETIME: datetime.timedelta = datetime.timedelta(hours=20)
 
+# How far apart the collections' reap chords are launched. Each chord opens with a
+# scan of the collection's every identifier into Redis, so launching every
+# collection in the same minute stacks all of those scans onto the default queue
+# at once -- the spread keeps the nightly kickoff from crowding out other work.
+REAP_KICKOFF_STAGGER: datetime.timedelta = datetime.timedelta(minutes=2)
+
 
 class ImportSkippedPayload(TypedDict):
     """Payload returned when import is skipped (workflow lock already held)."""
@@ -499,8 +505,10 @@ def reap_all_collections(task: Task) -> None:
             OverdriveAPI, registry=registry
         )
         collections = session.scalars(collection_query).all()
-    for collection in collections:
-        OverdriveAPI.reap_task(collection.id).apply_async()
+    for position, collection in enumerate(collections):
+        OverdriveAPI.reap_task(collection.id).apply_async(
+            countdown=position * REAP_KICKOFF_STAGGER.total_seconds()
+        )
 
 
 @shared_task(

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -682,7 +682,6 @@ def reap_collection(
 
         if (
             offset == 0
-            and total_items is not None
             and total_items > result.limit
             and len(result.listed) < result.limit
         ):
@@ -810,7 +809,7 @@ def _crawl_is_complete(
     task: Task,
     collection_name: str,
     crawled: int,
-    total_items: int | None,
+    total_items: int,
     *,
     single_page: bool,
     page_limit: int,
@@ -832,13 +831,6 @@ def _crawl_is_complete(
         it so that a lost page can never be mistaken for churn -- including the crawl's
         first backwards page, which has nothing above it to be checked against.
     """
-    if total_items is None:
-        task.log.error(
-            f"Overdrive reaper aborting for collection '{collection_name}': "
-            f"Overdrive did not report totalItems, so the crawl cannot be verified."
-        )
-        return False
-
     allowance = (
         0
         if single_page

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -698,21 +698,27 @@ def reap_collection(
             identifier_set.delete()
             return None
 
+        must_reach = min(result.total_items, total_items)
         if (
             previous_offset is None
             and offset != 0
-            and offset + len(result.listed) < result.total_items
+            and offset + len(result.listed) < must_reach
         ):
             # The walk's first backwards page runs to the end of the list, and is the
             # one page with nothing above it to be checked against. Its reach is
             # exactly knowable for that same reason: it has to arrive at the end.
-            # Measured against the count this page reports rather than the one the
-            # crawl started with, so a collection that shrank mid-crawl still passes.
+            #
+            # Which end depends on what the collection did in between. Titles removed
+            # since the first page shorten the list, so the smaller count is the one
+            # to insist on; titles added lengthen it, and under dateAdded:asc they
+            # land beyond where this page starts, so they are not this page's to
+            # reach -- nor can they be falsely reaped, being absent from the snapshot
+            # the chord took of what we hold.
             task.log.error(
                 f"Overdrive reaper aborting for collection '{collection_name}': the "
                 f"page at offset {offset} returned {len(result.listed)} titles and so "
-                f"stops short of the {result.total_items} Overdrive reports. Refusing "
-                f"to reap across a gap."
+                f"stops short of the {must_reach} Overdrive reports. Refusing to reap "
+                f"across a gap."
             )
             identifier_set.delete()
             return None

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -18,7 +18,7 @@ from palace.manager.celery.importer import (
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import apply
 from palace.manager.celery.tasks.identifiers import (
-    available_identifiers_query,
+    held_identifiers_query,
     queue_unavailable_updates,
 )
 from palace.manager.celery.utils import load_from_id, signature_with, validate_not_none
@@ -50,7 +50,9 @@ IMPORT_SKIPPED: str = "import_skipped"
 # a whole page must never be excused.
 REAP_CRAWL_ALLOWANCE: float = 0.001
 REAP_CRAWL_ALLOWANCE_FLOOR: int = 10
-REAP_CRAWL_ALLOWANCE_CAP: int = OverdriveAPI.PRODUCTS_PAGE_SIZE_LIMIT // 4
+# Capped as a fraction of the page size the crawl is actually walking in, which is the
+# one Overdrive applied rather than the one asked for.
+REAP_CRAWL_ALLOWANCE_PAGE_FRACTION: float = 0.25
 
 # How long the reaper's identifier sets outlive their creation. A crawl of the largest
 # collection can span more than a day, and both halves of the comparison have to still
@@ -565,18 +567,19 @@ def reap_collection(
     :param page_limit: The page size Overdrive applied to the crawl's first page,
         carried like ``total_items``. Every gap check is expressed in terms of it, so
         the walk's arithmetic only holds while it stays the same.
-    :param batch_size: Only ever set on a page queued by the previous per-title
-        reaper, whose ``offset`` meant something else entirely. Accepted so those
-        messages are discarded rather than failing to bind after a deploy; remove it
-        once no such message can still be in flight.
+    :param batch_size: Belonged to the previous per-title reaper and is ignored.
+        Accepted only so that a message carrying it still binds after a deploy; remove
+        it once no such message can be in flight.
     :return: The identifiers the collection currently lists, or None if the crawl was
         skipped, aborted, or could not be verified as complete.
     """
-    if batch_size is not None:
+    if offset != 0 and total_items is None and page_limit is None:
         # A page left over from the per-title reaper, whose `offset` was the last
-        # Identifier.id it processed. Running it as a product-list offset would crawl
-        # from an arbitrary point, so the run is dropped and the next scheduled one
-        # starts clean.
+        # Identifier.id it had processed. Every page this reaper queues carries the
+        # crawl's totalItems and page size along with the offset, so their absence at
+        # a non-zero offset is what identifies one. Running it as a product-list
+        # offset would crawl from an arbitrary point, so the run is dropped and the
+        # next scheduled one starts clean.
         task.log.info(
             f"Discarding a reap page queued by the previous reaper implementation "
             f"for collection {collection_id}."
@@ -747,7 +750,12 @@ def reap_collection(
 
         crawled = identifier_set.len()
         if not _crawl_is_complete(
-            task, collection_name, crawled, total_items, single_page=offset == 0
+            task,
+            collection_name,
+            crawled,
+            total_items,
+            single_page=offset == 0,
+            page_limit=page_limit,
         ):
             identifier_set.delete()
             return None
@@ -771,14 +779,17 @@ def _unowned_identifiers_to_mark(
     absence -- which is why the caller acts on it without waiting for the crawl to be
     shown complete.
 
-    Titles we already record as unavailable are left out, so the ones Overdrive keeps
-    listing as unowned do not generate an apply task on every pass.
+    Titles we already record as holding no copies are left out, so the ones Overdrive
+    keeps listing as unowned do not generate an apply task on every pass. The test is
+    whether we still record copies, not whether one is free to borrow: a weeded title
+    whose copies are all checked out is exactly the case worth marking, and it is one
+    the set difference can never catch, since Overdrive goes on listing it.
     """
     if not unowned:
         return []
 
     identifiers = session.scalars(
-        available_identifiers_query(collection_id).where(
+        held_identifiers_query(collection_id).where(
             Identifier.type == Identifier.OVERDRIVE_ID,
             Identifier.identifier.in_(
                 [identifier.identifier for identifier in unowned]
@@ -795,6 +806,7 @@ def _crawl_is_complete(
     total_items: int | None,
     *,
     single_page: bool,
+    page_limit: int,
 ) -> bool:
     """Decide whether a finished crawl covered the whole collection.
 
@@ -809,6 +821,9 @@ def _crawl_is_complete(
     :param single_page: Whether the whole collection arrived in one response. There is
         no window for churn in that case -- the products and the count were produced
         together -- so they are required to agree exactly.
+    :param page_limit: The page size the crawl walked in. The allowance is held below
+        it so that a lost page can never be mistaken for churn -- including the crawl's
+        first backwards page, which has nothing above it to be checked against.
     """
     if total_items is None:
         task.log.error(
@@ -821,7 +836,7 @@ def _crawl_is_complete(
         0
         if single_page
         else min(
-            REAP_CRAWL_ALLOWANCE_CAP,
+            max(1, int(page_limit * REAP_CRAWL_ALLOWANCE_PAGE_FRACTION)),
             max(REAP_CRAWL_ALLOWANCE_FLOOR, int(total_items * REAP_CRAWL_ALLOWANCE)),
         )
     )

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -3,6 +3,7 @@ from typing import Any, Literal, TypedDict, TypeGuard
 from uuid import uuid4
 
 from celery import chain, chord, group, shared_task
+from sqlalchemy.orm import Session
 
 from palace.util.datetime_helpers import utc_now
 
@@ -16,7 +17,12 @@ from palace.manager.celery.importer import (
 )
 from palace.manager.celery.task import Task
 from palace.manager.celery.tasks import apply
-from palace.manager.celery.utils import load_from_id, signature_with
+from palace.manager.celery.tasks.identifiers import (
+    available_identifiers_query,
+    queue_unavailable_updates,
+)
+from palace.manager.celery.utils import load_from_id, signature_with, validate_not_none
+from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.integration.license.overdrive.api import (
     BookInfoEndpoint,
     OverdriveAPI,
@@ -25,6 +31,8 @@ from palace.manager.integration.license.overdrive.importer import OverdriveImpor
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.redis.models.set import IdentifierSet
 from palace.manager.sqlalchemy.model.collection import Collection
+from palace.manager.sqlalchemy.model.identifier import Identifier
+from palace.manager.sqlalchemy.model.licensing import LicensePoolStatus
 from palace.manager.util.http.exception import (
     BadResponseException,
     RemoteIntegrationException,
@@ -34,11 +42,15 @@ from palace.manager.util.http.exception import (
 IMPORT_SKIPPED: str = "import_skipped"
 
 # How far a completed crawl may fall short of Overdrive's reported totalItems before
-# it is treated as incomplete. A crawl of a large collection runs for minutes while
+# it is treated as incomplete. A crawl of a large collection runs for hours while
 # titles are added and removed under it, so the count is expected to move a little;
-# the floor keeps small collections from being held to an unreachable standard.
+# the floor keeps small collections from being held to an unreachable standard. The
+# shortfall being allowed for is churn during the crawl, which does not scale with
+# collection size, so the cap keeps the allowance below one page -- a crawl that lost
+# a whole page must never be excused.
 REAP_CRAWL_ALLOWANCE: float = 0.001
 REAP_CRAWL_ALLOWANCE_FLOOR: int = 10
+REAP_CRAWL_ALLOWANCE_CAP: int = 500
 
 
 class ImportSkippedPayload(TypedDict):
@@ -502,34 +514,40 @@ def reap_collection(
     collection_id: int,
     *,
     page: str | None = None,
-    seen: int = 0,
+    total_items: int | None = None,
 ) -> IdentifierSet | None:
     """
-    Enumerate the titles an Overdrive collection currently holds.
+    Enumerate the titles an Overdrive collection currently lists.
 
     Walks the collection's product list one page at a time, re-queuing itself via
     ``task.replace()`` until the crawl is complete, and collects the identifiers into
-    a Redis set. Only ids are read -- no metadata or availability lookups -- so a
-    whole collection costs a handful of requests rather than one per title.
+    a Redis set. Only ids and ownership are read -- no metadata or availability
+    lookups -- so a whole collection costs a handful of requests rather than one per
+    title. See :meth:`OverdriveAPI.next_product_page` for how the crawl is paged.
 
-    The returned set is the "active" half of
-    :func:`~palace.manager.celery.tasks.identifiers.create_mark_unavailable_chord`:
-    identifiers the collection holds locally but which are absent from this set have
-    left the Overdrive collection and are marked exhausted. Titles Overdrive still
-    lists but no longer owns are excluded by :meth:`OverdriveAPI.fetch_product_page`,
-    so they are reaped on the same footing.
+    Titles are removed from a collection in two ways, and this handles them
+    differently:
 
-    Because reaping acts on the *absence* of an identifier, a partial crawl would
-    mark live titles as gone. The crawl is therefore checked against Overdrive's
-    ``totalItems`` before the set is handed on, and ``None`` is returned if it cannot
-    be shown to be complete -- which the chord body treats as a failed run and
-    aborts, marking nothing. Concurrency is governed by
-    :func:`~palace.manager.celery.importer.workflow_lock_guard`.
+    * Overdrive keeps weeded and expired titles in the product list, flagged
+      ``isOwnedByCollections: false``. That is direct evidence, so those titles are
+      marked as each page arrives, whether or not the crawl goes on to complete.
+    * A title can also leave the product list entirely. That can only be detected by
+      its *absence*, which is what the returned set is for: it is the "active" half of
+      :func:`~palace.manager.celery.tasks.identifiers.create_mark_unavailable_chord`,
+      and identifiers held locally but missing from it are marked exhausted.
+
+    Because the second half acts on absence, a partial crawl would mark live titles as
+    gone. The crawl is therefore checked against Overdrive's ``totalItems`` before the
+    set is handed on, and ``None`` is returned if it cannot be shown to be complete --
+    which the chord body treats as a failed run and aborts. Titles flagged unowned are
+    still marked in that case, since nothing about them was inferred. Concurrency is
+    governed by :func:`~palace.manager.celery.importer.workflow_lock_guard`.
 
     :param collection_id: The ID of the Overdrive collection to reap.
     :param page: The product-list page to fetch, as a url. None starts a new crawl.
-    :param seen: Running count of products returned by previous pages.
-    :return: The identifiers the collection currently holds, or None if the crawl was
+    :param total_items: Overdrive's collection size, as reported by the crawl's first
+        page and carried across the remaining ones.
+    :return: The identifiers the collection currently lists, or None if the crawl was
         skipped, aborted, or could not be verified as complete.
     """
     with workflow_lock_guard(
@@ -557,43 +575,101 @@ def reap_collection(
                 return None
 
             api = OverdriveAPI(session, collection)
-            endpoint = (
-                BookInfoEndpoint(page) if page else api.product_page_initial_endpoint()
-            )
+            endpoint = BookInfoEndpoint(page) if page else api.product_page_endpoint()
             result = api.fetch_product_page(endpoint)
+            next_page = api.next_product_page(result)
+            marked = _mark_unowned_identifiers(
+                task, session, collection, result.unowned
+            )
 
-        identifier_set.add(*result.active)
-        seen += result.seen
-
-        if result.next_page is not None:
+        identifier_set.add(*result.listed)
+        if total_items is None:
+            total_items = result.total_items
+        if marked:
             task.log.info(
-                f"Overdrive reaper crawling '{collection_name}': {seen} products seen "
-                f"of {result.total_items}."
+                f"Overdrive reaper marked {marked} title(s) Overdrive no longer owns "
+                f"in collection '{collection_name}'."
+            )
+
+        if next_page is not None:
+            task.log.info(
+                f"Overdrive reaper crawling '{collection_name}': "
+                f"{identifier_set.len()} of {total_items} titles seen."
             )
             raise task.replace(
-                signature_with(task, page=result.next_page.url, seen=seen)
+                signature_with(task, page=next_page.url, total_items=total_items)
             )
 
-        if not _crawl_is_complete(task, collection_name, seen, result.total_items):
+        crawled = identifier_set.len()
+        if not _crawl_is_complete(task, collection_name, crawled, total_items):
             identifier_set.delete()
             return None
 
         task.log.info(
             f"Overdrive reaper crawl complete for collection '{collection_name}': "
-            f"{seen} products seen, {identifier_set.len()} still owned."
+            f"{crawled} titles listed of {total_items} reported."
         )
         return identifier_set
 
 
+def _mark_unowned_identifiers(
+    task: Task,
+    session: Session,
+    collection: Collection,
+    unowned: tuple[IdentifierData, ...],
+) -> int:
+    """Mark the titles on a crawled page that Overdrive reports it no longer owns.
+
+    Overdrive keeps weeded and expired titles in the product list rather than dropping
+    them, so this is a statement that a title is gone rather than an inference from its
+    absence -- which is why it does not wait on the crawl being shown complete.
+
+    Only titles we still record as available are marked, so the titles Overdrive keeps
+    listing as unowned do not generate an apply task on every pass.
+    """
+    if not unowned:
+        return 0
+
+    identifiers = session.scalars(
+        available_identifiers_query(collection.id).where(
+            Identifier.type == Identifier.OVERDRIVE_ID,
+            Identifier.identifier.in_(
+                [identifier.identifier for identifier in unowned]
+            ),
+        )
+    ).all()
+    if not identifiers:
+        return 0
+
+    data_source = validate_not_none(
+        collection.data_source,
+        message="Collection has no data source! (data_source is None).",
+    )
+    return queue_unavailable_updates(
+        (IdentifierData.from_identifier(identifier) for identifier in identifiers),
+        collection_id=collection.id,
+        collection_name=collection.name,
+        data_source_name=data_source.name,
+        # Overdrive drops titles from a collection when a lease ends or a purchase is
+        # returned, not only when a title is withdrawn, so this means "no copies here
+        # now" rather than "revoke outstanding loans and holds".
+        status=LicensePoolStatus.EXHAUSTED,
+        log=task.log,
+    )
+
+
 def _crawl_is_complete(
-    task: Task, collection_name: str, seen: int, total_items: int | None
+    task: Task, collection_name: str, crawled: int, total_items: int | None
 ) -> bool:
     """Decide whether a finished crawl covered the whole collection.
 
-    A crawl runs for minutes against a collection that keeps changing underneath it,
-    so a small discrepancy against ``totalItems`` is expected -- titles added or
-    removed mid-crawl move the count. A large shortfall means pages were missed, and
-    reaping on that would mark live titles as gone.
+    ``crawled`` counts *distinct* identifiers, so a title returned twice cannot paper
+    over one that was missed.
+
+    A crawl runs for hours against a collection that keeps changing underneath it, so a
+    small discrepancy against ``totalItems`` is expected -- titles added or removed
+    mid-crawl move the count. A large shortfall means pages were missed, and reaping on
+    that would mark live titles as gone.
     """
     if total_items is None:
         task.log.error(
@@ -602,11 +678,14 @@ def _crawl_is_complete(
         )
         return False
 
-    allowance = max(REAP_CRAWL_ALLOWANCE_FLOOR, int(total_items * REAP_CRAWL_ALLOWANCE))
-    if seen + allowance < total_items:
+    allowance = min(
+        REAP_CRAWL_ALLOWANCE_CAP,
+        max(REAP_CRAWL_ALLOWANCE_FLOOR, int(total_items * REAP_CRAWL_ALLOWANCE)),
+    )
+    if crawled + allowance < total_items:
         task.log.error(
             f"Overdrive reaper aborting for collection '{collection_name}': crawl saw "
-            f"{seen} products but Overdrive reports {total_items} "
+            f"{crawled} titles but Overdrive reports {total_items} "
             f"(allowance {allowance}). Refusing to reap on an incomplete crawl."
         )
         return False

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -54,12 +54,14 @@ REAP_CRAWL_ALLOWANCE_FLOOR: int = 10
 # one Overdrive applied rather than the one asked for.
 REAP_CRAWL_ALLOWANCE_PAGE_FRACTION: float = 0.25
 
-# How long the reaper's identifier sets outlive their creation. A crawl of the largest
-# collection can span more than a day, and both halves of the comparison have to still
-# be there when it finishes. The sets are keyed on the run's task id, so an abandoned
-# run's keys cannot be picked up by the next pass -- they only take up space until they
-# expire.
-REAP_IDENTIFIER_SET_LIFETIME: datetime.timedelta = datetime.timedelta(hours=36)
+# How long the reaper's identifier sets outlive their creation, between two bounds.
+# Long enough to outlast a crawl of the largest collection, since the set built at the
+# start has to still be there at the end -- hours, against the default of twelve.
+# Shorter than the daily schedule, because a crawl that dies without reaching the chord
+# body leaves its sets behind: keyed on the run's task id, they cannot be picked up by
+# the next pass, so a collection that fails repeatedly would otherwise stack up a set
+# per run.
+REAP_IDENTIFIER_SET_LIFETIME: datetime.timedelta = datetime.timedelta(hours=20)
 
 
 class ImportSkippedPayload(TypedDict):

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -906,8 +906,12 @@ class OverdriveAPI(
             listed=listed,
             unowned=unowned,
             total_items=data.get("totalItems"),
-            # Overdrive caps the page size it applies, and echoes what it used.
-            limit=data.get("limit") or len(products),
+            # Overdrive caps the page size it applies, and echoes the one it used --
+            # the requested size, not the number of titles returned, so a short page
+            # still reports a full limit. Every gap check in the crawl is expressed
+            # against this, so a response without it is unusable rather than
+            # something to infer from the products themselves.
+            limit=data.get("limit") or 0,
         )
 
     async def fetch_book_info_list(

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -12,6 +12,7 @@ from urllib.parse import urlsplit
 
 import flask
 from celery.canvas import Signature
+from httpx import Headers
 from pydantic import ValidationError
 from requests import Response
 from requests.structures import CaseInsensitiveDict
@@ -124,7 +125,7 @@ from palace.manager.sqlalchemy.model.resource import Representation
 from palace.manager.sqlalchemy.util import get_one
 from palace.manager.util import base64
 from palace.manager.util.http.async_http import WORKER_DEFAULT_BACKOFF, AsyncClient
-from palace.manager.util.http.exception import BadResponseException
+from palace.manager.util.http.exception import BadResponseException, ResponseData
 from palace.manager.util.http.http import HTTP, RequestKwargs
 
 
@@ -142,20 +143,25 @@ class BookInfoEndpoint:
 class ProductPage:
     """One page of a collection's product list, as consumed by the reaper.
 
-    :param active: Identifiers for the titles on this page that the collection still
-        owns. Titles Overdrive reports as no longer owned are excluded, so they fall
-        out of the reaper's active set and are reaped like titles that left the feed
-        entirely.
-    :param seen: How many products the page contained, owned or not. Accumulated
-        across pages and compared against ``total_items`` to detect a truncated crawl.
+    :param listed: Identifiers for every title on the page, owned or not. The
+        reaper's set difference is taken against these, so a title Overdrive still
+        lists is never reaped for being absent -- if it is no longer owned it is
+        marked from ``unowned`` instead.
+    :param unowned: The subset of ``listed`` that Overdrive flags
+        ``isOwnedByCollections: false``. Overdrive keeps weeded and expired titles in
+        the product list rather than dropping them, so this is direct evidence that a
+        title is gone, as opposed to the inference drawn from an identifier's absence.
     :param total_items: Overdrive's count of the whole result set.
-    :param next_page: The following page, or None once the crawl is complete.
+    :param offset: Where this page starts in the result set, as echoed by Overdrive.
+    :param limit: The page size Overdrive applied, which may be smaller than the one
+        requested.
     """
 
-    active: tuple[IdentifierData, ...]
-    seen: int
+    listed: tuple[IdentifierData, ...]
+    unowned: tuple[IdentifierData, ...]
     total_items: int | None
-    next_page: BookInfoEndpoint | None
+    offset: int
+    limit: int
 
 
 class OverdriveAPI(
@@ -240,7 +246,7 @@ class OverdriveAPI(
 
     COLLECTION_PRODUCTS_ENDPOINT = (
         f"{HOST_ENDPOINT_BASE}/v1/collections/%(collection_token)s/products"
-        "?limit=%(limit)s&sort=%(sort)s"
+        "?limit=%(limit)s&offset=%(offset)s&sort=%(sort)s"
     )
 
     METADATA_ENDPOINT_BASE = "/v1/collections/%(collection_token)s/products"
@@ -276,13 +282,15 @@ class OverdriveAPI(
     # nothing but ids, so the response stays manageable.
     PRODUCTS_PAGE_SIZE_LIMIT = 2000
 
-    # Sorting the reaper's crawl by an immutable field keeps offset pagination
-    # stable. Overdrive's `next` links are offset-based, so under the default
-    # ordering a title whose metadata changes mid-crawl can shift position and
-    # slide past the cursor -- and a title the crawl never sees is
-    # indistinguishable from one that left the collection. dateAdded never
-    # changes, and sorting it ascending puts newly added titles beyond the
-    # cursor instead of shifting everything behind them.
+    # The reaper's crawl pages through offsets, so it needs an ordering that does
+    # not shift under it. Ties cannot be broken from here: Overdrive rejects every
+    # unique sort key (`id`, `reserveId` and `crossRefId` all return 400) and accepts
+    # a second sort key only to ignore it. dateAdded is heavily tied, too -- a bulk
+    # load can put thousands of titles on one value. Overdrive does resolve those ties
+    # consistently: the same offsets return the same titles across repeated requests,
+    # across page sizes, and across whole crawls. dateAdded is also immutable, so
+    # nothing the crawl reads can move a title from one position to another mid-run.
+    # See `next_product_page` for titles removed mid-crawl.
     PRODUCTS_CRAWL_SORT = "dateAdded:asc"
 
     EVENT_SOURCE = "Overdrive"
@@ -747,15 +755,16 @@ class OverdriveAPI(
 
         return BookInfoEndpoint(endpoint)
 
-    def product_page_initial_endpoint(
-        self, page_size: int | None = None
+    def product_page_endpoint(
+        self, offset: int = 0, page_size: int | None = None
     ) -> BookInfoEndpoint:
-        """Create the first-page url for a full crawl of the collection's products.
+        """Create the url for one page of a full crawl of the collection's products.
 
         Unlike :meth:`book_info_initial_endpoint` this is not filtered by update
         time: the reaper needs every title the collection currently holds, not only
         those that changed recently.
 
+        :param offset: Index of the first title the page should return.
         :param page_size: Titles per page. Capped at
             :attr:`PRODUCTS_PAGE_SIZE_LIMIT`, which is also the default.
         """
@@ -765,9 +774,42 @@ class OverdriveAPI(
             self.COLLECTION_PRODUCTS_ENDPOINT,
             collection_token=self.collection_token,
             limit=str(min(page_size, self.PRODUCTS_PAGE_SIZE_LIMIT)),
+            offset=str(offset),
             sort=self.PRODUCTS_CRAWL_SORT,
         )
         return BookInfoEndpoint(_make_link_safe(url))
+
+    def next_product_page(self, page: ProductPage) -> BookInfoEndpoint | None:
+        """The next page of a reaper crawl, or None once the collection is covered.
+
+        The crawl walks the product list *backwards*: the first page is fetched at
+        offset 0 to learn ``totalItems``, and from there each page steps back one
+        page-length until the start of the list is reached.
+
+        Walking forwards -- following Overdrive's ``next`` links -- would lose a
+        title every time one was removed mid-crawl. Removing a title shifts every
+        title behind it down one position, so the title sitting at the next page's
+        starting offset is never returned, and a title the crawl never saw is
+        indistinguishable from one that left the collection. Walking backwards, a
+        removal below the cursor can only shift a not-yet-crawled title further into
+        the region still being walked, and a removal above it cannot move that region
+        at all: titles are re-seen at worst, never skipped. The last page overlaps the
+        first, which is harmless because the identifiers are collected into a set.
+
+        :param page: The page just fetched.
+        """
+        if page.total_items is None or page.limit <= 0:
+            # Nothing to page with. The caller's completeness check refuses a crawl
+            # that cannot be shown to have covered the collection.
+            return None
+        if page.offset == 0:
+            if page.total_items <= page.limit:
+                return None
+            return self.product_page_endpoint(page.total_items - page.limit)
+        if page.offset <= page.limit:
+            # The first page already covered everything below this one.
+            return None
+        return self.product_page_endpoint(page.offset - page.limit)
 
     def fetch_product_page(self, endpoint: BookInfoEndpoint) -> ProductPage:
         """Fetch a single page of the collection's product list.
@@ -782,38 +824,49 @@ class OverdriveAPI(
         the identifiers in the database.
 
         :param endpoint: The page to fetch.
-        :return: The page's owned identifiers, product count, result-set size and
-            next page.
+        :raise BadResponseException: If Overdrive returns anything but a 200.
+        :return: The page's identifiers, the unowned subset, and the paging fields
+            needed to walk the rest of the crawl.
         """
-        status_code, _, content = self.get(endpoint.url)
+        status_code, headers, content = self.get(endpoint.url)
         if status_code != 200:
-            # Left to the caller's completeness check rather than raised here: a
-            # short page and a missing totalItems both surface there as "crawl
-            # could not be verified", which is the outcome either way.
-            self.log.error(
-                "Unexpected status code %s fetching Overdrive product page %s",
-                status_code,
+            # This endpoint returns the occasional transient 404, which self.get()
+            # allows through. Raising a retryable error lets the page be retried
+            # rather than discarding a crawl that may have been running for hours.
+            raise BadResponseException(
                 endpoint.url,
+                f"Unexpected status code {status_code} fetching Overdrive product page.",
+                ResponseData(
+                    status_code=status_code,
+                    url=endpoint.url,
+                    headers=Headers(headers),
+                    text=content.decode("utf-8", errors="replace"),
+                    content=content,
+                    extensions={},
+                ),
             )
         data = json.loads(content)
 
         products = data.get("products") or []
-        active = tuple(
+        listed = tuple(
             IdentifierData(
                 type=Identifier.OVERDRIVE_ID, identifier=product["id"].lower()
             )
             for product in products
-            # A title Overdrive still lists but no longer owns is as gone as one
-            # that left the feed, so it is left out of the active set.
-            if product.get("isOwnedByCollections") is not False
         )
-        next_url = OverdriveRepresentationExtractor.link(data, self.NEXT_REL)
+        unowned = tuple(
+            identifier
+            for identifier, product in zip(listed, products)
+            if product.get("isOwnedByCollections") is False
+        )
 
         return ProductPage(
-            active=active,
-            seen=len(products),
+            listed=listed,
+            unowned=unowned,
             total_items=data.get("totalItems"),
-            next_page=BookInfoEndpoint(next_url) if next_url else None,
+            offset=data.get("offset") or 0,
+            # Overdrive caps the page size it applies, and echoes what it used.
+            limit=data.get("limit") or len(products),
         )
 
     async def fetch_book_info_list(

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -857,13 +857,12 @@ class OverdriveAPI(
             needed to walk the rest of the crawl.
         """
         status_code, headers, content = self.get(endpoint.url)
-        if status_code != 200:
-            # This endpoint returns the occasional transient 404, which self.get()
-            # allows through. Raising a retryable error lets the page be retried
-            # rather than discarding a crawl that may have been running for hours.
-            raise BadResponseException(
+
+        def unusable(message: str) -> BadResponseException:
+            """A page the crawl can't use, as an error its task will retry."""
+            return BadResponseException(
                 endpoint.url,
-                f"Unexpected status code {status_code} fetching Overdrive product page.",
+                message,
                 ResponseData(
                     status_code=status_code,
                     url=endpoint.url,
@@ -873,7 +872,22 @@ class OverdriveAPI(
                     extensions={},
                 ),
             )
-        data = json.loads(content)
+
+        if status_code != 200:
+            # This endpoint returns the occasional transient 404, which self.get()
+            # allows through. Raising a retryable error lets the page be retried
+            # rather than discarding a crawl that may have been running for hours.
+            raise unusable(
+                f"Unexpected status code {status_code} fetching Overdrive product page."
+            )
+
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as exception:
+            # A 200 carrying something that isn't JSON -- an intermediary's error
+            # page, say -- is the same class of blip as the status codes above, and
+            # is worth the same retry rather than killing the crawl outright.
+            raise unusable("Overdrive product page was not valid JSON.") from exception
 
         products = data.get("products") or []
         listed = tuple(

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -53,6 +53,7 @@ from palace.manager.core.config import CannotLoadConfiguration, Configuration
 from palace.manager.core.exceptions import IntegrationException
 from palace.manager.core.selftest import SelfTestResult
 from palace.manager.data_layer.format import FormatData
+from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.data_layer.policy.replacement import ReplacementPolicy
 from palace.manager.integration.base import HasChildIntegrationConfiguration
 from palace.manager.integration.license.overdrive.advantage import (
@@ -115,6 +116,7 @@ from palace.manager.sqlalchemy.model.licensing import (
     DeliveryMechanism,
     LicensePool,
     LicensePoolDeliveryMechanism,
+    LicensePoolStatus,
     RightsStatus,
 )
 from palace.manager.sqlalchemy.model.patron import Hold, Patron
@@ -134,6 +136,26 @@ class OverdriveToken(NamedTuple):
 @dataclass
 class BookInfoEndpoint:
     url: str
+
+
+@dataclass(frozen=True)
+class ProductPage:
+    """One page of a collection's product list, as consumed by the reaper.
+
+    :param active: Identifiers for the titles on this page that the collection still
+        owns. Titles Overdrive reports as no longer owned are excluded, so they fall
+        out of the reaper's active set and are reaped like titles that left the feed
+        entirely.
+    :param seen: How many products the page contained, owned or not. Accumulated
+        across pages and compared against ``total_items`` to detect a truncated crawl.
+    :param total_items: Overdrive's count of the whole result set.
+    :param next_page: The following page, or None once the crawl is complete.
+    """
+
+    active: tuple[IdentifierData, ...]
+    seen: int
+    total_items: int | None
+    next_page: BookInfoEndpoint | None
 
 
 class OverdriveAPI(
@@ -216,6 +238,11 @@ class OverdriveAPI(
     )
     ALL_PRODUCTS_ENDPOINT = f"{HOST_ENDPOINT_BASE}/v1/collections/%(collection_token)s/products?sort=%(sort)s"
 
+    COLLECTION_PRODUCTS_ENDPOINT = (
+        f"{HOST_ENDPOINT_BASE}/v1/collections/%(collection_token)s/products"
+        "?limit=%(limit)s&sort=%(sort)s"
+    )
+
     METADATA_ENDPOINT_BASE = "/v1/collections/%(collection_token)s/products"
 
     METADATA_ENDPOINT = (
@@ -243,6 +270,21 @@ class OverdriveAPI(
     MAX_CREDENTIAL_AGE = 50 * 60
 
     PAGE_SIZE_LIMIT = 300
+
+    # The products endpoint honours a page size up to 2000; anything larger is
+    # silently capped. Only the reaper asks for pages this large, and it reads
+    # nothing but ids, so the response stays manageable.
+    PRODUCTS_PAGE_SIZE_LIMIT = 2000
+
+    # Sorting the reaper's crawl by an immutable field keeps offset pagination
+    # stable. Overdrive's `next` links are offset-based, so under the default
+    # ordering a title whose metadata changes mid-crawl can shift position and
+    # slide past the cursor -- and a title the crawl never sees is
+    # indistinguishable from one that left the collection. dateAdded never
+    # changes, and sorting it ascending puts newly added titles beyond the
+    # cursor instead of shifting everything behind them.
+    PRODUCTS_CRAWL_SORT = "dateAdded:asc"
+
     EVENT_SOURCE = "Overdrive"
 
     EVENT_DELAY = datetime.timedelta(minutes=120)
@@ -288,9 +330,20 @@ class OverdriveAPI(
     def reap_task(cls, collection_id: int) -> Signature:
         # Local import to avoid a circular import between this module and the
         # overdrive celery tasks module, which imports OverdriveAPI.
+        from palace.manager.celery.tasks.identifiers import (
+            create_mark_unavailable_chord,
+        )
         from palace.manager.celery.tasks.overdrive import reap_collection
 
-        return reap_collection.s(collection_id)
+        return create_mark_unavailable_chord(
+            collection_id,
+            reap_collection.s(collection_id),
+            # Overdrive drops titles from a collection when a lease ends or a
+            # purchase is returned, not only when a title is withdrawn, so a
+            # missing title means "no copies here now" rather than "revoke
+            # outstanding loans and holds".
+            status=LicensePoolStatus.EXHAUSTED,
+        )
 
     def __init__(self, _db: Session, collection: Collection) -> None:
         super().__init__(_db, collection)
@@ -693,6 +746,75 @@ class OverdriveAPI(
         endpoint: str = _make_link_safe(book_info_initial_endpoint)
 
         return BookInfoEndpoint(endpoint)
+
+    def product_page_initial_endpoint(
+        self, page_size: int | None = None
+    ) -> BookInfoEndpoint:
+        """Create the first-page url for a full crawl of the collection's products.
+
+        Unlike :meth:`book_info_initial_endpoint` this is not filtered by update
+        time: the reaper needs every title the collection currently holds, not only
+        those that changed recently.
+
+        :param page_size: Titles per page. Capped at
+            :attr:`PRODUCTS_PAGE_SIZE_LIMIT`, which is also the default.
+        """
+        if page_size is None:
+            page_size = self.PRODUCTS_PAGE_SIZE_LIMIT
+        url = self.endpoint(
+            self.COLLECTION_PRODUCTS_ENDPOINT,
+            collection_token=self.collection_token,
+            limit=str(min(page_size, self.PRODUCTS_PAGE_SIZE_LIMIT)),
+            sort=self.PRODUCTS_CRAWL_SORT,
+        )
+        return BookInfoEndpoint(_make_link_safe(url))
+
+    def fetch_product_page(self, endpoint: BookInfoEndpoint) -> ProductPage:
+        """Fetch a single page of the collection's product list.
+
+        Only ids and ownership are read from the response -- no metadata or
+        availability lookups are made -- which is what lets a whole collection be
+        enumerated in a handful of requests.
+
+        Overdrive returns product ids uppercased here but lowercased in availability
+        documents, and :meth:`Identifier.for_foreign_id` stores them lowercased. The
+        ids are normalised on the way out so the reaper's set operations line up with
+        the identifiers in the database.
+
+        :param endpoint: The page to fetch.
+        :return: The page's owned identifiers, product count, result-set size and
+            next page.
+        """
+        status_code, _, content = self.get(endpoint.url)
+        if status_code != 200:
+            # Left to the caller's completeness check rather than raised here: a
+            # short page and a missing totalItems both surface there as "crawl
+            # could not be verified", which is the outcome either way.
+            self.log.error(
+                "Unexpected status code %s fetching Overdrive product page %s",
+                status_code,
+                endpoint.url,
+            )
+        data = json.loads(content)
+
+        products = data.get("products") or []
+        active = tuple(
+            IdentifierData(
+                type=Identifier.OVERDRIVE_ID, identifier=product["id"].lower()
+            )
+            for product in products
+            # A title Overdrive still lists but no longer owns is as gone as one
+            # that left the feed, so it is left out of the active set.
+            if product.get("isOwnedByCollections") is not False
+        )
+        next_url = OverdriveRepresentationExtractor.link(data, self.NEXT_REL)
+
+        return ProductPage(
+            active=active,
+            seen=len(products),
+            total_items=data.get("totalItems"),
+            next_page=BookInfoEndpoint(next_url) if next_url else None,
+        )
 
     async def fetch_book_info_list(
         self,

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -153,23 +153,14 @@ class ProductPage:
         title is gone, as opposed to the inference drawn from an identifier's absence.
     :param total_items: Overdrive's count of the whole result set.
     :param limit: The page size Overdrive applied, which may be smaller than the one
-        requested.
+        requested. Always the size applied, never the number of titles returned, so a
+        page at the end of the list still reports a full one.
     """
 
     listed: tuple[IdentifierData, ...]
     unowned: tuple[IdentifierData, ...]
-    total_items: int | None
+    total_items: int
     limit: int
-
-    @property
-    def pageable(self) -> bool:
-        """Whether a crawl can work out where to go next from this page.
-
-        Distinct from having reached the end of the collection: a crawl that stops
-        because a page arrived without the fields it needs has covered an unknown
-        amount of the list, and must not be judged by the allowance for churn.
-        """
-        return self.total_items is not None and self.limit > 0
 
 
 class OverdriveAPI(
@@ -825,10 +816,6 @@ class OverdriveAPI(
         :param offset: The offset that page was requested at. Taken from the caller
             rather than the response so the walk cannot be talked into standing still.
         """
-        if page.total_items is None or page.limit <= 0:
-            # Nothing to page with. The caller's completeness check refuses a crawl
-            # that cannot be shown to have covered the collection.
-            return None
         if offset == 0:
             if page.total_items <= page.limit:
                 return None
@@ -889,6 +876,19 @@ class OverdriveAPI(
             # is worth the same retry rather than killing the crawl outright.
             raise unusable("Overdrive product page was not valid JSON.") from exception
 
+        # Overdrive caps the page size it applies and echoes the one it used -- the
+        # requested size, not the number of titles returned, so a short page still
+        # reports a full limit. Every gap check in the crawl is expressed against
+        # these two, and a page carrying neither is one more shape a blip can take:
+        # it gets the same retry, rather than being inferred from the body or taken
+        # as a reason to abandon the crawl.
+        total_items = data.get("totalItems")
+        limit = data.get("limit")
+        if total_items is None or not limit:
+            raise unusable(
+                "Overdrive product page carried no usable totalItems or page size."
+            )
+
         products = data.get("products") or []
         listed = tuple(
             IdentifierData(
@@ -905,13 +905,8 @@ class OverdriveAPI(
         return ProductPage(
             listed=listed,
             unowned=unowned,
-            total_items=data.get("totalItems"),
-            # Overdrive caps the page size it applies, and echoes the one it used --
-            # the requested size, not the number of titles returned, so a short page
-            # still reports a full limit. Every gap check in the crawl is expressed
-            # against this, so a response without it is unusable rather than
-            # something to infer from the products themselves.
-            limit=data.get("limit") or 0,
+            total_items=total_items,
+            limit=limit,
         )
 
     async def fetch_book_info_list(

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -290,12 +290,6 @@ class OverdriveAPI(
     # nothing but ids, so the response stays manageable.
     PRODUCTS_PAGE_SIZE_LIMIT = 2000
 
-    # How long the reaper's identifier sets outlive their creation. Long enough that
-    # a crawl of the largest collection cannot outlast the set it will be compared
-    # against, and short enough that an abandoned run is cleaned up well before the
-    # next daily pass.
-    REAP_IDENTIFIER_SET_LIFETIME = datetime.timedelta(hours=36)
-
     # How much of a page consecutive crawl pages share. See `next_product_offset`
     # for what the overlap absorbs; it is a fraction so that it scales with whatever
     # page size Overdrive actually applies.
@@ -360,7 +354,10 @@ class OverdriveAPI(
         from palace.manager.celery.tasks.identifiers import (
             create_mark_unavailable_chord,
         )
-        from palace.manager.celery.tasks.overdrive import reap_collection
+        from palace.manager.celery.tasks.overdrive import (
+            REAP_IDENTIFIER_SET_LIFETIME,
+            reap_collection,
+        )
 
         return create_mark_unavailable_chord(
             collection_id,
@@ -373,7 +370,7 @@ class OverdriveAPI(
             # The crawl walks a page at a time through the shared queue, so the
             # largest collections take hours. The other half of the chord is built
             # once, at the start, and has to still be there at the end.
-            expire_time=int(cls.REAP_IDENTIFIER_SET_LIFETIME.total_seconds()),
+            expire_time=int(REAP_IDENTIFIER_SET_LIFETIME.total_seconds()),
         )
 
     def __init__(self, _db: Session, collection: Collection) -> None:

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -161,6 +161,16 @@ class ProductPage:
     total_items: int | None
     limit: int
 
+    @property
+    def pageable(self) -> bool:
+        """Whether a crawl can work out where to go next from this page.
+
+        Distinct from having reached the end of the collection: a crawl that stops
+        because a page arrived without the fields it needs has covered an unknown
+        amount of the list, and must not be judged by the allowance for churn.
+        """
+        return self.total_items is not None and self.limit > 0
+
 
 class OverdriveAPI(
     PatronActivityCirculationAPI[OverdriveSettings, OverdriveLibrarySettings],
@@ -280,6 +290,12 @@ class OverdriveAPI(
     # nothing but ids, so the response stays manageable.
     PRODUCTS_PAGE_SIZE_LIMIT = 2000
 
+    # How long the reaper's identifier sets outlive their creation. Long enough that
+    # a crawl of the largest collection cannot outlast the set it will be compared
+    # against, and short enough that an abandoned run is cleaned up well before the
+    # next daily pass.
+    REAP_IDENTIFIER_SET_LIFETIME = datetime.timedelta(hours=36)
+
     # How much of a page consecutive crawl pages share. See `next_product_offset`
     # for what the overlap absorbs; it is a fraction so that it scales with whatever
     # page size Overdrive actually applies.
@@ -293,7 +309,7 @@ class OverdriveAPI(
     # consistently: the same offsets return the same titles across repeated requests,
     # across page sizes, and across whole crawls. dateAdded is also immutable, so
     # nothing the crawl reads can move a title from one position to another mid-run.
-    # See `next_product_page` for titles removed mid-crawl.
+    # See `next_product_offset` for titles removed mid-crawl.
     PRODUCTS_CRAWL_SORT = "dateAdded:asc"
 
     EVENT_SOURCE = "Overdrive"
@@ -354,6 +370,10 @@ class OverdriveAPI(
             # missing title means "no copies here now" rather than "revoke
             # outstanding loans and holds".
             status=LicensePoolStatus.EXHAUSTED,
+            # The crawl walks a page at a time through the shared queue, so the
+            # largest collections take hours. The other half of the chord is built
+            # once, at the start, and has to still be there at the end.
+            expire_time=int(cls.REAP_IDENTIFIER_SET_LIFETIME.total_seconds()),
         )
 
     def __init__(self, _db: Session, collection: Collection) -> None:

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -74,6 +74,7 @@ from palace.manager.integration.license.overdrive.constants import (
 from palace.manager.integration.license.overdrive.coverage import (
     OverdriveBibliographicCoverageProvider,
 )
+from palace.manager.integration.license.overdrive.crawl import ProductPage
 from palace.manager.integration.license.overdrive.exception import (
     InvalidFieldOptionError,
     OverdriveModelError,
@@ -137,30 +138,6 @@ class OverdriveToken(NamedTuple):
 @dataclass
 class BookInfoEndpoint:
     url: str
-
-
-@dataclass(frozen=True)
-class ProductPage:
-    """One page of a collection's product list, as consumed by the reaper.
-
-    :param listed: Identifiers for every title on the page, owned or not. The
-        reaper's set difference is taken against these, so a title Overdrive still
-        lists is never reaped for being absent -- if it is no longer owned it is
-        marked from ``unowned`` instead.
-    :param unowned: The subset of ``listed`` that Overdrive flags
-        ``isOwnedByCollections: false``. Overdrive keeps weeded and expired titles in
-        the product list rather than dropping them, so this is direct evidence that a
-        title is gone, as opposed to the inference drawn from an identifier's absence.
-    :param total_items: Overdrive's count of the whole result set.
-    :param limit: The page size Overdrive applied, which may be smaller than the one
-        requested. Always the size applied, never the number of titles returned, so a
-        page at the end of the list still reports a full one.
-    """
-
-    listed: tuple[IdentifierData, ...]
-    unowned: tuple[IdentifierData, ...]
-    total_items: int
-    limit: int
 
 
 class OverdriveAPI(
@@ -281,11 +258,6 @@ class OverdriveAPI(
     # nothing but ids, so the response stays manageable.
     PRODUCTS_PAGE_SIZE_LIMIT = 2000
 
-    # How much of a page consecutive crawl pages share. See `next_product_offset`
-    # for what the overlap absorbs; it is a fraction so that it scales with whatever
-    # page size Overdrive actually applies.
-    PRODUCTS_CRAWL_OVERLAP = 0.05
-
     # The reaper's crawl pages through offsets, so it needs an ordering that does
     # not shift under it. Ties cannot be broken from here: Overdrive rejects every
     # unique sort key (`id`, `reserveId` and `crossRefId` all return 400) and accepts
@@ -294,7 +266,8 @@ class OverdriveAPI(
     # consistently: the same offsets return the same titles across repeated requests,
     # across page sizes, and across whole crawls. dateAdded is also immutable, so
     # nothing the crawl reads can move a title from one position to another mid-run.
-    # See `next_product_offset` for titles removed mid-crawl.
+    # See :class:`~palace.manager.integration.license.overdrive.crawl.CrawlCursor`
+    # for titles removed mid-crawl.
     PRODUCTS_CRAWL_SORT = "dateAdded:asc"
 
     EVENT_SOURCE = "Overdrive"
@@ -790,42 +763,6 @@ class OverdriveAPI(
         )
         return BookInfoEndpoint(_make_link_safe(url))
 
-    def next_product_offset(self, page: ProductPage, offset: int) -> int | None:
-        """Where a reaper crawl goes next, or None once the collection is covered.
-
-        The crawl walks the product list *backwards*: the first page is fetched at
-        offset 0 to learn ``totalItems``, and from there each page steps back towards
-        the start of the list.
-
-        Walking forwards -- following Overdrive's ``next`` links -- would lose a
-        title every time one was removed mid-crawl. Removing a title shifts every
-        title behind it down one position, so the title sitting at the next page's
-        starting offset is never returned, and a title the crawl never saw is
-        indistinguishable from one that left the collection. Walking backwards, a
-        removal below the cursor can only shift a not-yet-crawled title further into
-        the region still being walked, and a removal above it cannot move that region
-        at all.
-
-        The step back is shorter than a page, so consecutive pages overlap. That
-        covers the mirror image of the same problem -- a title *inserted* below the
-        cursor pushes its neighbours up, one of them into the region already
-        crawled -- along with any ordering jitter within a tie group. Overlapping is
-        free: the identifiers are collected into a set.
-
-        :param page: The page just fetched.
-        :param offset: The offset that page was requested at. Taken from the caller
-            rather than the response so the walk cannot be talked into standing still.
-        """
-        if offset == 0:
-            if page.total_items <= page.limit:
-                return None
-            return page.total_items - page.limit
-        if offset <= page.limit:
-            # The first page already covered everything below this one.
-            return None
-        step = max(1, page.limit - int(page.limit * self.PRODUCTS_CRAWL_OVERLAP))
-        return max(0, offset - step)
-
     def fetch_product_page(self, endpoint: BookInfoEndpoint) -> ProductPage:
         """Fetch a single page of the collection's product list.
 
@@ -840,8 +777,10 @@ class OverdriveAPI(
 
         :param endpoint: The page to fetch.
         :raise BadResponseException: If Overdrive returns anything but a 200.
-        :return: The page's identifiers, the unowned subset, and the paging fields
-            needed to walk the rest of the crawl.
+        :return: The page's identifiers, the unowned subset, the raw product
+            dictionaries, and the paging fields a
+            :class:`~palace.manager.integration.license.overdrive.crawl.CrawlCursor`
+            needs to walk the rest of the crawl.
         """
         status_code, headers, content = self.get(endpoint.url)
 
@@ -907,6 +846,7 @@ class OverdriveAPI(
             unowned=unowned,
             total_items=total_items,
             limit=limit,
+            products=tuple(products),
         )
 
     async def fetch_book_info_list(

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -152,7 +152,6 @@ class ProductPage:
         the product list rather than dropping them, so this is direct evidence that a
         title is gone, as opposed to the inference drawn from an identifier's absence.
     :param total_items: Overdrive's count of the whole result set.
-    :param offset: Where this page starts in the result set, as echoed by Overdrive.
     :param limit: The page size Overdrive applied, which may be smaller than the one
         requested.
     """
@@ -160,7 +159,6 @@ class ProductPage:
     listed: tuple[IdentifierData, ...]
     unowned: tuple[IdentifierData, ...]
     total_items: int | None
-    offset: int
     limit: int
 
 
@@ -281,6 +279,11 @@ class OverdriveAPI(
     # silently capped. Only the reaper asks for pages this large, and it reads
     # nothing but ids, so the response stays manageable.
     PRODUCTS_PAGE_SIZE_LIMIT = 2000
+
+    # How much of a page consecutive crawl pages share. See `next_product_offset`
+    # for what the overlap absorbs; it is a fraction so that it scales with whatever
+    # page size Overdrive actually applies.
+    PRODUCTS_CRAWL_OVERLAP = 0.05
 
     # The reaper's crawl pages through offsets, so it needs an ordering that does
     # not shift under it. Ties cannot be broken from here: Overdrive rejects every
@@ -779,12 +782,12 @@ class OverdriveAPI(
         )
         return BookInfoEndpoint(_make_link_safe(url))
 
-    def next_product_page(self, page: ProductPage) -> BookInfoEndpoint | None:
-        """The next page of a reaper crawl, or None once the collection is covered.
+    def next_product_offset(self, page: ProductPage, offset: int) -> int | None:
+        """Where a reaper crawl goes next, or None once the collection is covered.
 
         The crawl walks the product list *backwards*: the first page is fetched at
-        offset 0 to learn ``totalItems``, and from there each page steps back one
-        page-length until the start of the list is reached.
+        offset 0 to learn ``totalItems``, and from there each page steps back towards
+        the start of the list.
 
         Walking forwards -- following Overdrive's ``next`` links -- would lose a
         title every time one was removed mid-crawl. Removing a title shifts every
@@ -793,23 +796,31 @@ class OverdriveAPI(
         indistinguishable from one that left the collection. Walking backwards, a
         removal below the cursor can only shift a not-yet-crawled title further into
         the region still being walked, and a removal above it cannot move that region
-        at all: titles are re-seen at worst, never skipped. The last page overlaps the
-        first, which is harmless because the identifiers are collected into a set.
+        at all.
+
+        The step back is shorter than a page, so consecutive pages overlap. That
+        covers the mirror image of the same problem -- a title *inserted* below the
+        cursor pushes its neighbours up, one of them into the region already
+        crawled -- along with any ordering jitter within a tie group. Overlapping is
+        free: the identifiers are collected into a set.
 
         :param page: The page just fetched.
+        :param offset: The offset that page was requested at. Taken from the caller
+            rather than the response so the walk cannot be talked into standing still.
         """
         if page.total_items is None or page.limit <= 0:
             # Nothing to page with. The caller's completeness check refuses a crawl
             # that cannot be shown to have covered the collection.
             return None
-        if page.offset == 0:
+        if offset == 0:
             if page.total_items <= page.limit:
                 return None
-            return self.product_page_endpoint(page.total_items - page.limit)
-        if page.offset <= page.limit:
+            return page.total_items - page.limit
+        if offset <= page.limit:
             # The first page already covered everything below this one.
             return None
-        return self.product_page_endpoint(page.offset - page.limit)
+        step = max(1, page.limit - int(page.limit * self.PRODUCTS_CRAWL_OVERLAP))
+        return max(0, offset - step)
 
     def fetch_product_page(self, endpoint: BookInfoEndpoint) -> ProductPage:
         """Fetch a single page of the collection's product list.
@@ -864,7 +875,6 @@ class OverdriveAPI(
             listed=listed,
             unowned=unowned,
             total_items=data.get("totalItems"),
-            offset=data.get("offset") or 0,
             # Overdrive caps the page size it applies, and echoes what it used.
             limit=data.get("limit") or len(products),
         )

--- a/src/palace/manager/integration/license/overdrive/crawl.py
+++ b/src/palace/manager/integration/license/overdrive/crawl.py
@@ -1,0 +1,321 @@
+"""Machinery for crawling an Overdrive collection's product list.
+
+Overdrive's product list is paged by offset and publishes no unique sort key
+(``id``, ``reserveId`` and ``crossRefId`` are all rejected), so a crawl has to
+establish coverage structurally rather than trust the paging. The
+:class:`CrawlCursor` here owns that arithmetic: where the next page is fetched,
+what each fetched page must be shown to reach, and whether a finished crawl can
+be trusted. Callers own everything else -- fetching pages, accumulating
+identifiers, and deciding what a fault costs them. The reaper aborts on any
+fault, because it acts on titles' *absence* from the crawl; a future delta
+harvest can treat the same faults as advisory, because a missed update is
+recovered by the next run's window.
+
+The cursor walks the list *backwards*: the first page is fetched at offset 0 to
+learn ``totalItems``, each following page steps back from the end of the list,
+and the walk finishes with a fresh page at offset 0. Walking forwards --
+following Overdrive's ``next`` links -- would lose a title every time one was
+removed mid-crawl: removing a title shifts every title behind it down one
+position, so the title sitting at the next page's starting offset is never
+returned, and a title the crawl never saw is indistinguishable from one that
+left the collection. Walking backwards, a removal below the cursor can only
+shift a not-yet-crawled title further into the region still being walked, and a
+removal above it cannot move that region at all. The step back is shorter than
+a page, so consecutive pages overlap; that absorbs the mirror image of the same
+problem -- a title *inserted* below the cursor pushes its neighbours up, one of
+them into the region already crawled -- along with any ordering jitter within a
+tie group. Overlapping is free when the identifiers are collected into a set.
+
+Ending with a fresh page at offset 0 is what closes the walk's last seam. The
+first page's snapshot of the start of the list is hours stale by the time a
+long crawl gets back there, and titles only ever move *down* the
+``dateAdded:asc`` ordering (removals shift them down; additions land at the
+end), so a title sitting just past the first page's edge when the crawl began
+can drift below it before the walk returns -- dodging every page unless the
+start is re-covered at the end.
+"""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from palace.util.datetime_helpers import utc_now
+
+from palace.manager.data_layer.identifier import IdentifierData
+
+# How much of a page consecutive crawl pages share. A fraction, so that it
+# scales with whatever page size Overdrive actually applies.
+CRAWL_OVERLAP: float = 0.05
+
+# How far a completed crawl may fall short of Overdrive's reported totalItems
+# before it is treated as incomplete. A crawl of a large collection runs for
+# hours while titles are added and removed under it, so the count is expected
+# to move a little; the floor keeps small collections from being held to an
+# unreachable standard. The shortfall being allowed for is churn during the
+# crawl, which does not scale with collection size, so the cap keeps the
+# allowance below one page -- a crawl that lost a whole page must never be
+# excused.
+CRAWL_ALLOWANCE: float = 0.001
+CRAWL_ALLOWANCE_FLOOR: int = 10
+# Capped as a fraction of the page size the crawl is actually walking in, which
+# is the one Overdrive applied rather than the one asked for.
+CRAWL_ALLOWANCE_PAGE_FRACTION: float = 0.25
+
+
+@dataclass(frozen=True)
+class ProductPage:
+    """One page of a collection's product list.
+
+    :param products: The raw product dictionaries exactly as Overdrive returned
+        them, for callers that need more than identifiers -- metadata and
+        availability links, say. The crawl itself reads nothing from them.
+    :param listed: Identifiers for every title on the page, owned or not. The
+        reaper's set difference is taken against these, so a title Overdrive
+        still lists is never reaped for being absent -- if it is no longer
+        owned it is marked from ``unowned`` instead.
+    :param unowned: The subset of ``listed`` that Overdrive flags
+        ``isOwnedByCollections: false``. Overdrive keeps weeded and expired
+        titles in the product list rather than dropping them, so this is direct
+        evidence that a title is gone, as opposed to the inference drawn from
+        an identifier's absence.
+    :param total_items: Overdrive's count of the whole result set.
+    :param limit: The page size Overdrive applied, which may be smaller than
+        the one requested. Always the size applied, never the number of titles
+        returned, so a page at the end of the list still reports a full one.
+    """
+
+    listed: tuple[IdentifierData, ...]
+    unowned: tuple[IdentifierData, ...]
+    total_items: int
+    limit: int
+    products: tuple[dict[str, Any], ...] = ()
+
+
+@dataclass(frozen=True)
+class CrawlFault:
+    """A page the crawl cannot reconcile with the walk so far.
+
+    :param reason: What the page failed to show, in terms a log line can carry.
+        The caller decides what a fault costs: the reaper aborts, since it acts
+        on absence; a harvest may only note it.
+    """
+
+    reason: str
+
+
+@dataclass(frozen=True)
+class CrawlComplete:
+    """A walk that covered the whole list, pending the completeness gate.
+
+    Structural coverage (every page reached the one before it) is established
+    by the walk itself; what remains is comparing how many *distinct* titles
+    the caller collected against Overdrive's count, which is the caller's to
+    supply because the cursor never sees the identifiers.
+    """
+
+    total_items: int
+    page_limit: int
+    single_page: bool
+    started_at: datetime.datetime
+
+    @property
+    def elapsed(self) -> datetime.timedelta:
+        """How long the crawl has been running."""
+        return utc_now() - self.started_at
+
+    def completeness_fault(self, crawled: int) -> CrawlFault | None:
+        """Judge whether the finished crawl covered the whole collection.
+
+        :param crawled: The number of *distinct* identifiers collected, so a
+            title returned twice cannot paper over one that was missed.
+        :return: None when the crawl can be trusted, or a :class:`CrawlFault`
+            when the shortfall exceeds what mid-crawl churn can explain. A
+            collection that arrived in a single response had no window for
+            churn -- its products and count were produced together -- so it is
+            required to agree exactly.
+        """
+        allowance = (
+            0
+            if self.single_page
+            else min(
+                max(1, int(self.page_limit * CRAWL_ALLOWANCE_PAGE_FRACTION)),
+                max(
+                    CRAWL_ALLOWANCE_FLOOR,
+                    int(self.total_items * CRAWL_ALLOWANCE),
+                ),
+            )
+        )
+        if crawled + allowance < self.total_items:
+            return CrawlFault(
+                f"The crawl saw {crawled} titles but Overdrive reports "
+                f"{self.total_items} (allowance {allowance}). Refusing to reap "
+                f"on an incomplete crawl."
+            )
+        return None
+
+
+@dataclass(frozen=True)
+class CrawlCursor:
+    """Where a backwards crawl of a product list stands.
+
+    A fresh cursor points at the crawl's first page (offset 0, with no paging
+    facts yet); :meth:`advance` consumes each fetched page and returns the
+    cursor for the next one, a :class:`CrawlComplete` once the list is
+    covered, or a :class:`CrawlFault` for a page the walk cannot use. Cursors
+    are immutable and JSON-serializable, so a paginated task can carry one
+    across ``task.replace()`` hand-offs as a single kwarg.
+
+    :param offset: The offset the current page is (to be) fetched at.
+    :param previous_offset: Where the previous page of the backwards walk
+        started, so the current one can be shown to reach it. None on the first
+        backwards page, which runs to the end of the list instead.
+    :param total_items: Overdrive's collection size as reported by the crawl's
+        first page, carried for the completeness gate.
+    :param page_limit: The page size Overdrive applied to the first page. Every
+        gap check is measured in it, so the walk's arithmetic only holds while
+        it stays the same.
+    :param started_at: When the crawl began, for wall-clock logging: the guards
+        are all sensitive to how long a crawl runs, so an abort without the
+        elapsed time is half a diagnosis.
+    """
+
+    offset: int = 0
+    previous_offset: int | None = None
+    total_items: int | None = None
+    page_limit: int | None = None
+    started_at: datetime.datetime = field(default_factory=utc_now)
+
+    @property
+    def elapsed(self) -> datetime.timedelta:
+        """How long the crawl has been running."""
+        return utc_now() - self.started_at
+
+    def advance(self, page: ProductPage) -> CrawlCursor | CrawlComplete | CrawlFault:
+        """Consume the page fetched at this cursor and say what comes next.
+
+        :param page: The page fetched at :attr:`offset`.
+        """
+        if self.total_items is None:
+            # The crawl's first page. It exists to learn the paging facts --
+            # coverage never depends on it, because the walk ends by fetching
+            # the start of the list again -- except when the whole collection
+            # arrives in this one response.
+            if page.total_items <= page.limit:
+                return self._complete(
+                    total_items=page.total_items,
+                    page_limit=page.limit,
+                    single_page=True,
+                )
+            return replace(
+                self,
+                offset=page.total_items - page.limit,
+                previous_offset=None,
+                total_items=page.total_items,
+                page_limit=page.limit,
+            )
+
+        # total_items and page_limit are always recorded together.
+        assert self.page_limit is not None
+
+        if page.limit != self.page_limit:
+            # Where a page reaches, and so where the walk can stop, is measured
+            # in page sizes. Overdrive echoes the size it applied, and the
+            # crawl asks for the same one every time, so a change mid-crawl
+            # means this arithmetic no longer describes the list.
+            return CrawlFault(
+                f"The page at offset {self.offset} was returned with a page "
+                f"size of {page.limit}, but the crawl has been walking in "
+                f"steps of {self.page_limit}. Refusing to reap on a crawl "
+                f"whose paging changed underneath it."
+            )
+
+        if self.previous_offset is None:
+            # The walk's first backwards page runs to the end of the list, and
+            # is the one page with nothing above it to be checked against. Its
+            # reach is exactly knowable for that same reason: it has to arrive
+            # at the end.
+            #
+            # Which end depends on what the collection did in between. Titles
+            # removed since the first page shorten the list, so the smaller
+            # count is the one to insist on; titles added lengthen it, and
+            # under dateAdded:asc they land beyond where this page starts, so
+            # they are not this page's to reach -- nor can they be falsely
+            # reaped, being absent from the snapshot the chord took of what we
+            # hold.
+            must_reach = min(page.total_items, self.total_items)
+            if self.offset + len(page.listed) < must_reach:
+                return CrawlFault(
+                    f"The page at offset {self.offset} returned "
+                    f"{len(page.listed)} titles and so stops short of the "
+                    f"{must_reach} Overdrive reports. Refusing to reap across "
+                    f"a gap."
+                )
+        elif self.offset + len(page.listed) < self.previous_offset:
+            # The walk steps back by a page size, but a page is free to return
+            # fewer titles than that. When one does, the step overshoots and
+            # leaves a strip of the list uncrawled -- which would reach the
+            # completeness gate as a shortfall indistinguishable from titles
+            # removed mid-crawl. Pages are only legitimately short at the end
+            # of the list, so every other page is required to reach the one
+            # before it.
+            return CrawlFault(
+                f"The page at offset {self.offset} returned "
+                f"{len(page.listed)} titles and so stops short of the region "
+                f"already crawled at {self.previous_offset}. Refusing to reap "
+                f"across a gap."
+            )
+
+        if self.offset == 0:
+            # The walk has re-fetched the start of the list, so its coverage
+            # is complete without leaning on the first page's stale snapshot.
+            return self._complete(
+                total_items=self.total_items,
+                page_limit=self.page_limit,
+                single_page=False,
+            )
+
+        step = max(1, self.page_limit - int(self.page_limit * CRAWL_OVERLAP))
+        return replace(
+            self,
+            offset=max(0, self.offset - step),
+            previous_offset=self.offset,
+        )
+
+    def _complete(
+        self, *, total_items: int, page_limit: int, single_page: bool
+    ) -> CrawlComplete:
+        """Build the completion record for this walk."""
+        return CrawlComplete(
+            total_items=total_items,
+            page_limit=page_limit,
+            single_page=single_page,
+            started_at=self.started_at,
+        )
+
+    def __json__(self) -> dict[str, Any]:
+        """Serialize for a Celery task kwarg; the inverse of :meth:`from_json`.
+
+        ``started_at`` travels as an ISO string so the round trip does not
+        depend on how the task serializer treats datetimes inside dicts.
+        """
+        return {
+            "offset": self.offset,
+            "previous_offset": self.previous_offset,
+            "total_items": self.total_items,
+            "page_limit": self.page_limit,
+            "started_at": self.started_at.isoformat(),
+        }
+
+    @classmethod
+    def from_json(cls, data: Mapping[str, Any]) -> CrawlCursor:
+        """Rebuild a cursor serialized by :meth:`__json__`."""
+        return cls(
+            offset=data["offset"],
+            previous_offset=data["previous_offset"],
+            total_items=data["total_items"],
+            page_limit=data["page_limit"],
+            started_at=datetime.datetime.fromisoformat(data["started_at"]),
+        )

--- a/src/palace/manager/integration/license/overdrive/representation.py
+++ b/src/palace/manager/integration/license/overdrive/representation.py
@@ -276,14 +276,14 @@ class OverdriveRepresentationExtractor(LoggerMixin):
         # The current behavior will respond to errors other than
         # NotFound by leaving the book alone, but this might not be
         # the right behavior.
-        if availability.error_code == "NotFound":
-            licenses_owned = 0
-            licenses_available = 0
-            patrons_in_hold_queue = 0
-        elif availability.is_owned_by_collections is False:
-            # Overdrive keeps weeded and expired titles in a collection's responses,
-            # flagged as no longer owned, so this is a statement that the collection
-            # has no copies -- not merely a document that omits the counts.
+        if (
+            availability.error_code == "NotFound"
+            or availability.is_owned_by_collections is False
+        ):
+            # Either Overdrive does not have the title at all, or it is one of the
+            # weeded and expired titles Overdrive keeps in a collection's responses
+            # flagged as no longer owned. Both state that the collection has no
+            # copies, rather than being a document that omits the counts.
             licenses_owned = 0
             licenses_available = 0
             patrons_in_hold_queue = 0

--- a/src/palace/manager/integration/license/overdrive/representation.py
+++ b/src/palace/manager/integration/license/overdrive/representation.py
@@ -242,10 +242,6 @@ class OverdriveRepresentationExtractor(LoggerMixin):
         # In Overdrive, 'reserved' books show up as books on hold.
         licenses_reserved = 0
 
-        licenses_owned = None
-        licenses_available = None
-        patrons_in_hold_queue = None
-
         # book_id takes precedence over the document's reserveId so that the
         # caller can override the identifier (e.g. after a circulation lookup
         # where the caller already knows the book's ID). Fall back to reserveId
@@ -284,7 +280,14 @@ class OverdriveRepresentationExtractor(LoggerMixin):
             licenses_owned = 0
             licenses_available = 0
             patrons_in_hold_queue = 0
-        elif availability.is_owned_by_collections is not False:
+        elif availability.is_owned_by_collections is False:
+            # Overdrive keeps weeded and expired titles in a collection's responses,
+            # flagged as no longer owned, so this is a statement that the collection
+            # has no copies -- not merely a document that omits the counts.
+            licenses_owned = 0
+            licenses_available = 0
+            patrons_in_hold_queue = 0
+        else:
             # We own this book.
             licenses_owned = 0
             licenses_available = 0
@@ -295,9 +298,7 @@ class OverdriveRepresentationExtractor(LoggerMixin):
 
             patrons_in_hold_queue = availability.number_of_holds
 
-        if licenses_owned is None:
-            license_status = None
-        elif licenses_owned > 0:
+        if licenses_owned > 0:
             license_status = LicensePoolStatus.ACTIVE
         else:
             license_status = LicensePoolStatus.EXHAUSTED

--- a/src/palace/manager/scripts/overdrive.py
+++ b/src/palace/manager/scripts/overdrive.py
@@ -48,7 +48,7 @@ class OverdriveReaperScript(Script):
                 )
             OverdriveAPI.reap_task(collection.id).apply_async()
             self.log.info(
-                f'The "reap_collection" task has been queued for collection '
+                f"A reap has been queued for collection "
                 f"'{parsed.collection_name}'. See the celery logs for details."
             )
         else:

--- a/src/palace/manager/scripts/overdrive.py
+++ b/src/palace/manager/scripts/overdrive.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from palace.util.exceptions import PalaceValueError
 
-from palace.manager.celery.tasks.overdrive import reap_all_collections, reap_collection
+from palace.manager.celery.tasks.overdrive import reap_all_collections
 from palace.manager.integration.license.overdrive.api import OverdriveAPI
 from palace.manager.scripts.base import Script
 from palace.manager.sqlalchemy.model.collection import Collection
@@ -46,7 +46,7 @@ class OverdriveReaperScript(Script):
                     f"Collection '{parsed.collection_name}' is not an Overdrive collection "
                     f"(protocol: '{collection.protocol}')."
                 )
-            reap_collection.delay(collection.id)
+            OverdriveAPI.reap_task(collection.id).apply_async()
             self.log.info(
                 f'The "reap_collection" task has been queued for collection '
                 f"'{parsed.collection_name}'. See the celery logs for details."

--- a/tests/files/overdrive/overdrive_product_page.json
+++ b/tests/files/overdrive/overdrive_product_page.json
@@ -1,0 +1,298 @@
+{
+  "limit": 300,
+  "offset": 12000,
+  "totalItems": 38434,
+  "id": "v2L1BdwAAAP____81K",
+  "products": [
+    {
+      "isOwnedByCollections": true,
+      "id": "DD128C0B-3915-441D-9A4E-BE874A727C9B",
+      "crossRefId": 9065272,
+      "mediaType": "eBook",
+      "title": "Clytemnestra",
+      "subtitle": "A Novel",
+      "sortTitle": "Clytemnestra A Novel",
+      "primaryCreator": {
+        "role": "Author",
+        "name": "Costanza Casati"
+      },
+      "dateAdded": "2023-02-04T00:13:00Z",
+      "formats": [
+        {
+          "id": "ebook-kindle",
+          "name": "Kindle Book",
+          "identifiers": [
+            {
+              "type": "ASIN",
+              "value": "B0B4BR6B9P"
+            }
+          ]
+        },
+        {
+          "id": "ebook-overdrive",
+          "name": "OverDrive Read",
+          "identifiers": [
+            {
+              "type": "ISBN",
+              "value": "9781728268255"
+            }
+          ]
+        }
+      ],
+      "images": {
+        "thumbnail": {
+          "href": "https://img1.od-cdn.com/ImageType-200/0174-1/{DD128C0B-3915-441D-9A4E-BE874A727C9B}IMG200.JPG",
+          "type": "image/jpeg"
+        },
+        "cover150Wide": {
+          "href": "https://img1.od-cdn.com/ImageType-150/0174-1/{DD128C0B-3915-441D-9A4E-BE874A727C9B}IMG150.JPG",
+          "type": "image/jpeg"
+        },
+        "cover": {
+          "href": "https://img1.od-cdn.com/ImageType-100/0174-1/{DD128C0B-3915-441D-9A4E-BE874A727C9B}IMG100.JPG",
+          "type": "image/jpeg"
+        },
+        "cover300Wide": {
+          "href": "https://img1.od-cdn.com/ImageType-400/0174-1/{DD128C0B-3915-441D-9A4E-BE874A727C9B}IMG400.JPG",
+          "type": "image/jpeg"
+        }
+      },
+      "contentDetails": [
+        {
+          "href": "https://link.overdrive.com?websiteID=119&titleID=9065272",
+          "type": "text/html",
+          "account": {
+            "id": 1106,
+            "name": "Library Connection, Inc. (CT)"
+          }
+        }
+      ],
+      "links": {
+        "self": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/dd128c0b-3915-441d-9a4e-be874a727c9b",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "metadata": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/dd128c0b-3915-441d-9a4e-be874a727c9b/metadata",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "availability": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/dd128c0b-3915-441d-9a4e-be874a727c9b/availability",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "availabilityV2": {
+          "href": "https://api.overdrive.com/v2/collections/v2L1BdwAAAP____81K/products/dd128c0b-3915-441d-9a4e-be874a727c9b/availability",
+          "type": "application/vnd.overdrive.api+json"
+        }
+      },
+      "otherFormatIdentifiers": [
+        {
+          "type": "ISBN",
+          "value": "9781728268231"
+        }
+      ],
+      "classifications": {}
+    },
+    {
+      "isOwnedByCollections": true,
+      "id": "7E8D422D-80F2-48DF-8CD6-8EC7FE8B0989",
+      "crossRefId": 9065326,
+      "mediaType": "eBook",
+      "title": "The Lonely Hearts Book Club",
+      "sortTitle": "Lonely Hearts Book Club",
+      "primaryCreator": {
+        "role": "Author",
+        "name": "Lucy Gilmore"
+      },
+      "dateAdded": "2023-05-01T23:52:00Z",
+      "formats": [
+        {
+          "id": "ebook-kindle",
+          "name": "Kindle Book",
+          "identifiers": [
+            {
+              "type": "ASIN",
+              "value": "B0B4BQXYNR"
+            }
+          ]
+        },
+        {
+          "id": "ebook-overdrive",
+          "name": "OverDrive Read",
+          "identifiers": [
+            {
+              "type": "ISBN",
+              "value": "9781728256238"
+            }
+          ]
+        }
+      ],
+      "images": {
+        "thumbnail": {
+          "href": "https://img1.od-cdn.com/ImageType-200/0174-1/{7E8D422D-80F2-48DF-8CD6-8EC7FE8B0989}IMG200.JPG",
+          "type": "image/jpeg"
+        },
+        "cover150Wide": {
+          "href": "https://img1.od-cdn.com/ImageType-150/0174-1/{7E8D422D-80F2-48DF-8CD6-8EC7FE8B0989}IMG150.JPG",
+          "type": "image/jpeg"
+        },
+        "cover": {
+          "href": "https://img1.od-cdn.com/ImageType-100/0174-1/{7E8D422D-80F2-48DF-8CD6-8EC7FE8B0989}IMG100.JPG",
+          "type": "image/jpeg"
+        },
+        "cover300Wide": {
+          "href": "https://img1.od-cdn.com/ImageType-400/0174-1/{7E8D422D-80F2-48DF-8CD6-8EC7FE8B0989}IMG400.JPG",
+          "type": "image/jpeg"
+        }
+      },
+      "contentDetails": [
+        {
+          "href": "https://link.overdrive.com?websiteID=119&titleID=9065326",
+          "type": "text/html",
+          "account": {
+            "id": 1106,
+            "name": "Library Connection, Inc. (CT)"
+          }
+        }
+      ],
+      "links": {
+        "self": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/7e8d422d-80f2-48df-8cd6-8ec7fe8b0989",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "metadata": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/7e8d422d-80f2-48df-8cd6-8ec7fe8b0989/metadata",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "availability": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/7e8d422d-80f2-48df-8cd6-8ec7fe8b0989/availability",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "availabilityV2": {
+          "href": "https://api.overdrive.com/v2/collections/v2L1BdwAAAP____81K/products/7e8d422d-80f2-48df-8cd6-8ec7fe8b0989/availability",
+          "type": "application/vnd.overdrive.api+json"
+        }
+      },
+      "otherFormatIdentifiers": [
+        {
+          "type": "ISBN",
+          "value": "9781728256214"
+        }
+      ],
+      "classifications": {}
+    },
+    {
+      "isOwnedByCollections": false,
+      "id": "7B4FD6E8-7EB6-41A5-BF97-4FA2CA95A474",
+      "crossRefId": 9253739,
+      "mediaType": "eBook",
+      "title": "Only the Dead",
+      "sortTitle": "Only the Dead",
+      "series": "Terminal List",
+      "seriesId": 503239,
+      "readingOrder": "6",
+      "primaryCreator": {
+        "role": "Author",
+        "name": "Jack Carr"
+      },
+      "dateAdded": "2023-05-13T21:33:00Z",
+      "formats": [
+        {
+          "id": "ebook-kindle",
+          "name": "Kindle Book",
+          "identifiers": [
+            {
+              "type": "ASIN",
+              "value": "B0BG3BDD5P"
+            }
+          ]
+        },
+        {
+          "id": "ebook-overdrive",
+          "name": "OverDrive Read",
+          "identifiers": [
+            {
+              "type": "ISBN",
+              "value": "9781982181727"
+            }
+          ]
+        }
+      ],
+      "images": {
+        "thumbnail": {
+          "href": "https://img1.od-cdn.com/ImageType-200/0439-1/{7B4FD6E8-7EB6-41A5-BF97-4FA2CA95A474}IMG200.JPG",
+          "type": "image/jpeg"
+        },
+        "cover150Wide": {
+          "href": "https://img1.od-cdn.com/ImageType-150/0439-1/{7B4FD6E8-7EB6-41A5-BF97-4FA2CA95A474}IMG150.JPG",
+          "type": "image/jpeg"
+        },
+        "cover": {
+          "href": "https://img1.od-cdn.com/ImageType-100/0439-1/{7B4FD6E8-7EB6-41A5-BF97-4FA2CA95A474}IMG100.JPG",
+          "type": "image/jpeg"
+        },
+        "cover300Wide": {
+          "href": "https://img1.od-cdn.com/ImageType-400/0439-1/{7B4FD6E8-7EB6-41A5-BF97-4FA2CA95A474}IMG400.JPG",
+          "type": "image/jpeg"
+        }
+      },
+      "contentDetails": [
+        {
+          "href": "https://link.overdrive.com?websiteID=119&titleID=9253739",
+          "type": "text/html",
+          "account": {
+            "id": 1106,
+            "name": "Library Connection, Inc. (CT)"
+          }
+        }
+      ],
+      "links": {
+        "self": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/7b4fd6e8-7eb6-41a5-bf97-4fa2ca95a474",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "metadata": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/7b4fd6e8-7eb6-41a5-bf97-4fa2ca95a474/metadata",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "availability": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/7b4fd6e8-7eb6-41a5-bf97-4fa2ca95a474/availability",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "availabilityV2": {
+          "href": "https://api.overdrive.com/v2/collections/v2L1BdwAAAP____81K/products/7b4fd6e8-7eb6-41a5-bf97-4fa2ca95a474/availability",
+          "type": "application/vnd.overdrive.api+json"
+        }
+      },
+      "otherFormatIdentifiers": [
+        {
+          "type": "ISBN",
+          "value": "9781982181710"
+        }
+      ],
+      "classifications": {}
+    }
+  ],
+  "links": {
+    "self": {
+      "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products?limit=300&offset=12000&sort=dateadded%3Adesc",
+      "type": "application/vnd.overdrive.api+json"
+    },
+    "first": {
+      "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products?limit=300&offset=0&sort=dateadded%3Adesc",
+      "type": "application/vnd.overdrive.api+json"
+    },
+    "prev": {
+      "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products?limit=300&offset=11700&sort=dateadded%3Adesc",
+      "type": "application/vnd.overdrive.api+json"
+    },
+    "next": {
+      "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products?limit=300&offset=12300&sort=dateadded%3Adesc",
+      "type": "application/vnd.overdrive.api+json"
+    },
+    "last": {
+      "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products?limit=300&offset=38400&sort=dateadded%3Adesc",
+      "type": "application/vnd.overdrive.api+json"
+    }
+  }
+}

--- a/tests/files/overdrive/overdrive_product_page_last.json
+++ b/tests/files/overdrive/overdrive_product_page_last.json
@@ -1,0 +1,174 @@
+{
+  "limit": 2,
+  "offset": 38432,
+  "totalItems": 38434,
+  "id": "v2L1BdwAAAP____81K",
+  "products": [
+    {
+      "isOwnedByCollections": true,
+      "id": "D9FFF371-29DF-4970-A436-3E406489E8D7",
+      "crossRefId": 12594215,
+      "mediaType": "Magazine",
+      "title": "Freizeitwoche",
+      "sortTitle": "Freizeitwoche",
+      "series": "Freizeitwoche",
+      "dateAdded": "2026-07-25T13:15:00Z",
+      "edition": "31/2026",
+      "formats": [
+        {
+          "id": "magazine-overdrive",
+          "name": "OverDrive Magazine",
+          "identifiers": [
+            {
+              "type": "PublisherCatalogNumber",
+              "value": "45551"
+            }
+          ]
+        }
+      ],
+      "images": {
+        "thumbnail": {
+          "href": "https://img1.od-cdn.com/ImageType-200/11052-1/{426678C8-912B-49FB-B660-6CE1567193C5}IMG200.JPG",
+          "type": "image/jpeg"
+        },
+        "cover150Wide": {
+          "href": "https://img1.od-cdn.com/ImageType-150/11052-1/{426678C8-912B-49FB-B660-6CE1567193C5}IMG150.JPG",
+          "type": "image/jpeg"
+        },
+        "cover": {
+          "href": "https://img1.od-cdn.com/ImageType-100/11052-1/{426678C8-912B-49FB-B660-6CE1567193C5}IMG100.JPG",
+          "type": "image/jpeg"
+        },
+        "cover300Wide": {
+          "href": "https://img1.od-cdn.com/ImageType-400/11052-1/{426678C8-912B-49FB-B660-6CE1567193C5}IMG400.JPG",
+          "type": "image/jpeg"
+        }
+      },
+      "contentDetails": [
+        {
+          "href": "https://link.overdrive.com?websiteID=119&titleID=12594215",
+          "type": "text/html",
+          "account": {
+            "id": 1106,
+            "name": "Library Connection, Inc. (CT)"
+          }
+        }
+      ],
+      "links": {
+        "self": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/d9fff371-29df-4970-a436-3e406489e8d7",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "metadata": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/d9fff371-29df-4970-a436-3e406489e8d7/metadata",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "availability": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/d9fff371-29df-4970-a436-3e406489e8d7/availability",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "availabilityV2": {
+          "href": "https://api.overdrive.com/v2/collections/v2L1BdwAAAP____81K/products/d9fff371-29df-4970-a436-3e406489e8d7/availability",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "issues": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/d9fff371-29df-4970-a436-3e406489e8d7/issues",
+          "type": "application/vnd.overdrive.api+json"
+        }
+      },
+      "classifications": {}
+    },
+    {
+      "isOwnedByCollections": true,
+      "id": "6FE419F7-EF10-43DB-9809-E53B03E2EA08",
+      "crossRefId": 12594214,
+      "mediaType": "Magazine",
+      "title": "Astrowoche",
+      "sortTitle": "Astrowoche",
+      "series": "Astrowoche",
+      "dateAdded": "2026-07-25T13:15:00Z",
+      "edition": "31/2026",
+      "formats": [
+        {
+          "id": "magazine-overdrive",
+          "name": "OverDrive Magazine",
+          "identifiers": [
+            {
+              "type": "PublisherCatalogNumber",
+              "value": "45544"
+            }
+          ]
+        }
+      ],
+      "images": {
+        "thumbnail": {
+          "href": "https://img1.od-cdn.com/ImageType-200/11052-1/{E1703E10-B996-49C3-A950-994E7462FF65}IMG200.JPG",
+          "type": "image/jpeg"
+        },
+        "cover150Wide": {
+          "href": "https://img1.od-cdn.com/ImageType-150/11052-1/{E1703E10-B996-49C3-A950-994E7462FF65}IMG150.JPG",
+          "type": "image/jpeg"
+        },
+        "cover": {
+          "href": "https://img1.od-cdn.com/ImageType-100/11052-1/{E1703E10-B996-49C3-A950-994E7462FF65}IMG100.JPG",
+          "type": "image/jpeg"
+        },
+        "cover300Wide": {
+          "href": "https://img1.od-cdn.com/ImageType-400/11052-1/{E1703E10-B996-49C3-A950-994E7462FF65}IMG400.JPG",
+          "type": "image/jpeg"
+        }
+      },
+      "contentDetails": [
+        {
+          "href": "https://link.overdrive.com?websiteID=119&titleID=12594214",
+          "type": "text/html",
+          "account": {
+            "id": 1106,
+            "name": "Library Connection, Inc. (CT)"
+          }
+        }
+      ],
+      "links": {
+        "self": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/6fe419f7-ef10-43db-9809-e53b03e2ea08",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "metadata": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/6fe419f7-ef10-43db-9809-e53b03e2ea08/metadata",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "availability": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/6fe419f7-ef10-43db-9809-e53b03e2ea08/availability",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "availabilityV2": {
+          "href": "https://api.overdrive.com/v2/collections/v2L1BdwAAAP____81K/products/6fe419f7-ef10-43db-9809-e53b03e2ea08/availability",
+          "type": "application/vnd.overdrive.api+json"
+        },
+        "issues": {
+          "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products/6fe419f7-ef10-43db-9809-e53b03e2ea08/issues",
+          "type": "application/vnd.overdrive.api+json"
+        }
+      },
+      "classifications": {}
+    }
+  ],
+  "links": {
+    "self": {
+      "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products?limit=2&offset=38432&sort=dateadded%3Aasc",
+      "type": "application/vnd.overdrive.api+json"
+    },
+    "first": {
+      "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products?limit=2&offset=0&sort=dateadded%3Aasc",
+      "type": "application/vnd.overdrive.api+json"
+    },
+    "prev": {
+      "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products?limit=2&offset=38430&sort=dateadded%3Aasc",
+      "type": "application/vnd.overdrive.api+json"
+    },
+    "last": {
+      "href": "https://api.overdrive.com/v1/collections/v2L1BdwAAAP____81K/products?limit=2&offset=38432&sort=dateadded%3Aasc",
+      "type": "application/vnd.overdrive.api+json"
+    }
+  }
+}

--- a/tests/manager/celery/tasks/test_identifiers.py
+++ b/tests/manager/celery/tasks/test_identifiers.py
@@ -392,7 +392,7 @@ class TestCreateMarkUnavailableChord:
         # Check that we didn't leave any redis keys behind
         assert redis_fixture.keys() == []
 
-    def test_missing_existing_set_is_an_error_when_the_collection_has_identifiers(
+    def test_missing_existing_set_is_a_warning_when_the_collection_has_identifiers(
         self,
         db: DatabaseTransactionFixture,
         identifier_tasks_fixture: IdentifierTasksFixture,
@@ -401,8 +401,11 @@ class TestCreateMarkUnavailableChord:
         """A set that expired mid-run threw away work; an empty collection did not.
 
         Both reach this point as "the set does not exist in Redis", because an empty
-        set is never materialised in Redis, so the collection itself is what tells
-        the two apart.
+        set is never materialised in Redis. The collection is checked to tell the two
+        apart, but only loosely: the check runs when the chord body fires, hours
+        after a long crawl began, and imports may have added identifiers in
+        between -- so this is a warning about work possibly lost, not an error about
+        work certainly lost.
         """
         caplog.set_level(LogLevel.info)
         collection = db.collection()
@@ -417,8 +420,9 @@ class TestCreateMarkUnavailableChord:
         ).wait()
 
         assert result is False
-        assert "a completed run has been discarded" in caplog.text
-        assert LogLevel.error in {record.levelname for record in caplog.records}
+        assert "outlived its set and was discarded" in caplog.text
+        assert LogLevel.warning in {record.levelname for record in caplog.records}
+        assert LogLevel.error not in {record.levelname for record in caplog.records}
 
     def test_expire_time_covers_a_long_running_active_side(
         self,

--- a/tests/manager/celery/tasks/test_identifiers.py
+++ b/tests/manager/celery/tasks/test_identifiers.py
@@ -388,6 +388,37 @@ class TestCreateMarkUnavailableChord:
         # Check that we didn't leave any redis keys behind
         assert redis_fixture.keys() == []
 
+    def test_expire_time_covers_a_long_running_active_side(
+        self,
+        db: DatabaseTransactionFixture,
+        redis_fixture: RedisFixture,
+        identifier_tasks_fixture: IdentifierTasksFixture,
+    ) -> None:
+        """The existing-identifier set has to outlive the other half of the chord.
+
+        It is built once, at the start, and never touched again, so a distributor
+        whose active-side task runs for hours would otherwise find it expired and
+        discard the whole run.
+        """
+        collection = db.collection()
+        identifier_tasks_fixture.license_pools(collection=collection, count=2)
+        expire_time = 36 * 60 * 60
+
+        response = identifiers.existing_available_identifiers.delay(
+            collection.id, expire_time=expire_time
+        ).wait()
+
+        # The lifetime travels with the set, so the chord body rebuilds it unchanged.
+        assert response["expire_time"] == expire_time
+        default_lifetime = IdentifierSet(
+            identifier_tasks_fixture.redis_client
+        ).expire_time
+        assert expire_time > default_lifetime.total_seconds()
+
+        identifier_set = identifier_tasks_fixture.set_from_response(response)
+        assert identifier_set.exists()
+        identifier_set.delete()
+
     def test_exception(
         self,
         db: DatabaseTransactionFixture,

--- a/tests/manager/celery/tasks/test_identifiers.py
+++ b/tests/manager/celery/tasks/test_identifiers.py
@@ -197,6 +197,52 @@ class TestMarkIdentifiersUnavailable:
         assert existing_set.exists() is False
         assert active_set.exists() is False
 
+    @pytest.mark.parametrize(
+        "status_kwargs,expected_status",
+        [
+            pytest.param({}, LicensePoolStatus.REMOVED, id="default"),
+            pytest.param(
+                {"status": LicensePoolStatus.EXHAUSTED},
+                LicensePoolStatus.EXHAUSTED,
+                id="explicit",
+            ),
+        ],
+    )
+    def test_status(
+        self,
+        db: DatabaseTransactionFixture,
+        identifier_tasks_fixture: IdentifierTasksFixture,
+        status_kwargs: dict[str, LicensePoolStatus],
+        expected_status: LicensePoolStatus,
+    ) -> None:
+        """The recorded status defaults to REMOVED but can be overridden.
+
+        Distributors that drop titles when a lease ends, rather than only when a
+        title is withdrawn, want EXHAUSTED so outstanding loans and holds survive.
+        """
+        collection = db.collection()
+        license_pools = identifier_tasks_fixture.license_pools(
+            collection=collection, count=2
+        )
+
+        existing_set = IdentifierSet(identifier_tasks_fixture.redis_client)
+        existing_set.add(*identifier_tasks_fixture.identifiers(license_pools))
+        active_set = IdentifierSet(identifier_tasks_fixture.redis_client)
+        active_set.add(*identifier_tasks_fixture.identifiers(license_pools[:1]))
+
+        with patch.object(identifiers, "circulation_apply") as mock_apply:
+            identifiers.mark_identifiers_unavailable.delay(
+                [existing_set, active_set],
+                collection_id=collection.id,
+                **status_kwargs,
+            ).wait()
+
+        mock_apply.delay.assert_called_once()
+        circulation = mock_apply.delay.call_args.kwargs["circulation"]
+        assert circulation.status == expected_status
+        assert circulation.licenses_owned == 0
+        assert circulation.licenses_available == 0
+
     def test_run_with_nonexistent_sets(
         self,
         db: DatabaseTransactionFixture,

--- a/tests/manager/celery/tasks/test_identifiers.py
+++ b/tests/manager/celery/tasks/test_identifiers.py
@@ -263,6 +263,10 @@ class TestMarkIdentifiersUnavailable:
         ).wait()
         assert result is False
         assert "Existing identifiers set does not exist in Redis" in caplog.text
+        # The collection has nothing available to reap, so marking nothing is the
+        # right outcome and does not deserve an error.
+        assert "The collection has none to mark" in caplog.text
+        assert LogLevel.error not in {record.levelname for record in caplog.records}
 
         # Add an identifier to the existing set, so it now exists
         existing_set.add(IdentifierData.from_identifier(db.identifier()))
@@ -387,6 +391,34 @@ class TestCreateMarkUnavailableChord:
 
         # Check that we didn't leave any redis keys behind
         assert redis_fixture.keys() == []
+
+    def test_missing_existing_set_is_an_error_when_the_collection_has_identifiers(
+        self,
+        db: DatabaseTransactionFixture,
+        identifier_tasks_fixture: IdentifierTasksFixture,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A set that expired mid-run threw away work; an empty collection did not.
+
+        Both reach this point as "the set does not exist in Redis", because an empty
+        set is never materialised in Redis, so the collection itself is what tells
+        the two apart.
+        """
+        caplog.set_level(LogLevel.info)
+        collection = db.collection()
+        identifier_tasks_fixture.license_pools(collection=collection, count=1)
+
+        result = identifiers.mark_identifiers_unavailable.delay(
+            [
+                IdentifierSet(identifier_tasks_fixture.redis_client),
+                IdentifierSet(identifier_tasks_fixture.redis_client),
+            ],
+            collection_id=collection.id,
+        ).wait()
+
+        assert result is False
+        assert "a completed run has been discarded" in caplog.text
+        assert LogLevel.error in {record.levelname for record in caplog.records}
 
     def test_expire_time_covers_a_long_running_active_side(
         self,

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -1385,9 +1385,13 @@ class TestOverdriveReaper:
         """
         collection = overdrive_api_fixture.collection
         caplog.set_level(LogLevel.error)
+        # The page returned everything its own limit allowed, so the structural
+        # checks pass and the shortfall is left to the completeness gate.
         mock_crawl(
             mock_api_class,
-            product_page(listed=overdrive_identifiers("id-one"), total_items=5000),
+            product_page(
+                listed=overdrive_identifiers("id-one"), total_items=5000, limit=1
+            ),
         )
 
         async_result = overdrive.reap_collection.delay(collection.id)
@@ -1502,7 +1506,9 @@ class TestOverdriveReaper:
         caplog.set_level(LogLevel.error)
         api = mock_crawl(
             mock_api_class,
-            product_page(listed=overdrive_identifiers("id-one"), total_items=2005),
+            product_page(
+                listed=overdrive_identifiers("id-one"), total_items=2005, limit=1
+            ),
             product_page(listed=(), total_items=None, limit=0),
         )
         # The walk would otherwise read the second page as "collection covered".
@@ -1677,6 +1683,36 @@ class TestOverdriveReaper:
             redis_fixture.client, reap_key(collection.id, async_result.id)
         )
         assert not partial_set.exists()
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_aborts_on_a_short_first_page(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """The walk joins back onto the first page using the page size.
+
+        A first page that returned fewer titles than that does not reach where the
+        walk stops, so the strip in between would never be crawled -- the same gap
+        the per-page check catches everywhere else in the walk.
+        """
+        collection = overdrive_api_fixture.collection
+        caplog.set_level(LogLevel.error)
+        mock_crawl(
+            mock_api_class,
+            product_page(
+                listed=overdrive_identifiers("id-one"), total_items=6000, limit=2000
+            ),
+        )
+
+        result = overdrive.reap_collection.delay(collection.id).wait()
+
+        assert result is None
+        assert "cannot join back onto it" in caplog.text
 
     def test_reap_collection_discards_a_page_from_the_previous_reaper(
         self,

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -22,6 +22,9 @@ from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.integration.license.overdrive.api import (
     BookInfoEndpoint,
     OverdriveAPI,
+)
+from palace.manager.integration.license.overdrive.crawl import (
+    CrawlCursor,
     ProductPage,
 )
 from palace.manager.integration.license.overdrive.importer import (
@@ -1246,14 +1249,13 @@ def product_page(
 def mock_crawl(mock_api_class: MagicMock, *pages: ProductPage) -> MagicMock:
     """Point a mocked OverdriveAPI at the given pages, walked in order.
 
-    The mocked API has to be told where the walk ends; otherwise
-    `next_product_offset` returns a Mock and the crawl never finishes.
+    Only the fetch is mocked: the pages drive the real
+    :class:`~palace.manager.integration.license.overdrive.crawl.CrawlCursor`,
+    so their ``total_items`` and ``limit`` have to describe a walk the cursor
+    would actually take.
     """
     api = mock_api_class.return_value
     api.fetch_product_page.side_effect = list(pages)
-    api.next_product_offset.side_effect = [
-        (index + 1) * 100 for index in range(len(pages) - 1)
-    ] + [None]
     return api
 
 
@@ -1346,22 +1348,31 @@ class TestOverdriveReaper:
         almost the whole collection as gone.
         """
         collection = overdrive_api_fixture.collection
+        # A three-title list crawled in pages of two: the first page learns the
+        # count, the walk jumps to the end, and it finishes with a fresh page
+        # at the start of the list.
         first_page = overdrive_identifiers("id-one", "id-two")
-        second_page = overdrive_identifiers("id-three")
+        end_page = overdrive_identifiers("id-two", "id-three")
         api = mock_crawl(
             mock_api_class,
             product_page(listed=first_page, total_items=3, limit=2),
-            product_page(listed=second_page, total_items=3, limit=2),
+            product_page(listed=end_page, total_items=3, limit=2),
+            product_page(listed=first_page, total_items=3, limit=2),
         )
 
         result = overdrive.reap_collection.delay(collection.id).wait()
 
-        assert api.fetch_product_page.call_count == 2
-        # Each page was requested at the offset the walk handed back, so a crawl
-        # cannot be talked into re-requesting the page it just fetched.
-        assert api.product_page_endpoint.call_args_list == [call(0), call(100)]
+        assert api.fetch_product_page.call_count == 3
+        # Each page was requested at the offset the walk handed back, and the
+        # walk ends by re-fetching offset 0 rather than trusting the first
+        # page's stale snapshot of the start of the list.
+        assert api.product_page_endpoint.call_args_list == [
+            call(0),
+            call(1),
+            call(0),
+        ]
         identifier_set = IdentifierSet(redis_fixture.client, result["key"])
-        assert identifier_set.get() == set(first_page) | set(second_page)
+        assert identifier_set.get() == set(first_page) | set(end_page)
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_aborts_on_incomplete_crawl(
@@ -1381,13 +1392,21 @@ class TestOverdriveReaper:
         """
         collection = overdrive_api_fixture.collection
         caplog.set_level(LogLevel.error)
-        # The page returned everything its own limit allowed, so the structural
-        # checks pass and the shortfall is left to the completeness gate.
+        # A 30-title collection crawled in pages of 20 while six titles are
+        # removed from the uncrawled region after the first page: every page
+        # reaches the one before it, so the structural checks pass, and the
+        # shortfall of six -- past the allowance of five -- is left for the
+        # completeness gate.
+        first_and_last = overdrive_identifiers(*(f"k{index}" for index in range(20)))
+        end_page = overdrive_identifiers(
+            *(f"k{index}" for index in range(10, 20)),
+            *(f"k{index}" for index in range(26, 30)),
+        )
         mock_crawl(
             mock_api_class,
-            product_page(
-                listed=overdrive_identifiers("id-one"), total_items=5000, limit=1
-            ),
+            product_page(listed=first_and_last, total_items=30, limit=20),
+            product_page(listed=end_page, total_items=24, limit=20),
+            product_page(listed=first_and_last, total_items=24, limit=20),
         )
 
         async_result = overdrive.reap_collection.delay(collection.id)
@@ -1416,20 +1435,27 @@ class TestOverdriveReaper:
         it.
         """
         collection = overdrive_api_fixture.collection
-        first_page = overdrive_identifiers("id-one", "id-two")
-        second_page = overdrive_identifiers("id-three")
-        listed = first_page + second_page
-        total_items = len(listed) + overdrive.REAP_CRAWL_ALLOWANCE_FLOOR
+        # A 30-title collection crawled in pages of 20 while three titles are
+        # removed from the uncrawled region after the first page -- a shortfall
+        # inside the allowance of five.
+        first_and_last = overdrive_identifiers(*(f"k{index}" for index in range(20)))
+        end_page = overdrive_identifiers(
+            *(f"k{index}" for index in range(10, 20)),
+            *(f"k{index}" for index in range(23, 30)),
+        )
         mock_crawl(
             mock_api_class,
-            product_page(listed=first_page, total_items=total_items),
-            product_page(listed=second_page, total_items=total_items),
+            product_page(listed=first_and_last, total_items=30, limit=20),
+            product_page(listed=end_page, total_items=27, limit=20),
+            product_page(listed=first_and_last, total_items=27, limit=20),
         )
 
         result = overdrive.reap_collection.delay(collection.id).wait()
 
         assert result is not None
-        assert IdentifierSet(redis_fixture.client, result["key"]).get() == set(listed)
+        assert IdentifierSet(redis_fixture.client, result["key"]).get() == set(
+            first_and_last
+        ) | set(end_page)
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_requires_an_exact_count_for_a_single_page(
@@ -1486,7 +1512,10 @@ class TestOverdriveReaper:
         )
 
         async_result = overdrive.reap_collection.delay(
-            collection.id, offset=4000, total_items=6000, page_limit=2000
+            collection.id,
+            cursor=CrawlCursor(
+                offset=4000, total_items=6000, page_limit=2000
+            ).__json__(),
         )
 
         assert async_result.wait() is None
@@ -1495,56 +1524,6 @@ class TestOverdriveReaper:
             redis_fixture.client, reap_key(collection.id, async_result.id)
         )
         assert not partial_set.exists()
-
-    @pytest.mark.parametrize(
-        "reported_now,returned,aborts",
-        [
-            pytest.param(6000, 2000, False, id="unchanged, full page"),
-            pytest.param(6001, 2000, False, id="a title added since the first page"),
-            pytest.param(6100, 2000, False, id="many titles added"),
-            pytest.param(5990, 1990, False, id="titles removed since the first page"),
-            pytest.param(6000, 1990, True, id="page truncated"),
-        ],
-    )
-    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
-    def test_reap_collection_first_backwards_page_tolerates_a_growing_collection(
-        self,
-        mock_api_class: MagicMock,
-        db: DatabaseTransactionFixture,
-        celery_fixture: CeleryFixture,
-        overdrive_api_fixture: OverdriveAPIFixture,
-        redis_fixture: RedisFixture,
-        caplog: pytest.LogCaptureFixture,
-        reported_now: int,
-        returned: int,
-        aborts: bool,
-    ):
-        """Which end the first backwards page must reach depends on what changed.
-
-        It starts one page back from where the collection ended when the crawl began,
-        so a full page arrives exactly at that count. Titles added since then sit
-        beyond it -- not this page's to reach, and absent from the snapshot the chord
-        took of what we hold, so they cannot be falsely reaped. Titles removed shorten
-        the list, and that shorter count is the one it has to reach.
-        """
-        collection = overdrive_api_fixture.collection
-        caplog.set_level(LogLevel.error)
-        mock_crawl(
-            mock_api_class,
-            product_page(
-                listed=overdrive_identifiers(*(f"id-{i}" for i in range(returned))),
-                total_items=reported_now,
-                limit=2000,
-            ),
-        )
-
-        overdrive.reap_collection.delay(
-            collection.id, offset=4000, total_items=6000, page_limit=2000
-        ).wait()
-
-        # Asserted on this check rather than the run's outcome: a single mocked page
-        # is not a complete crawl, so the run ends either way.
-        assert ("Refusing to reap across a gap" in caplog.text) is aborts
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_aborts_on_a_gap_between_pages(
@@ -1564,23 +1543,23 @@ class TestOverdriveReaper:
         """
         collection = overdrive_api_fixture.collection
         caplog.set_level(LogLevel.error)
-        api = mock_crawl(
+        mock_crawl(
             mock_api_class,
-            product_page(listed=overdrive_identifiers("id-one"), total_items=6000),
             # Requested at offset 3000, but reaches only 3001 -- short of the 4000
             # the previous page started at.
             product_page(listed=overdrive_identifiers("id-two"), total_items=6000),
         )
-        api.next_product_offset.side_effect = [4000, 3000, None]
 
-        # Mid-crawl pages carry the crawl's state, which is also what tells them apart
-        # from a page left over from the previous reaper.
+        # Mid-crawl pages carry the crawl's cursor, which is also what tells them
+        # apart from a page left over from the previous reaper.
         async_result = overdrive.reap_collection.delay(
             collection.id,
-            offset=3000,
-            previous_offset=4000,
-            total_items=6000,
-            page_limit=2000,
+            cursor=CrawlCursor(
+                offset=3000,
+                previous_offset=4000,
+                total_items=6000,
+                page_limit=2000,
+            ).__json__(),
         )
 
         assert async_result.wait() is None
@@ -1589,36 +1568,6 @@ class TestOverdriveReaper:
             redis_fixture.client, reap_key(collection.id, async_result.id)
         )
         assert not partial_set.exists()
-
-    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
-    def test_reap_collection_aborts_on_a_short_first_page(
-        self,
-        mock_api_class: MagicMock,
-        db: DatabaseTransactionFixture,
-        celery_fixture: CeleryFixture,
-        overdrive_api_fixture: OverdriveAPIFixture,
-        redis_fixture: RedisFixture,
-        caplog: pytest.LogCaptureFixture,
-    ):
-        """The walk joins back onto the first page using the page size.
-
-        A first page that returned fewer titles than that does not reach where the
-        walk stops, so the strip in between would never be crawled -- the same gap
-        the per-page check catches everywhere else in the walk.
-        """
-        collection = overdrive_api_fixture.collection
-        caplog.set_level(LogLevel.error)
-        mock_crawl(
-            mock_api_class,
-            product_page(
-                listed=overdrive_identifiers("id-one"), total_items=6000, limit=2000
-            ),
-        )
-
-        result = overdrive.reap_collection.delay(collection.id).wait()
-
-        assert result is None
-        assert "cannot join back onto it" in caplog.text
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_aborts_when_the_page_size_changes(
@@ -1638,16 +1587,17 @@ class TestOverdriveReaper:
         """
         collection = overdrive_api_fixture.collection
         caplog.set_level(LogLevel.error)
-        api = mock_crawl(
+        mock_crawl(
             mock_api_class,
+            # The first page walks in twenties; the next page comes back sized
+            # ten.
             product_page(
-                listed=overdrive_identifiers("id-one"), total_items=6000, limit=1
+                listed=overdrive_identifiers("id-one"), total_items=30, limit=20
             ),
             product_page(
-                listed=overdrive_identifiers("id-two"), total_items=6000, limit=500
+                listed=overdrive_identifiers("id-two"), total_items=30, limit=10
             ),
         )
-        api.next_product_offset.side_effect = [4000, None]
 
         result = overdrive.reap_collection.delay(collection.id).wait()
 
@@ -1666,8 +1616,8 @@ class TestOverdriveReaper:
         Its `offset` was the last Identifier.id it had processed, so binding it as a
         product-list offset would crawl from an arbitrary point in the collection. It
         re-queued itself with only a collection id and an offset -- never a
-        `batch_size`, which was left at its default -- so the absence of the crawl
-        state this reaper always carries is what identifies one.
+        `batch_size`, which was left at its default -- so a bare non-zero offset
+        without the cursor this reaper always carries is what identifies one.
         """
         collection = overdrive_api_fixture.collection
         caplog.set_level(LogLevel.info)
@@ -1705,75 +1655,6 @@ class TestOverdriveReaper:
             ).wait()
 
         assert result is not None
-
-    @pytest.mark.parametrize(
-        "crawled,total_items,single_page,expected",
-        [
-            pytest.param(1_000, 1_000, False, True, id="exact match"),
-            pytest.param(0, 5, False, True, id="floor covers a tiny collection"),
-            pytest.param(0, 100, False, False, id="shortfall beyond the floor"),
-            pytest.param(
-                4_000_000 - 400, 4_000_000, False, True, id="churn within the cap"
-            ),
-            pytest.param(
-                4_000_000 - 2_000,
-                4_000_000,
-                False,
-                False,
-                id="a lost page is not excused",
-            ),
-            pytest.param(1_000, 1_000, True, True, id="single page, counts agree"),
-            pytest.param(999, 1_000, True, False, id="single page, one short"),
-        ],
-    )
-    def test_crawl_is_complete(
-        self,
-        crawled: int,
-        total_items: int,
-        single_page: bool,
-        expected: bool,
-    ):
-        """The allowance absorbs churn during a crawl, but never a whole lost page.
-
-        It is capped because the churn it exists for does not scale with collection
-        size, while a proportional allowance does: 0.1% of a 4M-title collection would
-        be two full pages, so a crawl that silently dropped one would be accepted and
-        those titles reaped. A collection that arrived in a single response had no
-        window for churn at all, so its counts have to agree exactly.
-        """
-        assert (
-            overdrive._crawl_is_complete(
-                MagicMock(),
-                "collection name",
-                crawled,
-                total_items,
-                single_page=single_page,
-                page_limit=2000,
-            )
-            is expected
-        )
-
-    def test_crawl_allowance_stays_under_a_page(self):
-        """A lost page must never be excused, whatever page size Overdrive applied.
-
-        The allowance is meant to absorb churn during a crawl, and the crawl's first
-        backwards page has nothing above it to be checked against -- so if the
-        allowance ever reached a whole page, an empty response there would be
-        indistinguishable from titles removed mid-crawl.
-        """
-        for page_limit in (2000, 300, 25):
-            lost_page = 10_000_000
-            assert (
-                overdrive._crawl_is_complete(
-                    MagicMock(),
-                    "collection name",
-                    lost_page - page_limit,
-                    lost_page,
-                    single_page=False,
-                    page_limit=page_limit,
-                )
-                is False
-            )
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_marks_titles_overdrive_no_longer_owns(
@@ -1850,9 +1731,11 @@ class TestOverdriveReaper:
         collection = overdrive_api_fixture.collection
         overdrive_pool(db, collection, "id-weeded")
         weeded = overdrive_identifiers("id-weeded")
+        # A single-page crawl one title short of Overdrive's count: the
+        # completeness gate rejects it, but the weed was stated outright.
         mock_crawl(
             mock_api_class,
-            product_page(listed=weeded, unowned=weeded, total_items=5000, limit=1),
+            product_page(listed=weeded, unowned=weeded, total_items=2),
         )
 
         with patch.object(identifiers, "circulation_apply") as mock_apply:

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -1657,6 +1657,33 @@ class TestOverdriveReaper:
         assert result is not None
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_skips_an_empty_collection(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """A collection Overdrive lists nothing for is skipped, not an error.
+
+        An empty identifier set is never materialised in Redis, and the chord
+        body deliberately refuses to reap a whole collection from a missing
+        set -- so handing it one would raise on every scheduled run. The
+        documented "skipped" result (None) lets the chord end quietly instead.
+        """
+        collection = overdrive_api_fixture.collection
+        caplog.set_level(LogLevel.info)
+        mock_crawl(mock_api_class, product_page(listed=(), total_items=0))
+
+        result = overdrive.reap_collection.delay(collection.id).wait()
+
+        assert result is None
+        assert "lists no titles" in caplog.text
+        assert "aborting" not in caplog.text
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_marks_titles_overdrive_no_longer_owns(
         self,
         mock_api_class: MagicMock,

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -16,7 +16,7 @@ from palace.manager.celery.importer import (
     reap_key,
     reap_workflow_lock,
 )
-from palace.manager.celery.tasks import identifiers, overdrive
+from palace.manager.celery.tasks import overdrive
 from palace.manager.celery.tasks.overdrive import import_collection_group
 from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.integration.license.overdrive.api import (
@@ -34,7 +34,7 @@ from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.coverage import Timestamp
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.identifier import Identifier
-from palace.manager.sqlalchemy.model.licensing import LicensePool, LicensePoolStatus
+from palace.manager.sqlalchemy.model.licensing import LicensePool
 from palace.manager.util.http.exception import BadResponseException
 from tests.fixtures.celery import ApplyTaskFixture, CeleryFixture
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -1231,14 +1231,10 @@ def product_page(
     *,
     listed: tuple[IdentifierData, ...] = (),
     unowned: tuple[IdentifierData, ...] = (),
-    total_items: int | None = None,
+    total_items: int,
     limit: int = 2000,
 ) -> ProductPage:
-    """Build a ProductPage.
-
-    `total_items` is passed through as given, so a test can ask for the case where
-    Overdrive omits it.
-    """
+    """Build a ProductPage."""
     return ProductPage(
         listed=listed,
         unowned=unowned,
@@ -1405,29 +1401,6 @@ class TestOverdriveReaper:
         assert not partial_set.exists()
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
-    def test_reap_collection_aborts_when_total_items_missing(
-        self,
-        mock_api_class: MagicMock,
-        db: DatabaseTransactionFixture,
-        celery_fixture: CeleryFixture,
-        overdrive_api_fixture: OverdriveAPIFixture,
-        redis_fixture: RedisFixture,
-        caplog: pytest.LogCaptureFixture,
-    ):
-        """Without totalItems there is no way to show the crawl was complete."""
-        collection = overdrive_api_fixture.collection
-        caplog.set_level(LogLevel.error)
-        mock_crawl(
-            mock_api_class,
-            product_page(listed=overdrive_identifiers("id-one"), total_items=None),
-        )
-
-        result = overdrive.reap_collection.delay(collection.id).wait()
-
-        assert result is None
-        assert "no usable totalItems or page size" in caplog.text
-
-    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_tolerates_small_shortfall(
         self,
         mock_api_class: MagicMock,
@@ -1487,7 +1460,7 @@ class TestOverdriveReaper:
         assert "Refusing to reap on an incomplete crawl" in caplog.text
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
-    def test_reap_collection_aborts_when_a_page_cannot_be_paged_from(
+    def test_reap_collection_aborts_when_the_first_backwards_page_is_short(
         self,
         mock_api_class: MagicMock,
         db: DatabaseTransactionFixture,
@@ -1496,178 +1469,32 @@ class TestOverdriveReaper:
         redis_fixture: RedisFixture,
         caplog: pytest.LogCaptureFixture,
     ):
-        """Giving up mid-walk is not the same as reaching the start of the list.
+        """The page that starts the backwards walk has nothing above it to reach.
 
-        A page that arrives without the fields the walk needs stops the crawl at an
-        unknown point, so it aborts outright rather than letting the shortfall be
-        weighed against an allowance meant for churn.
+        Every other page is checked against the one before it, and this one runs to
+        the end of the list -- so it is checked against the end of the list instead,
+        which is where it has to arrive.
         """
         collection = overdrive_api_fixture.collection
         caplog.set_level(LogLevel.error)
-        api = mock_crawl(
+        mock_crawl(
             mock_api_class,
+            # Requested at offset 4000 of a 6000-title list, so it should reach 6000.
             product_page(
-                listed=overdrive_identifiers("id-one"), total_items=2005, limit=1
+                listed=overdrive_identifiers("id-one"), total_items=6000, limit=2000
             ),
-            product_page(listed=(), total_items=None, limit=0),
         )
-        # The walk would otherwise read the second page as "collection covered".
-        api.next_product_offset.side_effect = [5, None]
 
-        async_result = overdrive.reap_collection.delay(collection.id)
+        async_result = overdrive.reap_collection.delay(
+            collection.id, offset=4000, total_items=6000, page_limit=2000
+        )
 
         assert async_result.wait() is None
-        assert "cannot be continued or verified" in caplog.text
+        assert "stops short of the 6000 Overdrive reports" in caplog.text
         partial_set = IdentifierSet(
             redis_fixture.client, reap_key(collection.id, async_result.id)
         )
         assert not partial_set.exists()
-
-    @pytest.mark.parametrize(
-        "crawled,total_items,single_page,expected",
-        [
-            pytest.param(1_000, None, False, False, id="totalItems missing"),
-            pytest.param(1_000, 1_000, False, True, id="exact match"),
-            pytest.param(0, 5, False, True, id="floor covers a tiny collection"),
-            pytest.param(0, 100, False, False, id="shortfall beyond the floor"),
-            pytest.param(
-                4_000_000 - 400, 4_000_000, False, True, id="churn within the cap"
-            ),
-            pytest.param(
-                4_000_000 - 2_000,
-                4_000_000,
-                False,
-                False,
-                id="a lost page is not excused",
-            ),
-            pytest.param(1_000, 1_000, True, True, id="single page, counts agree"),
-            pytest.param(999, 1_000, True, False, id="single page, one short"),
-        ],
-    )
-    def test_crawl_is_complete(
-        self,
-        crawled: int,
-        total_items: int | None,
-        single_page: bool,
-        expected: bool,
-    ):
-        """The allowance absorbs churn during a crawl, but never a whole lost page.
-
-        It is capped because the churn it exists for does not scale with collection
-        size, while a proportional allowance does: 0.1% of a 4M-title collection would
-        be two full pages, so a crawl that silently dropped one would be accepted and
-        those titles reaped. A collection that arrived in a single response had no
-        window for churn at all, so its counts have to agree exactly.
-        """
-        assert (
-            overdrive._crawl_is_complete(
-                MagicMock(),
-                "collection name",
-                crawled,
-                total_items,
-                single_page=single_page,
-                page_limit=2000,
-            )
-            is expected
-        )
-
-    def test_crawl_allowance_stays_under_a_page(self):
-        """A lost page must never be excused, whatever page size Overdrive applied.
-
-        The allowance is meant to absorb churn during a crawl, and the crawl's first
-        backwards page has nothing above it to be checked against -- so if the
-        allowance ever reached a whole page, an empty response there would be
-        indistinguishable from titles removed mid-crawl.
-        """
-        for page_limit in (2000, 300, 25):
-            lost_page = 10_000_000
-            assert (
-                overdrive._crawl_is_complete(
-                    MagicMock(),
-                    "collection name",
-                    lost_page - page_limit,
-                    lost_page,
-                    single_page=False,
-                    page_limit=page_limit,
-                )
-                is False
-            )
-
-    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
-    def test_reap_collection_marks_titles_overdrive_no_longer_owns(
-        self,
-        mock_api_class: MagicMock,
-        db: DatabaseTransactionFixture,
-        celery_fixture: CeleryFixture,
-        overdrive_api_fixture: OverdriveAPIFixture,
-        redis_fixture: RedisFixture,
-    ):
-        """Weeded titles are marked from Overdrive's flag, not from their absence.
-
-        Overdrive keeps weeded and expired titles in the product list, flagged
-        `isOwnedByCollections: false`. That is a statement that the title is gone, so
-        it is acted on directly rather than inferred from a set difference.
-        """
-        collection = overdrive_api_fixture.collection
-        overdrive_pool(db, collection, "id-weeded")
-        overdrive_pool(db, collection, "id-available")
-        already_gone = overdrive_pool(db, collection, "id-already-gone")
-        already_gone.licenses_owned = already_gone.licenses_available = 0
-        db.session.flush()
-
-        listed = overdrive_identifiers("id-weeded", "id-available", "id-already-gone")
-        mock_crawl(
-            mock_api_class,
-            product_page(
-                listed=listed,
-                unowned=overdrive_identifiers("id-weeded", "id-already-gone"),
-                total_items=3,
-            ),
-        )
-
-        with patch.object(identifiers, "circulation_apply") as mock_apply:
-            result = overdrive.reap_collection.delay(collection.id).wait()
-
-        # Only the weeded title we still record as available is marked. The one that is
-        # already unavailable is left alone, so the titles Overdrive goes on listing as
-        # unowned do not generate an apply task on every pass.
-        mock_apply.delay.assert_called_once()
-        circulation = mock_apply.delay.call_args.kwargs["circulation"]
-        assert circulation.primary_identifier_data.identifier == "id-weeded"
-        assert circulation.licenses_owned == 0
-        assert circulation.licenses_available == 0
-        assert circulation.status == LicensePoolStatus.EXHAUSTED
-
-        # Unowned titles stay in the returned set, so the chord's set difference does
-        # not mark them a second time.
-        assert IdentifierSet(redis_fixture.client, result["key"]).get() == set(listed)
-
-    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
-    def test_reap_collection_marks_unowned_titles_on_an_incomplete_crawl(
-        self,
-        mock_api_class: MagicMock,
-        db: DatabaseTransactionFixture,
-        celery_fixture: CeleryFixture,
-        overdrive_api_fixture: OverdriveAPIFixture,
-        redis_fixture: RedisFixture,
-    ):
-        """A crawl that cannot be verified still marks what Overdrive stated outright.
-
-        Only the half that acts on absence needs a complete crawl.
-        """
-        collection = overdrive_api_fixture.collection
-        overdrive_pool(db, collection, "id-weeded")
-        weeded = overdrive_identifiers("id-weeded")
-        mock_crawl(
-            mock_api_class,
-            product_page(listed=weeded, unowned=weeded, total_items=5000),
-        )
-
-        with patch.object(identifiers, "circulation_apply") as mock_apply:
-            result = overdrive.reap_collection.delay(collection.id).wait()
-
-        assert result is None
-        mock_apply.delay.assert_called_once()
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_aborts_on_a_gap_between_pages(

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -16,7 +16,7 @@ from palace.manager.celery.importer import (
     reap_key,
     reap_workflow_lock,
 )
-from palace.manager.celery.tasks import overdrive
+from palace.manager.celery.tasks import identifiers, overdrive
 from palace.manager.celery.tasks.overdrive import import_collection_group
 from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.integration.license.overdrive.api import (
@@ -34,7 +34,7 @@ from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.coverage import Timestamp
 from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.identifier import Identifier
-from palace.manager.sqlalchemy.model.licensing import LicensePool
+from palace.manager.sqlalchemy.model.licensing import LicensePool, LicensePoolStatus
 from palace.manager.util.http.exception import BadResponseException
 from tests.fixtures.celery import ApplyTaskFixture, CeleryFixture
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -1655,6 +1655,161 @@ class TestOverdriveReaper:
             ).wait()
 
         assert result is not None
+
+    @pytest.mark.parametrize(
+        "crawled,total_items,single_page,expected",
+        [
+            pytest.param(1_000, 1_000, False, True, id="exact match"),
+            pytest.param(0, 5, False, True, id="floor covers a tiny collection"),
+            pytest.param(0, 100, False, False, id="shortfall beyond the floor"),
+            pytest.param(
+                4_000_000 - 400, 4_000_000, False, True, id="churn within the cap"
+            ),
+            pytest.param(
+                4_000_000 - 2_000,
+                4_000_000,
+                False,
+                False,
+                id="a lost page is not excused",
+            ),
+            pytest.param(1_000, 1_000, True, True, id="single page, counts agree"),
+            pytest.param(999, 1_000, True, False, id="single page, one short"),
+        ],
+    )
+    def test_crawl_is_complete(
+        self,
+        crawled: int,
+        total_items: int,
+        single_page: bool,
+        expected: bool,
+    ):
+        """The allowance absorbs churn during a crawl, but never a whole lost page.
+
+        It is capped because the churn it exists for does not scale with collection
+        size, while a proportional allowance does: 0.1% of a 4M-title collection would
+        be two full pages, so a crawl that silently dropped one would be accepted and
+        those titles reaped. A collection that arrived in a single response had no
+        window for churn at all, so its counts have to agree exactly.
+        """
+        assert (
+            overdrive._crawl_is_complete(
+                MagicMock(),
+                "collection name",
+                crawled,
+                total_items,
+                single_page=single_page,
+                page_limit=2000,
+            )
+            is expected
+        )
+
+    def test_crawl_allowance_stays_under_a_page(self):
+        """A lost page must never be excused, whatever page size Overdrive applied.
+
+        The allowance is meant to absorb churn during a crawl, and the crawl's first
+        backwards page has nothing above it to be checked against -- so if the
+        allowance ever reached a whole page, an empty response there would be
+        indistinguishable from titles removed mid-crawl.
+        """
+        for page_limit in (2000, 300, 25):
+            lost_page = 10_000_000
+            assert (
+                overdrive._crawl_is_complete(
+                    MagicMock(),
+                    "collection name",
+                    lost_page - page_limit,
+                    lost_page,
+                    single_page=False,
+                    page_limit=page_limit,
+                )
+                is False
+            )
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_marks_titles_overdrive_no_longer_owns(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+    ):
+        """Weeded titles are marked from Overdrive's flag, not from their absence.
+
+        Overdrive keeps weeded and expired titles in the product list, flagged
+        `isOwnedByCollections: false`. That is a statement that the title is gone, so
+        it is acted on directly rather than inferred from a set difference.
+        """
+        collection = overdrive_api_fixture.collection
+        overdrive_pool(db, collection, "id-weeded")
+        overdrive_pool(db, collection, "id-available")
+        # A weeded title whose copies are all checked out: still held, so still worth
+        # marking, and one the set difference can never reach.
+        on_loan = overdrive_pool(db, collection, "id-on-loan")
+        on_loan.licenses_available = 0
+        already_gone = overdrive_pool(db, collection, "id-already-gone")
+        already_gone.licenses_owned = already_gone.licenses_available = 0
+        db.session.flush()
+
+        listed = overdrive_identifiers(
+            "id-weeded", "id-available", "id-on-loan", "id-already-gone"
+        )
+        mock_crawl(
+            mock_api_class,
+            product_page(
+                listed=listed,
+                unowned=overdrive_identifiers(
+                    "id-weeded", "id-on-loan", "id-already-gone"
+                ),
+                total_items=4,
+            ),
+        )
+
+        with patch.object(identifiers, "circulation_apply") as mock_apply:
+            result = overdrive.reap_collection.delay(collection.id).wait()
+
+        # The title with no copies left is not re-marked, so the ones Overdrive goes
+        # on listing as unowned do not generate an apply task on every pass.
+        marked = {
+            call.kwargs["circulation"].primary_identifier_data.identifier
+            for call in mock_apply.delay.call_args_list
+        }
+        assert marked == {"id-weeded", "id-on-loan"}
+        circulation = mock_apply.delay.call_args.kwargs["circulation"]
+        assert circulation.licenses_owned == 0
+        assert circulation.licenses_available == 0
+        assert circulation.status == LicensePoolStatus.EXHAUSTED
+
+        # Unowned titles stay in the returned set, so the chord's set difference does
+        # not mark them a second time.
+        assert IdentifierSet(redis_fixture.client, result["key"]).get() == set(listed)
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_marks_unowned_titles_on_an_incomplete_crawl(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+    ):
+        """A crawl that cannot be verified still marks what Overdrive stated outright.
+
+        Only the half that acts on absence needs a complete crawl.
+        """
+        collection = overdrive_api_fixture.collection
+        overdrive_pool(db, collection, "id-weeded")
+        weeded = overdrive_identifiers("id-weeded")
+        mock_crawl(
+            mock_api_class,
+            product_page(listed=weeded, unowned=weeded, total_items=5000, limit=1),
+        )
+
+        with patch.object(identifiers, "circulation_apply") as mock_apply:
+            result = overdrive.reap_collection.delay(collection.id).wait()
+
+        assert result is None
+        mock_apply.delay.assert_called_once()
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_skips_collection_marked_for_deletion(

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -1714,6 +1714,40 @@ class TestOverdriveReaper:
         assert result is None
         assert "cannot join back onto it" in caplog.text
 
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_aborts_when_the_page_size_changes(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Every gap check measures in page sizes, so one that changes invalidates them.
+
+        Overdrive echoes the size it applied -- the requested one, not the number of
+        titles returned -- and the crawl asks for the same size every time, so a
+        change means the walk's arithmetic no longer describes the list.
+        """
+        collection = overdrive_api_fixture.collection
+        caplog.set_level(LogLevel.error)
+        api = mock_crawl(
+            mock_api_class,
+            product_page(
+                listed=overdrive_identifiers("id-one"), total_items=6000, limit=1
+            ),
+            product_page(
+                listed=overdrive_identifiers("id-two"), total_items=6000, limit=500
+            ),
+        )
+        api.next_product_offset.side_effect = [4000, None]
+
+        result = overdrive.reap_collection.delay(collection.id).wait()
+
+        assert result is None
+        assert "whose paging changed underneath it" in caplog.text
+
     def test_reap_collection_discards_a_page_from_the_previous_reaper(
         self,
         db: DatabaseTransactionFixture,

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -1232,7 +1232,6 @@ def product_page(
     listed: tuple[IdentifierData, ...] = (),
     unowned: tuple[IdentifierData, ...] = (),
     total_items: int | None = None,
-    offset: int = 0,
     limit: int = 2000,
 ) -> ProductPage:
     """Build a ProductPage.
@@ -1244,7 +1243,6 @@ def product_page(
         listed=listed,
         unowned=unowned,
         total_items=total_items,
-        offset=offset,
         limit=limit,
     )
 
@@ -1253,13 +1251,12 @@ def mock_crawl(mock_api_class: MagicMock, *pages: ProductPage) -> MagicMock:
     """Point a mocked OverdriveAPI at the given pages, walked in order.
 
     The mocked API has to be told where the walk ends; otherwise
-    `next_product_page` returns a truthy Mock and the crawl never finishes.
+    `next_product_offset` returns a Mock and the crawl never finishes.
     """
     api = mock_api_class.return_value
     api.fetch_product_page.side_effect = list(pages)
-    api.next_product_page.side_effect = [
-        BookInfoEndpoint(f"http://od/products?offset={index + 1}")
-        for index in range(len(pages) - 1)
+    api.next_product_offset.side_effect = [
+        (index + 1) * 100 for index in range(len(pages) - 1)
     ] + [None]
     return api
 
@@ -1357,17 +1354,16 @@ class TestOverdriveReaper:
         second_page = overdrive_identifiers("id-three")
         api = mock_crawl(
             mock_api_class,
-            product_page(listed=first_page, total_items=3, offset=0, limit=2),
-            product_page(listed=second_page, total_items=3, offset=2, limit=2),
+            product_page(listed=first_page, total_items=3, limit=2),
+            product_page(listed=second_page, total_items=3, limit=2),
         )
 
         result = overdrive.reap_collection.delay(collection.id).wait()
 
         assert api.fetch_product_page.call_count == 2
-        # The second page was fetched from the url the walk handed back.
-        assert api.fetch_product_page.call_args_list[1].args[0] == BookInfoEndpoint(
-            "http://od/products?offset=1"
-        )
+        # Each page was requested at the offset the walk handed back, so a crawl
+        # cannot be talked into re-requesting the page it just fetched.
+        assert api.product_page_endpoint.call_args_list == [call(0), call(100)]
         identifier_set = IdentifierSet(redis_fixture.client, result["key"])
         assert identifier_set.get() == set(first_page) | set(second_page)
 

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -1310,7 +1310,14 @@ class TestOverdriveReaper:
             ],
             any_order=True,
         )
-        assert mock_reap_task.return_value.apply_async.call_count == 3
+        # Kickoffs are staggered: each reap chord opens with a full-collection
+        # identifier scan, and launching them all in the same minute would stack
+        # those scans onto the default queue at once.
+        stagger = overdrive.REAP_KICKOFF_STAGGER.total_seconds()
+        assert sorted(
+            kickoff.kwargs["countdown"]
+            for kickoff in mock_reap_task.return_value.apply_async.call_args_list
+        ) == [0 * stagger, 1 * stagger, 2 * stagger]
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_returns_listed_identifiers(

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -1641,6 +1641,70 @@ class TestOverdriveReaper:
         mock_apply.delay.assert_called_once()
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_aborts_on_a_gap_between_pages(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """A page that returns fewer titles than the walk stepped back by leaves a gap.
+
+        The step is a page size, but a page may return fewer than that, and the
+        uncrawled strip would otherwise reach the completeness check as a shortfall
+        indistinguishable from titles removed mid-crawl.
+        """
+        collection = overdrive_api_fixture.collection
+        caplog.set_level(LogLevel.error)
+        api = mock_crawl(
+            mock_api_class,
+            product_page(listed=overdrive_identifiers("id-one"), total_items=6000),
+            # Requested at offset 3000, but reaches only 3001 -- short of the 4000
+            # the previous page started at.
+            product_page(listed=overdrive_identifiers("id-two"), total_items=6000),
+        )
+        api.next_product_offset.side_effect = [4000, 3000, None]
+
+        async_result = overdrive.reap_collection.apply_async(
+            (collection.id,), {"offset": 3000, "previous_offset": 4000}
+        )
+
+        assert async_result.wait() is None
+        assert "Refusing to reap across a gap" in caplog.text
+        partial_set = IdentifierSet(
+            redis_fixture.client, reap_key(collection.id, async_result.id)
+        )
+        assert not partial_set.exists()
+
+    def test_reap_collection_discards_a_page_from_the_previous_reaper(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Pages queued by the per-title reaper are dropped, not run.
+
+        Its `offset` was the last Identifier.id it had processed, so binding it as a
+        product-list offset would crawl from an arbitrary point in the collection.
+        """
+        collection = overdrive_api_fixture.collection
+        caplog.set_level(LogLevel.info)
+
+        with patch(
+            "palace.manager.celery.tasks.overdrive.OverdriveAPI"
+        ) as mock_api_class:
+            result = overdrive.reap_collection.apply_async(
+                (collection.id,), {"offset": 918273, "batch_size": 50}
+            ).wait()
+
+        assert result is None
+        mock_api_class.return_value.fetch_product_page.assert_not_called()
+        assert "previous reaper implementation" in caplog.text
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_skips_collection_marked_for_deletion(
         self,
         mock_api_class: MagicMock,

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -1421,7 +1421,7 @@ class TestOverdriveReaper:
         result = overdrive.reap_collection.delay(collection.id).wait()
 
         assert result is None
-        assert "did not report totalItems" in caplog.text
+        assert "no usable totalItems or page size" in caplog.text
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_tolerates_small_shortfall(
@@ -1432,15 +1432,21 @@ class TestOverdriveReaper:
         overdrive_api_fixture: OverdriveAPIFixture,
         redis_fixture: RedisFixture,
     ):
-        """Titles added or removed mid-crawl move totalItems, which is not a failure."""
+        """Titles added or removed mid-crawl move totalItems, which is not a failure.
+
+        The allowance only applies to a crawl that spanned more than one response --
+        that is the only kind with a window for the collection to change underneath
+        it.
+        """
         collection = overdrive_api_fixture.collection
-        listed = overdrive_identifiers("id-one", "id-two")
+        first_page = overdrive_identifiers("id-one", "id-two")
+        second_page = overdrive_identifiers("id-three")
+        listed = first_page + second_page
+        total_items = len(listed) + overdrive.REAP_CRAWL_ALLOWANCE_FLOOR
         mock_crawl(
             mock_api_class,
-            product_page(
-                listed=listed,
-                total_items=len(listed) + overdrive.REAP_CRAWL_ALLOWANCE_FLOOR,
-            ),
+            product_page(listed=first_page, total_items=total_items),
+            product_page(listed=second_page, total_items=total_items),
         )
 
         result = overdrive.reap_collection.delay(collection.id).wait()
@@ -1448,32 +1454,112 @@ class TestOverdriveReaper:
         assert result is not None
         assert IdentifierSet(redis_fixture.client, result["key"]).get() == set(listed)
 
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_requires_an_exact_count_for_a_single_page(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """A collection that arrives in one response had no window for churn.
+
+        Its products and its totalItems were produced together, so a shortfall is
+        Overdrive truncating the response rather than the collection moving, and the
+        allowance for churn should not excuse it.
+        """
+        collection = overdrive_api_fixture.collection
+        caplog.set_level(LogLevel.error)
+        mock_crawl(
+            mock_api_class,
+            product_page(listed=overdrive_identifiers("id-one"), total_items=2),
+        )
+
+        result = overdrive.reap_collection.delay(collection.id).wait()
+
+        assert result is None
+        assert "Refusing to reap on an incomplete crawl" in caplog.text
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_aborts_when_a_page_cannot_be_paged_from(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Giving up mid-walk is not the same as reaching the start of the list.
+
+        A page that arrives without the fields the walk needs stops the crawl at an
+        unknown point, so it aborts outright rather than letting the shortfall be
+        weighed against an allowance meant for churn.
+        """
+        collection = overdrive_api_fixture.collection
+        caplog.set_level(LogLevel.error)
+        api = mock_crawl(
+            mock_api_class,
+            product_page(listed=overdrive_identifiers("id-one"), total_items=2005),
+            product_page(listed=(), total_items=None, limit=0),
+        )
+        # The walk would otherwise read the second page as "collection covered".
+        api.next_product_offset.side_effect = [5, None]
+
+        async_result = overdrive.reap_collection.delay(collection.id)
+
+        assert async_result.wait() is None
+        assert "cannot be continued or verified" in caplog.text
+        partial_set = IdentifierSet(
+            redis_fixture.client, reap_key(collection.id, async_result.id)
+        )
+        assert not partial_set.exists()
+
     @pytest.mark.parametrize(
-        "crawled,total_items,expected",
+        "crawled,total_items,single_page,expected",
         [
-            pytest.param(1_000, None, False, id="totalItems missing"),
-            pytest.param(1_000, 1_000, True, id="exact match"),
-            pytest.param(0, 5, True, id="floor covers a tiny collection"),
-            pytest.param(0, 100, False, id="shortfall beyond the floor"),
-            pytest.param(4_000_000 - 400, 4_000_000, True, id="churn within the cap"),
+            pytest.param(1_000, None, False, False, id="totalItems missing"),
+            pytest.param(1_000, 1_000, False, True, id="exact match"),
+            pytest.param(0, 5, False, True, id="floor covers a tiny collection"),
+            pytest.param(0, 100, False, False, id="shortfall beyond the floor"),
             pytest.param(
-                4_000_000 - 2_000, 4_000_000, False, id="a lost page is not excused"
+                4_000_000 - 400, 4_000_000, False, True, id="churn within the cap"
             ),
+            pytest.param(
+                4_000_000 - 2_000,
+                4_000_000,
+                False,
+                False,
+                id="a lost page is not excused",
+            ),
+            pytest.param(1_000, 1_000, True, True, id="single page, counts agree"),
+            pytest.param(999, 1_000, True, False, id="single page, one short"),
         ],
     )
     def test_crawl_is_complete(
-        self, crawled: int, total_items: int | None, expected: bool
+        self,
+        crawled: int,
+        total_items: int | None,
+        single_page: bool,
+        expected: bool,
     ):
         """The allowance absorbs churn during a crawl, but never a whole lost page.
 
         It is capped because the churn it exists for does not scale with collection
         size, while a proportional allowance does: 0.1% of a 4M-title collection would
         be two full pages, so a crawl that silently dropped one would be accepted and
-        those titles reaped.
+        those titles reaped. A collection that arrived in a single response had no
+        window for churn at all, so its counts have to agree exactly.
         """
         assert (
             overdrive._crawl_is_complete(
-                MagicMock(), "collection name", crawled, total_items
+                MagicMock(),
+                "collection name",
+                crawled,
+                total_items,
+                single_page=single_page,
             )
             is expected
         )

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -1566,9 +1566,32 @@ class TestOverdriveReaper:
                 crawled,
                 total_items,
                 single_page=single_page,
+                page_limit=2000,
             )
             is expected
         )
+
+    def test_crawl_allowance_stays_under_a_page(self):
+        """A lost page must never be excused, whatever page size Overdrive applied.
+
+        The allowance is meant to absorb churn during a crawl, and the crawl's first
+        backwards page has nothing above it to be checked against -- so if the
+        allowance ever reached a whole page, an empty response there would be
+        indistinguishable from titles removed mid-crawl.
+        """
+        for page_limit in (2000, 300, 25):
+            lost_page = 10_000_000
+            assert (
+                overdrive._crawl_is_complete(
+                    MagicMock(),
+                    "collection name",
+                    lost_page - page_limit,
+                    lost_page,
+                    single_page=False,
+                    page_limit=page_limit,
+                )
+                is False
+            )
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_marks_titles_overdrive_no_longer_owns(
@@ -1673,8 +1696,14 @@ class TestOverdriveReaper:
         )
         api.next_product_offset.side_effect = [4000, 3000, None]
 
-        async_result = overdrive.reap_collection.apply_async(
-            (collection.id,), {"offset": 3000, "previous_offset": 4000}
+        # Mid-crawl pages carry the crawl's state, which is also what tells them apart
+        # from a page left over from the previous reaper.
+        async_result = overdrive.reap_collection.delay(
+            collection.id,
+            offset=3000,
+            previous_offset=4000,
+            total_items=6000,
+            page_limit=2000,
         )
 
         assert async_result.wait() is None
@@ -1758,7 +1787,10 @@ class TestOverdriveReaper:
         """Pages queued by the per-title reaper are dropped, not run.
 
         Its `offset` was the last Identifier.id it had processed, so binding it as a
-        product-list offset would crawl from an arbitrary point in the collection.
+        product-list offset would crawl from an arbitrary point in the collection. It
+        re-queued itself with only a collection id and an offset -- never a
+        `batch_size`, which was left at its default -- so the absence of the crawl
+        state this reaper always carries is what identifies one.
         """
         collection = overdrive_api_fixture.collection
         caplog.set_level(LogLevel.info)
@@ -1766,13 +1798,36 @@ class TestOverdriveReaper:
         with patch(
             "palace.manager.celery.tasks.overdrive.OverdriveAPI"
         ) as mock_api_class:
-            result = overdrive.reap_collection.apply_async(
-                (collection.id,), {"offset": 918273, "batch_size": 50}
+            result = overdrive.reap_collection.delay(
+                collection.id, offset=918273
             ).wait()
 
         assert result is None
         mock_api_class.return_value.fetch_product_page.assert_not_called()
         assert "previous reaper implementation" in caplog.text
+
+    def test_reap_collection_binds_a_page_carrying_batch_size(
+        self,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+    ):
+        """A message carrying the old reaper's parameter still binds, and is ignored."""
+        collection = overdrive_api_fixture.collection
+
+        with patch(
+            "palace.manager.celery.tasks.overdrive.OverdriveAPI"
+        ) as mock_api_class:
+            mock_crawl(
+                mock_api_class,
+                product_page(listed=overdrive_identifiers("id-one"), total_items=1),
+            )
+            result = overdrive.reap_collection.delay(
+                collection.id, batch_size=50
+            ).wait()
+
+        assert result is not None
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_skips_collection_marked_for_deletion(

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -1496,6 +1496,56 @@ class TestOverdriveReaper:
         )
         assert not partial_set.exists()
 
+    @pytest.mark.parametrize(
+        "reported_now,returned,aborts",
+        [
+            pytest.param(6000, 2000, False, id="unchanged, full page"),
+            pytest.param(6001, 2000, False, id="a title added since the first page"),
+            pytest.param(6100, 2000, False, id="many titles added"),
+            pytest.param(5990, 1990, False, id="titles removed since the first page"),
+            pytest.param(6000, 1990, True, id="page truncated"),
+        ],
+    )
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_first_backwards_page_tolerates_a_growing_collection(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+        reported_now: int,
+        returned: int,
+        aborts: bool,
+    ):
+        """Which end the first backwards page must reach depends on what changed.
+
+        It starts one page back from where the collection ended when the crawl began,
+        so a full page arrives exactly at that count. Titles added since then sit
+        beyond it -- not this page's to reach, and absent from the snapshot the chord
+        took of what we hold, so they cannot be falsely reaped. Titles removed shorten
+        the list, and that shorter count is the one it has to reach.
+        """
+        collection = overdrive_api_fixture.collection
+        caplog.set_level(LogLevel.error)
+        mock_crawl(
+            mock_api_class,
+            product_page(
+                listed=overdrive_identifiers(*(f"id-{i}" for i in range(returned))),
+                total_items=reported_now,
+                limit=2000,
+            ),
+        )
+
+        overdrive.reap_collection.delay(
+            collection.id, offset=4000, total_items=6000, page_limit=2000
+        ).wait()
+
+        # Asserted on this check rather than the run's outcome: a single mocked page
+        # is not a complete crawl, so the run ends either way.
+        assert ("Refusing to reap across a gap" in caplog.text) is aborts
+
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_aborts_on_a_gap_between_pages(
         self,

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -16,7 +16,7 @@ from palace.manager.celery.importer import (
     reap_key,
     reap_workflow_lock,
 )
-from palace.manager.celery.tasks import overdrive
+from palace.manager.celery.tasks import identifiers, overdrive
 from palace.manager.celery.tasks.overdrive import import_collection_group
 from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.integration.license.overdrive.api import (
@@ -32,7 +32,9 @@ from palace.manager.service.redis.models.set import IdentifierSet
 from palace.manager.sqlalchemy.constants import IdentifierType
 from palace.manager.sqlalchemy.model.collection import Collection
 from palace.manager.sqlalchemy.model.coverage import Timestamp
+from palace.manager.sqlalchemy.model.datasource import DataSource
 from palace.manager.sqlalchemy.model.identifier import Identifier
+from palace.manager.sqlalchemy.model.licensing import LicensePool, LicensePoolStatus
 from palace.manager.util.http.exception import BadResponseException
 from tests.fixtures.celery import ApplyTaskFixture, CeleryFixture
 from tests.fixtures.database import DatabaseTransactionFixture
@@ -1227,28 +1229,62 @@ class TestIntegration:
 
 def product_page(
     *,
-    active: tuple[IdentifierData, ...] = (),
-    seen: int | None = None,
+    listed: tuple[IdentifierData, ...] = (),
+    unowned: tuple[IdentifierData, ...] = (),
     total_items: int | None = None,
-    next_page: BookInfoEndpoint | None = None,
+    offset: int = 0,
+    limit: int = 2000,
 ) -> ProductPage:
-    """Build a ProductPage, defaulting `seen` to the number of active identifiers.
+    """Build a ProductPage.
 
     `total_items` is passed through as given, so a test can ask for the case where
     Overdrive omits it.
     """
     return ProductPage(
-        active=active,
-        seen=len(active) if seen is None else seen,
+        listed=listed,
+        unowned=unowned,
         total_items=total_items,
-        next_page=next_page,
+        offset=offset,
+        limit=limit,
     )
+
+
+def mock_crawl(mock_api_class: MagicMock, *pages: ProductPage) -> MagicMock:
+    """Point a mocked OverdriveAPI at the given pages, walked in order.
+
+    The mocked API has to be told where the walk ends; otherwise
+    `next_product_page` returns a truthy Mock and the crawl never finishes.
+    """
+    api = mock_api_class.return_value
+    api.fetch_product_page.side_effect = list(pages)
+    api.next_product_page.side_effect = [
+        BookInfoEndpoint(f"http://od/products?offset={index + 1}")
+        for index in range(len(pages) - 1)
+    ] + [None]
+    return api
 
 
 def overdrive_identifiers(*identifiers: str) -> tuple[IdentifierData, ...]:
     return tuple(
         IdentifierData(type=Identifier.OVERDRIVE_ID, identifier=identifier)
         for identifier in identifiers
+    )
+
+
+def overdrive_pool(
+    db: DatabaseTransactionFixture, collection: Collection, identifier: str
+) -> LicensePool:
+    """Create an available Overdrive license pool with the given identifier."""
+    edition = db.edition(
+        data_source_name=DataSource.OVERDRIVE,
+        identifier_type=Identifier.OVERDRIVE_ID,
+        identifier_id=identifier,
+    )
+    return db.licensepool(
+        edition,
+        collection=collection,
+        data_source_name=DataSource.OVERDRIVE,
+        open_access=False,
     )
 
 
@@ -1282,7 +1318,7 @@ class TestOverdriveReaper:
         assert mock_reap_task.return_value.apply_async.call_count == 3
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
-    def test_reap_collection_returns_owned_identifiers(
+    def test_reap_collection_returns_listed_identifiers(
         self,
         mock_api_class: MagicMock,
         db: DatabaseTransactionFixture,
@@ -1290,17 +1326,15 @@ class TestOverdriveReaper:
         overdrive_api_fixture: OverdriveAPIFixture,
         redis_fixture: RedisFixture,
     ):
-        """A completed crawl returns the identifiers the collection still holds."""
+        """A completed crawl returns every identifier the collection still lists."""
         collection = overdrive_api_fixture.collection
-        active = overdrive_identifiers("id-one", "id-two")
-        mock_api_class.return_value.fetch_product_page.return_value = product_page(
-            active=active, seen=3, total_items=3
-        )
+        listed = overdrive_identifiers("id-one", "id-two")
+        mock_crawl(mock_api_class, product_page(listed=listed, total_items=2))
 
         result = overdrive.reap_collection.delay(collection.id).wait()
 
         identifier_set = IdentifierSet(redis_fixture.client, result["key"])
-        assert identifier_set.get() == set(active)
+        assert identifier_set.get() == set(listed)
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_pages_until_crawl_completes(
@@ -1311,23 +1345,31 @@ class TestOverdriveReaper:
         overdrive_api_fixture: OverdriveAPIFixture,
         redis_fixture: RedisFixture,
     ):
-        """A page with a successor re-queues the task with the next url and running count."""
+        """The identifiers from every page end up in one set.
+
+        Each page runs as a fresh task via task.replace(), and the set is keyed on the
+        task id, which Celery preserves across that hand-off. If it ever stopped doing
+        so, the crawl would return only its final page and the reaper would mark
+        almost the whole collection as gone.
+        """
         collection = overdrive_api_fixture.collection
-        mock_api_class.return_value.fetch_product_page.return_value = product_page(
-            active=overdrive_identifiers("id-one"),
-            seen=2,
-            total_items=10,
-            next_page=BookInfoEndpoint("http://od/products?offset=2"),
+        first_page = overdrive_identifiers("id-one", "id-two")
+        second_page = overdrive_identifiers("id-three")
+        api = mock_crawl(
+            mock_api_class,
+            product_page(listed=first_page, total_items=3, offset=0, limit=2),
+            product_page(listed=second_page, total_items=3, offset=2, limit=2),
         )
 
-        with patch.object(overdrive.reap_collection, "replace") as mock_replace:
-            mock_replace.side_effect = Exception("replaced")
-            with pytest.raises(Exception, match="replaced"):
-                overdrive.reap_collection.delay(collection.id).wait()
+        result = overdrive.reap_collection.delay(collection.id).wait()
 
-        replace_sig = mock_replace.call_args[0][0]
-        assert replace_sig.kwargs["page"] == "http://od/products?offset=2"
-        assert replace_sig.kwargs["seen"] == 2
+        assert api.fetch_product_page.call_count == 2
+        # The second page was fetched from the url the walk handed back.
+        assert api.fetch_product_page.call_args_list[1].args[0] == BookInfoEndpoint(
+            "http://od/products?offset=1"
+        )
+        identifier_set = IdentifierSet(redis_fixture.client, result["key"])
+        assert identifier_set.get() == set(first_page) | set(second_page)
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_aborts_on_incomplete_crawl(
@@ -1347,8 +1389,9 @@ class TestOverdriveReaper:
         """
         collection = overdrive_api_fixture.collection
         caplog.set_level(LogLevel.error)
-        mock_api_class.return_value.fetch_product_page.return_value = product_page(
-            active=overdrive_identifiers("id-one"), seen=1, total_items=5000
+        mock_crawl(
+            mock_api_class,
+            product_page(listed=overdrive_identifiers("id-one"), total_items=5000),
         )
 
         async_result = overdrive.reap_collection.delay(collection.id)
@@ -1374,8 +1417,9 @@ class TestOverdriveReaper:
         """Without totalItems there is no way to show the crawl was complete."""
         collection = overdrive_api_fixture.collection
         caplog.set_level(LogLevel.error)
-        mock_api_class.return_value.fetch_product_page.return_value = product_page(
-            active=overdrive_identifiers("id-one"), seen=1, total_items=None
+        mock_crawl(
+            mock_api_class,
+            product_page(listed=overdrive_identifiers("id-one"), total_items=None),
         )
 
         result = overdrive.reap_collection.delay(collection.id).wait()
@@ -1394,17 +1438,125 @@ class TestOverdriveReaper:
     ):
         """Titles added or removed mid-crawl move totalItems, which is not a failure."""
         collection = overdrive_api_fixture.collection
-        active = overdrive_identifiers("id-one", "id-two")
-        mock_api_class.return_value.fetch_product_page.return_value = product_page(
-            active=active,
-            seen=1000,
-            total_items=1000 + overdrive.REAP_CRAWL_ALLOWANCE_FLOOR,
+        listed = overdrive_identifiers("id-one", "id-two")
+        mock_crawl(
+            mock_api_class,
+            product_page(
+                listed=listed,
+                total_items=len(listed) + overdrive.REAP_CRAWL_ALLOWANCE_FLOOR,
+            ),
         )
 
         result = overdrive.reap_collection.delay(collection.id).wait()
 
         assert result is not None
-        assert IdentifierSet(redis_fixture.client, result["key"]).get() == set(active)
+        assert IdentifierSet(redis_fixture.client, result["key"]).get() == set(listed)
+
+    @pytest.mark.parametrize(
+        "crawled,total_items,expected",
+        [
+            pytest.param(1_000, None, False, id="totalItems missing"),
+            pytest.param(1_000, 1_000, True, id="exact match"),
+            pytest.param(0, 5, True, id="floor covers a tiny collection"),
+            pytest.param(0, 100, False, id="shortfall beyond the floor"),
+            pytest.param(4_000_000 - 400, 4_000_000, True, id="churn within the cap"),
+            pytest.param(
+                4_000_000 - 2_000, 4_000_000, False, id="a lost page is not excused"
+            ),
+        ],
+    )
+    def test_crawl_is_complete(
+        self, crawled: int, total_items: int | None, expected: bool
+    ):
+        """The allowance absorbs churn during a crawl, but never a whole lost page.
+
+        It is capped because the churn it exists for does not scale with collection
+        size, while a proportional allowance does: 0.1% of a 4M-title collection would
+        be two full pages, so a crawl that silently dropped one would be accepted and
+        those titles reaped.
+        """
+        assert (
+            overdrive._crawl_is_complete(
+                MagicMock(), "collection name", crawled, total_items
+            )
+            is expected
+        )
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_marks_titles_overdrive_no_longer_owns(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+    ):
+        """Weeded titles are marked from Overdrive's flag, not from their absence.
+
+        Overdrive keeps weeded and expired titles in the product list, flagged
+        `isOwnedByCollections: false`. That is a statement that the title is gone, so
+        it is acted on directly rather than inferred from a set difference.
+        """
+        collection = overdrive_api_fixture.collection
+        overdrive_pool(db, collection, "id-weeded")
+        overdrive_pool(db, collection, "id-available")
+        already_gone = overdrive_pool(db, collection, "id-already-gone")
+        already_gone.licenses_owned = already_gone.licenses_available = 0
+        db.session.flush()
+
+        listed = overdrive_identifiers("id-weeded", "id-available", "id-already-gone")
+        mock_crawl(
+            mock_api_class,
+            product_page(
+                listed=listed,
+                unowned=overdrive_identifiers("id-weeded", "id-already-gone"),
+                total_items=3,
+            ),
+        )
+
+        with patch.object(identifiers, "circulation_apply") as mock_apply:
+            result = overdrive.reap_collection.delay(collection.id).wait()
+
+        # Only the weeded title we still record as available is marked. The one that is
+        # already unavailable is left alone, so the titles Overdrive goes on listing as
+        # unowned do not generate an apply task on every pass.
+        mock_apply.delay.assert_called_once()
+        circulation = mock_apply.delay.call_args.kwargs["circulation"]
+        assert circulation.primary_identifier_data.identifier == "id-weeded"
+        assert circulation.licenses_owned == 0
+        assert circulation.licenses_available == 0
+        assert circulation.status == LicensePoolStatus.EXHAUSTED
+
+        # Unowned titles stay in the returned set, so the chord's set difference does
+        # not mark them a second time.
+        assert IdentifierSet(redis_fixture.client, result["key"]).get() == set(listed)
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_marks_unowned_titles_on_an_incomplete_crawl(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+    ):
+        """A crawl that cannot be verified still marks what Overdrive stated outright.
+
+        Only the half that acts on absence needs a complete crawl.
+        """
+        collection = overdrive_api_fixture.collection
+        overdrive_pool(db, collection, "id-weeded")
+        weeded = overdrive_identifiers("id-weeded")
+        mock_crawl(
+            mock_api_class,
+            product_page(listed=weeded, unowned=weeded, total_items=5000),
+        )
+
+        with patch.object(identifiers, "circulation_apply") as mock_apply:
+            result = overdrive.reap_collection.delay(collection.id).wait()
+
+        assert result is None
+        mock_apply.delay.assert_called_once()
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_skips_collection_marked_for_deletion(

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -11,13 +11,18 @@ from celery.result import AsyncResult
 from palace.util.datetime_helpers import datetime_utc
 from palace.util.log import LogLevel
 
-from palace.manager.celery.importer import import_workflow_lock, reap_workflow_lock
+from palace.manager.celery.importer import (
+    import_workflow_lock,
+    reap_key,
+    reap_workflow_lock,
+)
 from palace.manager.celery.tasks import overdrive
 from palace.manager.celery.tasks.overdrive import import_collection_group
 from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.integration.license.overdrive.api import (
     BookInfoEndpoint,
     OverdriveAPI,
+    ProductPage,
 )
 from palace.manager.integration.license.overdrive.importer import (
     FeedImportResult,
@@ -1220,6 +1225,33 @@ class TestIntegration:
         return identifier
 
 
+def product_page(
+    *,
+    active: tuple[IdentifierData, ...] = (),
+    seen: int | None = None,
+    total_items: int | None = None,
+    next_page: BookInfoEndpoint | None = None,
+) -> ProductPage:
+    """Build a ProductPage, defaulting `seen` to the number of active identifiers.
+
+    `total_items` is passed through as given, so a test can ask for the case where
+    Overdrive omits it.
+    """
+    return ProductPage(
+        active=active,
+        seen=len(active) if seen is None else seen,
+        total_items=total_items,
+        next_page=next_page,
+    )
+
+
+def overdrive_identifiers(*identifiers: str) -> tuple[IdentifierData, ...]:
+    return tuple(
+        IdentifierData(type=Identifier.OVERDRIVE_ID, identifier=identifier)
+        for identifier in identifiers
+    )
+
+
 class TestOverdriveReaper:
     """Tests for the reap_all_collections and reap_collection Celery tasks."""
 
@@ -1228,7 +1260,7 @@ class TestOverdriveReaper:
         db: DatabaseTransactionFixture,
         celery_fixture: CeleryFixture,
     ):
-        """reap_all_collections queues reap_collection for every Overdrive collection,
+        """reap_all_collections queues a reap for every Overdrive collection,
         including child (Advantage) collections."""
         db.default_collection()  # non-Overdrive, should be ignored
         collection1 = db.collection(protocol=OverdriveAPI)
@@ -1236,10 +1268,10 @@ class TestOverdriveReaper:
         child_collection = db.collection(protocol=OverdriveAPI)
         child_collection.parent = collection1
 
-        with patch.object(overdrive, "reap_collection") as mock_reap:
+        with patch.object(OverdriveAPI, "reap_task") as mock_reap_task:
             overdrive.reap_all_collections.delay().wait()
 
-        mock_reap.delay.assert_has_calls(
+        mock_reap_task.assert_has_calls(
             [
                 call(collection1.id),
                 call(collection2.id),
@@ -1247,10 +1279,58 @@ class TestOverdriveReaper:
             ],
             any_order=True,
         )
-        assert mock_reap.delay.call_count == 3
+        assert mock_reap_task.return_value.apply_async.call_count == 3
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
-    def test_reap_collection_empty(
+    def test_reap_collection_returns_owned_identifiers(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+    ):
+        """A completed crawl returns the identifiers the collection still holds."""
+        collection = overdrive_api_fixture.collection
+        active = overdrive_identifiers("id-one", "id-two")
+        mock_api_class.return_value.fetch_product_page.return_value = product_page(
+            active=active, seen=3, total_items=3
+        )
+
+        result = overdrive.reap_collection.delay(collection.id).wait()
+
+        identifier_set = IdentifierSet(redis_fixture.client, result["key"])
+        assert identifier_set.get() == set(active)
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_pages_until_crawl_completes(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+    ):
+        """A page with a successor re-queues the task with the next url and running count."""
+        collection = overdrive_api_fixture.collection
+        mock_api_class.return_value.fetch_product_page.return_value = product_page(
+            active=overdrive_identifiers("id-one"),
+            seen=2,
+            total_items=10,
+            next_page=BookInfoEndpoint("http://od/products?offset=2"),
+        )
+
+        with patch.object(overdrive.reap_collection, "replace") as mock_replace:
+            mock_replace.side_effect = Exception("replaced")
+            with pytest.raises(Exception, match="replaced"):
+                overdrive.reap_collection.delay(collection.id).wait()
+
+        replace_sig = mock_replace.call_args[0][0]
+        assert replace_sig.kwargs["page"] == "http://od/products?offset=2"
+        assert replace_sig.kwargs["seen"] == 2
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_aborts_on_incomplete_crawl(
         self,
         mock_api_class: MagicMock,
         db: DatabaseTransactionFixture,
@@ -1259,17 +1339,52 @@ class TestOverdriveReaper:
         redis_fixture: RedisFixture,
         caplog: pytest.LogCaptureFixture,
     ):
-        """When no identifiers exist for a collection, reap_collection logs complete and returns."""
+        """A crawl that saw far fewer products than Overdrive reports marks nothing.
+
+        Reaping acts on the absence of an identifier, so handing a partial crawl to the
+        chord would mark live titles as gone. Returning None instead makes the chord
+        body abort.
+        """
         collection = overdrive_api_fixture.collection
-        caplog.set_level(LogLevel.info)
+        caplog.set_level(LogLevel.error)
+        mock_api_class.return_value.fetch_product_page.return_value = product_page(
+            active=overdrive_identifiers("id-one"), seen=1, total_items=5000
+        )
 
-        overdrive.reap_collection.delay(collection.id).wait()
+        async_result = overdrive.reap_collection.delay(collection.id)
 
-        mock_api_class.return_value.update_licensepool.assert_not_called()
-        assert "complete" in caplog.text
+        assert async_result.wait() is None
+        assert "Refusing to reap on an incomplete crawl" in caplog.text
+        # The partial set is not left behind in Redis for the chord to pick up.
+        partial_set = IdentifierSet(
+            redis_fixture.client, reap_key(collection.id, async_result.id)
+        )
+        assert not partial_set.exists()
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
-    def test_reap_collection_processes_batch(
+    def test_reap_collection_aborts_when_total_items_missing(
+        self,
+        mock_api_class: MagicMock,
+        db: DatabaseTransactionFixture,
+        celery_fixture: CeleryFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Without totalItems there is no way to show the crawl was complete."""
+        collection = overdrive_api_fixture.collection
+        caplog.set_level(LogLevel.error)
+        mock_api_class.return_value.fetch_product_page.return_value = product_page(
+            active=overdrive_identifiers("id-one"), seen=1, total_items=None
+        )
+
+        result = overdrive.reap_collection.delay(collection.id).wait()
+
+        assert result is None
+        assert "did not report totalItems" in caplog.text
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
+    def test_reap_collection_tolerates_small_shortfall(
         self,
         mock_api_class: MagicMock,
         db: DatabaseTransactionFixture,
@@ -1277,73 +1392,40 @@ class TestOverdriveReaper:
         overdrive_api_fixture: OverdriveAPIFixture,
         redis_fixture: RedisFixture,
     ):
-        """reap_collection calls update_licensepool for each identifier in the batch."""
+        """Titles added or removed mid-crawl move totalItems, which is not a failure."""
         collection = overdrive_api_fixture.collection
-        edition1 = db.edition()
-        edition2 = db.edition()
-        pool1 = db.licensepool(edition1, collection=collection)
-        pool2 = db.licensepool(edition2, collection=collection)
-        db.session.flush()
+        active = overdrive_identifiers("id-one", "id-two")
+        mock_api_class.return_value.fetch_product_page.return_value = product_page(
+            active=active,
+            seen=1000,
+            total_items=1000 + overdrive.REAP_CRAWL_ALLOWANCE_FLOOR,
+        )
 
-        overdrive.reap_collection.delay(collection.id).wait()
+        result = overdrive.reap_collection.delay(collection.id).wait()
 
-        mock_api = mock_api_class.return_value
-        identifiers_called = {
-            c.args[0] for c in mock_api.update_licensepool.call_args_list
-        }
-        assert pool1.identifier.identifier in identifiers_called
-        assert pool2.identifier.identifier in identifiers_called
+        assert result is not None
+        assert IdentifierSet(redis_fixture.client, result["key"]).get() == set(active)
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
-    def test_reap_collection_replaces_when_full_batch(
+    def test_reap_collection_skips_collection_marked_for_deletion(
         self,
         mock_api_class: MagicMock,
         db: DatabaseTransactionFixture,
         celery_fixture: CeleryFixture,
         overdrive_api_fixture: OverdriveAPIFixture,
         redis_fixture: RedisFixture,
+        caplog: pytest.LogCaptureFixture,
     ):
-        """When a full batch is processed, task.replace is raised with the next offset."""
         collection = overdrive_api_fixture.collection
-        # Create exactly batch_size identifiers to trigger replace
-        batch_size = 3
-        pools = [
-            db.licensepool(db.edition(), collection=collection)
-            for _ in range(batch_size)
-        ]
+        collection.marked_for_deletion = True
         db.session.flush()
-        last_id = max(p.identifier.id for p in pools)
+        caplog.set_level(LogLevel.warning)
 
-        with patch.object(overdrive.reap_collection, "replace") as mock_replace:
-            mock_replace.side_effect = Exception("replaced")
-            with pytest.raises(Exception, match="replaced"):
-                overdrive.reap_collection.delay(
-                    collection.id, batch_size=batch_size
-                ).wait()
+        result = overdrive.reap_collection.delay(collection.id).wait()
 
-            replace_sig = mock_replace.call_args[0][0]
-            assert replace_sig.kwargs["offset"] == last_id
-            assert "lock_value" not in replace_sig.kwargs
-
-    @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
-    def test_reap_collection_stops_on_partial_batch(
-        self,
-        mock_api_class: MagicMock,
-        db: DatabaseTransactionFixture,
-        celery_fixture: CeleryFixture,
-        overdrive_api_fixture: OverdriveAPIFixture,
-        redis_fixture: RedisFixture,
-    ):
-        """When fewer identifiers than batch_size exist, the task completes without replacing."""
-        collection = overdrive_api_fixture.collection
-        batch_size = 10
-        db.licensepool(db.edition(), collection=collection)
-        db.session.flush()
-
-        with patch.object(overdrive.reap_collection, "replace") as mock_replace:
-            overdrive.reap_collection.delay(collection.id, batch_size=batch_size).wait()
-
-        mock_replace.assert_not_called()
+        assert result is None
+        mock_api_class.return_value.fetch_product_page.assert_not_called()
+        assert "marked for deletion" in caplog.text
 
     def test_reap_collection_lock_not_released_on_autoretry(
         self,
@@ -1352,32 +1434,29 @@ class TestOverdriveReaper:
         overdrive_api_fixture: OverdriveAPIFixture,
         redis_fixture: RedisFixture,
     ):
-        """A retryable failure holds the workflow lock and each retry re-runs the reap.
+        """A retryable failure holds the workflow lock and each retry re-runs the crawl.
 
         The workflow lock is keyed on ``task.request.id``, which Celery preserves across
-        retries, so every retry re-acquires the same workflow lock and re-runs the batch,
+        retries, so every retry re-acquires the same workflow lock and re-runs the page,
         rather than skipping as if another run were in progress. The lock stays held so no
         concurrent run can start.
         """
         collection = overdrive_api_fixture.collection
-        db.licensepool(db.edition(), collection=collection)
-        db.session.flush()
-
         mock_response = MockRequestsResponse(500, content="Internal Server Error")
 
         with patch(
             "palace.manager.celery.tasks.overdrive.OverdriveAPI"
         ) as mock_api_class:
-            mock_api_class.return_value.update_licensepool.side_effect = (
+            mock_api_class.return_value.fetch_product_page.side_effect = (
                 BadResponseException("http://test.com", "Bad response", mock_response)
             )
 
             with celery_fixture.patch_retry_backoff():
                 overdrive.reap_collection.delay(collection.id).get(propagate=False)
 
-            # The reap was re-run on every retry (1 initial attempt + max_retries=4),
+            # The crawl was re-run on every retry (1 initial attempt + max_retries=4),
             # not skipped as an "already in progress" run.
-            assert mock_api_class.return_value.update_licensepool.call_count == 5
+            assert mock_api_class.return_value.fetch_product_page.call_count == 5
 
         # Lock is still held after retries exhaust; it expires via the Redis TTL.
         workflow_lock = reap_workflow_lock(
@@ -1393,10 +1472,8 @@ class TestOverdriveReaper:
         redis_fixture: RedisFixture,
         caplog: pytest.LogCaptureFixture,
     ):
-        """On the first batch, if the workflow lock is already held, the task skips without processing."""
+        """If the workflow lock is already held, the task skips without crawling."""
         collection = overdrive_api_fixture.collection
-        db.licensepool(db.edition(), collection=collection)
-        db.session.flush()
 
         lock_value = str(uuid4())
         workflow_lock = reap_workflow_lock(
@@ -1409,9 +1486,10 @@ class TestOverdriveReaper:
         with patch(
             "palace.manager.celery.tasks.overdrive.OverdriveAPI"
         ) as mock_api_class:
-            overdrive.reap_collection.delay(collection.id).wait()
-            mock_api_class.return_value.update_licensepool.assert_not_called()
+            result = overdrive.reap_collection.delay(collection.id).wait()
+            mock_api_class.return_value.fetch_product_page.assert_not_called()
 
+        assert result is None
         assert "skipped" in caplog.text
         assert "already in progress" in caplog.text
         workflow_lock.release()

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -28,10 +28,15 @@ from palace.manager.api.circulation.fulfillment import (
     StreamingFulfillment,
 )
 from palace.manager.api.config import Configuration
-from palace.manager.celery.tasks import overdrive as overdrive_celery
+from palace.manager.celery.tasks import (
+    identifiers as identifiers_celery,
+    overdrive as overdrive_celery,
+)
 from palace.manager.core.config import CannotLoadConfiguration
 from palace.manager.core.exceptions import IntegrationException
+from palace.manager.data_layer.identifier import IdentifierData
 from palace.manager.integration.license.overdrive.api import (
+    BookInfoEndpoint,
     OverdriveAPI,
     OverdriveToken,
 )
@@ -60,6 +65,7 @@ from palace.manager.sqlalchemy.model.identifier import Identifier
 from palace.manager.sqlalchemy.model.licensing import (
     DeliveryMechanism,
     LicensePool,
+    LicensePoolStatus,
     RightsStatus,
 )
 from palace.manager.sqlalchemy.model.patron import Hold
@@ -77,11 +83,116 @@ from tests.mocks.mock import MockRequestsResponse
 class TestOverdriveAPI:
     def test_reap_task(self) -> None:
         collection_id = MagicMock()
-        with patch.object(overdrive_celery, "reap_collection") as mock_reap:
+        with (
+            patch.object(overdrive_celery, "reap_collection") as mock_reap,
+            patch.object(
+                identifiers_celery, "create_mark_unavailable_chord"
+            ) as mock_chord,
+        ):
             result = OverdriveAPI.reap_task(collection_id)
 
         mock_reap.s.assert_called_once_with(collection_id)
-        assert result == mock_reap.s.return_value
+        # Overdrive drops titles when a lease ends, so a missing title means the
+        # copies are gone, not that outstanding loans and holds should be revoked.
+        mock_chord.assert_called_once_with(
+            collection_id,
+            mock_reap.s.return_value,
+            status=LicensePoolStatus.EXHAUSTED,
+        )
+        assert result == mock_chord.return_value
+
+    def test_product_page_initial_endpoint(
+        self, overdrive_api_fixture: OverdriveAPIFixture
+    ) -> None:
+        endpoint = overdrive_api_fixture.api.product_page_initial_endpoint()
+
+        assert "/v1/collections/fake%20collection%20token/products" in endpoint.url
+        assert f"limit={OverdriveAPI.PRODUCTS_PAGE_SIZE_LIMIT}" in endpoint.url
+        # _make_link_safe escapes the colon in the sort value; Overdrive accepts
+        # either form.
+        assert "sort=dateAdded%3Aasc" in endpoint.url
+
+    def test_product_page_initial_endpoint_caps_page_size(
+        self, overdrive_api_fixture: OverdriveAPIFixture
+    ) -> None:
+        endpoint = overdrive_api_fixture.api.product_page_initial_endpoint(
+            page_size=100_000
+        )
+        assert f"limit={OverdriveAPI.PRODUCTS_PAGE_SIZE_LIMIT}" in endpoint.url
+
+    def test_fetch_product_page(
+        self, overdrive_api_fixture: OverdriveAPIFixture
+    ) -> None:
+        data, raw = overdrive_api_fixture.sample_json("overdrive_product_page.json")
+        overdrive_api_fixture.mock_http.queue_response(200, content=data)
+
+        page = overdrive_api_fixture.api.fetch_product_page(
+            BookInfoEndpoint("http://products/")
+        )
+
+        # Every product on the page is counted, whether or not it is still owned,
+        # because the count is what gets checked against totalItems.
+        assert page.seen == len(raw["products"]) == 3
+        assert page.total_items == raw["totalItems"]
+        assert page.next_page is not None
+        assert page.next_page.url == raw["links"]["next"]["href"]
+
+        # The title Overdrive no longer owns is left out of the active set, so it is
+        # reaped alongside titles that dropped out of the feed entirely.
+        not_owned = [
+            p["id"] for p in raw["products"] if p.get("isOwnedByCollections") is False
+        ]
+        assert len(not_owned) == 1
+        assert len(page.active) == 2
+        assert not_owned[0].lower() not in {i.identifier for i in page.active}
+
+    def test_fetch_product_page_last_page(
+        self, overdrive_api_fixture: OverdriveAPIFixture
+    ) -> None:
+        data, raw = overdrive_api_fixture.sample_json(
+            "overdrive_product_page_last.json"
+        )
+        overdrive_api_fixture.mock_http.queue_response(200, content=data)
+
+        page = overdrive_api_fixture.api.fetch_product_page(
+            BookInfoEndpoint("http://products/")
+        )
+
+        assert "next" not in raw["links"]
+        assert page.next_page is None
+        assert page.seen == 2
+
+    def test_fetch_product_page_normalizes_identifier_case(
+        self,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        db: DatabaseTransactionFixture,
+    ) -> None:
+        """Crawled identifiers must take the form the database stores.
+
+        Overdrive sends product ids uppercased in the product list but lowercased in
+        availability documents, and `Identifier.for_foreign_id` lowercases them on the
+        way in. If the crawl preserved the feed's casing, no crawled identifier would
+        match a stored one and the reaper would treat every title in the collection as
+        having been removed.
+        """
+        data, raw = overdrive_api_fixture.sample_json("overdrive_product_page.json")
+        overdrive_api_fixture.mock_http.queue_response(200, content=data)
+
+        # Guard the premise: if Overdrive ever starts sending lowercase ids here,
+        # this test stops proving anything and should be revisited.
+        assert any(p["id"] != p["id"].lower() for p in raw["products"])
+
+        page = overdrive_api_fixture.api.fetch_product_page(
+            BookInfoEndpoint("http://products/")
+        )
+
+        for product in raw["products"]:
+            if product.get("isOwnedByCollections") is False:
+                continue
+            identifier, _ = Identifier.for_foreign_id(
+                db.session, Identifier.OVERDRIVE_ID, product["id"]
+            )
+            assert IdentifierData.from_identifier(identifier) in page.active
 
     def test_patron_activity_exception_collection_none(
         self,

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -141,8 +141,6 @@ class TestOverdriveAPI:
             pytest.param(2500, 2000, 5000, 600, id="steps back from a ragged offset"),
             pytest.param(1000, 2000, 5000, None, id="stops inside the first page"),
             pytest.param(2000, 2000, 5000, None, id="stops at the first page boundary"),
-            pytest.param(0, 2000, None, None, id="no totalItems to walk with"),
-            pytest.param(0, 0, 5000, None, id="no limit to walk with"),
         ],
     )
     def test_next_product_offset(
@@ -150,7 +148,7 @@ class TestOverdriveAPI:
         overdrive_api_fixture: OverdriveAPIFixture,
         offset: int,
         limit: int,
-        total_items: int | None,
+        total_items: int,
         expected: int | None,
     ) -> None:
         page = ProductPage(listed=(), unowned=(), total_items=total_items, limit=limit)
@@ -278,6 +276,36 @@ class TestOverdriveAPI:
             )
 
         assert "was not valid JSON" in str(excinfo.value)
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            pytest.param({"products": [], "limit": 2000}, id="no totalItems"),
+            pytest.param({"products": [], "totalItems": 10}, id="no limit"),
+            pytest.param(
+                {"products": [], "totalItems": 10, "limit": 0}, id="zero limit"
+            ),
+        ],
+    )
+    def test_fetch_product_page_raises_without_paging_fields(
+        self, overdrive_api_fixture: OverdriveAPIFixture, payload: dict[str, object]
+    ) -> None:
+        """A page the crawl cannot walk from is retried, not reasoned about.
+
+        Every gap check the crawl makes is expressed in terms of these two fields, so
+        a response missing either is as unusable as a bad status code -- and is the
+        same class of blip, deserving the same retry rather than the loss of a crawl.
+        """
+        overdrive_api_fixture.mock_http.queue_response(
+            200, content=json.dumps(payload).encode()
+        )
+
+        with pytest.raises(BadResponseException) as excinfo:
+            overdrive_api_fixture.api.fetch_product_page(
+                BookInfoEndpoint("http://products/")
+            )
+
+        assert "no usable totalItems or page size" in str(excinfo.value)
 
     def test_fetch_product_page_normalizes_identifier_case(
         self,

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -260,6 +260,25 @@ class TestOverdriveAPI:
         assert excinfo.value.response.status_code == 404
         assert BadResponseException in overdrive_celery.reap_collection.autoretry_for
 
+    def test_fetch_product_page_raises_on_a_body_that_is_not_json(
+        self, overdrive_api_fixture: OverdriveAPIFixture
+    ) -> None:
+        """A 200 carrying something other than JSON is the same class of blip.
+
+        An intermediary's error page would otherwise raise JSONDecodeError, which is
+        outside the task's retry policy, and kill a crawl of several hours.
+        """
+        overdrive_api_fixture.mock_http.queue_response(
+            200, content=b"<html>not json</html>"
+        )
+
+        with pytest.raises(BadResponseException) as excinfo:
+            overdrive_api_fixture.api.fetch_product_page(
+                BookInfoEndpoint("http://products/")
+            )
+
+        assert "was not valid JSON" in str(excinfo.value)
+
     def test_fetch_product_page_normalizes_identifier_case(
         self,
         overdrive_api_fixture: OverdriveAPIFixture,

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, create_autospec, patch
-from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
@@ -125,39 +124,32 @@ class TestOverdriveAPI:
         assert f"limit={OverdriveAPI.PRODUCTS_PAGE_SIZE_LIMIT}" in endpoint.url
 
     @pytest.mark.parametrize(
-        "offset,limit,total_items,expected_offset",
+        "offset,limit,total_items,expected",
         [
             pytest.param(0, 2000, 1500, None, id="first page covers the collection"),
             pytest.param(
                 0, 2000, 2000, None, id="first page is exactly the collection"
             ),
             pytest.param(0, 2000, 5000, 3000, id="first page jumps to the end"),
-            pytest.param(3000, 2000, 5000, 1000, id="walks backwards"),
+            pytest.param(3000, 2000, 5000, 1100, id="steps back by less than a page"),
+            pytest.param(2500, 2000, 5000, 600, id="steps back from a ragged offset"),
             pytest.param(1000, 2000, 5000, None, id="stops inside the first page"),
             pytest.param(2000, 2000, 5000, None, id="stops at the first page boundary"),
             pytest.param(0, 2000, None, None, id="no totalItems to walk with"),
             pytest.param(0, 0, 5000, None, id="no limit to walk with"),
         ],
     )
-    def test_next_product_page(
+    def test_next_product_offset(
         self,
         overdrive_api_fixture: OverdriveAPIFixture,
         offset: int,
         limit: int,
         total_items: int | None,
-        expected_offset: int | None,
+        expected: int | None,
     ) -> None:
-        page = ProductPage(
-            listed=(), unowned=(), total_items=total_items, offset=offset, limit=limit
-        )
+        page = ProductPage(listed=(), unowned=(), total_items=total_items, limit=limit)
 
-        next_page = overdrive_api_fixture.api.next_product_page(page)
-
-        if expected_offset is None:
-            assert next_page is None
-        else:
-            assert next_page is not None
-            assert f"offset={expected_offset}" in next_page.url
+        assert overdrive_api_fixture.api.next_product_offset(page, offset) == expected
 
     @pytest.mark.parametrize(
         "total_items,limit",
@@ -169,32 +161,27 @@ class TestOverdriveAPI:
             pytest.param(101, 100, id="one title past the first page"),
         ],
     )
-    def test_next_product_page_leaves_no_gap(
+    def test_next_product_offset_leaves_no_gap(
         self, overdrive_api_fixture: OverdriveAPIFixture, total_items: int, limit: int
     ) -> None:
         """Walking the pages must cover every offset in the collection.
 
         A gap would be indistinguishable from titles that left the collection, and
-        the reaper would mark them as gone.
+        the reaper would mark them as gone. The walk must also terminate, so every
+        step after the first has to move towards the start of the list.
         """
         api = overdrive_api_fixture.api
+        page = ProductPage(listed=(), unowned=(), total_items=total_items, limit=limit)
         covered: set[int] = set()
         offset = 0
 
         for _ in range(100):
             covered.update(range(offset, min(offset + limit, total_items)))
-            next_page = api.next_product_page(
-                ProductPage(
-                    listed=(),
-                    unowned=(),
-                    total_items=total_items,
-                    offset=offset,
-                    limit=limit,
-                )
-            )
-            if next_page is None:
+            next_offset = api.next_product_offset(page, offset)
+            if next_offset is None:
                 break
-            offset = int(parse_qs(urlsplit(next_page.url).query)["offset"][0])
+            assert offset == 0 or next_offset < offset
+            offset = next_offset
         else:
             pytest.fail("The crawl never reached the start of the collection.")
 
@@ -227,10 +214,9 @@ class TestOverdriveAPI:
     def test_fetch_product_page_reads_paging_from_response(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ) -> None:
-        """The crawl pages by offset, so it uses the values Overdrive echoes back.
+        """The walk steps by the page size Overdrive applied, not the one requested.
 
-        Overdrive caps the page size it applies, so the requested limit is not
-        necessarily the one that was used.
+        Overdrive caps the page size, so the two are not necessarily the same.
         """
         data, raw = overdrive_api_fixture.sample_json(
             "overdrive_product_page_last.json"
@@ -241,7 +227,6 @@ class TestOverdriveAPI:
             BookInfoEndpoint("http://products/")
         )
 
-        assert page.offset == raw["offset"] == 38432
         assert page.limit == raw["limit"] == 2
         assert len(page.listed) == 2
         assert page.unowned == ()

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -39,7 +39,6 @@ from palace.manager.integration.license.overdrive.api import (
     BookInfoEndpoint,
     OverdriveAPI,
     OverdriveToken,
-    ProductPage,
 )
 from palace.manager.integration.license.overdrive.constants import OverdriveConstants
 from palace.manager.integration.license.overdrive.exception import (
@@ -129,68 +128,6 @@ class TestOverdriveAPI:
         endpoint = overdrive_api_fixture.api.product_page_endpoint(page_size=100_000)
         assert f"limit={OverdriveAPI.PRODUCTS_PAGE_SIZE_LIMIT}" in endpoint.url
 
-    @pytest.mark.parametrize(
-        "offset,limit,total_items,expected",
-        [
-            pytest.param(0, 2000, 1500, None, id="first page covers the collection"),
-            pytest.param(
-                0, 2000, 2000, None, id="first page is exactly the collection"
-            ),
-            pytest.param(0, 2000, 5000, 3000, id="first page jumps to the end"),
-            pytest.param(3000, 2000, 5000, 1100, id="steps back by less than a page"),
-            pytest.param(2500, 2000, 5000, 600, id="steps back from a ragged offset"),
-            pytest.param(1000, 2000, 5000, None, id="stops inside the first page"),
-            pytest.param(2000, 2000, 5000, None, id="stops at the first page boundary"),
-        ],
-    )
-    def test_next_product_offset(
-        self,
-        overdrive_api_fixture: OverdriveAPIFixture,
-        offset: int,
-        limit: int,
-        total_items: int,
-        expected: int | None,
-    ) -> None:
-        page = ProductPage(listed=(), unowned=(), total_items=total_items, limit=limit)
-
-        assert overdrive_api_fixture.api.next_product_offset(page, offset) == expected
-
-    @pytest.mark.parametrize(
-        "total_items,limit",
-        [
-            pytest.param(1050, 100, id="ragged final page"),
-            pytest.param(1000, 100, id="exact multiple"),
-            pytest.param(100, 100, id="single page"),
-            pytest.param(1, 100, id="single title"),
-            pytest.param(101, 100, id="one title past the first page"),
-        ],
-    )
-    def test_next_product_offset_leaves_no_gap(
-        self, overdrive_api_fixture: OverdriveAPIFixture, total_items: int, limit: int
-    ) -> None:
-        """Walking the pages must cover every offset in the collection.
-
-        A gap would be indistinguishable from titles that left the collection, and
-        the reaper would mark them as gone. The walk must also terminate, so every
-        step after the first has to move towards the start of the list.
-        """
-        api = overdrive_api_fixture.api
-        page = ProductPage(listed=(), unowned=(), total_items=total_items, limit=limit)
-        covered: set[int] = set()
-        offset = 0
-
-        for _ in range(100):
-            covered.update(range(offset, min(offset + limit, total_items)))
-            next_offset = api.next_product_offset(page, offset)
-            if next_offset is None:
-                break
-            assert offset == 0 or next_offset < offset
-            offset = next_offset
-        else:
-            pytest.fail("The crawl never reached the start of the collection.")
-
-        assert covered == set(range(total_items))
-
     def test_fetch_product_page(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ) -> None:
@@ -205,6 +142,10 @@ class TestOverdriveAPI:
         # title Overdrive still returns is never reaped for being absent.
         assert len(page.listed) == len(raw["products"]) == 3
         assert page.total_items == raw["totalItems"]
+
+        # The raw product dictionaries ride along untouched, for consumers that
+        # need more than identifiers -- metadata and availability links, say.
+        assert page.products == tuple(raw["products"])
 
         # The title Overdrive no longer owns is reported separately, so it can be
         # marked from Overdrive's own flag rather than inferred from its absence.

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -101,9 +101,11 @@ class TestOverdriveAPI:
             collection_id,
             mock_reap.s.return_value,
             status=LicensePoolStatus.EXHAUSTED,
-            expire_time=int(OverdriveAPI.REAP_IDENTIFIER_SET_LIFETIME.total_seconds()),
+            expire_time=int(
+                overdrive_celery.REAP_IDENTIFIER_SET_LIFETIME.total_seconds()
+            ),
         )
-        assert OverdriveAPI.REAP_IDENTIFIER_SET_LIFETIME > timedelta(hours=12)
+        assert overdrive_celery.REAP_IDENTIFIER_SET_LIFETIME > timedelta(hours=12)
         assert result == mock_chord.return_value
 
     def test_product_page_endpoint(

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, create_autospec, patch
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
@@ -39,6 +40,7 @@ from palace.manager.integration.license.overdrive.api import (
     BookInfoEndpoint,
     OverdriveAPI,
     OverdriveToken,
+    ProductPage,
 )
 from palace.manager.integration.license.overdrive.constants import OverdriveConstants
 from palace.manager.integration.license.overdrive.exception import (
@@ -101,24 +103,102 @@ class TestOverdriveAPI:
         )
         assert result == mock_chord.return_value
 
-    def test_product_page_initial_endpoint(
+    def test_product_page_endpoint(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ) -> None:
-        endpoint = overdrive_api_fixture.api.product_page_initial_endpoint()
+        endpoint = overdrive_api_fixture.api.product_page_endpoint()
 
         assert "/v1/collections/fake%20collection%20token/products" in endpoint.url
         assert f"limit={OverdriveAPI.PRODUCTS_PAGE_SIZE_LIMIT}" in endpoint.url
+        assert "offset=0" in endpoint.url
         # _make_link_safe escapes the colon in the sort value; Overdrive accepts
         # either form.
         assert "sort=dateAdded%3Aasc" in endpoint.url
 
-    def test_product_page_initial_endpoint_caps_page_size(
+        offset_endpoint = overdrive_api_fixture.api.product_page_endpoint(4000)
+        assert "offset=4000" in offset_endpoint.url
+
+    def test_product_page_endpoint_caps_page_size(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ) -> None:
-        endpoint = overdrive_api_fixture.api.product_page_initial_endpoint(
-            page_size=100_000
-        )
+        endpoint = overdrive_api_fixture.api.product_page_endpoint(page_size=100_000)
         assert f"limit={OverdriveAPI.PRODUCTS_PAGE_SIZE_LIMIT}" in endpoint.url
+
+    @pytest.mark.parametrize(
+        "offset,limit,total_items,expected_offset",
+        [
+            pytest.param(0, 2000, 1500, None, id="first page covers the collection"),
+            pytest.param(
+                0, 2000, 2000, None, id="first page is exactly the collection"
+            ),
+            pytest.param(0, 2000, 5000, 3000, id="first page jumps to the end"),
+            pytest.param(3000, 2000, 5000, 1000, id="walks backwards"),
+            pytest.param(1000, 2000, 5000, None, id="stops inside the first page"),
+            pytest.param(2000, 2000, 5000, None, id="stops at the first page boundary"),
+            pytest.param(0, 2000, None, None, id="no totalItems to walk with"),
+            pytest.param(0, 0, 5000, None, id="no limit to walk with"),
+        ],
+    )
+    def test_next_product_page(
+        self,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        offset: int,
+        limit: int,
+        total_items: int | None,
+        expected_offset: int | None,
+    ) -> None:
+        page = ProductPage(
+            listed=(), unowned=(), total_items=total_items, offset=offset, limit=limit
+        )
+
+        next_page = overdrive_api_fixture.api.next_product_page(page)
+
+        if expected_offset is None:
+            assert next_page is None
+        else:
+            assert next_page is not None
+            assert f"offset={expected_offset}" in next_page.url
+
+    @pytest.mark.parametrize(
+        "total_items,limit",
+        [
+            pytest.param(1050, 100, id="ragged final page"),
+            pytest.param(1000, 100, id="exact multiple"),
+            pytest.param(100, 100, id="single page"),
+            pytest.param(1, 100, id="single title"),
+            pytest.param(101, 100, id="one title past the first page"),
+        ],
+    )
+    def test_next_product_page_leaves_no_gap(
+        self, overdrive_api_fixture: OverdriveAPIFixture, total_items: int, limit: int
+    ) -> None:
+        """Walking the pages must cover every offset in the collection.
+
+        A gap would be indistinguishable from titles that left the collection, and
+        the reaper would mark them as gone.
+        """
+        api = overdrive_api_fixture.api
+        covered: set[int] = set()
+        offset = 0
+
+        for _ in range(100):
+            covered.update(range(offset, min(offset + limit, total_items)))
+            next_page = api.next_product_page(
+                ProductPage(
+                    listed=(),
+                    unowned=(),
+                    total_items=total_items,
+                    offset=offset,
+                    limit=limit,
+                )
+            )
+            if next_page is None:
+                break
+            offset = int(parse_qs(urlsplit(next_page.url).query)["offset"][0])
+        else:
+            pytest.fail("The crawl never reached the start of the collection.")
+
+        assert covered == set(range(total_items))
 
     def test_fetch_product_page(
         self, overdrive_api_fixture: OverdriveAPIFixture
@@ -130,25 +210,28 @@ class TestOverdriveAPI:
             BookInfoEndpoint("http://products/")
         )
 
-        # Every product on the page is counted, whether or not it is still owned,
-        # because the count is what gets checked against totalItems.
-        assert page.seen == len(raw["products"]) == 3
+        # Every product on the page is listed, whether or not it is still owned: a
+        # title Overdrive still returns is never reaped for being absent.
+        assert len(page.listed) == len(raw["products"]) == 3
         assert page.total_items == raw["totalItems"]
-        assert page.next_page is not None
-        assert page.next_page.url == raw["links"]["next"]["href"]
 
-        # The title Overdrive no longer owns is left out of the active set, so it is
-        # reaped alongside titles that dropped out of the feed entirely.
+        # The title Overdrive no longer owns is reported separately, so it can be
+        # marked from Overdrive's own flag rather than inferred from its absence.
         not_owned = [
             p["id"] for p in raw["products"] if p.get("isOwnedByCollections") is False
         ]
         assert len(not_owned) == 1
-        assert len(page.active) == 2
-        assert not_owned[0].lower() not in {i.identifier for i in page.active}
+        assert {i.identifier for i in page.unowned} == {not_owned[0].lower()}
+        assert set(page.unowned) <= set(page.listed)
 
-    def test_fetch_product_page_last_page(
+    def test_fetch_product_page_reads_paging_from_response(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ) -> None:
+        """The crawl pages by offset, so it uses the values Overdrive echoes back.
+
+        Overdrive caps the page size it applies, so the requested limit is not
+        necessarily the one that was used.
+        """
         data, raw = overdrive_api_fixture.sample_json(
             "overdrive_product_page_last.json"
         )
@@ -158,9 +241,33 @@ class TestOverdriveAPI:
             BookInfoEndpoint("http://products/")
         )
 
-        assert "next" not in raw["links"]
-        assert page.next_page is None
-        assert page.seen == 2
+        assert page.offset == raw["offset"] == 38432
+        assert page.limit == raw["limit"] == 2
+        assert len(page.listed) == 2
+        assert page.unowned == ()
+
+    def test_fetch_product_page_raises_on_error_status(
+        self, overdrive_api_fixture: OverdriveAPIFixture
+    ) -> None:
+        """A bad response is raised, not parsed.
+
+        Overdrive returns the occasional transient 404 here, and `get` lets 404
+        through. BadResponseException is in the reap task's `autoretry_for`, so the
+        page is retried rather than a crawl of several hours being thrown away on one
+        blip -- and a non-JSON error body no longer kills the task outright.
+        """
+        overdrive_api_fixture.mock_http.queue_response(
+            404, content=b"<html>not json</html>"
+        )
+
+        with pytest.raises(BadResponseException) as excinfo:
+            overdrive_api_fixture.api.fetch_product_page(
+                BookInfoEndpoint("http://products/")
+            )
+
+        assert "Unexpected status code 404" in str(excinfo.value)
+        assert excinfo.value.response.status_code == 404
+        assert BadResponseException in overdrive_celery.reap_collection.autoretry_for
 
     def test_fetch_product_page_normalizes_identifier_case(
         self,
@@ -187,12 +294,10 @@ class TestOverdriveAPI:
         )
 
         for product in raw["products"]:
-            if product.get("isOwnedByCollections") is False:
-                continue
             identifier, _ = Identifier.for_foreign_id(
                 db.session, Identifier.OVERDRIVE_ID, product["id"]
             )
-            assert IdentifierData.from_identifier(identifier) in page.active
+            assert IdentifierData.from_identifier(identifier) in page.listed
 
     def test_patron_activity_exception_collection_none(
         self,

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -95,11 +95,15 @@ class TestOverdriveAPI:
         mock_reap.s.assert_called_once_with(collection_id)
         # Overdrive drops titles when a lease ends, so a missing title means the
         # copies are gone, not that outstanding loans and holds should be revoked.
+        # The crawl runs for hours on a large collection, so the set it will be
+        # compared against has to outlive the default expiry.
         mock_chord.assert_called_once_with(
             collection_id,
             mock_reap.s.return_value,
             status=LicensePoolStatus.EXHAUSTED,
+            expire_time=int(OverdriveAPI.REAP_IDENTIFIER_SET_LIFETIME.total_seconds()),
         )
+        assert OverdriveAPI.REAP_IDENTIFIER_SET_LIFETIME > timedelta(hours=12)
         assert result == mock_chord.return_value
 
     def test_product_page_endpoint(

--- a/tests/manager/integration/license/overdrive/test_crawl.py
+++ b/tests/manager/integration/license/overdrive/test_crawl.py
@@ -1,0 +1,333 @@
+"""Tests for the Overdrive product-list crawl machinery."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import pytest
+
+from palace.util.datetime_helpers import utc_now
+
+from palace.manager.data_layer.identifier import IdentifierData
+from palace.manager.integration.license.overdrive.crawl import (
+    CRAWL_ALLOWANCE_FLOOR,
+    CrawlComplete,
+    CrawlCursor,
+    CrawlFault,
+    ProductPage,
+)
+from palace.manager.sqlalchemy.model.identifier import Identifier
+
+
+def identifiers(*names: str) -> tuple[IdentifierData, ...]:
+    return tuple(
+        IdentifierData(type=Identifier.OVERDRIVE_ID, identifier=name) for name in names
+    )
+
+
+def page_of(
+    *,
+    listed: tuple[IdentifierData, ...] = (),
+    total_items: int,
+    limit: int = 2000,
+) -> ProductPage:
+    return ProductPage(listed=listed, unowned=(), total_items=total_items, limit=limit)
+
+
+def page_from(source: list[str], offset: int, limit: int) -> ProductPage:
+    """Serve the page a product list of ``source`` would return at ``offset``."""
+    return page_of(
+        listed=identifiers(*source[offset : offset + limit]),
+        total_items=len(source),
+        limit=limit,
+    )
+
+
+def walk(
+    source: list[str],
+    limit: int,
+    on_page: list[Callable[[list[str]], None]] | None = None,
+) -> tuple[set[str], CrawlComplete | CrawlFault, list[int]]:
+    """Drive a cursor over ``source``, mutating it between pages if asked.
+
+    :param source: The product list being crawled, as a list of title ids. Pages
+        are cut from it at fetch time, so changes to it between pages behave
+        like collection churn during a crawl.
+    :param limit: The page size the simulated Overdrive applies.
+    :param on_page: Optional callables, one applied to ``source`` after each
+        page is fetched, simulating churn at that moment of the crawl. Shorter
+        lists stop mutating; None mutates nothing.
+    :return: The distinct ids collected, the walk's outcome, and the offsets
+        fetched in order.
+    """
+    cursor = CrawlCursor()
+    collected: set[str] = set()
+    offsets: list[int] = []
+    # Generous bound so a cursor bug cannot loop the test forever.
+    for index in range(len(source) + 10):
+        offsets.append(cursor.offset)
+        page = page_from(source, cursor.offset, limit)
+        collected.update(identifier.identifier for identifier in page.listed)
+        step = cursor.advance(page)
+        if on_page is not None and index < len(on_page):
+            on_page[index](source)
+        if not isinstance(step, CrawlCursor):
+            return collected, step, offsets
+        cursor = step
+    raise AssertionError("The walk never terminated.")
+
+
+class TestCrawlCursor:
+    @pytest.mark.parametrize(
+        "total_items,limit,expected_offset",
+        [
+            pytest.param(1500, 2000, None, id="first page covers the collection"),
+            pytest.param(2000, 2000, None, id="first page is exactly the collection"),
+            pytest.param(5000, 2000, 3000, id="first page jumps to the end"),
+        ],
+    )
+    def test_advance_from_the_first_page(
+        self, total_items: int, limit: int, expected_offset: int | None
+    ) -> None:
+        cursor = CrawlCursor()
+        step = cursor.advance(page_of(total_items=total_items, limit=limit))
+
+        if expected_offset is None:
+            assert isinstance(step, CrawlComplete)
+            assert step.single_page
+            assert step.total_items == total_items
+        else:
+            assert isinstance(step, CrawlCursor)
+            assert step.offset == expected_offset
+            assert step.previous_offset is None
+            assert step.total_items == total_items
+            assert step.page_limit == limit
+            # The crawl's start time survives the hand-off, so wall-clock
+            # logging spans the whole crawl rather than one page.
+            assert step.started_at == cursor.started_at
+
+    @pytest.mark.parametrize(
+        "total_items,limit",
+        [
+            pytest.param(1050, 100, id="ragged final page"),
+            pytest.param(1000, 100, id="exact multiple"),
+            pytest.param(100, 100, id="single page"),
+            pytest.param(1, 100, id="single title"),
+            pytest.param(101, 100, id="one title past the first page"),
+        ],
+    )
+    def test_walk_covers_the_whole_list(self, total_items: int, limit: int) -> None:
+        """Walking the pages must cover every title and terminate.
+
+        A gap would be indistinguishable from titles that left the collection,
+        and the reaper would mark them as gone.
+        """
+        source = [f"title-{index}" for index in range(total_items)]
+
+        collected, outcome, offsets = walk(source, limit)
+
+        assert isinstance(outcome, CrawlComplete)
+        assert collected == set(source)
+        assert outcome.completeness_fault(len(collected)) is None
+
+    def test_walk_ends_by_recrawling_the_start(self) -> None:
+        """A multi-page walk finishes with a fresh page at offset 0.
+
+        The first page's snapshot of the start of the list goes stale over a
+        long crawl, so the walk never leans on it: coverage ends where it
+        began, on a page fetched last.
+        """
+        source = [f"title-{index}" for index in range(59)]
+
+        _, outcome, offsets = walk(source, 20)
+
+        assert isinstance(outcome, CrawlComplete)
+        assert not outcome.single_page
+        assert offsets[0] == 0
+        assert offsets[-1] == 0
+        # In between, the walk only ever moves towards the start of the list.
+        backwards = offsets[1:]
+        assert backwards == sorted(backwards, reverse=True)
+
+    def test_walk_collects_a_title_that_drifts_below_the_first_page(self) -> None:
+        """Titles only move down the dateAdded:asc ordering, and the walk
+        re-covers the start of the list, so a title that drifts below the first
+        page's edge mid-crawl is still collected.
+
+        This is the seam a walk that stopped at ``offset <= limit`` would
+        leave open: hard removals among the oldest titles shift a title from
+        just past the first page's coverage down into a strip covered only by
+        the first page's stale snapshot.
+        """
+        # At crawl start "drifter" sits at index 21, just past the first
+        # page's coverage of [0, 20).
+        source = (
+            [f"title-{index}" for index in range(21)]
+            + ["drifter"]
+            + [f"title-{index}" for index in range(22, 59)]
+        )
+
+        def remove_two_of_the_oldest(current: list[str]) -> None:
+            del current[0:2]
+
+        collected, outcome, _ = walk(
+            source,
+            20,
+            # The removal lands after the second page, once the walk is out at
+            # the end of the list, shifting "drifter" down to index 19.
+            on_page=[lambda _: None, remove_two_of_the_oldest],
+        )
+
+        assert isinstance(outcome, CrawlComplete)
+        assert "drifter" in collected
+        assert outcome.completeness_fault(len(collected)) is None
+
+    @pytest.mark.parametrize(
+        "reported_now,returned,faults",
+        [
+            pytest.param(6000, 2000, False, id="unchanged, full page"),
+            pytest.param(6001, 2000, False, id="a title added since the first page"),
+            pytest.param(6100, 2000, False, id="many titles added"),
+            pytest.param(5990, 1990, False, id="titles removed since the first page"),
+            pytest.param(6000, 1990, True, id="page truncated"),
+        ],
+    )
+    def test_first_backwards_page_must_reach_the_end(
+        self, reported_now: int, returned: int, faults: bool
+    ) -> None:
+        """Which end the first backwards page must reach depends on what changed.
+
+        It starts one page back from where the collection ended when the crawl
+        began, so a full page arrives exactly at that count. Titles added since
+        then sit beyond it -- not this page's to reach. Titles removed shorten
+        the list, and that shorter count is the one it has to reach.
+        """
+        cursor = CrawlCursor(offset=4000, total_items=6000, page_limit=2000)
+        page = page_of(
+            listed=identifiers(*(f"title-{index}" for index in range(returned))),
+            total_items=reported_now,
+        )
+
+        step = cursor.advance(page)
+
+        if faults:
+            assert isinstance(step, CrawlFault)
+            assert "Refusing to reap across a gap" in step.reason
+        else:
+            assert isinstance(step, CrawlCursor)
+
+    def test_every_other_page_must_reach_the_one_before_it(self) -> None:
+        """A page that returns fewer titles than the walk stepped back by
+        leaves a strip of the list uncrawled, indistinguishable at the
+        completeness gate from titles removed mid-crawl."""
+        cursor = CrawlCursor(
+            offset=3000, previous_offset=4000, total_items=6000, page_limit=2000
+        )
+
+        step = cursor.advance(page_of(listed=identifiers("only"), total_items=6000))
+
+        assert isinstance(step, CrawlFault)
+        assert "Refusing to reap across a gap" in step.reason
+        assert "already crawled at 4000" in step.reason
+
+    def test_page_size_change_faults(self) -> None:
+        """Every gap check measures in page sizes, so one that changes
+        invalidates the walk's arithmetic."""
+        cursor = CrawlCursor(offset=4000, total_items=6000, page_limit=2000)
+
+        step = cursor.advance(
+            page_of(
+                listed=identifiers(*(f"title-{index}" for index in range(500))),
+                total_items=6000,
+                limit=500,
+            )
+        )
+
+        assert isinstance(step, CrawlFault)
+        assert "whose paging changed underneath it" in step.reason
+
+    def test_serialization_round_trip(self) -> None:
+        """A cursor survives the JSON wire format a task kwarg travels as."""
+        cursor = CrawlCursor(
+            offset=3000, previous_offset=4000, total_items=6000, page_limit=2000
+        )
+
+        rebuilt = CrawlCursor.from_json(json.loads(json.dumps(cursor.__json__())))
+
+        assert rebuilt == cursor
+
+        fresh = CrawlCursor()
+        assert CrawlCursor.from_json(json.loads(json.dumps(fresh.__json__()))) == fresh
+
+
+class TestCrawlComplete:
+    @pytest.mark.parametrize(
+        "crawled,total_items,single_page,complete",
+        [
+            pytest.param(1_000, 1_000, False, True, id="exact match"),
+            pytest.param(0, 5, False, True, id="floor covers a tiny collection"),
+            pytest.param(0, 100, False, False, id="shortfall beyond the floor"),
+            pytest.param(
+                4_000_000 - 400, 4_000_000, False, True, id="churn within the cap"
+            ),
+            pytest.param(
+                4_000_000 - 2_000,
+                4_000_000,
+                False,
+                False,
+                id="a lost page is not excused",
+            ),
+            pytest.param(1_000, 1_000, True, True, id="single page, counts agree"),
+            pytest.param(999, 1_000, True, False, id="single page, one short"),
+        ],
+    )
+    def test_completeness_fault(
+        self, crawled: int, total_items: int, single_page: bool, complete: bool
+    ) -> None:
+        """The allowance absorbs churn during a crawl, but never a whole lost page.
+
+        It is capped because the churn it exists for does not scale with
+        collection size, while a proportional allowance does: 0.1% of a
+        4M-title collection would be two full pages, so a crawl that silently
+        dropped one would be accepted and those titles reaped. A collection
+        that arrived in a single response had no window for churn at all, so
+        its counts have to agree exactly.
+        """
+        outcome = CrawlComplete(
+            total_items=total_items,
+            page_limit=2000,
+            single_page=single_page,
+            started_at=utc_now(),
+        )
+
+        fault = outcome.completeness_fault(crawled)
+
+        if complete:
+            assert fault is None
+        else:
+            assert isinstance(fault, CrawlFault)
+            assert "Refusing to reap on an incomplete crawl" in fault.reason
+
+    def test_allowance_stays_under_a_page(self) -> None:
+        """A lost page must never be excused, whatever page size Overdrive applied.
+
+        The allowance is meant to absorb churn during a crawl, and the crawl's
+        first backwards page has nothing above it to be checked against -- so
+        if the allowance ever reached a whole page, an empty response there
+        would be indistinguishable from titles removed mid-crawl.
+        """
+        lost_page = 10_000_000
+        for page_limit in (2000, 300, 25):
+            outcome = CrawlComplete(
+                total_items=lost_page,
+                page_limit=page_limit,
+                single_page=False,
+                started_at=utc_now(),
+            )
+            assert outcome.completeness_fault(lost_page - page_limit) is not None
+
+    def test_floor_is_the_constant(self) -> None:
+        """The floor keeps small collections from being held to an unreachable
+        standard; pin it so a change is a deliberate one."""
+        assert CRAWL_ALLOWANCE_FLOOR == 10

--- a/tests/manager/integration/license/overdrive/test_representation.py
+++ b/tests/manager/integration/license/overdrive/test_representation.py
@@ -183,20 +183,19 @@ class TestOverdriveRepresentationExtractor:
         # Status should be EXHAUSTED since licenses_owned is 0
         assert LicensePoolStatus.EXHAUSTED == data.status
 
-    def test_book_info_to_circulation_no_ownership_data(
+    def test_book_info_to_circulation_not_owned(
         self, overdrive_api_fixture: OverdriveAPIFixture
     ):
-        """
-        Test that status is None when we don't have ownership information.
+        """A title Overdrive reports as no longer owned has no copies.
 
-        This test case is here since its possible for this to happen the way
-        the code is currently written, but it's not a situation that I have observed
-        in the wild.
+        Overdrive keeps weeded and expired titles in a collection's responses flagged
+        `isOwnedByCollections: false`, so the flag states that the collection holds no
+        copies. Treating it as missing data instead would leave the title on the shelf
+        indefinitely, since nothing else about the document says it is gone.
         """
         fixture = overdrive_api_fixture
         extractor = OverdriveRepresentationExtractor(fixture.api)
 
-        # isOwnedByCollections=False means the collection does not own this book.
         availability = Availability.model_validate(
             {
                 "reserveId": "test-id-12345",
@@ -206,11 +205,10 @@ class TestOverdriveRepresentationExtractor:
 
         data = extractor.book_info_to_circulation(availability)
 
-        # When we don't own the book and there's no error, licenses_owned is None
-        assert data.licenses_owned is None
-        assert data.licenses_available is None
-        # Status should also be None when we don't have ownership information
-        assert data.status is None
+        assert data.licenses_owned == 0
+        assert data.licenses_available == 0
+        assert data.patrons_in_hold_queue == 0
+        assert data.status == LicensePoolStatus.EXHAUSTED
 
     def test_book_info_with_metadata(self, overdrive_api_fixture: OverdriveAPIFixture):
         # Tests that can convert an overdrive json block into a Metadata object.

--- a/tests/manager/scripts/test_overdrive.py
+++ b/tests/manager/scripts/test_overdrive.py
@@ -43,7 +43,7 @@ class TestOverdriveReaperScript:
             )
             mock.assert_called_once_with(collection.id)
             mock.return_value.apply_async.assert_called_once_with()
-            assert '"reap_collection" task has been queued' in caplog.text
+            assert "A reap has been queued" in caplog.text
 
     def test_reap_collection_wrong_protocol(
         self,

--- a/tests/manager/scripts/test_overdrive.py
+++ b/tests/manager/scripts/test_overdrive.py
@@ -37,11 +37,12 @@ class TestOverdriveReaperScript:
     ) -> None:
         caplog.set_level(LogLevel.info)
         collection = db.collection(protocol=OverdriveAPI)
-        with patch("palace.manager.scripts.overdrive.reap_collection") as mock:
+        with patch.object(OverdriveAPI, "reap_task") as mock:
             OverdriveReaperScript(db.session, services_fixture.services).do_run(
                 ["--collection-name", collection.name]
             )
-            mock.delay.assert_called_once_with(collection.id)
+            mock.assert_called_once_with(collection.id)
+            mock.return_value.apply_async.assert_called_once_with()
             assert '"reap_collection" task has been queued' in caplog.text
 
     def test_reap_collection_wrong_protocol(


### PR DESCRIPTION
## Description

Replaces the Overdrive reaper's per-title availability polling with a crawl of the collection's product list, and marks what the crawl shows is gone.

Overdrive removes titles from a collection in two ways, and the reaper treats them differently:

- **Weeded and expired titles stay in the product list**, flagged `isOwnedByCollections: false` — which is what [Overdrive's docs](https://developer.overdrive.com/apis/search) give as the way to detect them. That is a statement, not an inference, so those titles are marked as each page arrives, whether or not the crawl goes on to complete. Only titles we still record as holding copies are marked, so the standing weeds in a collection don't queue an apply task on every pass — including the case where every copy is checked out, which the set difference can never reach because Overdrive goes on listing the title.
- **A title can also leave the product list entirely.** That is only detectable from its *absence*, so the crawl's identifiers are handed to `create_mark_unavailable_chord` and the set difference against what we hold locally is marked. This half needs the crawl to be complete, and aborts if it can't be shown to be.

Everything is marked `EXHAUSTED` rather than `REMOVED`: Overdrive drops titles when a lease ends or a purchase is returned, not only when a title is withdrawn, so outstanding loans and holds should survive. `mark_identifiers_unavailable` gains a `status` parameter for this, defaulting to `REMOVED` so the OPDS reapers are unchanged.

### The crawl

Overdrive's `next` links are offset-based and it publishes no unique sort key (`id`, `reserveId` and `crossRefId` are all rejected), so a forward walk loses one title for every title removed underneath it — the rest shift down and the title at the next page's starting offset is never returned. The crawl therefore **walks backwards**: the first page is fetched at offset 0 to learn `totalItems`, each page steps back towards the start of the list, and the walk finishes with a fresh page at offset 0. A removal below the cursor can then only push a not-yet-crawled title deeper into the region still being walked. Consecutive pages overlap by 5% of the page size, which absorbs the mirror case — a title inserted below the cursor pushing one past it — and any ordering jitter within a tie group.

Finishing on a fresh page at offset 0 is what closes the walk's last seam. Titles only ever move *down* the `dateAdded:asc` ordering — removals shift them down, additions land at the end — so the first page's snapshot of the start of the list goes stale over an hours-long crawl, and a title sitting just past its edge at crawl start could drift below it mid-crawl and dodge every page. Re-covering the start at the end means coverage never leans on the first page at all, which also retires the short-first-page check an earlier revision of this branch needed.

Because reaping on absence is only safe if the crawl really covered the list, coverage is established structurally rather than inferred from a count:

- the first backwards page must reach the end of the list, being the one page with nothing above it to check against;
- every other page — including the final one at offset 0 — must reach the offset the page before it started at;
- the page size Overdrive applied must stay the same, since every check above is measured in it;
- and what remains is compared against `totalItems`, counting *distinct* identifiers so a title returned twice cannot paper over one that was missed. The allowance for mid-crawl churn is capped at a quarter of a page, so a lost page can never be excused, and is zero for a collection that arrived in a single response, which had no window for churn at all.

Any of these failing aborts the run and marks nothing from absence. A bad status code, a body that isn't JSON, and a page missing `totalItems` or `limit` are all raised as a retryable `BadResponseException` — this endpoint returns transient 404s — so a blip costs a page rather than a crawl that has been running for hours.

The walk lives in a new `integration/license/overdrive/crawl.py` as an immutable `CrawlCursor`: `advance(page)` returns the next cursor, a `CrawlComplete`, or a typed `CrawlFault`, and the reap task just drives it — fetch, mark weeds, advance, re-queue or finish — carrying the cursor across `task.replace()` as a single serialized kwarg rather than one walk field at a time. The reaper aborts on any fault because it acts on absence; the module is deliberately shaped so a future harvest can walk the same pages (`ProductPage` keeps the raw product dictionaries) and treat the same faults as advisory.

Three smaller behaviors ride along: a collection Overdrive lists nothing for is skipped quietly instead of handing the chord body a never-materialised set that raises on every scheduled run; the nightly kickoffs are staggered two minutes apart, so every collection's opening identifier scan doesn't land on the default queue in the same minute; and a missing existing-set at the chord body is now a warning about work *possibly* lost rather than an error about work certainly lost, since the body fires hours after the snapshot and imports may have added identifiers in between.

## Motivation and Context

PP-4908. The old reaper called `update_licensepool()` for every identifier in a collection — one serial availability request per title. On the largest circulation managers that is millions of requests per pass: it occupied 83–99.7% of the default queue's worker capacity, and a full pass took ~87 hours against a daily schedule, so it never completed. Removal detection does not need per-title availability: the product list returns 2,000 titles per request, so the largest collection costs ~2,050 requests (~4.6h) instead of ~4.1M.

Measured against library 1106 in production while designing this:

- **Weeded titles are flagged, not dropped** — 631 standing in a 38,434-title collection — and they also flow through the `lastUpdateTime` feed (32 in 24h, 296 in 7 days), so the 3-hourly import has already been reaping them via `copiesOwned: 0`. The set difference, the only mechanism that can falsely reap, covers what is left: titles that vanish with no change event, ~13/day per 38k titles.
- **Offset paging really does skip titles** when one is removed mid-crawl, and `totalItems` decrements in step with the shortfall, so a count check cannot see it. Hence the backwards walk.
- **Tie order is stable.** `dateAdded` is heavily tied — a bulk load of magazine issues puts 5,379 titles on one value, and 11 tie groups straddle a page boundary — and no field in the payload breaks those ties, while a second sort key is accepted only to be ignored. Overdrive resolves them consistently regardless: repeated requests, differing page sizes, and two full crawls agree exactly, the crawls placing all 38,434 titles at identical indexes.
- **`limit` is echoed as the size requested**, not the number of titles returned, so a page at the end of the list still reports a full one — which is what lets a short page be read as truncation.

**Overdrive's [Digital Inventory API](https://developer.overdrive.com/api-docs/discovery-apis/digital-inventory-api) was evaluated and rejected.** It publishes a daily snapshot of a collection's reserveIds and is documented for exactly this diff, but it lists titles an account *owns copies of*, while our collections mirror the products feed — titles the account *can lend*, own copies plus consortium-shared ones. The consortium file held 22,986 ids against 37,803 owned in the products feed; an Advantage account's file 7,338 against 25,863. Both were also 19 days stale despite the documented daily rebuild.

## How Has This Been Tested?

- Unit tests covering: the cursor's walk as a property test — every offset covered and the walk terminating, across ragged, exact-multiple, and single-page collections; a temporal regression test in which titles removed mid-crawl shift a title below the first page's edge, and the walk must still collect it; each gap check, the page-size guard, and the completeness allowance, including that a lost page is never excused at any page size; a multi-page crawl through a real Celery worker, pinning that identifiers accumulate across `task.replace()` and that the walk ends by re-fetching offset 0; marking from the ownership flag, including a title whose copies are all checked out, one already unavailable that must not be re-marked, and marking still happening when the crawl aborts; identifier lowercasing, since getting it wrong would reap entire collections; the empty-collection skip; the staggered kickoff; and pages left over from the previous reaper being discarded rather than crawled from an arbitrary offset. The task tests drive the real cursor with internally consistent page sequences rather than mocking the walk, so a disagreement between the cursor and the task fails them.
- `tox -e py312-docker` over `tests/manager/celery`, `tests/manager/integration/license/opds`, `tests/manager/integration/license/overdrive`, and `tests/manager/scripts/test_overdrive.py` — 877 passing.
- `mypy` clean across 1,160 source files.
- Read-only probes against library 1106 in production for every measurement quoted above.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
