### PR TITLE
Add logging and setting overrides for active SAML ACS URL(s) (PP-4899)

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,9 +413,11 @@ clearing that setting returns the integration to this default.
   - `metadata_default`: use the endpoint marked `isDefault="true"`, falling back to the lowest `index`.
   - `defer_to_idp`: name no endpoint, leaving the identity provider to use whichever one it has registered.
 
-Identity providers are registered against the endpoint this selects, so changing it is a coordinated
-configuration change with the identity provider rather than a preference. An unrecognized value is ignored:
-it is logged as an error and the built-in default (`first_index`) is used instead.
+Whichever policy ends up in effect for an integration determines the endpoint named in its authentication
+requests, and identity providers are registered against a specific endpoint. Changing the effective policy
+is therefore a coordinated configuration change with the identity provider rather than a preference. An
+unrecognized value here is ignored: it is logged as an error and the built-in default (`first_index`) is
+used instead.
 
 #### DeMarque WebReader
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,21 @@ settings in the future.
 - `PALACE_SAML_SP_METADATA_FILE`: Path to SP metadata XML file
 - `PALACE_SAML_SP_METADATA`: Inline SP metadata XML content
 
+When SP metadata declares more than one `AssertionConsumerService` endpoint, only one of them is named in
+the authentication requests we send. The following variable sets the site-wide default rule for choosing it,
+which applies to any SAML integration that leaves its own "Assertion Consumer Service Endpoint Selection"
+setting unset in the Administrative Interface. An integration that does set it overrides this default, and
+clearing that setting returns the integration to this default.
+
+- `PALACE_SAML_SP_ACS_SELECTION_POLICY`: One of
+  - `first_index` (the default): use the endpoint with the lowest `index`, ignoring `isDefault`.
+  - `metadata_default`: use the endpoint marked `isDefault="true"`, falling back to the lowest `index`.
+  - `defer_to_idp`: name no endpoint, leaving the identity provider to use whichever one it has registered.
+
+Identity providers are registered against the endpoint this selects, so changing it is a coordinated
+configuration change with the identity provider rather than a preference. An unrecognized value is ignored:
+it is logged as an error and the built-in default (`first_index`) is used instead.
+
 #### DeMarque WebReader
 
 For DeMarque WebReader JWT authentication, the following environment variables can be configured. All are

--- a/src/palace/manager/integration/patron_auth/saml/auth.py
+++ b/src/palace/manager/integration/patron_auth/saml/auth.py
@@ -366,10 +366,11 @@ class SAMLAuthenticationManager:
             # The request named no endpoint, so there is nothing to compare. Record the
             # identity provider's choice, which is what pinning a policy would select.
             asserted_acs_url = None
-            self._logger.debug(
-                f"SAML response for IdP '{idp_entity_id}' arrived at "
-                f"'{received_acs_url}', chosen by the identity provider"
-            )
+            if self._logger.isEnabledFor(logging.DEBUG):
+                self._logger.debug(
+                    f"SAML response for IdP '{idp_entity_id}' arrived at "
+                    f"'{received_acs_url}', chosen by the identity provider"
+                )
         else:
             asserted_acs_url = self._get_asserted_acs_url(auth)
             self._warn_on_acs_endpoint_mismatch(

--- a/src/palace/manager/integration/patron_auth/saml/auth.py
+++ b/src/palace/manager/integration/patron_auth/saml/auth.py
@@ -8,6 +8,7 @@ from flask import request
 from flask_babel import lazy_gettext as _
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.errors import OneLogin_Saml2_Error
+from onelogin.saml2.utils import OneLogin_Saml2_Utils
 
 from palace.manager.integration.patron_auth.saml.configuration.model import (
     SAMLConfigurationError,
@@ -124,6 +125,49 @@ class SAMLAuthenticationManager:
 
         return request_data
 
+    @staticmethod
+    def _get_asserted_acs_url(auth: OneLogin_Saml2_Auth) -> str | None:
+        """Return the ACS URL that we send in our authentication requests.
+
+        This is the endpoint selected from the SP metadata by the configuration
+        layer. It is the value an IdP compares against its own registered ACS URL.
+
+        :param auth: OneLogin_Saml2_Auth object
+        :return: Asserted ACS URL, or None if none is configured
+        """
+        acs = auth.get_settings().get_sp_data().get("assertionConsumerService", {})
+        url = acs.get("url")
+
+        return url if isinstance(url, str) and url else None
+
+    def _warn_on_acs_endpoint_mismatch(
+        self, idp_entity_id: str, asserted_url: str | None, received_url: str
+    ) -> None:
+        """Warn when a response arrives at an ACS endpoint we did not assert.
+
+        An SP may publish several AssertionConsumerService endpoints, and a request
+        names at most one of them. Requests naming none leave nothing to compare, so
+        they are ignored. Otherwise an IdP registered against a different endpoint
+        fails authentication with an IdP-authored message that names both URLs but
+        not which side chose which, so recording both makes the mismatch diagnosable
+        from our own logs.
+        """
+        if asserted_url is None:
+            return
+
+        # Normalize like OneLogin, so that we get only legitimate warnings.
+        if OneLogin_Saml2_Utils.normalize_url(
+            asserted_url
+        ) == OneLogin_Saml2_Utils.normalize_url(received_url):
+            return
+
+        self._logger.warning(
+            f"SAML response for IdP '{idp_entity_id}' arrived at '{received_url}', but the "
+            f"authentication request asserted '{asserted_url}'. The identity provider is "
+            f"likely registered against a different Assertion Consumer Service endpoint "
+            f"than the one selected from our Service Provider metadata."
+        )
+
     def _create_auth_object(
         self,
         db: sqlalchemy.orm.session.Session,
@@ -209,6 +253,10 @@ class SAMLAuthenticationManager:
             redirect_url = auth.login(return_to_url, force_authn=force_authn)
 
             if self._logger.isEnabledFor(logging.DEBUG):
+                self._logger.debug(
+                    f"AuthnRequest for IdP '{idp_entity_id}' asserts ACS endpoint "
+                    f"'{self._get_asserted_acs_url(auth)}'"
+                )
                 self._logger.debug(f"SAML request: {auth.get_last_request_xml()}")
 
             self._logger.info(
@@ -258,6 +306,13 @@ class SAMLAuthenticationManager:
             )
 
         auth = self._get_auth_object(db, idp_entity_id)
+
+        asserted_acs_url = self._get_asserted_acs_url(auth)
+        received_acs_url = OneLogin_Saml2_Utils.get_self_url_no_query(request_data)
+        self._warn_on_acs_endpoint_mismatch(
+            idp_entity_id, asserted_acs_url, received_acs_url
+        )
+
         auth.process_response()
 
         if self._logger.isEnabledFor(logging.DEBUG):
@@ -276,9 +331,15 @@ class SAMLAuthenticationManager:
 
             return subject
         else:
-            self._logger.error(auth.get_last_error_reason())
+            error_reason = auth.get_last_error_reason()
 
-            return SAML_AUTHENTICATION_ERROR.detailed(auth.get_last_error_reason())
+            self._logger.error(
+                f"SAML authentication failed for IdP '{idp_entity_id}': {error_reason} "
+                f"(request asserted ACS endpoint '{asserted_acs_url}'; response arrived "
+                f"at '{received_acs_url}')"
+            )
+
+            return SAML_AUTHENTICATION_ERROR.detailed(error_reason)
 
     def start_logout(
         self,

--- a/src/palace/manager/integration/patron_auth/saml/auth.py
+++ b/src/palace/manager/integration/patron_auth/saml/auth.py
@@ -234,8 +234,12 @@ class SAMLAuthenticationManager:
         return auth
 
     def _defers_acs_to_idp(self) -> bool:
-        """Whether requests should name no ACS endpoint at all."""
-        policy = self._configuration.configuration.service_provider_acs_selection_policy
+        """Whether requests should name no ACS endpoint at all.
+
+        Resolved through the configuration rather than read from the integration
+        setting, so that a site-wide default from the environment is honored.
+        """
+        policy = self._configuration.get_acs_selection_policy()
 
         return policy is SAMLACSSelectionPolicy.DEFER_TO_IDP
 

--- a/src/palace/manager/integration/patron_auth/saml/auth.py
+++ b/src/palace/manager/integration/patron_auth/saml/auth.py
@@ -174,7 +174,7 @@ class SAMLAuthenticationManager:
     def _warn_on_acs_endpoint_mismatch(
         self, idp_entity_id: str, asserted_url: str | None, received_url: str
     ) -> None:
-        """Warn when a response arrives at an ACS endpoint we did not assert.
+        """Warn when a response arrives at an ACS endpoint that we did not expect.
 
         An SP may publish several AssertionConsumerService endpoints, and a request
         names at most one of them. Requests naming none leave nothing to compare, so

--- a/src/palace/manager/integration/patron_auth/saml/auth.py
+++ b/src/palace/manager/integration/patron_auth/saml/auth.py
@@ -300,10 +300,16 @@ class SAMLAuthenticationManager:
             redirect_url = auth.login(return_to_url, force_authn=force_authn)
 
             if self._logger.isEnabledFor(logging.DEBUG):
-                self._logger.debug(
-                    f"AuthnRequest for IdP '{idp_entity_id}' asserts ACS endpoint "
-                    f"'{self._get_asserted_acs_url(auth)}'"
-                )
+                if self._defers_acs_to_idp():
+                    self._logger.debug(
+                        f"AuthnRequest for IdP '{idp_entity_id}' names no ACS endpoint; "
+                        f"the identity provider will use the one it has registered"
+                    )
+                else:
+                    self._logger.debug(
+                        f"AuthnRequest for IdP '{idp_entity_id}' asserts ACS endpoint "
+                        f"'{self._get_asserted_acs_url(auth)}'"
+                    )
                 self._logger.debug(f"SAML request: {auth.get_last_request_xml()}")
 
             self._logger.info(

--- a/src/palace/manager/integration/patron_auth/saml/auth.py
+++ b/src/palace/manager/integration/patron_auth/saml/auth.py
@@ -6,9 +6,12 @@ from urllib.parse import urlparse
 
 from flask import request
 from flask_babel import lazy_gettext as _
+from lxml.etree import tostring
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
+from onelogin.saml2.authn_request import OneLogin_Saml2_Authn_Request
 from onelogin.saml2.errors import OneLogin_Saml2_Error
 from onelogin.saml2.utils import OneLogin_Saml2_Utils
+from onelogin.saml2.xmlparser import fromstring
 
 from palace.manager.integration.patron_auth.saml.configuration.model import (
     SAMLConfigurationError,
@@ -16,6 +19,9 @@ from palace.manager.integration.patron_auth.saml.configuration.model import (
 )
 from palace.manager.integration.patron_auth.saml.configuration.service_provider import (
     SamlServiceProviderConfiguration,
+)
+from palace.manager.integration.patron_auth.saml.metadata.model import (
+    SAMLACSSelectionPolicy,
 )
 from palace.manager.integration.patron_auth.saml.metadata.parser import (
     SAMLSubjectParser,
@@ -59,6 +65,31 @@ SAML_NO_ACCESS_ERROR = pd(
     title=_("No access."),
     detail=_("Patron does not have access based on their attributes."),
 )
+
+
+# The SAML toolkit is untyped, so its classes are Any and cannot normally be subclassed.
+class AcsOmittingAuthnRequest(OneLogin_Saml2_Authn_Request):  # type: ignore[misc]
+    """An AuthnRequest that names no AssertionConsumerService endpoint.
+
+    SAML 2.0 Core section 3.4.1 permits a request to omit both
+    AssertionConsumerServiceURL and ProtocolBinding, in which case the IdP responds to
+    the endpoint it has registered for the SP. The toolkit always writes both, so they
+    are removed after the request is built.
+    """
+
+    ACS_ATTRIBUTES = ("AssertionConsumerServiceURL", "ProtocolBinding")
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        # get_request() and the redirect signature are both derived from this value, so
+        # stripping it here keeps the signature over what is actually sent.
+        root = fromstring(self.get_xml().encode())
+
+        for attribute in self.ACS_ATTRIBUTES:
+            root.attrib.pop(attribute, None)
+
+        self._authn_request = tostring(root, encoding="unicode")
 
 
 class SAMLAuthenticationManager:
@@ -192,9 +223,21 @@ class SAMLAuthenticationManager:
         request_data = self._get_request_data()
         if settings is None:
             settings = self._configuration.get_settings(db, idp_entity_id)
+
         auth = OneLogin_Saml2_Auth(request_data, old_settings=settings)
 
+        if self._defers_acs_to_idp():
+            # Set on the instance rather than globally, so integrations using other
+            # policies are unaffected.
+            auth.authn_request_class = AcsOmittingAuthnRequest
+
         return auth
+
+    def _defers_acs_to_idp(self) -> bool:
+        """Whether requests should name no ACS endpoint at all."""
+        policy = self._configuration.configuration.service_provider_acs_selection_policy
+
+        return policy is SAMLACSSelectionPolicy.DEFER_TO_IDP
 
     def _get_auth_object(self, db, idp_entity_id):
         """Return a cached OneLogin_Saml2_Auth object.
@@ -307,11 +350,21 @@ class SAMLAuthenticationManager:
 
         auth = self._get_auth_object(db, idp_entity_id)
 
-        asserted_acs_url = self._get_asserted_acs_url(auth)
         received_acs_url = OneLogin_Saml2_Utils.get_self_url_no_query(request_data)
-        self._warn_on_acs_endpoint_mismatch(
-            idp_entity_id, asserted_acs_url, received_acs_url
-        )
+
+        if self._defers_acs_to_idp():
+            # The request named no endpoint, so there is nothing to compare. Record the
+            # identity provider's choice, which is what pinning a policy would select.
+            asserted_acs_url = None
+            self._logger.debug(
+                f"SAML response for IdP '{idp_entity_id}' arrived at "
+                f"'{received_acs_url}', chosen by the identity provider"
+            )
+        else:
+            asserted_acs_url = self._get_asserted_acs_url(auth)
+            self._warn_on_acs_endpoint_mismatch(
+                idp_entity_id, asserted_acs_url, received_acs_url
+            )
 
         auth.process_response()
 
@@ -333,9 +386,10 @@ class SAMLAuthenticationManager:
         else:
             error_reason = auth.get_last_error_reason()
 
+            asserted = f"'{asserted_acs_url}'" if asserted_acs_url else "none"
             self._logger.error(
                 f"SAML authentication failed for IdP '{idp_entity_id}': {error_reason} "
-                f"(request asserted ACS endpoint '{asserted_acs_url}'; response arrived "
+                f"(request asserted ACS endpoint {asserted}; response arrived "
                 f"at '{received_acs_url}')"
             )
 

--- a/src/palace/manager/integration/patron_auth/saml/configuration/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/configuration/model.py
@@ -171,6 +171,9 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
                 SAMLACSSelectionPolicy.METADATA_DEFAULT.value: (
                     "Metadata default (isDefault, otherwise lowest index)"
                 ),
+                SAMLACSSelectionPolicy.DEFER_TO_IDP.value: (
+                    "Defer to identity provider (name no endpoint in the request)"
+                ),
             },
         ),
     ] = SAMLACSSelectionPolicy.FIRST_INDEX

--- a/src/palace/manager/integration/patron_auth/saml/configuration/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/configuration/model.py
@@ -30,6 +30,7 @@ from palace.manager.integration.patron_auth.saml.configuration.service_provider 
 )
 from palace.manager.integration.patron_auth.saml.metadata.federations import incommon
 from palace.manager.integration.patron_auth.saml.metadata.model import (
+    SAMLACSSelectionPolicy,
     SAMLAttributeType,
     SAMLBinding,
     SAMLIdentityProviderMetadata,
@@ -153,6 +154,26 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
             use_monospace_font=True,
         ),
     ] = None
+    service_provider_acs_selection_policy: Annotated[
+        SAMLACSSelectionPolicy,
+        FormMetadata(
+            label="Assertion Consumer Service Endpoint Selection",
+            description=(
+                "Which Assertion Consumer Service endpoint to name in authentication requests, "
+                "when the Service Provider metadata declares more than one. "
+                "'Lowest index' deliberately ignores the isDefault attribute: identity providers "
+                "are registered against the endpoint it selects, so changing this is a "
+                "coordinated configuration change with the identity provider, not a preference."
+            ),
+            type=FormFieldType.SELECT,
+            options={
+                SAMLACSSelectionPolicy.FIRST_INDEX.value: "Lowest index (ignore isDefault)",
+                SAMLACSSelectionPolicy.METADATA_DEFAULT.value: (
+                    "Metadata default (isDefault, otherwise lowest index)"
+                ),
+            },
+        ),
+    ] = SAMLACSSelectionPolicy.FIRST_INDEX
     federated_identity_provider_entity_ids: Annotated[
         list[str] | None,
         FormMetadata(
@@ -638,7 +659,12 @@ class SAMLOneLoginConfiguration(LoggerMixin):
                 )
             )
 
-        parsing_results = self._metadata_parser.parse(metadata)
+        # The ACS selection policy applies only to SP metadata, so this parse uses its
+        # own parser rather than the one shared with identity provider parsing.
+        service_provider_parser = SAMLMetadataParser(
+            acs_selection_policy=self._configuration.service_provider_acs_selection_policy
+        )
+        parsing_results = service_provider_parser.parse(metadata)
 
         if not isinstance(parsing_results, list) or len(parsing_results) != 1:
             raise SAMLConfigurationError(

--- a/src/palace/manager/integration/patron_auth/saml/configuration/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/configuration/model.py
@@ -155,7 +155,7 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
         ),
     ] = None
     service_provider_acs_selection_policy: Annotated[
-        SAMLACSSelectionPolicy,
+        SAMLACSSelectionPolicy | None,
         FormMetadata(
             label="Assertion Consumer Service Endpoint Selection",
             description=(
@@ -163,10 +163,14 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
                 "when the Service Provider metadata declares more than one. "
                 "'Lowest index' deliberately ignores the isDefault attribute: identity providers "
                 "are registered against the endpoint it selects, so changing this is a "
-                "coordinated configuration change with the identity provider, not a preference."
+                "coordinated configuration change with the identity provider, not a preference. "
+                "Leave unset to use the site-wide default from "
+                "PALACE_SAML_SP_ACS_SELECTION_POLICY, which is itself 'Lowest index' unless "
+                "configured otherwise."
             ),
             type=FormFieldType.SELECT,
             options={
+                "": "Use site-wide default",
                 SAMLACSSelectionPolicy.FIRST_INDEX.value: "Lowest index (ignore isDefault)",
                 SAMLACSSelectionPolicy.METADATA_DEFAULT.value: (
                     "Metadata default (isDefault, otherwise lowest index)"
@@ -176,7 +180,7 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
                 ),
             },
         ),
-    ] = SAMLACSSelectionPolicy.FIRST_INDEX
+    ] = None
     federated_identity_provider_entity_ids: Annotated[
         list[str] | None,
         FormMetadata(
@@ -626,6 +630,25 @@ class SAMLOneLoginConfiguration(LoggerMixin):
 
         return identity_providers
 
+    def get_acs_selection_policy(self) -> SAMLACSSelectionPolicy:
+        """Resolve the ACS endpoint selection policy for this integration.
+
+        The integration's own setting wins. An integration that leaves it unset uses
+        the site-wide default from the environment, and failing that the built-in
+        default.
+
+        This is the single source of truth for the policy: callers that need to know
+        how requests are built must use it rather than reading the setting, which on
+        its own does not account for the environment.
+
+        :return: Policy to apply when parsing this integration's SP metadata
+        """
+        return (
+            self._configuration.service_provider_acs_selection_policy
+            or self._sp_configuration.acs_selection_policy
+            or SAMLACSSelectionPolicy.FIRST_INDEX
+        )
+
     def _load_service_provider(self) -> SAMLServiceProviderMetadata:
         """Loads SP settings from integration configuration or environment.
 
@@ -665,7 +688,7 @@ class SAMLOneLoginConfiguration(LoggerMixin):
         # The ACS selection policy applies only to SP metadata, so this parse uses its
         # own parser rather than the one shared with identity provider parsing.
         service_provider_parser = SAMLMetadataParser(
-            acs_selection_policy=self._configuration.service_provider_acs_selection_policy
+            acs_selection_policy=self.get_acs_selection_policy()
         )
         parsing_results = service_provider_parser.parse(metadata)
 

--- a/src/palace/manager/integration/patron_auth/saml/configuration/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/configuration/model.py
@@ -1,11 +1,13 @@
 import re
+from collections.abc import Mapping
 from datetime import datetime
 from re import Pattern
 from threading import Lock
-from typing import Annotated, Any
+from typing import Annotated, Any, Final
 
 from annotated_types import Ge, Le
 from flask_babel import lazy_gettext as _
+from frozendict import frozendict
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
 from pydantic import PositiveInt, field_validator
 from sqlalchemy.orm import Session
@@ -26,10 +28,12 @@ from palace.manager.integration.patron_auth.saml.configuration.problem_details i
     SAML_INCORRECT_PRIVATE_KEY,
 )
 from palace.manager.integration.patron_auth.saml.configuration.service_provider import (
+    ACS_SELECTION_POLICY_ENV_VAR,
     SamlServiceProviderConfiguration,
 )
 from palace.manager.integration.patron_auth.saml.metadata.federations import incommon
 from palace.manager.integration.patron_auth.saml.metadata.model import (
+    DEFAULT_ACS_SELECTION_POLICY,
     SAMLACSSelectionPolicy,
     SAMLAttributeType,
     SAMLBinding,
@@ -126,6 +130,17 @@ def _validate_filter_expression(cls: type[BaseSettings], v: str | None) -> str |
     return v
 
 
+# Names shown in the administrative interface. Also used in the field's description, so
+# that the stated default follows DEFAULT_ACS_SELECTION_POLICY rather than being restated.
+ACS_SELECTION_POLICY_LABELS: Final[Mapping[SAMLACSSelectionPolicy, str]] = frozendict(
+    {
+        SAMLACSSelectionPolicy.FIRST_INDEX: "Lowest index",
+        SAMLACSSelectionPolicy.METADATA_DEFAULT: "Metadata default",
+        SAMLACSSelectionPolicy.DEFER_TO_IDP: "Defer to identity provider",
+    }
+)
+
+
 class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
     """SAML Web SSO Authentication settings"""
 
@@ -159,25 +174,27 @@ class SAMLWebSSOAuthSettings(AuthProviderSettings, LoggerMixin):
         FormMetadata(
             label="Assertion Consumer Service Endpoint Selection",
             description=(
-                "Which Assertion Consumer Service endpoint to name in authentication requests, "
-                "when the Service Provider metadata declares more than one. "
-                "'Lowest index' deliberately ignores the isDefault attribute: identity providers "
-                "are registered against the endpoint it selects, so changing this is a "
-                "coordinated configuration change with the identity provider, not a preference. "
-                "Leave unset to use the site-wide default from "
-                "PALACE_SAML_SP_ACS_SELECTION_POLICY, which is itself 'Lowest index' unless "
-                "configured otherwise."
+                "(Optional) How we choose which Assertion Consumer Service (ACS) endpoint "
+                "(if any) to name in authentication requests when the Service Provider "
+                "metadata declares more than one. "
+                f"'{ACS_SELECTION_POLICY_LABELS[SAMLACSSelectionPolicy.FIRST_INDEX]}' "
+                "deliberately ignores the isDefault attribute and selects the lowest index "
+                "attribute value. Leave unset to use the site-wide default (currently "
+                f"'{ACS_SELECTION_POLICY_LABELS[DEFAULT_ACS_SELECTION_POLICY]}' unless "
+                f"overridden by the {ACS_SELECTION_POLICY_ENV_VAR} environment variable)."
+                "<br>"
+                "<br>"
+                "NOTE: The selected ACS endpoint, if present, must align with the Identity "
+                "Provider's configuration, so coordination with our IdP partner may be "
+                "required when changing this value."
             ),
             type=FormFieldType.SELECT,
             options={
                 "": "Use site-wide default",
-                SAMLACSSelectionPolicy.FIRST_INDEX.value: "Lowest index (ignore isDefault)",
-                SAMLACSSelectionPolicy.METADATA_DEFAULT.value: (
-                    "Metadata default (isDefault, otherwise lowest index)"
-                ),
-                SAMLACSSelectionPolicy.DEFER_TO_IDP.value: (
-                    "Defer to identity provider (name no endpoint in the request)"
-                ),
+                **{
+                    policy.value: label
+                    for policy, label in ACS_SELECTION_POLICY_LABELS.items()
+                },
             },
         ),
     ] = None
@@ -646,7 +663,7 @@ class SAMLOneLoginConfiguration(LoggerMixin):
         return (
             self._configuration.service_provider_acs_selection_policy
             or self._sp_configuration.acs_selection_policy
-            or SAMLACSSelectionPolicy.FIRST_INDEX
+            or DEFAULT_ACS_SELECTION_POLICY
         )
 
     def _load_service_provider(self) -> SAMLServiceProviderMetadata:

--- a/src/palace/manager/integration/patron_auth/saml/configuration/service_provider.py
+++ b/src/palace/manager/integration/patron_auth/saml/configuration/service_provider.py
@@ -3,17 +3,25 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from pydantic import field_validator
 from pydantic_settings import SettingsConfigDict
 
+from palace.util.log import LoggerMixin
+
 from palace.manager.core.config import CannotLoadConfiguration
+from palace.manager.integration.patron_auth.saml.metadata.model import (
+    SAMLACSSelectionPolicy,
+)
 from palace.manager.service.configuration.service_configuration import (
     ServiceConfiguration,
 )
 
+ACS_SELECTION_POLICY_ENV_VAR = "PALACE_SAML_SP_ACS_SELECTION_POLICY"
 
-class SamlServiceProviderConfiguration(ServiceConfiguration):
+
+class SamlServiceProviderConfiguration(ServiceConfiguration, LoggerMixin):
     """SAML Service Provider configuration loaded from environment variables.
 
     Supports both file-based and inline content configuration for SP private key
@@ -24,6 +32,8 @@ class SamlServiceProviderConfiguration(ServiceConfiguration):
         PALACE_SAML_SP_PRIVATE_KEY: Inline SP private key content
         PALACE_SAML_SP_METADATA_FILE: Path to SP metadata XML file
         PALACE_SAML_SP_METADATA: Inline SP metadata XML content
+        PALACE_SAML_SP_ACS_SELECTION_POLICY: Default ACS endpoint selection policy,
+            used by integrations that do not set one of their own
     """
 
     model_config = SettingsConfigDict(env_prefix="PALACE_SAML_SP_")
@@ -35,6 +45,33 @@ class SamlServiceProviderConfiguration(ServiceConfiguration):
     # Inline content options (value is the content)
     private_key: str | None = None
     metadata: str | None = None
+
+    # Site-wide default for integrations that leave their own policy unset.
+    acs_selection_policy: SAMLACSSelectionPolicy | None = None
+
+    @field_validator("acs_selection_policy", mode="before")
+    @classmethod
+    def validate_acs_selection_policy(cls, value: Any) -> SAMLACSSelectionPolicy | None:
+        """Ignore an unrecognized policy rather than refusing to start.
+
+        This setting has a safe built-in default, so a typo in the environment should
+        not take the application down. The error names the accepted values, since a
+        misconfigured default is otherwise invisible until a login fails.
+        """
+        if value is None or value == "":
+            return None
+
+        try:
+            return SAMLACSSelectionPolicy(value)
+        except ValueError:
+            accepted = ", ".join(policy.value for policy in SAMLACSSelectionPolicy)
+            cls.logger().error(
+                f"{ACS_SELECTION_POLICY_ENV_VAR} has an unrecognized value "
+                f"'{value}'. Expected one of: {accepted}. Integrations without their "
+                f"own policy will use the default instead."
+            )
+
+            return None
 
     @field_validator("private_key_file")
     @classmethod

--- a/src/palace/manager/integration/patron_auth/saml/metadata/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/model.py
@@ -328,6 +328,21 @@ class SAMLBinding(Enum):
     DEFLATE = OneLogin_Saml2_Constants.BINDING_DEFLATE
 
 
+class SAMLACSSelectionPolicy(Enum):
+    """Rule for choosing which ACS endpoint to name in an AuthnRequest.
+
+    Only applies when the SP metadata declares more than one
+    AssertionConsumerService endpoint for the required binding.
+    """
+
+    # Lowest index, ignoring isDefault. Identity providers are registered against
+    # the endpoint this picks, so it is the default.
+    FIRST_INDEX = "first_index"
+
+    # The SAML rule: isDefault="true" wins, falling back to the lowest index.
+    METADATA_DEFAULT = "metadata_default"
+
+
 class SAMLNameIDFormat(Enum):
     """Enumeration of SAML name ID formats"""
 

--- a/src/palace/manager/integration/patron_auth/saml/metadata/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/model.py
@@ -333,10 +333,13 @@ class SAMLACSSelectionPolicy(Enum):
 
     Only applies when the SP metadata declares more than one
     AssertionConsumerService endpoint for the required binding.
+
+    Which rule applies to a given integration is resolved by
+    SAMLOneLoginConfiguration.get_acs_selection_policy().
     """
 
-    # Lowest index, ignoring isDefault. Identity providers are registered against
-    # the endpoint this picks, so it is the default.
+    # Lowest index, ignoring isDefault. Identity providers are registered against the
+    # endpoint this picks, which is why it is the built-in fallback.
     FIRST_INDEX = "first_index"
 
     # The SAML rule: isDefault="true" wins, falling back to the lowest index.

--- a/src/palace/manager/integration/patron_auth/saml/metadata/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/model.py
@@ -4,7 +4,7 @@ from enum import Enum
 from json import JSONDecoder, JSONEncoder
 from json.decoder import WHITESPACE  # type: ignore
 from re import Pattern
-from typing import Any
+from typing import Any, Final
 
 from onelogin.saml2.constants import OneLogin_Saml2_Constants
 
@@ -348,6 +348,10 @@ class SAMLACSSelectionPolicy(Enum):
     # Name no endpoint at all, leaving the identity provider to use whichever one it
     # has registered. A mismatch between the two sides then cannot arise.
     DEFER_TO_IDP = "defer_to_idp"
+
+
+# Applied when neither the integration nor the environment selects a policy.
+DEFAULT_ACS_SELECTION_POLICY: Final = SAMLACSSelectionPolicy.FIRST_INDEX
 
 
 class SAMLNameIDFormat(Enum):

--- a/src/palace/manager/integration/patron_auth/saml/metadata/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/model.py
@@ -336,6 +336,10 @@ class SAMLACSSelectionPolicy(Enum):
 
     Which rule applies to a given integration is resolved by
     SAMLOneLoginConfiguration.get_acs_selection_policy().
+
+    The values are an external contract, appearing in PALACE_SAML_SP_ACS_SELECTION_POLICY
+    and in each integration's stored settings, so they are spelled out rather than derived
+    from the member names. Renaming a member must not silently change them.
     """
 
     # Lowest index, ignoring isDefault. Identity providers are registered against the
@@ -346,7 +350,7 @@ class SAMLACSSelectionPolicy(Enum):
     METADATA_DEFAULT = "metadata_default"
 
     # Name no endpoint at all, leaving the identity provider to use whichever one it
-    # has registered. A mismatch between the two sides then cannot arise.
+    # has registered. Assumes we can receive at every endpoint our metadata publishes.
     DEFER_TO_IDP = "defer_to_idp"
 
 

--- a/src/palace/manager/integration/patron_auth/saml/metadata/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/model.py
@@ -342,6 +342,10 @@ class SAMLACSSelectionPolicy(Enum):
     # The SAML rule: isDefault="true" wins, falling back to the lowest index.
     METADATA_DEFAULT = "metadata_default"
 
+    # Name no endpoint at all, leaving the identity provider to use whichever one it
+    # has registered. A mismatch between the two sides then cannot arise.
+    DEFER_TO_IDP = "defer_to_idp"
+
 
 class SAMLNameIDFormat(Enum):
     """Enumeration of SAML name ID formats"""

--- a/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
@@ -462,15 +462,17 @@ class SAMLMetadataParser:
             provider_node,
             "./md:AssertionConsumerService[@Binding='%s']" % required_acs_binding.value,
         )
-        # Identity providers are registered against the endpoint selected here, so
-        # the default policy preserves the lowest-index choice and ignores isDefault.
-        # Honoring isDefault is opt-in per integration.
-        if self._acs_selection_policy is SAMLACSSelectionPolicy.METADATA_DEFAULT:
+        # Identity providers are registered against the endpoint selected here, so the
+        # default policy preserves the lowest-index choice and ignores isDefault.
+        # Honoring isDefault is opt-in per integration. DEFER_TO_IDP still resolves an
+        # endpoint, because the SAML toolkit requires one in its settings; requests
+        # under that policy simply do not name it.
+        if self._acs_selection_policy is SAMLACSSelectionPolicy.FIRST_INDEX:
+            acs_service_node = self._select_first_indexed_element(acs_service_nodes)
+        else:
             acs_service_node = self._select_default_or_first_indexed_element(
                 acs_service_nodes
             )
-        else:
-            acs_service_node = self._select_first_indexed_element(acs_service_nodes)
 
         if acs_service_node is not None:
             acs_url = acs_service_node.get("Location", None)

--- a/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
@@ -10,6 +10,7 @@ from onelogin.saml2.xmlparser import RestrictedElement, fromstring
 from palace.util.exceptions import BasePalaceException
 
 from palace.manager.integration.patron_auth.saml.metadata.model import (
+    DEFAULT_ACS_SELECTION_POLICY,
     SAMLACSSelectionPolicy,
     SAMLAttribute,
     SAMLAttributeStatement,
@@ -68,14 +69,13 @@ class SAMLMetadataParser:
 
     def __init__(
         self,
-        skip_incorrect_providers=False,
-        acs_selection_policy: SAMLACSSelectionPolicy = SAMLACSSelectionPolicy.FIRST_INDEX,
-    ):
+        skip_incorrect_providers: bool = False,
+        acs_selection_policy: SAMLACSSelectionPolicy = DEFAULT_ACS_SELECTION_POLICY,
+    ) -> None:
         """Initialize a new instance of MetadataParser class.
 
         :param skip_incorrect_providers: Boolean value indicating whether the parse should skip
             incorrect SAML provider declarations instead of raising an exception
-        :type skip_incorrect_providers: bool
 
         :param acs_selection_policy: Rule for choosing among several
             AssertionConsumerService endpoints declared in SP metadata

--- a/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
@@ -385,8 +385,9 @@ class SAMLMetadataParser:
             "./md:SingleSignOnService[@Binding='%s']" % required_sso_binding.value,
         )
         if len(sso_nodes) > 0:
-            sso_node = self._select_default_or_first_indexed_element(sso_nodes)
-            sso_url = sso_node.get("Location", None)
+            # SingleSignOnService is an EndpointType, which declares neither index nor
+            # isDefault, so there is nothing to select by and the first declaration wins.
+            sso_url = sso_nodes[0].get("Location", None)
             sso_service = SAMLService(sso_url, required_sso_binding)
         else:
             raise SAMLMetadataParsingError(
@@ -403,8 +404,9 @@ class SAMLMetadataParser:
             "./md:SingleLogoutService[@Binding='%s']" % required_slo_binding.value,
         )
         if len(slo_nodes) > 0:
-            slo_node = self._select_default_or_first_indexed_element(slo_nodes)
-            slo_url = slo_node.get("Location", None)
+            # SingleLogoutService is an EndpointType, which declares neither index nor
+            # isDefault, so there is nothing to select by and the first declaration wins.
+            slo_url = slo_nodes[0].get("Location", None)
             slo_service = SAMLService(slo_url, required_slo_binding)
 
         signing_certificate_nodes = OneLogin_Saml2_XML.query(
@@ -512,10 +514,10 @@ class SAMLMetadataParser:
     def _parse_index(node: RestrictedElement) -> int:
         """Return a node's "index" attribute, treating an absent one as 0.
 
-        SSO and SLO endpoints carry no "index" at all, so they all tie at 0 and keep
-        document order. The schema requires "index" on AssertionConsumerService, so an
-        absent one there means invalid metadata rather than a meaningful rank; it ties
-        with any endpoint declaring index="0".
+        Only AssertionConsumerService reaches this, and the schema requires "index"
+        there, so an absent one means invalid metadata rather than a meaningful rank.
+        Such a node ties with any endpoint declaring index="0", and document order
+        then decides between them.
 
         :param node: XML node
         :return: Value of the "index" attribute, or 0 when it is absent

--- a/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
@@ -10,6 +10,7 @@ from onelogin.saml2.xmlparser import RestrictedElement, fromstring
 from palace.util.exceptions import BasePalaceException
 
 from palace.manager.integration.patron_auth.saml.metadata.model import (
+    SAMLACSSelectionPolicy,
     SAMLAttribute,
     SAMLAttributeStatement,
     SAMLAttributeType,
@@ -65,14 +66,22 @@ class SAMLMetadataParsingResult:
 class SAMLMetadataParser:
     """Parses SAML metadata"""
 
-    def __init__(self, skip_incorrect_providers=False):
+    def __init__(
+        self,
+        skip_incorrect_providers=False,
+        acs_selection_policy: SAMLACSSelectionPolicy = SAMLACSSelectionPolicy.FIRST_INDEX,
+    ):
         """Initialize a new instance of MetadataParser class.
 
         :param skip_incorrect_providers: Boolean value indicating whether the parse should skip
             incorrect SAML provider declarations instead of raising an exception
         :type skip_incorrect_providers: bool
+
+        :param acs_selection_policy: Rule for choosing among several
+            AssertionConsumerService endpoints declared in SP metadata
         """
         self._skip_incorrect_providers = skip_incorrect_providers
+        self._acs_selection_policy = acs_selection_policy
 
         self._logger = logging.getLogger(__name__)
 
@@ -453,10 +462,15 @@ class SAMLMetadataParser:
             provider_node,
             "./md:AssertionConsumerService[@Binding='%s']" % required_acs_binding.value,
         )
-        # ACS selection uses the lowest index and ignores isDefault. Identity
-        # providers are registered against the endpoint this picks, so changing the
-        # rule is a coordinated configuration migration rather than a parser change.
-        acs_service_node = self._select_first_indexed_element(acs_service_nodes)
+        # Identity providers are registered against the endpoint selected here, so
+        # the default policy preserves the lowest-index choice and ignores isDefault.
+        # Honoring isDefault is opt-in per integration.
+        if self._acs_selection_policy is SAMLACSSelectionPolicy.METADATA_DEFAULT:
+            acs_service_node = self._select_default_or_first_indexed_element(
+                acs_service_nodes
+            )
+        else:
+            acs_service_node = self._select_first_indexed_element(acs_service_nodes)
 
         if acs_service_node is not None:
             acs_url = acs_service_node.get("Location", None)

--- a/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
@@ -462,11 +462,9 @@ class SAMLMetadataParser:
             provider_node,
             "./md:AssertionConsumerService[@Binding='%s']" % required_acs_binding.value,
         )
-        # Identity providers are registered against the endpoint selected here, so the
-        # default policy preserves the lowest-index choice and ignores isDefault.
-        # Honoring isDefault is opt-in per integration. DEFER_TO_IDP still resolves an
-        # endpoint, because the SAML toolkit requires one in its settings; requests
-        # under that policy simply do not name it.
+        # DEFER_TO_IDP resolves an endpoint just as METADATA_DEFAULT does, even though
+        # requests under it name no endpoint, because the SAML toolkit requires an ACS
+        # URL in its settings. Choosing the policy is the caller's business.
         if self._acs_selection_policy is SAMLACSSelectionPolicy.FIRST_INDEX:
             acs_service_node = self._select_first_indexed_element(acs_service_nodes)
         else:

--- a/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/parser.py
@@ -426,34 +426,22 @@ class SAMLMetadataParser:
 
     def _parse_sp_metadata(
         self,
-        provider_node,
-        entity_id,
-        ui_info,
-        organization,
-        required_acs_binding=SAMLBinding.HTTP_POST,
-    ):
+        provider_node: RestrictedElement,
+        entity_id: str,
+        ui_info: SAMLUIInfo,
+        organization: SAMLOrganization,
+        required_acs_binding: SAMLBinding = SAMLBinding.HTTP_POST,
+    ) -> SAMLServiceProviderMetadata:
         """Parses SPSSODescriptor node and translates it into a ServiceProvider object
 
         :param provider_node: SPSSODescriptor node containing SP metadata
-        :param provider_node: onelogin.saml2.xmlparser.RestrictedElement
-
-        :param entity_id: String containing IdP's entityID
-        :type entity_id: string
-
-        :param ui_info: UIInfo object containing IdP's description
-        :type ui_info: UIInfo
-
+        :param entity_id: String containing SP's entityID
+        :param ui_info: UIInfo object containing SP's description
         :param organization: Organization object containing basic information about an organization
             responsible for a SAML entity or role
-        :type organization: Organization
-
-        :param required_acs_binding: Required binding for Assertion Consumer Service (HTTP-Redirect by default)
-        :type required_acs_binding: Binding
-
-        :return: ServiceProvider containing SP metadata
-        :rtype: ServiceProvider
-
-        :raise: MetadataParsingError
+        :param required_acs_binding: Required binding for Assertion Consumer Service
+        :return: SAMLServiceProviderMetadata containing SP metadata
+        :raise SAMLMetadataParsingError: If the SP metadata cannot be parsed
         """
         authn_requests_signed = provider_node.get("AuthnRequestsSigned", False)
         want_assertions_signed = provider_node.get("WantAssertionsSigned", False)
@@ -465,10 +453,12 @@ class SAMLMetadataParser:
             provider_node,
             "./md:AssertionConsumerService[@Binding='%s']" % required_acs_binding.value,
         )
-        if len(acs_service_nodes) > 0:
-            acs_service_node = self._select_default_or_first_indexed_element(
-                acs_service_nodes
-            )
+        # ACS selection uses the lowest index and ignores isDefault. Identity
+        # providers are registered against the endpoint this picks, so changing the
+        # rule is a coordinated configuration migration rather than a parser change.
+        acs_service_node = self._select_first_indexed_element(acs_service_nodes)
+
+        if acs_service_node is not None:
             acs_url = acs_service_node.get("Location", None)
             acs_service = SAMLService(acs_url, required_acs_binding)
         else:
@@ -504,49 +494,76 @@ class SAMLMetadataParser:
 
         return sp
 
-    def _select_default_element(self, nodes):
+    @staticmethod
+    def _parse_index(node: RestrictedElement) -> int:
+        """Return a node's "index" attribute, treating an absent one as 0.
+
+        SSO and SLO endpoints carry no "index" at all, so they all tie at 0 and keep
+        document order. The schema requires "index" on AssertionConsumerService, so an
+        absent one there means invalid metadata rather than a meaningful rank; it ties
+        with any endpoint declaring index="0".
+
+        :param node: XML node
+        :return: Value of the "index" attribute, or 0 when it is absent
+        :raise SAMLMetadataParsingError: If "index" is present but not an integer
+        """
+        index = node.get("index")
+
+        if index is None:
+            return 0
+
+        try:
+            return int(index)
+        except ValueError as exception:
+            raise SAMLMetadataParsingError(
+                _(f"Invalid index attribute '{index}': expected an integer")
+            ) from exception
+
+    @staticmethod
+    def _parse_is_default(node: RestrictedElement) -> bool:
+        """Return a node's "isDefault" attribute as an XML schema boolean.
+
+        :param node: XML node
+        :return: True when the node is marked as the default endpoint
+        """
+        return node.get("isDefault") in ("true", "1")
+
+    def _select_default_element(
+        self, nodes: list[RestrictedElement]
+    ) -> RestrictedElement | None:
         """Selects a node with attribute "isDefault=true"
 
         :param nodes: List of XML nodes
-        :type nodes: List[onelogin.saml2.xmlparser.RestrictedElement]
-
         :return: "Default" node or None if there is no one
-        :rtype: Optional[onelogin.saml2.xmlparser.RestrictedElement]
         """
-        default_nodes = [node for node in nodes if node.get("isDefault", False)]
+        default_nodes = [node for node in nodes if self._parse_is_default(node)]
 
-        default_node = self._select_first_indexed_element(default_nodes)
+        return self._select_first_indexed_element(default_nodes)
 
-        return default_node
-
-    def _select_first_indexed_element(self, nodes):
+    def _select_first_indexed_element(
+        self, nodes: list[RestrictedElement]
+    ) -> RestrictedElement | None:
         """Sorts a list of XML nodes by "index" attribute and selects the first node
 
         :param nodes: List of XML nodes
-        :type nodes: List[onelogin.saml2.xmlparser.RestrictedElement]
-
         :return: Node with the smallest index or None if there is no one
-        :rtype: Optional[onelogin.saml2.xmlparser.RestrictedElement]
         """
         if not nodes:
             return None
 
-        nodes = sorted(nodes, key=lambda node: node.get("index", 0))
+        return sorted(nodes, key=self._parse_index)[0]
 
-        return nodes[0]
-
-    def _select_default_or_first_indexed_element(self, nodes):
+    def _select_default_or_first_indexed_element(
+        self, nodes: list[RestrictedElement]
+    ) -> RestrictedElement | None:
         """Selects a node with attribute "isDefault=true" or a node with the smallest "index" attribute
 
         :param nodes: List of XML nodes
-        :type nodes: List[onelogin.saml2.xmlparser.RestrictedElement]
-
         :return: "Default" node or the node with the smallest "index" attribute or None if there is no one
-        :rtype: Optional[onelogin.saml2.xmlparser.RestrictedElement]
         """
         default_node = self._select_default_element(nodes)
 
-        if default_node:
+        if default_node is not None:
             return default_node
 
         return self._select_first_indexed_element(nodes)

--- a/tests/manager/integration/patron_auth/saml/configuration/test_model.py
+++ b/tests/manager/integration/patron_auth/saml/configuration/test_model.py
@@ -19,6 +19,7 @@ from palace.manager.integration.patron_auth.saml.configuration.problem_details i
 )
 from palace.manager.integration.patron_auth.saml.metadata.federations import incommon
 from palace.manager.integration.patron_auth.saml.metadata.model import (
+    SAMLACSSelectionPolicy,
     SAMLBinding,
     SAMLIdentityProviderMetadata,
     SAMLNameIDFormat,
@@ -715,7 +716,65 @@ class TestSAMLSettings:
         )
 
 
+SP_METADATA_WITH_TWO_ACS_ENDPOINTS = (
+    '<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" '
+    'entityID="http://sp.example.org/metadata">'
+    '<md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">'
+    '<md:AssertionConsumerService index="1" '
+    'Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" '
+    'Location="https://example.org/saml_callback"/>'
+    '<md:AssertionConsumerService index="2" isDefault="true" '
+    'Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" '
+    'Location="https://example.org/saml/callback"/>'
+    "</md:SPSSODescriptor>"
+    "</md:EntityDescriptor>"
+)
+
+
 class TestSAMLOneLoginConfiguration:
+    def test_acs_selection_policy_defaults_to_first_index(
+        self, create_saml_configuration
+    ):
+        """The default preserves the endpoint identity providers are registered against."""
+        configuration = create_saml_configuration()
+
+        assert (
+            configuration.service_provider_acs_selection_policy
+            is SAMLACSSelectionPolicy.FIRST_INDEX
+        )
+
+    @pytest.mark.parametrize(
+        "policy, expected_url",
+        [
+            pytest.param(
+                SAMLACSSelectionPolicy.FIRST_INDEX,
+                "https://example.org/saml_callback",
+                id="first-index-ignores-is-default",
+            ),
+            pytest.param(
+                SAMLACSSelectionPolicy.METADATA_DEFAULT,
+                "https://example.org/saml/callback",
+                id="metadata-default-honors-is-default",
+            ),
+        ],
+    )
+    def test_acs_selection_policy_reaches_the_parser(
+        self,
+        create_saml_configuration,
+        policy: SAMLACSSelectionPolicy,
+        expected_url: str,
+    ):
+        """The integration setting decides which published ACS endpoint is asserted."""
+        configuration = create_saml_configuration(
+            service_provider_xml_metadata=SP_METADATA_WITH_TWO_ACS_ENDPOINTS,
+            service_provider_acs_selection_policy=policy,
+        )
+        onelogin_configuration = SAMLOneLoginConfiguration(configuration)
+
+        service_provider = onelogin_configuration.get_service_provider()
+
+        assert service_provider.acs_service.url == expected_url
+
     def test_get_identity_provider_settings_returns_correct_result(self):
         # Arrange
         configuration = create_autospec(spec=SAMLWebSSOAuthSettings)

--- a/tests/manager/integration/patron_auth/saml/configuration/test_model.py
+++ b/tests/manager/integration/patron_auth/saml/configuration/test_model.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 from datetime import datetime
 from unittest.mock import MagicMock, call, create_autospec
@@ -732,16 +733,101 @@ SP_METADATA_WITH_TWO_ACS_ENDPOINTS = (
 
 
 class TestSAMLOneLoginConfiguration:
-    def test_acs_selection_policy_defaults_to_first_index(
-        self, create_saml_configuration
-    ):
-        """The default preserves the endpoint identity providers are registered against."""
+    def test_acs_selection_policy_is_unset_by_default(self, create_saml_configuration):
+        """An unset integration setting means 'use the site-wide default'."""
         configuration = create_saml_configuration()
 
-        assert (
-            configuration.service_provider_acs_selection_policy
-            is SAMLACSSelectionPolicy.FIRST_INDEX
+        assert configuration.service_provider_acs_selection_policy is None
+
+    def test_acs_selection_policy_can_be_reset_from_the_admin_interface(self):
+        """The admin interface clears a setting by sending an empty string."""
+        settings = SAMLWebSSOAuthSettings(
+            service_provider_xml_metadata=saml_strings.CORRECT_XML_WITH_ONE_SP,
+            service_provider_acs_selection_policy="",
         )
+
+        assert settings.service_provider_acs_selection_policy is None
+
+    @pytest.mark.parametrize(
+        "env_policy, settings_policy, expected_policy",
+        [
+            pytest.param(
+                None,
+                None,
+                SAMLACSSelectionPolicy.FIRST_INDEX,
+                id="neither-set-uses-built-in-default",
+            ),
+            pytest.param(
+                SAMLACSSelectionPolicy.METADATA_DEFAULT.value,
+                None,
+                SAMLACSSelectionPolicy.METADATA_DEFAULT,
+                id="environment-supplies-the-default",
+            ),
+            pytest.param(
+                None,
+                SAMLACSSelectionPolicy.DEFER_TO_IDP,
+                SAMLACSSelectionPolicy.DEFER_TO_IDP,
+                id="integration-setting-is-used",
+            ),
+            pytest.param(
+                SAMLACSSelectionPolicy.METADATA_DEFAULT.value,
+                SAMLACSSelectionPolicy.DEFER_TO_IDP,
+                SAMLACSSelectionPolicy.DEFER_TO_IDP,
+                id="integration-setting-overrides-the-environment",
+            ),
+            pytest.param(
+                "not-a-policy",
+                None,
+                SAMLACSSelectionPolicy.FIRST_INDEX,
+                id="invalid-environment-value-falls-back",
+            ),
+            pytest.param(
+                "",
+                None,
+                SAMLACSSelectionPolicy.FIRST_INDEX,
+                id="empty-environment-value-falls-back",
+            ),
+            pytest.param(
+                "not-a-policy",
+                SAMLACSSelectionPolicy.METADATA_DEFAULT,
+                SAMLACSSelectionPolicy.METADATA_DEFAULT,
+                id="invalid-environment-value-does-not-disturb-the-setting",
+            ),
+        ],
+    )
+    def test_get_acs_selection_policy(
+        self,
+        monkeypatch_env: MonkeyPatchEnvFixture,
+        create_saml_configuration: Callable[..., SAMLWebSSOAuthSettings],
+        env_policy: str | None,
+        settings_policy: SAMLACSSelectionPolicy | None,
+        expected_policy: SAMLACSSelectionPolicy,
+    ):
+        """The integration setting wins, then the environment, then the built-in default."""
+        monkeypatch_env("PALACE_SAML_SP_ACS_SELECTION_POLICY", env_policy)
+        configuration = create_saml_configuration(
+            service_provider_acs_selection_policy=settings_policy
+        )
+
+        onelogin_configuration = SAMLOneLoginConfiguration(configuration)
+
+        assert onelogin_configuration.get_acs_selection_policy() is expected_policy
+
+    def test_invalid_acs_selection_policy_in_environment_is_logged(
+        self,
+        monkeypatch_env: MonkeyPatchEnvFixture,
+        create_saml_configuration: Callable[..., SAMLWebSSOAuthSettings],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """A misconfigured default is otherwise invisible until a login fails."""
+        caplog.set_level(logging.ERROR)
+        monkeypatch_env("PALACE_SAML_SP_ACS_SELECTION_POLICY", "not-a-policy")
+
+        SAMLOneLoginConfiguration(create_saml_configuration())
+
+        assert "PALACE_SAML_SP_ACS_SELECTION_POLICY" in caplog.text
+        assert "not-a-policy" in caplog.text
+        assert SAMLACSSelectionPolicy.FIRST_INDEX.value in caplog.text
 
     @pytest.mark.parametrize(
         "policy, expected_url",

--- a/tests/manager/integration/patron_auth/saml/configuration/test_model.py
+++ b/tests/manager/integration/patron_auth/saml/configuration/test_model.py
@@ -811,12 +811,6 @@ class TestSAMLOneLoginConfiguration:
                 id="invalid-environment-value-falls-back",
             ),
             pytest.param(
-                "",
-                None,
-                SAMLACSSelectionPolicy.FIRST_INDEX,
-                id="empty-environment-value-falls-back",
-            ),
-            pytest.param(
                 "not-a-policy",
                 SAMLACSSelectionPolicy.METADATA_DEFAULT,
                 SAMLACSSelectionPolicy.METADATA_DEFAULT,
@@ -841,6 +835,28 @@ class TestSAMLOneLoginConfiguration:
         onelogin_configuration = SAMLOneLoginConfiguration(configuration)
 
         assert onelogin_configuration.get_acs_selection_policy() is expected_policy
+
+    def test_empty_acs_selection_policy_in_environment_is_not_an_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        create_saml_configuration: Callable[..., SAMLWebSSOAuthSettings],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """An explicitly empty value means 'unset', not a misconfiguration.
+
+        Set through monkeypatch directly, because the monkeypatch_env fixture deletes
+        the variable for a falsy value rather than setting it empty.
+        """
+        caplog.set_level(logging.ERROR)
+        monkeypatch.setenv("PALACE_SAML_SP_ACS_SELECTION_POLICY", "")
+
+        onelogin_configuration = SAMLOneLoginConfiguration(create_saml_configuration())
+
+        assert (
+            onelogin_configuration.get_acs_selection_policy()
+            is SAMLACSSelectionPolicy.FIRST_INDEX
+        )
+        assert "PALACE_SAML_SP_ACS_SELECTION_POLICY" not in caplog.text
 
     def test_invalid_acs_selection_policy_in_environment_is_logged(
         self,

--- a/tests/manager/integration/patron_auth/saml/configuration/test_model.py
+++ b/tests/manager/integration/patron_auth/saml/configuration/test_model.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from collections.abc import Callable
 from datetime import datetime
@@ -36,6 +37,7 @@ from palace.manager.sqlalchemy.model.saml import (
     SAMLFederatedIdentityProvider,
     SAMLFederation,
 )
+from palace.manager.util.json import json_serializer
 from palace.manager.util.problem_detail import ProblemDetail, ProblemDetailException
 from tests.fixtures.database import DatabaseTransactionFixture
 from tests.fixtures.test_utils import MonkeyPatchEnvFixture
@@ -738,6 +740,33 @@ class TestSAMLOneLoginConfiguration:
         configuration = create_saml_configuration()
 
         assert configuration.service_provider_acs_selection_policy is None
+
+    @pytest.mark.parametrize(
+        "policy",
+        [pytest.param(policy, id=policy.value) for policy in SAMLACSSelectionPolicy],
+    )
+    def test_acs_selection_policy_survives_settings_dict_round_trip(
+        self, policy: SAMLACSSelectionPolicy
+    ):
+        """settings_dict is stored as JSONB, so the policy has to survive that trip.
+
+        Serialized through the session's own serializer, which is what the write
+        actually uses.
+        """
+        settings = SAMLWebSSOAuthSettings(
+            service_provider_xml_metadata=saml_strings.CORRECT_XML_WITH_ONE_SP,
+            service_provider_acs_selection_policy=policy,
+        )
+
+        settings_dict = json.loads(json_serializer(settings.model_dump()))
+
+        assert settings_dict["service_provider_acs_selection_policy"] == policy.value
+        assert (
+            SAMLWebSSOAuthSettings(
+                **settings_dict
+            ).service_provider_acs_selection_policy
+            is policy
+        )
 
     def test_acs_selection_policy_can_be_reset_from_the_admin_interface(self):
         """The admin interface clears a setting by sending an empty string."""

--- a/tests/manager/integration/patron_auth/saml/configuration/test_model.py
+++ b/tests/manager/integration/patron_auth/saml/configuration/test_model.py
@@ -12,6 +12,7 @@ from palace.manager.api.admin.problem_details import (
     INVALID_CONFIGURATION_OPTION,
 )
 from palace.manager.integration.patron_auth.saml.configuration.model import (
+    ACS_SELECTION_POLICY_LABELS,
     SAMLOneLoginConfiguration,
     SAMLWebSSOAuthSettings,
 )
@@ -19,8 +20,12 @@ from palace.manager.integration.patron_auth.saml.configuration.problem_details i
     SAML_INCORRECT_METADATA,
     SAML_INCORRECT_PRIVATE_KEY,
 )
+from palace.manager.integration.patron_auth.saml.configuration.service_provider import (
+    ACS_SELECTION_POLICY_ENV_VAR,
+)
 from palace.manager.integration.patron_auth.saml.metadata.federations import incommon
 from palace.manager.integration.patron_auth.saml.metadata.model import (
+    DEFAULT_ACS_SELECTION_POLICY,
     SAMLACSSelectionPolicy,
     SAMLBinding,
     SAMLIdentityProviderMetadata,
@@ -767,6 +772,26 @@ class TestSAMLOneLoginConfiguration:
             ).service_provider_acs_selection_policy
             is policy
         )
+
+    def test_acs_selection_policy_form_field_tracks_the_policies(self):
+        """The description states the default rather than restating it as fixed prose.
+
+        Guards against the description drifting from DEFAULT_ACS_SELECTION_POLICY, and
+        against a new policy being added without being offered in the form.
+        """
+        field = SAMLWebSSOAuthSettings.model_fields[
+            "service_provider_acs_selection_policy"
+        ]
+        form_metadata = next(m for m in field.metadata if hasattr(m, "label"))
+
+        assert (
+            f"'{ACS_SELECTION_POLICY_LABELS[DEFAULT_ACS_SELECTION_POLICY]}'"
+            in form_metadata.description
+        )
+        assert ACS_SELECTION_POLICY_ENV_VAR in form_metadata.description
+        assert set(form_metadata.options) == {""} | {
+            policy.value for policy in SAMLACSSelectionPolicy
+        }
 
     def test_acs_selection_policy_can_be_reset_from_the_admin_interface(self):
         """The admin interface clears a setting by sending an empty string."""

--- a/tests/manager/integration/patron_auth/saml/metadata/test_parser.py
+++ b/tests/manager/integration/patron_auth/saml/metadata/test_parser.py
@@ -7,6 +7,7 @@ from onelogin.saml2.utils import OneLogin_Saml2_XML
 from onelogin.saml2.xmlparser import RestrictedElement, fromstring
 
 from palace.manager.integration.patron_auth.saml.metadata.model import (
+    SAMLACSSelectionPolicy,
     SAMLAttribute,
     SAMLAttributeStatement,
     SAMLAttributeType,
@@ -760,6 +761,35 @@ class TestSAMLMetadataParser:
         parsing_results = metadata_parser.parse(_sp_metadata(*acs_elements))
 
         [parsing_result] = parsing_results
+        assert parsing_result.provider.acs_service.url == expected_url
+
+    @pytest.mark.parametrize(
+        "policy, expected_url",
+        [
+            pytest.param(
+                SAMLACSSelectionPolicy.FIRST_INDEX,
+                ACS_OLD_URL,
+                id="first-index-ignores-is-default",
+            ),
+            pytest.param(
+                SAMLACSSelectionPolicy.METADATA_DEFAULT,
+                ACS_NEW_URL,
+                id="metadata-default-honors-is-default",
+            ),
+        ],
+    )
+    def test_parse_applies_acs_selection_policy(
+        self, policy: SAMLACSSelectionPolicy, expected_url: str
+    ):
+        """The selection policy decides between the lowest index and isDefault."""
+        metadata_parser = SAMLMetadataParser(acs_selection_policy=policy)
+        metadata = _sp_metadata(
+            _acs_element(ACS_OLD_URL, index="1"),
+            _acs_element(ACS_NEW_URL, index="2", is_default="true"),
+        )
+
+        [parsing_result] = metadata_parser.parse(metadata)
+
         assert parsing_result.provider.acs_service.url == expected_url
 
     def test_parse_raises_exception_when_acs_index_is_not_an_integer(self):

--- a/tests/manager/integration/patron_auth/saml/metadata/test_parser.py
+++ b/tests/manager/integration/patron_auth/saml/metadata/test_parser.py
@@ -3,7 +3,8 @@ from unittest.mock import MagicMock, create_autospec
 import pytest
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from onelogin.saml2.settings import OneLogin_Saml2_Settings
-from onelogin.saml2.xmlparser import RestrictedElement
+from onelogin.saml2.utils import OneLogin_Saml2_XML
+from onelogin.saml2.xmlparser import RestrictedElement, fromstring
 
 from palace.manager.integration.patron_auth.saml.metadata.model import (
     SAMLAttribute,
@@ -26,6 +27,36 @@ from palace.manager.integration.patron_auth.saml.metadata.parser import (
     SAMLSubjectParser,
 )
 from tests.mocks import saml_strings
+
+ACS_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+ACS_OLD_URL = "https://il.thepalaceproject.org/saml_callback"
+ACS_NEW_URL = "https://il.thepalaceproject.org/saml/callback"
+
+
+def _acs_element(
+    location: str, index: str | None = None, is_default: str | None = None
+) -> str:
+    """Build an AssertionConsumerService element for SP metadata."""
+    attributes = [f'Binding="{ACS_BINDING}"', f'Location="{location}"']
+
+    if index is not None:
+        attributes.append(f'index="{index}"')
+    if is_default is not None:
+        attributes.append(f'isDefault="{is_default}"')
+
+    return f"<md:AssertionConsumerService {' '.join(attributes)}/>"
+
+
+def _sp_metadata(*acs_elements: str) -> str:
+    """Build minimal SP metadata declaring the given ACS endpoints."""
+    return (
+        '<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" '
+        'entityID="http://sp.example.org/metadata">'
+        '<md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">'
+        f"{''.join(acs_elements)}"
+        "</md:SPSSODescriptor>"
+        "</md:EntityDescriptor>"
+    )
 
 
 class TestSAMLMetadataParser:
@@ -643,6 +674,146 @@ class TestSAMLMetadataParser:
             metadata_parser.parse(
                 incorrect_xml_with_one_sp_metadata_without_acs_service
             )
+
+    @pytest.mark.parametrize(
+        "acs_elements, expected_url",
+        [
+            pytest.param(
+                [_acs_element(ACS_NEW_URL, index="1")],
+                ACS_NEW_URL,
+                id="single-endpoint",
+            ),
+            pytest.param(
+                [_acs_element(ACS_NEW_URL, index="1", is_default="true")],
+                ACS_NEW_URL,
+                id="single-endpoint-marked-default",
+            ),
+            pytest.param(
+                [
+                    _acs_element(ACS_OLD_URL, index="1"),
+                    _acs_element(ACS_NEW_URL, index="2"),
+                ],
+                ACS_OLD_URL,
+                id="no-endpoint-marked-default",
+            ),
+            pytest.param(
+                [
+                    _acs_element(ACS_OLD_URL, index="1", is_default="true"),
+                    _acs_element(ACS_NEW_URL, index="2"),
+                ],
+                ACS_OLD_URL,
+                id="lowest-index-marked-default",
+            ),
+            pytest.param(
+                [
+                    _acs_element(ACS_OLD_URL, index="1"),
+                    _acs_element(ACS_NEW_URL, index="2", is_default="true"),
+                ],
+                ACS_OLD_URL,
+                id="higher-index-marked-default",
+            ),
+            pytest.param(
+                [
+                    _acs_element(ACS_OLD_URL, index="1", is_default="false"),
+                    _acs_element(ACS_NEW_URL, index="2", is_default="true"),
+                ],
+                ACS_OLD_URL,
+                id="lowest-index-marked-not-default",
+            ),
+            pytest.param(
+                [
+                    _acs_element(ACS_NEW_URL, index="10"),
+                    _acs_element(ACS_OLD_URL, index="9"),
+                ],
+                ACS_OLD_URL,
+                id="index-compared-numerically-not-as-string",
+            ),
+            pytest.param(
+                [
+                    _acs_element(ACS_OLD_URL),
+                    _acs_element(ACS_NEW_URL, index="2"),
+                ],
+                ACS_OLD_URL,
+                id="endpoint-without-index-treated-as-zero",
+            ),
+            pytest.param(
+                [
+                    _acs_element(ACS_NEW_URL, index="0"),
+                    _acs_element(ACS_OLD_URL),
+                ],
+                ACS_NEW_URL,
+                id="index-zero-ties-with-absent-index-document-order-wins",
+            ),
+        ],
+    )
+    def test_parse_selects_acs_endpoint_with_lowest_index(
+        self, acs_elements: list[str], expected_url: str
+    ):
+        """ACS selection uses the lowest index and ignores isDefault.
+
+        Identity providers are registered against the endpoint chosen here, so these
+        results are a compatibility guarantee, not an implementation detail. The
+        "higher-index-marked-default" case is the shape most integrations use.
+        """
+        metadata_parser = SAMLMetadataParser()
+
+        parsing_results = metadata_parser.parse(_sp_metadata(*acs_elements))
+
+        [parsing_result] = parsing_results
+        assert parsing_result.provider.acs_service.url == expected_url
+
+    def test_parse_raises_exception_when_acs_index_is_not_an_integer(self):
+        metadata_parser = SAMLMetadataParser()
+
+        with pytest.raises(SAMLMetadataParsingError):
+            metadata_parser.parse(
+                _sp_metadata(_acs_element(ACS_NEW_URL, index="first"))
+            )
+
+    @pytest.mark.parametrize(
+        "acs_elements, expected_url",
+        [
+            pytest.param(
+                [
+                    _acs_element(ACS_OLD_URL, index="1"),
+                    _acs_element(ACS_NEW_URL, index="2", is_default="true"),
+                ],
+                ACS_NEW_URL,
+                id="default-wins-over-lower-index",
+            ),
+            pytest.param(
+                [
+                    _acs_element(ACS_OLD_URL, index="1", is_default="false"),
+                    _acs_element(ACS_NEW_URL, index="2", is_default="true"),
+                ],
+                ACS_NEW_URL,
+                id="is-default-false-is-not-a-default",
+            ),
+            pytest.param(
+                [
+                    _acs_element(ACS_OLD_URL, index="1"),
+                    _acs_element(ACS_NEW_URL, index="2"),
+                ],
+                ACS_OLD_URL,
+                id="falls-back-to-lowest-index",
+            ),
+        ],
+    )
+    def test_select_default_or_first_indexed_element(
+        self, acs_elements: list[str], expected_url: str
+    ):
+        """The default-aware selector honors isDefault.
+
+        ACS selection does not use this selector; it is pinned to the lowest index.
+        """
+        metadata_parser = SAMLMetadataParser()
+        document = fromstring(_sp_metadata(*acs_elements).encode())
+        nodes = OneLogin_Saml2_XML.query(document, "//md:AssertionConsumerService")
+
+        selected = metadata_parser._select_default_or_first_indexed_element(nodes)
+
+        assert selected is not None
+        assert selected.get("Location") == expected_url
 
     @pytest.mark.parametrize(
         "correct_xml_with_one_sp",

--- a/tests/manager/integration/patron_auth/saml/metadata/test_parser.py
+++ b/tests/manager/integration/patron_auth/saml/metadata/test_parser.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
@@ -776,6 +777,11 @@ class TestSAMLMetadataParser:
                 ACS_NEW_URL,
                 id="metadata-default-honors-is-default",
             ),
+            pytest.param(
+                SAMLACSSelectionPolicy.DEFER_TO_IDP,
+                ACS_NEW_URL,
+                id="defer-to-idp-still-resolves-an-endpoint",
+            ),
         ],
     )
     def test_parse_applies_acs_selection_policy(
@@ -791,6 +797,54 @@ class TestSAMLMetadataParser:
         [parsing_result] = metadata_parser.parse(metadata)
 
         assert parsing_result.provider.acs_service.url == expected_url
+
+    @pytest.mark.parametrize(
+        "element, binding, accessor",
+        [
+            pytest.param(
+                "SingleSignOnService",
+                "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                lambda provider: provider.sso_service.url,
+                id="single-sign-on-service",
+            ),
+            pytest.param(
+                "SingleLogoutService",
+                "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                lambda provider: provider.slo_service.url,
+                id="single-logout-service",
+            ),
+        ],
+    )
+    def test_parse_ignores_is_default_on_endpoint_type_elements(
+        self,
+        element: str,
+        binding: str,
+        accessor: Callable[[SAMLIdentityProviderMetadata], str],
+    ):
+        """Only IndexedEndpointType declares index and isDefault.
+
+        SingleSignOnService and SingleLogoutService are plain EndpointType, so an
+        isDefault attribute on them is meaningless and the first declaration wins.
+        Metadata carrying one is schema-invalid but parses without complaint.
+        """
+        metadata_parser = SAMLMetadataParser()
+        metadata = (
+            '<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" '
+            'entityID="http://idp.example.org/metadata">'
+            "<md:IDPSSODescriptor "
+            'protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">'
+            f'<md:{element} Binding="{binding}" Location="https://idp.example.org/first"/>'
+            f'<md:{element} Binding="{binding}" Location="https://idp.example.org/second" '
+            'isDefault="true"/>'
+            '<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" '
+            'Location="https://idp.example.org/filler"/>'
+            "</md:IDPSSODescriptor>"
+            "</md:EntityDescriptor>"
+        )
+
+        [parsing_result] = metadata_parser.parse(metadata)
+
+        assert accessor(parsing_result.provider) == "https://idp.example.org/first"
 
     def test_parse_raises_exception_when_acs_index_is_not_an_integer(self):
         metadata_parser = SAMLMetadataParser()

--- a/tests/manager/integration/patron_auth/saml/metadata/test_parser.py
+++ b/tests/manager/integration/patron_auth/saml/metadata/test_parser.py
@@ -888,7 +888,8 @@ class TestSAMLMetadataParser:
     ):
         """The default-aware selector honors isDefault.
 
-        ACS selection does not use this selector; it is pinned to the lowest index.
+        Used for ACS selection under the METADATA_DEFAULT and DEFER_TO_IDP policies;
+        FIRST_INDEX bypasses it and is pinned to the lowest index.
         """
         metadata_parser = SAMLMetadataParser()
         document = fromstring(_sp_metadata(*acs_elements).encode())

--- a/tests/manager/integration/patron_auth/saml/test_auth.py
+++ b/tests/manager/integration/patron_auth/saml/test_auth.py
@@ -387,6 +387,70 @@ class TestSAMLAuthenticationManager:
         if service_provider.authn_requests_signed:
             assert "Signature" in query_items
 
+    def test_start_authentication_logs_that_no_acs_endpoint_is_named(
+        self,
+        controller_fixture: ControllerFixture,
+        create_saml_configuration,
+        create_mock_onelogin_configuration: Callable[..., SAMLOneLoginConfiguration],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Deferring names no endpoint, so the log must not claim one was asserted."""
+        caplog.set_level(logging.DEBUG)
+
+        onelogin_configuration = create_mock_onelogin_configuration(
+            SERVICE_PROVIDER_WITH_UNSIGNED_REQUESTS,
+            IDENTITY_PROVIDERS,
+            create_saml_configuration(
+                service_provider_acs_selection_policy=SAMLACSSelectionPolicy.DEFER_TO_IDP
+            ),
+        )
+        authentication_manager = SAMLAuthenticationManager(
+            onelogin_configuration, SAMLSubjectParser()
+        )
+
+        with controller_fixture.app.test_request_context("/"):
+            authentication_manager.start_authentication(
+                controller_fixture.db.session, saml_strings.IDP_1_ENTITY_ID, ""
+            )
+
+        assert "names no ACS endpoint" in caplog.text
+        assert "asserts ACS endpoint" not in caplog.text
+
+    def test_start_authentication_defers_to_idp_from_the_environment(
+        self,
+        controller_fixture: ControllerFixture,
+        monkeypatch: pytest.MonkeyPatch,
+        create_saml_configuration,
+        create_mock_onelogin_configuration: Callable[..., SAMLOneLoginConfiguration],
+    ):
+        """A site-wide policy has to reach request building, not just metadata parsing."""
+        monkeypatch.setenv("PALACE_SAML_SP_ACS_SELECTION_POLICY", "defer_to_idp")
+
+        onelogin_configuration = create_mock_onelogin_configuration(
+            SERVICE_PROVIDER_WITH_UNSIGNED_REQUESTS,
+            IDENTITY_PROVIDERS,
+            create_saml_configuration(),
+        )
+        authentication_manager = SAMLAuthenticationManager(
+            onelogin_configuration, SAMLSubjectParser()
+        )
+
+        with controller_fixture.app.test_request_context("/"):
+            result = authentication_manager.start_authentication(
+                controller_fixture.db.session, saml_strings.IDP_1_ENTITY_ID, ""
+            )
+
+        assert isinstance(result, str)
+        query_items = parse_qs(urlsplit(result).query)
+        saml_request_dom = fromstring(
+            OneLogin_Saml2_Utils.decode_base64_and_inflate(
+                query_items["SAMLRequest"][0]
+            )
+        )
+
+        assert saml_request_dom.get("AssertionConsumerServiceURL") is None
+        assert saml_request_dom.get("ProtocolBinding") is None
+
     def test_finish_authentication_does_not_warn_when_deferring_to_idp(
         self,
         controller_fixture: ControllerFixture,

--- a/tests/manager/integration/patron_auth/saml/test_auth.py
+++ b/tests/manager/integration/patron_auth/saml/test_auth.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 from copy import copy
 from unittest.mock import MagicMock, create_autospec, patch
@@ -283,6 +284,206 @@ class TestSAMLAuthenticationManager:
 
                     # Assert
                     assert expected_value == result
+
+    def _create_authentication_manager(
+        self,
+        create_saml_configuration,
+        create_mock_onelogin_configuration: Callable[..., SAMLOneLoginConfiguration],
+        identity_provider_entity_id: str,
+        strict_mode: bool,
+    ) -> SAMLAuthenticationManager:
+        """Build a manager whose SP asserts saml_strings.SP_ACS_URL."""
+        identity_providers = [
+            copy(identity_provider) for identity_provider in IDENTITY_PROVIDERS
+        ]
+        identity_providers[0].entity_id = identity_provider_entity_id
+
+        configuration = create_saml_configuration(
+            service_provider_debug_mode=False,
+            service_provider_strict_mode=strict_mode,
+        )
+        onelogin_configuration = create_mock_onelogin_configuration(
+            SERVICE_PROVIDER_WITH_UNSIGNED_REQUESTS, identity_providers, configuration
+        )
+
+        return SAMLAuthenticationManager(onelogin_configuration, SAMLSubjectParser())
+
+    def test_start_authentication_logs_asserted_acs_endpoint(
+        self,
+        controller_fixture: ControllerFixture,
+        create_saml_configuration,
+        create_mock_onelogin_configuration: Callable[..., SAMLOneLoginConfiguration],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """The endpoint named in the AuthnRequest is recorded for later comparison."""
+        caplog.set_level(logging.DEBUG)
+
+        identity_provider_entity_id = "http://idp.hilbertteam.net/idp/shibboleth"
+        authentication_manager = self._create_authentication_manager(
+            create_saml_configuration,
+            create_mock_onelogin_configuration,
+            identity_provider_entity_id,
+            strict_mode=False,
+        )
+
+        with controller_fixture.app.test_request_context("/"):
+            authentication_manager.start_authentication(
+                controller_fixture.db.session,
+                identity_provider_entity_id,
+                "http://localhost/return",
+            )
+
+        assert f"asserts ACS endpoint '{saml_strings.SP_ACS_URL}'" in caplog.text
+
+    @staticmethod
+    def _acs_mismatch_warned(caplog: pytest.LogCaptureFixture) -> bool:
+        """Whether the ACS endpoint mismatch warning was emitted.
+
+        Matched on a phrase unique to the warning, since the failure branch names
+        both endpoints too.
+        """
+        return any(
+            record.levelno == logging.WARNING
+            and "but the authentication request asserted" in record.getMessage()
+            for record in caplog.records
+        )
+
+    @pytest.mark.parametrize(
+        "asserted_url, received_url, expected_warning",
+        [
+            pytest.param(
+                "https://example.org/saml_callback",
+                "https://example.org/saml/callback",
+                True,
+                id="different-paths",
+            ),
+            pytest.param(
+                "https://example.org/saml/callback",
+                "https://example.org/saml/callback",
+                False,
+                id="identical",
+            ),
+            pytest.param(
+                "https://EXAMPLE.org/saml/callback",
+                "https://example.org/saml/callback",
+                False,
+                id="host-case-only",
+            ),
+            pytest.param(
+                None,
+                "https://example.org/saml/callback",
+                False,
+                id="no-asserted-url",
+            ),
+        ],
+    )
+    def test_warn_on_acs_endpoint_mismatch(
+        self,
+        create_saml_configuration,
+        create_mock_onelogin_configuration: Callable[..., SAMLOneLoginConfiguration],
+        caplog: pytest.LogCaptureFixture,
+        asserted_url: str | None,
+        received_url: str,
+        expected_warning: bool,
+    ):
+        caplog.set_level(logging.WARNING)
+
+        authentication_manager = self._create_authentication_manager(
+            create_saml_configuration,
+            create_mock_onelogin_configuration,
+            "http://idp.hilbertteam.net/idp/shibboleth",
+            strict_mode=False,
+        )
+
+        authentication_manager._warn_on_acs_endpoint_mismatch(
+            "http://idp.example.com", asserted_url, received_url
+        )
+
+        assert self._acs_mismatch_warned(caplog) is expected_warning
+
+    @pytest.mark.parametrize(
+        "request_path, base_url, expected_warning",
+        [
+            pytest.param(
+                "/SAML2/POST",
+                "http://localhost",
+                True,
+                id="response-at-endpoint-we-did-not-assert",
+            ),
+            pytest.param(
+                "/idp/profile/SAML2/POST",
+                "http://sp.hilbertteam.net",
+                False,
+                id="response-at-asserted-endpoint",
+            ),
+        ],
+    )
+    def test_finish_authentication_warns_on_acs_endpoint_mismatch(
+        self,
+        controller_fixture: ControllerFixture,
+        create_saml_configuration,
+        create_mock_onelogin_configuration: Callable[..., SAMLOneLoginConfiguration],
+        caplog: pytest.LogCaptureFixture,
+        request_path: str,
+        base_url: str,
+        expected_warning: bool,
+    ):
+        caplog.set_level(logging.WARNING)
+
+        identity_provider_entity_id = "http://idp.hilbertteam.net/idp/shibboleth"
+        authentication_manager = self._create_authentication_manager(
+            create_saml_configuration,
+            create_mock_onelogin_configuration,
+            identity_provider_entity_id,
+            strict_mode=False,
+        )
+        saml_response = base64.b64encode(saml_strings.SAML_COLUMBIA_RESPONSE)
+
+        with controller_fixture.app.test_request_context(
+            request_path, base_url=base_url, data={"SAMLResponse": saml_response}
+        ):
+            authentication_manager.finish_authentication(
+                controller_fixture.db.session, identity_provider_entity_id
+            )
+
+        assert self._acs_mismatch_warned(caplog) is expected_warning
+
+        if expected_warning:
+            assert saml_strings.SP_ACS_URL in caplog.text
+            assert "http://localhost/SAML2/POST" in caplog.text
+
+    def test_finish_authentication_failure_logs_acs_endpoints(
+        self,
+        controller_fixture: ControllerFixture,
+        create_saml_configuration,
+        create_mock_onelogin_configuration: Callable[..., SAMLOneLoginConfiguration],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """A failed authentication records both ACS endpoints alongside the IdP's reason."""
+        caplog.set_level(logging.ERROR)
+
+        identity_provider_entity_id = "http://idp.hilbertteam.net/idp/shibboleth"
+        authentication_manager = self._create_authentication_manager(
+            create_saml_configuration,
+            create_mock_onelogin_configuration,
+            identity_provider_entity_id,
+            strict_mode=True,
+        )
+        saml_response = base64.b64encode(saml_strings.SAML_COLUMBIA_RESPONSE)
+
+        with controller_fixture.app.test_request_context(
+            "/SAML2/POST",
+            base_url="http://localhost",
+            data={"SAMLResponse": saml_response},
+        ):
+            result = authentication_manager.finish_authentication(
+                controller_fixture.db.session, identity_provider_entity_id
+            )
+
+        assert isinstance(result, ProblemDetail)
+        assert "SAML authentication failed" in caplog.text
+        assert saml_strings.SP_ACS_URL in caplog.text
+        assert "http://localhost/SAML2/POST" in caplog.text
 
     def test_start_logout_success(
         self,

--- a/tests/manager/integration/patron_auth/saml/test_auth.py
+++ b/tests/manager/integration/patron_auth/saml/test_auth.py
@@ -20,6 +20,7 @@ from palace.manager.integration.patron_auth.saml.configuration.model import (
     SAMLWebSSOAuthSettings,
 )
 from palace.manager.integration.patron_auth.saml.metadata.model import (
+    SAMLACSSelectionPolicy,
     SAMLAttribute,
     SAMLAttributeStatement,
     SAMLAttributeType,
@@ -291,6 +292,7 @@ class TestSAMLAuthenticationManager:
         create_mock_onelogin_configuration: Callable[..., SAMLOneLoginConfiguration],
         identity_provider_entity_id: str,
         strict_mode: bool,
+        acs_selection_policy: SAMLACSSelectionPolicy = SAMLACSSelectionPolicy.FIRST_INDEX,
     ) -> SAMLAuthenticationManager:
         """Build a manager whose SP asserts saml_strings.SP_ACS_URL."""
         identity_providers = [
@@ -301,12 +303,120 @@ class TestSAMLAuthenticationManager:
         configuration = create_saml_configuration(
             service_provider_debug_mode=False,
             service_provider_strict_mode=strict_mode,
+            service_provider_acs_selection_policy=acs_selection_policy,
         )
         onelogin_configuration = create_mock_onelogin_configuration(
             SERVICE_PROVIDER_WITH_UNSIGNED_REQUESTS, identity_providers, configuration
         )
 
         return SAMLAuthenticationManager(onelogin_configuration, SAMLSubjectParser())
+
+    @pytest.mark.parametrize(
+        "service_provider",
+        [
+            pytest.param(SERVICE_PROVIDER_WITH_UNSIGNED_REQUESTS, id="unsigned"),
+            pytest.param(SERVICE_PROVIDER_WITH_SIGNED_REQUESTS, id="signed"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "policy, expect_acs_attributes",
+        [
+            pytest.param(
+                SAMLACSSelectionPolicy.FIRST_INDEX,
+                True,
+                id="first-index-names-an-endpoint",
+            ),
+            pytest.param(
+                SAMLACSSelectionPolicy.METADATA_DEFAULT,
+                True,
+                id="metadata-default-names-an-endpoint",
+            ),
+            pytest.param(
+                SAMLACSSelectionPolicy.DEFER_TO_IDP,
+                False,
+                id="defer-to-idp-names-no-endpoint",
+            ),
+        ],
+    )
+    def test_start_authentication_acs_attributes_follow_policy(
+        self,
+        controller_fixture: ControllerFixture,
+        create_saml_configuration,
+        create_mock_onelogin_configuration: Callable[..., SAMLOneLoginConfiguration],
+        service_provider: SAMLServiceProviderMetadata,
+        policy: SAMLACSSelectionPolicy,
+        expect_acs_attributes: bool,
+    ):
+        """Deferring to the IdP omits both endpoint attributes from the request."""
+        configuration = create_saml_configuration(
+            service_provider_acs_selection_policy=policy
+        )
+        onelogin_configuration = create_mock_onelogin_configuration(
+            service_provider, IDENTITY_PROVIDERS, configuration
+        )
+        authentication_manager = SAMLAuthenticationManager(
+            onelogin_configuration, SAMLSubjectParser()
+        )
+
+        with controller_fixture.app.test_request_context("/"):
+            result = authentication_manager.start_authentication(
+                controller_fixture.db.session, saml_strings.IDP_1_ENTITY_ID, ""
+            )
+
+        assert isinstance(result, str)
+        query_items = parse_qs(urlsplit(result).query)
+        decoded_saml_request = OneLogin_Saml2_Utils.decode_base64_and_inflate(
+            query_items["SAMLRequest"][0]
+        )
+
+        # Removing the attributes must leave a schema-valid AuthnRequest.
+        validation_result = OneLogin_Saml2_XML.validate_xml(
+            decoded_saml_request, "saml-schema-protocol-2.0.xsd", False
+        )
+        assert isinstance(validation_result, OneLogin_Saml2_XML._element_class)
+
+        saml_request_dom = fromstring(decoded_saml_request)
+        assert (
+            saml_request_dom.get("AssertionConsumerServiceURL") is not None
+        ) is expect_acs_attributes
+        assert (
+            saml_request_dom.get("ProtocolBinding") is not None
+        ) is expect_acs_attributes
+
+        # The signature is computed from the request as sent, so it survives stripping.
+        if service_provider.authn_requests_signed:
+            assert "Signature" in query_items
+
+    def test_finish_authentication_does_not_warn_when_deferring_to_idp(
+        self,
+        controller_fixture: ControllerFixture,
+        create_saml_configuration,
+        create_mock_onelogin_configuration: Callable[..., SAMLOneLoginConfiguration],
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Nothing was asserted, so an unexpected endpoint is not a mismatch."""
+        caplog.set_level(logging.WARNING)
+
+        identity_provider_entity_id = "http://idp.hilbertteam.net/idp/shibboleth"
+        authentication_manager = self._create_authentication_manager(
+            create_saml_configuration,
+            create_mock_onelogin_configuration,
+            identity_provider_entity_id,
+            strict_mode=False,
+            acs_selection_policy=SAMLACSSelectionPolicy.DEFER_TO_IDP,
+        )
+        saml_response = base64.b64encode(saml_strings.SAML_COLUMBIA_RESPONSE)
+
+        with controller_fixture.app.test_request_context(
+            "/SAML2/POST",
+            base_url="http://localhost",
+            data={"SAMLResponse": saml_response},
+        ):
+            authentication_manager.finish_authentication(
+                controller_fixture.db.session, identity_provider_entity_id
+            )
+
+        assert self._acs_mismatch_warned(caplog) is False
 
     def test_start_authentication_logs_asserted_acs_endpoint(
         self,


### PR DESCRIPTION
## Description

SAML Service Provider metadata may declare more than one callback (Assertion Consumer Service)
endpoint. Until now, the endpoint named in our authentication requests was fixed, so moving to a different one was not possible without a code or per-integration SP metadata change.

- Each SAML integration can now choose how that endpoint is selected:
  - **Lowest index** (default) — reproduces current behavior
  - **Metadata default** — honors the `isDefault` attribute in the metadata
  - **Defer to the identity provider** — name no endpoint, letting the identity provider use whichever one it has registered (not all IdPs may support this).
  - A new environment variable may override the site-wide default / fallback for integrations that do not choose one, and clearing the setting in the Admin UI returns an integration to the active site-wide default.

- Adds our own logging that identifies when a response arrives at an endpoint other than one we expected, which previously could only be diagnosed from an (external) IdPs error message.

- Improves endpoint selection, which previously ignored the metadata's own default attribute and compared endpoint indexes as text rather than as numbers.

Existing integrations are unaffected, as the default reproduces current behavior.

## Motivation and Context

Some patron auth integrations need to move to a different SAML callback endpoint, but that change has to be coordinated with each identity provider partner individually. Making the choice a per-integration setting allows endpoints to be migrated incrementally, rather than requiring every partner to change at the same time.

[Jira PP-4899]

## How Has This Been Tested?

- Manual testing of admin UI interaction in local dev environment.
- New and updated tests for the new functionality.
- All tests / checks pass locally.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
