### PR TITLE
Pin kombu to unreleased commit to fix worker hang after Redis connection reset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,12 @@ dependencies = [
     "joserfc>=1.7.4,<2",
     "jsonschema>=4.22.0,<5",
     "jwcrypto>=1.5.8,<2",
+    # kombu is a dependency of celery. We pin it to an unreleased commit here, because we
+    # need the fix from https://github.com/celery/kombu/pull/2498, so that celery workers
+    # recover when their redis broker connection is reset. This pin should be removed
+    # (see the git source in [tool.uv.sources]) once a kombu release containing that fix
+    # is published and picked up by our celery dependency.
+    "kombu",
     "levenshtein>=0.27,<0.28",
     "lxml[html-clean]==6.1.1",
     "nameparser>=2.0.0,<3",  # nameparser is for author name manipulations
@@ -394,6 +400,7 @@ spaces_indent_inline_array = 4
 trailing_comma_inline_array = true
 
 [tool.uv.sources]
+kombu = {git = "https://github.com/celery/kombu.git", rev = "2c8372c6b35b6c61bb6cf93470c57d9eab8836b8"}
 palace-opds = {workspace = true}
 palace-util = {workspace = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
     # kombu is a dependency of celery. We pin it to an unreleased commit here, because we
     # need the fix from https://github.com/celery/kombu/pull/2498, so that celery workers
     # recover when their redis broker connection is reset. This pin should be removed
-    # (see the git source in [tool.uv.sources]) once a kombu release containing that fix
+    # (see the source in [tool.uv.sources]) once a kombu release containing that fix
     # is published and picked up by our celery dependency.
     "kombu",
     "levenshtein>=0.27,<0.28",
@@ -400,7 +400,7 @@ spaces_indent_inline_array = 4
 trailing_comma_inline_array = true
 
 [tool.uv.sources]
-kombu = {git = "https://github.com/celery/kombu.git", rev = "2c8372c6b35b6c61bb6cf93470c57d9eab8836b8"}
+kombu = {url = "https://github.com/celery/kombu/archive/2c8372c6b35b6c61bb6cf93470c57d9eab8836b8.tar.gz"}
 palace-opds = {workspace = true}
 palace-util = {workspace = true}
 

--- a/uv.lock
+++ b/uv.lock
@@ -1457,16 +1457,12 @@ wheels = [
 [[package]]
 name = "kombu"
 version = "5.6.2"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/celery/kombu.git?rev=2c8372c6b35b6c61bb6cf93470c57d9eab8836b8#2c8372c6b35b6c61bb6cf93470c57d9eab8836b8" }
 dependencies = [
     { name = "amqp" },
     { name = "packaging" },
     { name = "tzdata" },
     { name = "vine" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594, upload-time = "2025-12-29T20:30:07.779Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219, upload-time = "2025-12-29T20:30:05.74Z" },
 ]
 
 [package.optional-dependencies]
@@ -2067,6 +2063,7 @@ dependencies = [
     { name = "joserfc" },
     { name = "jsonschema" },
     { name = "jwcrypto" },
+    { name = "kombu" },
     { name = "levenshtein" },
     { name = "lxml", extra = ["html-clean"] },
     { name = "nameparser" },
@@ -2172,6 +2169,7 @@ requires-dist = [
     { name = "joserfc", specifier = ">=1.7.4,<2" },
     { name = "jsonschema", specifier = ">=4.22.0,<5" },
     { name = "jwcrypto", specifier = ">=1.5.8,<2" },
+    { name = "kombu", git = "https://github.com/celery/kombu.git?rev=2c8372c6b35b6c61bb6cf93470c57d9eab8836b8" },
     { name = "levenshtein", specifier = ">=0.27,<0.28" },
     { name = "lxml", extras = ["html-clean"], specifier = "==6.1.1" },
     { name = "nameparser", specifier = ">=2.0.0,<3" },

--- a/uv.lock
+++ b/uv.lock
@@ -1457,13 +1457,14 @@ wheels = [
 [[package]]
 name = "kombu"
 version = "5.6.2"
-source = { git = "https://github.com/celery/kombu.git?rev=2c8372c6b35b6c61bb6cf93470c57d9eab8836b8#2c8372c6b35b6c61bb6cf93470c57d9eab8836b8" }
+source = { url = "https://github.com/celery/kombu/archive/2c8372c6b35b6c61bb6cf93470c57d9eab8836b8.tar.gz" }
 dependencies = [
     { name = "amqp" },
     { name = "packaging" },
     { name = "tzdata" },
     { name = "vine" },
 ]
+sdist = { hash = "sha256:9cc46518bd8eba06fd6ce9704dc7f6e492269a930db0282c87f30a16ce3f0a10" }
 
 [package.optional-dependencies]
 redis = [
@@ -1474,6 +1475,38 @@ sqs = [
     { name = "pycurl", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32'" },
     { name = "urllib3" },
 ]
+
+[package.metadata]
+requires-dist = [
+    { name = "amqp", specifier = ">=5.1.1,<6.0.0" },
+    { name = "azure-identity", marker = "extra == 'azurestoragequeues'", specifier = ">=1.12.0" },
+    { name = "azure-servicebus", marker = "extra == 'azureservicebus'", specifier = ">=7.10.0" },
+    { name = "azure-storage-queue", marker = "extra == 'azurestoragequeues'", specifier = ">=12.6.0" },
+    { name = "boto3", marker = "extra == 'sqs'", specifier = ">=1.26.143" },
+    { name = "confluent-kafka", marker = "extra == 'confluentkafka'", specifier = ">=2.2.0" },
+    { name = "google-cloud-monitoring", marker = "extra == 'gcpubsub'", specifier = ">=2.16.0" },
+    { name = "google-cloud-pubsub", marker = "extra == 'gcpubsub'", specifier = ">=2.18.4" },
+    { name = "grpcio", marker = "extra == 'gcpubsub'", specifier = "==1.76.0" },
+    { name = "kazoo", marker = "extra == 'zookeeper'", specifier = ">=2.8.0" },
+    { name = "librabbitmq", marker = "python_full_version < '3.11' and extra == 'librabbitmq'", specifier = ">=2.0.0" },
+    { name = "msgpack", marker = "extra == 'msgpack'", specifier = "==1.1.2" },
+    { name = "packaging" },
+    { name = "protobuf", marker = "extra == 'gcpubsub'", specifier = "==6.33.6" },
+    { name = "pycurl", marker = "platform_python_implementation == 'CPython' and sys_platform != 'win32' and extra == 'sqs'", specifier = ">=7.43.0.5" },
+    { name = "pymongo", marker = "extra == 'mongodb'", specifier = "==4.15.3" },
+    { name = "pyro4", marker = "extra == 'pyro'", specifier = "==4.82" },
+    { name = "python-consul2", marker = "extra == 'consul'", specifier = "==0.1.5" },
+    { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=3.10" },
+    { name = "qpid-python", marker = "extra == 'qpid'", specifier = "==1.36.0.post1" },
+    { name = "qpid-tools", marker = "extra == 'qpid'", specifier = "==1.36.0.post1" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=4.5.2,!=4.5.5,!=5.0.2,<7.1" },
+    { name = "softlayer-messaging", marker = "extra == 'slmq'", specifier = ">=1.0.3" },
+    { name = "sqlalchemy", marker = "extra == 'sqlalchemy'", specifier = ">=1.4.48,<2.1" },
+    { name = "tzdata", specifier = ">=2025.2" },
+    { name = "urllib3", marker = "extra == 'sqs'", specifier = ">=1.26.16" },
+    { name = "vine", specifier = "==5.1.0" },
+]
+provides-extras = ["msgpack", "yaml", "redis", "mongodb", "sqs", "gcpubsub", "zookeeper", "sqlalchemy", "librabbitmq", "pyro", "slmq", "azurestoragequeues", "azureservicebus", "qpid", "consul", "confluentkafka"]
 
 [[package]]
 name = "levenshtein"
@@ -2169,7 +2202,7 @@ requires-dist = [
     { name = "joserfc", specifier = ">=1.7.4,<2" },
     { name = "jsonschema", specifier = ">=4.22.0,<5" },
     { name = "jwcrypto", specifier = ">=1.5.8,<2" },
-    { name = "kombu", git = "https://github.com/celery/kombu.git?rev=2c8372c6b35b6c61bb6cf93470c57d9eab8836b8" },
+    { name = "kombu", url = "https://github.com/celery/kombu/archive/2c8372c6b35b6c61bb6cf93470c57d9eab8836b8.tar.gz" },
     { name = "levenshtein", specifier = ">=0.27,<0.28" },
     { name = "lxml", extras = ["html-clean"], specifier = "==6.1.1" },
     { name = "nameparser", specifier = ">=2.0.0,<3" },


### PR DESCRIPTION
## Description

Pins `kombu` to an unreleased upstream commit ([`2c8372c`](https://github.com/celery/kombu/commit/2c8372c6b35b6c61bb6cf93470c57d9eab8836b8), the merge commit of [celery/kombu#2498](https://github.com/celery/kombu/pull/2498)) via a direct dependency and a `[tool.uv.sources]` entry pointing at GitHub's commit archive tarball. Using the tarball URL rather than a git source lets uv fetch it over plain HTTPS, so no git executable is needed in the docker images. kombu still identifies as 5.6.2 at this commit, so celery's own dependency constraint remains satisfied.

This pin is a temporary bandaid: it should be removed once a kombu release containing the fix (5.7.0 milestone) is published. The comment in `pyproject.toml` documents the removal condition.

## Motivation and Context

When a celery worker's Redis broker connection is reset (e.g. by a Redis failover or restart), the worker logs `consumer: Connection to broker lost. Trying to re-establish the connection...` and then permanently stops consuming from all queues, while beat and already-running tasks continue. We hit this in production on 2026-08-11 (~10:54 UTC) on `fl-florida-scripts` and at least one other instance; the only recovery is restarting the worker.

This is [celery/celery#10205](https://github.com/celery/celery/issues/10205): kombu's redis transport timer callbacks (`maybe_restore_messages`, `maybe_check_subclient_health`) raise `ConnectionError` through the event loop while the connection is down, and each reconnect attempt registers new timers without cancelling the old ones, so stale timers accumulate and repeatedly crash the loop. The celery half of the fix ([celery/celery#10218](https://github.com/celery/celery/pull/10218)) is already in celery 5.6.3, which we run — our incident shows it is insufficient on its own. The kombu half ([celery/kombu#2498](https://github.com/celery/kombu/pull/2498)) is merged but unreleased.

Opened as a **draft**: we may prefer to wait for the kombu release. This PR is ready to merge if the hang recurs before that release ships.

## How Has This Been Tested?

- Verified the installed kombu at the pinned commit contains both halves of the fix: the `connection_errors` guards inside `maybe_restore_messages` / `maybe_check_subclient_health`, and the timer references (`_restore_messages_tref` / `_subclient_health_tref`) that are cancelled on reconnect.
- `tox -e py312-docker -- tests/manager/celery/ tests/manager/service/celery/` — 445 passed.
- Built the `common` stage of `docker/Dockerfile` locally (both `uv sync` steps succeed with no git in the image) and confirmed the installed kombu inside the image contains the fix.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
