### PR TITLE
Walk the Overdrive full import over the product list

### DIFF
--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -28,10 +28,14 @@ from palace.manager.integration.license.overdrive.api import (
     OverdriveAPI,
 )
 from palace.manager.integration.license.overdrive.crawl import (
+    CrawlComplete,
     CrawlCursor,
     CrawlFault,
 )
-from palace.manager.integration.license.overdrive.importer import OverdriveImporter
+from palace.manager.integration.license.overdrive.importer import (
+    FeedImportResult,
+    OverdriveImporter,
+)
 from palace.manager.service.celery.celery import QueueNames
 from palace.manager.service.redis.models.set import IdentifierSet
 from palace.manager.sqlalchemy.model.collection import Collection
@@ -88,6 +92,7 @@ def import_collection(
     *,
     import_all: bool = False,
     page: str | None = None,
+    cursor: dict[str, Any] | None = None,
     modified_since: datetime.datetime | None = None,
     start_time: datetime.datetime | None = None,
     return_identifiers: bool = True,
@@ -101,11 +106,31 @@ def import_collection(
     to process subsequent pages while maintaining the same modified_since timestamp
     and start_time across all pages.
 
+    The two kinds of import page through the API differently:
+
+    * A delta import (``import_all=False``) follows the update-filtered feed's
+      ``next`` links, carrying the page url in ``page``.
+    * A full import (``import_all=True``) crawls the whole ``dateAdded:asc``
+      product list with a
+      :class:`~palace.manager.integration.license.overdrive.crawl.CrawlCursor`,
+      carried in ``cursor``. The update feed is ordered by update time, which
+      reshuffles on every circulation event anywhere in the collection, so a
+      multi-hour walk of the whole list over it skips titles; the product list
+      is ordered by a key that never changes. A structural fault ends the crawl
+      early: the titles already processed stay imported and the identifier set
+      is still returned (a child import can use a partial set), but the import
+      timestamp is left unchanged so the next delta import's window still
+      reaches back past the incomplete run. A message queued by a release that
+      paged full imports over the update feed still carries ``page``, and is
+      finished the old way.
+
     :param collection_id: The ID of the collection to import
     :param import_all: If True, import all titles regardless of whether they have changed.
         If False, import titles that have changed since the modified_since date.
     :param page: The "page" to be processed. The page param is a url represented as a string. A None value means the
         import will start from the beginning of the set.
+    :param cursor: The serialized crawl cursor for a full import's next page.
+        None starts the crawl from the beginning.
     :param modified_since: Only process titles modified after this datetime. This field parameter is ignored if
         import_all is True. If import_all is False and modified_since is None, then only titles after the last import
         timestamp's start time will be imported. If there is no prior timestamp, all titles will be imported.
@@ -163,47 +188,140 @@ def import_collection(
                 parent_identifier_set=parent_identifier_set,
             )
 
-            if modified_since is None:
-                if import_all:
-                    modified_since = None
-                else:
+            crawl_step: CrawlCursor | CrawlComplete | CrawlFault | None = None
+            result: FeedImportResult | None = None
+
+            if import_all and page is None:
+                # Full import: crawl the whole product list. A message from a
+                # release that paged full imports over the update feed carries
+                # `page`, and falls through to the branch below to be finished
+                # the way it was started.
+                crawl_cursor = (
+                    CrawlCursor.from_json(cursor)
+                    if cursor is not None
+                    else CrawlCursor()
+                )
+                task.log.info(
+                    f"OverDrive full import started: '{collection_name}' "
+                    f"offset: {crawl_cursor.offset}"
+                )
+                products_result = importer.import_products_page(
+                    apply_bibliographic=apply.bibliographic_apply.delay,
+                    apply_circulation=apply.circulation_apply.delay,
+                    cursor=crawl_cursor,
+                )
+                crawl_step = products_result.step
+
+                task.log.info(
+                    f"OverDrive full import page complete: '{collection_name}' "
+                    f"Offset: {crawl_cursor.offset}. "
+                    f"Processed: {products_result.processed_count}. "
+                )
+
+                if identifier_set:
+                    task.log.info(
+                        f"OverDrive collection import '{collection_name}': Total processed in run so far: {identifier_set.len()}"
+                    )
+
+                if isinstance(crawl_step, CrawlFault):
+                    # Unlike the reaper, nothing here acts on a title's absence:
+                    # a crawl that cannot be continued costs staleness, not
+                    # correctness, and everything already processed is real. The
+                    # timestamp is left unchanged so the incomplete sweep is not
+                    # recorded as a finished import.
+                    task.log.error(
+                        f"OverDrive full import of '{collection_name}' stopped "
+                        f"after {crawl_cursor.elapsed}: {crawl_step.reason} The "
+                        f"titles already processed are imported; the import "
+                        f"timestamp is unchanged."
+                    )
+                elif isinstance(crawl_step, CrawlComplete):
+                    if (
+                        identifier_set is not None
+                        and (
+                            fault := crawl_step.completeness_fault(identifier_set.len())
+                        )
+                        is not None
+                    ):
+                        # Advisory for the same reason a fault is not fatal: the
+                        # shortfall marks titles this sweep did not reach, not
+                        # titles wrongly touched.
+                        task.log.warning(
+                            f"OverDrive full import of '{collection_name}' finished "
+                            f"short after {crawl_step.elapsed}: {fault.reason}"
+                        )
                     timestamp = importer.get_timestamp()
-                    modified_since = timestamp.start
+                    timestamp.start = start_time
+                    timestamp.finish = utc_now()
+                    task.log.info(
+                        f"OverDrive full import complete: '{collection_name}' "
+                        f"Total time: {timestamp.elapsed}."
+                    )
+            else:
+                if modified_since is None:
+                    if import_all:
+                        modified_since = None
+                    else:
+                        timestamp = importer.get_timestamp()
+                        modified_since = timestamp.start
 
-            task.log.info(
-                f"OverDrive import started: '{collection_name}' Modified since: {modified_since}, "
-                f"page: {None if not page else page}"
-            )
-
-            endpoint = None if not page else BookInfoEndpoint(page)
-
-            result = importer.import_collection(
-                apply_bibliographic=apply.bibliographic_apply.delay,
-                apply_circulation=apply.circulation_apply.delay,
-                endpoint=endpoint,
-                modified_since=modified_since,
-            )
-
-            task.log.info(
-                f"OverDrive import page complete: '{collection_name}' Page: {result.current_page}. "
-                f"Processed: {result.processed_count}. "
-            )
-
-            if identifier_set:
                 task.log.info(
-                    f"OverDrive collection import '{collection_name}': Total processed in run so far: {identifier_set.len()}"
+                    f"OverDrive import started: '{collection_name}' Modified since: {modified_since}, "
+                    f"page: {None if not page else page}"
                 )
 
-            if result.next_page is None:
-                # We are done. We only update the timestamp once we have processed all pages.
-                # To make sure that if we fail or are interrupted, we re-process any
-                # titles we may have missed.
-                timestamp = importer.get_timestamp()
-                timestamp.start = start_time
-                timestamp.finish = utc_now()
-                task.log.info(
-                    f"OverDrive import complete: '{collection_name}' Total time: {timestamp.elapsed}."
+                endpoint = None if not page else BookInfoEndpoint(page)
+
+                result = importer.import_collection(
+                    apply_bibliographic=apply.bibliographic_apply.delay,
+                    apply_circulation=apply.circulation_apply.delay,
+                    endpoint=endpoint,
+                    modified_since=modified_since,
                 )
+
+                task.log.info(
+                    f"OverDrive import page complete: '{collection_name}' Page: {result.current_page}. "
+                    f"Processed: {result.processed_count}. "
+                )
+
+                if identifier_set:
+                    task.log.info(
+                        f"OverDrive collection import '{collection_name}': Total processed in run so far: {identifier_set.len()}"
+                    )
+
+                if result.next_page is None:
+                    # We are done. We only update the timestamp once we have processed all pages.
+                    # To make sure that if we fail or are interrupted, we re-process any
+                    # titles we may have missed.
+                    timestamp = importer.get_timestamp()
+                    timestamp.start = start_time
+                    timestamp.finish = utc_now()
+                    task.log.info(
+                        f"OverDrive import complete: '{collection_name}' Total time: {timestamp.elapsed}."
+                    )
+
+        if isinstance(crawl_step, CrawlCursor):
+            task.log.info(
+                f"OverDrive full import re-queueing: '{collection_name}' "
+                f"Next offset: {crawl_step.offset}."
+            )
+            raise task.replace(
+                signature_with(
+                    task,
+                    cursor=crawl_step.__json__(),
+                    # start_time is resolved from None on the first page, so it
+                    # must be carried forward explicitly rather than refilled
+                    # from the original arguments.
+                    start_time=start_time,
+                )
+            )
+        elif crawl_step is not None:
+            # The crawl finished or faulted; either way this run is over and
+            # whatever was collected is the result.
+            return identifier_set
+
+        # The delta path always produced a result when the crawl did not run.
+        assert result is not None
 
         if result.next_page is not None:
             task.log.info(

--- a/src/palace/manager/celery/tasks/overdrive.py
+++ b/src/palace/manager/celery/tasks/overdrive.py
@@ -664,7 +664,8 @@ def reap_collection(
         if isinstance(step, CrawlFault):
             task.log.error(
                 f"Overdrive reaper aborting for collection '{collection_name}' "
-                f"after {crawl_cursor.elapsed}: {step.reason}"
+                f"after {crawl_cursor.elapsed}: {step.reason} Refusing to reap "
+                f"on a crawl that cannot be shown complete."
             )
             identifier_set.delete()
             return None
@@ -680,7 +681,8 @@ def reap_collection(
         if (fault := step.completeness_fault(crawled)) is not None:
             task.log.error(
                 f"Overdrive reaper aborting for collection '{collection_name}' "
-                f"after {step.elapsed}: {fault.reason}"
+                f"after {step.elapsed}: {fault.reason} Refusing to reap on a "
+                f"crawl that cannot be shown complete."
             )
             identifier_set.delete()
             return None

--- a/src/palace/manager/integration/license/overdrive/api.py
+++ b/src/palace/manager/integration/license/overdrive/api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import json
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Sequence
 from dataclasses import dataclass
 from functools import partial
 from threading import RLock
@@ -866,7 +866,6 @@ class OverdriveAPI(
         """
         base_url = self.endpoint(self.HOST_ENDPOINT_BASE)
         async with self._create_configured_async_client(base_url=base_url) as client:
-            books: dict[str, Any] = {}
             extractor_class = extractor_class or OverdriveRepresentationExtractor
             req = client.get(endpoint.url)
             response = await req
@@ -875,7 +874,6 @@ class OverdriveAPI(
             next_endpoint: BookInfoEndpoint | None = (
                 BookInfoEndpoint(next_url) if next_url else None
             )
-            async_task_list = list()
             response_products = data.get("products")
             if response_products is None:
                 # Overdrive omits the 'products' key entirely when a collection
@@ -897,26 +895,81 @@ class OverdriveAPI(
                     f"Overdrive response missing 'products' key. Response data: {data}",
                     response,
                 )
-            for product in response_products:
-                identifier = product["id"].lower()
-                books[identifier] = product
-                if fetch_metadata:
-                    async_task_list.append(
-                        self._get_metadata_async(base_url, product, client)
+            books = await self._hydrate_products(
+                client,
+                base_url,
+                response_products,
+                fetch_metadata=fetch_metadata,
+                fetch_availability=fetch_availability,
+            )
+            return books, next_endpoint
+
+    async def hydrate_products(
+        self,
+        products: Sequence[dict[str, Any]],
+        *,
+        fetch_metadata: bool = False,
+        fetch_availability: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Attach metadata and availability documents to raw product dictionaries.
+
+        This is the per-title half of an import: given the product entries from
+        any products response -- an update-filtered page or a full product-list
+        crawl -- it fetches each title's ``metadata`` and ``availabilityV2``
+        documents concurrently and attaches them under those keys, ready for
+        :class:`~palace.manager.integration.license.overdrive.importer.OverdriveImporter`
+        to process. Products are de-duplicated by (lowercased) id, matching the
+        behaviour of :meth:`fetch_book_info_list`.
+
+        :param products: Raw product dictionaries, e.g.
+            :attr:`~palace.manager.integration.license.overdrive.crawl.ProductPage.products`.
+        :param fetch_metadata: Whether to fetch each title's metadata document.
+        :param fetch_availability: Whether to fetch each title's availability
+            document.
+        :return: The hydrated product dictionaries.
+        """
+        base_url = self.endpoint(self.HOST_ENDPOINT_BASE)
+        async with self._create_configured_async_client(base_url=base_url) as client:
+            return await self._hydrate_products(
+                client,
+                base_url,
+                products,
+                fetch_metadata=fetch_metadata,
+                fetch_availability=fetch_availability,
+            )
+
+    async def _hydrate_products(
+        self,
+        client: AsyncClient,
+        base_url: str,
+        products: Sequence[dict[str, Any]],
+        *,
+        fetch_metadata: bool,
+        fetch_availability: bool,
+    ) -> list[dict[str, Any]]:
+        """Hydrate ``products`` using an already-open async client."""
+        books: dict[str, Any] = {}
+        async_task_list = []
+        for product in products:
+            identifier = product["id"].lower()
+            books[identifier] = product
+            if fetch_metadata:
+                async_task_list.append(
+                    self._get_metadata_async(base_url, product, client)
+                )
+
+            if fetch_availability:
+                async_task_list.append(
+                    self._get_availability_async(
+                        base_url,
+                        product,
+                        client,
                     )
+                )
 
-                if fetch_availability:
-                    async_task_list.append(
-                        self._get_availability_async(
-                            base_url,
-                            product,
-                            client,
-                        )
-                    )
+        await asyncio.gather(*async_task_list)
 
-            await asyncio.gather(*async_task_list)
-
-            return list(books.values()), next_endpoint
+        return list(books.values())
 
     async def _get_availability_async(
         self, base_url: str, book_info: dict[str, Any], client: AsyncClient

--- a/src/palace/manager/integration/license/overdrive/crawl.py
+++ b/src/palace/manager/integration/license/overdrive/crawl.py
@@ -98,9 +98,11 @@ class ProductPage:
 class CrawlFault:
     """A page the crawl cannot reconcile with the walk so far.
 
-    :param reason: What the page failed to show, in terms a log line can carry.
-        The caller decides what a fault costs: the reaper aborts, since it acts
-        on absence; a harvest may only note it.
+    :param reason: What the page failed to show. The wording is deliberately
+        consequence-free -- it states the arithmetic, not what to do about
+        it -- because the caller decides what a fault costs: the reaper aborts,
+        since it acts on absence; a harvest stops the walk but keeps what it
+        imported. Each caller appends its own consequence when it logs.
     """
 
     reason: str
@@ -150,9 +152,8 @@ class CrawlComplete:
         )
         if crawled + allowance < self.total_items:
             return CrawlFault(
-                f"The crawl saw {crawled} titles but Overdrive reports "
-                f"{self.total_items} (allowance {allowance}). Refusing to reap "
-                f"on an incomplete crawl."
+                f"The crawl saw {crawled} distinct titles of the "
+                f"{self.total_items} Overdrive reports (allowance {allowance})."
             )
         return None
 
@@ -226,10 +227,10 @@ class CrawlCursor:
             # crawl asks for the same one every time, so a change mid-crawl
             # means this arithmetic no longer describes the list.
             return CrawlFault(
-                f"The page at offset {self.offset} was returned with a page "
-                f"size of {page.limit}, but the crawl has been walking in "
-                f"steps of {self.page_limit}. Refusing to reap on a crawl "
-                f"whose paging changed underneath it."
+                f"The page at offset {self.offset} came back with a page size "
+                f"of {page.limit} after the crawl had been walking in steps of "
+                f"{self.page_limit}, so the walk's arithmetic no longer "
+                f"describes the list."
             )
 
         if self.previous_offset is None:
@@ -249,9 +250,9 @@ class CrawlCursor:
             if self.offset + len(page.listed) < must_reach:
                 return CrawlFault(
                     f"The page at offset {self.offset} returned "
-                    f"{len(page.listed)} titles and so stops short of the "
-                    f"{must_reach} Overdrive reports. Refusing to reap across "
-                    f"a gap."
+                    f"{len(page.listed)} titles and stops short of the "
+                    f"{must_reach} Overdrive reports, so the walk cannot be "
+                    f"shown to reach the end of the list."
                 )
         elif self.offset + len(page.listed) < self.previous_offset:
             # The walk steps back by a page size, but a page is free to return
@@ -263,9 +264,9 @@ class CrawlCursor:
             # before it.
             return CrawlFault(
                 f"The page at offset {self.offset} returned "
-                f"{len(page.listed)} titles and so stops short of the region "
-                f"already crawled at {self.previous_offset}. Refusing to reap "
-                f"across a gap."
+                f"{len(page.listed)} titles and stops short of the region "
+                f"already crawled at {self.previous_offset}, leaving a strip "
+                f"of the list uncovered."
             )
 
         if self.offset == 0:

--- a/src/palace/manager/integration/license/overdrive/importer.py
+++ b/src/palace/manager/integration/license/overdrive/importer.py
@@ -19,6 +19,11 @@ from palace.manager.integration.license.overdrive.api import (
     BookInfoEndpoint,
     OverdriveAPI,
 )
+from palace.manager.integration.license.overdrive.crawl import (
+    CrawlComplete,
+    CrawlCursor,
+    CrawlFault,
+)
 from palace.manager.integration.license.overdrive.model import Availability
 from palace.manager.integration.license.overdrive.representation import (
     OverdriveRepresentationExtractor,
@@ -37,6 +42,19 @@ from palace.manager.sqlalchemy.util import get_one_or_create
 class FeedImportResult:
     current_page: BookInfoEndpoint
     next_page: BookInfoEndpoint | None = None
+    processed_count: int = 0
+
+
+@dataclass(frozen=True)
+class ProductsImportResult:
+    """The outcome of importing one page of a full product-list crawl.
+
+    :param step: What the crawl cursor decided after this page: the cursor for
+        the next page, completion, or a fault.
+    :param processed_count: The number of books processed from this page.
+    """
+
+    step: CrawlCursor | CrawlComplete | CrawlFault
     processed_count: int = 0
 
 
@@ -288,3 +306,83 @@ class OverdriveImporter(LoggerMixin):
             current_page=endpoint,
             processed_count=len(identifiers),
         )
+
+    def import_products_page(
+        self,
+        *,
+        apply_bibliographic: ApplyBibliographicCallable,
+        apply_circulation: ApplyCirculationCallable,
+        cursor: CrawlCursor,
+        page_size: int = DEFAULT_PAGE_SIZE,
+    ) -> ProductsImportResult:
+        """Import one page of a full crawl of the collection's product list.
+
+        This is the full-harvest counterpart of :meth:`import_collection`: the
+        same hydration and processing, but enumerated by a
+        :class:`~palace.manager.integration.license.overdrive.crawl.CrawlCursor`
+        over the ``dateAdded:asc`` product list rather than by following the
+        update-filtered feed's ``next`` links. dateAdded is immutable, so a
+        multi-hour crawl of a large collection walks an ordering that does not
+        reshuffle on every circulation event the way the update feed's does --
+        the cursor's coverage guarantees hold, and every title is visited once.
+
+        The page's books are hydrated and processed whatever the cursor decides:
+        a fault ends the crawl, but the titles this page carried are still
+        real -- interpreting the fault is the caller's job.
+
+        :param apply_bibliographic: Callback to apply bibliographic updates.
+        :param apply_circulation: Callback to apply circulation updates.
+        :param cursor: The crawl cursor for the page to fetch.
+        :param page_size: Titles per page. Sized for the per-title hydration
+            cost, not the crawl: each book on the page costs its own metadata
+            and availability requests.
+        :return: A :class:`ProductsImportResult` carrying the cursor's decision
+            and the number of books processed.
+        """
+        policy = ReplacementPolicy(
+            identifiers=False,
+            subjects=True,
+            contributions=True,
+            formats=True,
+            links=True,
+        )
+
+        page = self._api.fetch_product_page(
+            self._api.product_page_endpoint(cursor.offset, page_size)
+        )
+        step = cursor.advance(page)
+
+        # Metadata is fetched upfront for main collections and lazily for
+        # advantage collections, exactly as in import_collection: the parent
+        # identifier set implies the parent already imported the metadata.
+        fetch_metadata = self._parent_identifiers is None
+        books = asyncio.run(
+            self._api.hydrate_products(
+                page.products,
+                fetch_metadata=fetch_metadata,
+                fetch_availability=True,
+            )
+        )
+
+        identifiers = []
+        for book in books:
+            identifier, _ = self._process_book(
+                book, fetch_metadata, policy, apply_bibliographic, apply_circulation
+            )
+            identifiers.append(identifier)
+
+        if self._identifier_set is not None:
+            self._identifier_set.add(*identifiers)
+
+        timestamp = self.get_timestamp()
+        achievements = [f"Total items queued for import: {len(identifiers)}."]
+        if (elapsed_time := timestamp.elapsed_seconds) is not None:
+            achievements.append(f"Elapsed time: {elapsed_time:.2f} seconds.")
+        timestamp.achievements = "\n".join(achievements)
+
+        self.log.info(
+            f"Imported {len(identifiers)} book(s) at offset {cursor.offset} of the "
+            f"product list for collection {self._collection.name} "
+            f"(id={self._collection.id})."
+        )
+        return ProductsImportResult(step=step, processed_count=len(identifiers))

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, Mock, call, patch
 from uuid import uuid4
 
 import pytest
 from celery.result import AsyncResult
 
-from palace.util.datetime_helpers import datetime_utc
+from palace.util.datetime_helpers import datetime_utc, utc_now
 from palace.util.log import LogLevel
 
 from palace.manager.celery.importer import (
@@ -24,12 +25,15 @@ from palace.manager.integration.license.overdrive.api import (
     OverdriveAPI,
 )
 from palace.manager.integration.license.overdrive.crawl import (
+    CrawlComplete,
     CrawlCursor,
+    CrawlFault,
     ProductPage,
 )
 from palace.manager.integration.license.overdrive.importer import (
     FeedImportResult,
     OverdriveImporter,
+    ProductsImportResult,
 )
 from palace.manager.service.redis.models.set import IdentifierSet
 from palace.manager.sqlalchemy.constants import IdentifierType
@@ -102,6 +106,27 @@ class OverdriveImportFixture:
         mock_importer.import_collection.return_value = mock_result
         return mock_importer, mock_timestamp
 
+    @staticmethod
+    def create_mock_products_importer(
+        *steps: CrawlCursor | CrawlComplete | CrawlFault,
+    ) -> tuple[Mock, Mock]:
+        """Create a mock importer whose product-list crawl walks the given steps.
+
+        :param steps: What each successive import_products_page call's cursor
+            decided, one entry per page.
+        :return: Tuple of (mock_importer, mock_timestamp)
+        """
+        mock_importer = Mock(spec=OverdriveImporter)
+        mock_timestamp = Mock(spec=Timestamp)
+        mock_timestamp.start = None
+        mock_timestamp.finish = None
+        mock_timestamp.elapsed = "10 seconds"
+        mock_importer.get_timestamp.return_value = mock_timestamp
+        mock_importer.import_products_page.side_effect = [
+            ProductsImportResult(step=step, processed_count=5) for step in steps
+        ]
+        return mock_importer, mock_timestamp
+
 
 @pytest.fixture
 def overdrive_import_fixture(
@@ -157,26 +182,170 @@ class TestImportCollection:
         mock_importer_class: MagicMock,
         overdrive_import_fixture: OverdriveImportFixture,
     ):
-        """Test import_collection with import_all=True.
+        """import_all crawls the whole product list, not the update feed.
 
-        When import_all=True, modified_since should be set to None,
-        which bypasses the out-of-scope check in the importer.
+        The update feed is ordered by update time, which reshuffles on every
+        circulation event, so a multi-hour walk of the whole collection over it
+        skips titles; the product list's dateAdded ordering never changes.
         """
         collection = overdrive_import_fixture.collection
 
-        # Create mock importer
-        mock_importer, _ = overdrive_import_fixture.create_mock_importer()
+        mock_importer, mock_timestamp = (
+            overdrive_import_fixture.create_mock_products_importer(
+                CrawlComplete(
+                    total_items=0,
+                    page_limit=100,
+                    single_page=True,
+                    started_at=utc_now(),
+                )
+            )
+        )
         mock_importer_class.return_value = mock_importer
 
         # Run the task with import_all=True
         overdrive.import_collection.delay(collection.id, import_all=True).wait()
 
-        # Verify importer was created WITHOUT import_all parameter (removed)
-        call_kwargs = mock_importer_class.call_args.kwargs
-        assert "import_all" not in call_kwargs
+        # The crawl ran, starting from a fresh cursor; the feed walk did not.
+        mock_importer.import_products_page.assert_called_once()
+        cursor = mock_importer.import_products_page.call_args.kwargs["cursor"]
+        assert cursor == CrawlCursor(started_at=cursor.started_at)
+        mock_importer.import_collection.assert_not_called()
 
-        # Verify modified_since is None when import_all is True (bypasses out-of-scope check)
+        # The crawl completed, so the timestamp was finalized.
+        assert mock_timestamp.start is not None
+        assert mock_timestamp.finish is not None
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveImporter")
+    def test_import_collection_import_all_replaces_with_cursor(
+        self,
+        mock_importer_class: MagicMock,
+        overdrive_import_fixture: OverdriveImportFixture,
+    ):
+        """A multi-page crawl carries its cursor across task.replace()."""
+        collection = overdrive_import_fixture.collection
+
+        next_cursor = CrawlCursor(
+            offset=150, previous_offset=250, total_items=1000, page_limit=100
+        )
+        mock_importer, _ = overdrive_import_fixture.create_mock_products_importer(
+            next_cursor,
+            CrawlComplete(
+                total_items=0, page_limit=100, single_page=False, started_at=utc_now()
+            ),
+        )
+        mock_importer_class.return_value = mock_importer
+
+        overdrive.import_collection.delay(collection.id, import_all=True).wait()
+
+        # The second page was driven by the cursor the first page handed back,
+        # round-tripped through the task kwargs.
+        assert mock_importer.import_products_page.call_count == 2
+        second_cursor = mock_importer.import_products_page.call_args_list[1].kwargs[
+            "cursor"
+        ]
+        assert second_cursor == next_cursor
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveImporter")
+    def test_import_collection_import_all_fault_keeps_what_was_imported(
+        self,
+        mock_importer_class: MagicMock,
+        overdrive_import_fixture: OverdriveImportFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """A crawl fault ends a full import early without discarding it.
+
+        Unlike the reaper, nothing here acts on a title's absence, so an
+        unfinishable crawl costs staleness rather than correctness: the run
+        still returns its identifier set (a child import can use a partial
+        set), but the import timestamp is left unchanged so the incomplete
+        sweep is not recorded as a finished import.
+        """
+        collection = overdrive_import_fixture.collection
+        caplog.set_level(LogLevel.error)
+
+        mock_importer, mock_timestamp = (
+            overdrive_import_fixture.create_mock_products_importer(
+                CrawlFault("The page at offset 100 could not be reconciled.")
+            )
+        )
+        mock_importer_class.return_value = mock_importer
+
+        result = overdrive.import_collection.delay(
+            collection.id, import_all=True
+        ).wait()
+
+        assert result is not None
+        assert result["key"]
+        assert mock_timestamp.start is None
+        assert mock_timestamp.finish is None
+        assert "could not be reconciled" in caplog.text
+        assert "timestamp is unchanged" in caplog.text
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveImporter")
+    def test_import_collection_import_all_completeness_is_advisory(
+        self,
+        mock_importer_class: MagicMock,
+        overdrive_import_fixture: OverdriveImportFixture,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """A count shortfall warns but still finishes a full import.
+
+        The shortfall marks titles this sweep did not reach, not titles
+        wrongly touched, so the import completes and the timestamp advances.
+        """
+        collection = overdrive_import_fixture.collection
+        caplog.set_level(LogLevel.warning)
+
+        # The mock importer adds nothing to the identifier set, so a non-zero
+        # totalItems reads as a shortfall at the completeness gate.
+        mock_importer, mock_timestamp = (
+            overdrive_import_fixture.create_mock_products_importer(
+                CrawlComplete(
+                    total_items=500,
+                    page_limit=100,
+                    single_page=False,
+                    started_at=utc_now(),
+                )
+            )
+        )
+        mock_importer_class.return_value = mock_importer
+
+        result = overdrive.import_collection.delay(
+            collection.id, import_all=True
+        ).wait()
+
+        assert result is not None
+        assert "finished short" in caplog.text
+        assert "distinct titles" in caplog.text
+        assert mock_timestamp.start is not None
+        assert mock_timestamp.finish is not None
+
+    @patch("palace.manager.celery.tasks.overdrive.OverdriveImporter")
+    def test_import_collection_import_all_legacy_page_uses_feed(
+        self,
+        mock_importer_class: MagicMock,
+        overdrive_import_fixture: OverdriveImportFixture,
+    ):
+        """A full-import page from the previous release finishes the old way.
+
+        The release that paged full imports over the update feed re-queued
+        them with a `page` url. Restarting such a run as a crawl would repeat
+        hours of work, so the page is honored on the path that queued it.
+        """
+        collection = overdrive_import_fixture.collection
+
+        mock_importer, _ = overdrive_import_fixture.create_mock_importer()
+        mock_importer_class.return_value = mock_importer
+
+        overdrive.import_collection.delay(
+            collection.id, import_all=True, page="http://legacy.page/"
+        ).wait()
+
+        mock_importer.import_products_page.assert_not_called()
         import_call = mock_importer.import_collection.call_args
+        assert import_call.kwargs["endpoint"] == BookInfoEndpoint(
+            url="http://legacy.page/"
+        )
         assert import_call.kwargs["modified_since"] is None
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveImporter")
@@ -1153,7 +1322,12 @@ class TestIntegration:
         redis_fixture: RedisFixture,
         apply_task_fixture: ApplyTaskFixture,
     ):
-        """Test import with parent identifiers provided and Overdrive data."""
+        """A full import flows from Overdrive data to database records.
+
+        import_all crawls the product list: the page itself arrives over the
+        synchronous client, and each title's metadata and availability are
+        hydrated over the async client.
+        """
         collection = overdrive_api_fixture.collection
         availability_data, availability_json = overdrive_api_fixture.sample_json(
             "overdrive_availability_information.json"
@@ -1162,29 +1336,23 @@ class TestIntegration:
             "bibliographic_information_book_list_test.json"
         )
         (
-            overdrive_book_list_with_next_link_data,
+            _,
             overdrive_book_list_with_next_link_json,
         ) = overdrive_api_fixture.sample_json("overdrive_book_list_with_next_link.json")
 
         book = overdrive_book_list_with_next_link_json["products"][0]
 
-        (
-            overdrive_book_list_last_page_no_products_data,
-            overdrive_book_list_last_page_no_products_json,
-        ) = overdrive_api_fixture.sample_json(
-            "overdrive_book_list_last_page_no_products.json"
-        )
-        mock_async_client = overdrive_api_fixture.mock_async_client
-        mock_async_client.queue_response(
-            200, content=overdrive_book_list_with_next_link_data
+        # A single-page product list carrying the one book.
+        overdrive_api_fixture.mock_http.queue_response(
+            200,
+            content=json.dumps(
+                {"totalItems": 1, "limit": 300, "products": [book]}
+            ).encode(),
         )
 
+        mock_async_client = overdrive_api_fixture.mock_async_client
         mock_async_client.queue_response(200, content=metadata_data)
         mock_async_client.queue_response(200, content=availability_data)
-
-        mock_async_client.queue_response(
-            200, content=overdrive_book_list_last_page_no_products_data
-        )
 
         # sanity check that the identifier does not exist
         assert not self._get_identifier(book, overdrive_api_fixture)

--- a/tests/manager/celery/tasks/test_overdrive.py
+++ b/tests/manager/celery/tasks/test_overdrive.py
@@ -1419,7 +1419,9 @@ class TestOverdriveReaper:
         async_result = overdrive.reap_collection.delay(collection.id)
 
         assert async_result.wait() is None
-        assert "Refusing to reap on an incomplete crawl" in caplog.text
+        assert (
+            "Refusing to reap on a crawl that cannot be shown complete" in caplog.text
+        )
         # The partial set is not left behind in Redis for the chord to pick up.
         partial_set = IdentifierSet(
             redis_fixture.client, reap_key(collection.id, async_result.id)
@@ -1490,7 +1492,9 @@ class TestOverdriveReaper:
         result = overdrive.reap_collection.delay(collection.id).wait()
 
         assert result is None
-        assert "Refusing to reap on an incomplete crawl" in caplog.text
+        assert (
+            "Refusing to reap on a crawl that cannot be shown complete" in caplog.text
+        )
 
     @patch("palace.manager.celery.tasks.overdrive.OverdriveAPI")
     def test_reap_collection_aborts_when_the_first_backwards_page_is_short(
@@ -1570,7 +1574,8 @@ class TestOverdriveReaper:
         )
 
         assert async_result.wait() is None
-        assert "Refusing to reap across a gap" in caplog.text
+        assert "leaving a strip of the list uncovered" in caplog.text
+        assert "Refusing to reap" in caplog.text
         partial_set = IdentifierSet(
             redis_fixture.client, reap_key(collection.id, async_result.id)
         )
@@ -1609,7 +1614,7 @@ class TestOverdriveReaper:
         result = overdrive.reap_collection.delay(collection.id).wait()
 
         assert result is None
-        assert "whose paging changed underneath it" in caplog.text
+        assert "no longer describes the list" in caplog.text
 
     def test_reap_collection_discards_a_page_from_the_previous_reaper(
         self,

--- a/tests/manager/integration/license/overdrive/test_api.py
+++ b/tests/manager/integration/license/overdrive/test_api.py
@@ -3038,6 +3038,43 @@ class TestSyncBookshelf:
         assert book_info_list[0]["metadata"]
         assert book_info_list[0]["availabilityV2"]
 
+    async def test_hydrate_products(
+        self,
+        overdrive_api_fixture: OverdriveAPIFixture,
+    ):
+        """Raw product dictionaries can be hydrated on their own.
+
+        This is the per-title half of an import, split from the page fetch so
+        that any enumeration of products -- the update feed or a product-list
+        crawl -- can share it.
+        """
+        availability_data, _ = overdrive_api_fixture.sample_json(
+            "overdrive_availability_information.json"
+        )
+        metadata_data, _ = overdrive_api_fixture.sample_json(
+            "bibliographic_information_book_list_test.json"
+        )
+        _, product_page_json = overdrive_api_fixture.sample_json(
+            "overdrive_product_page.json"
+        )
+        api = overdrive_api_fixture.api
+
+        product = dict(product_page_json["products"][0])
+        mock_async_client = overdrive_api_fixture.mock_async_client
+        mock_async_client.queue_response(200, content=metadata_data)
+        mock_async_client.queue_response(200, content=availability_data)
+
+        books = await api.hydrate_products(
+            [product], fetch_metadata=True, fetch_availability=True
+        )
+
+        assert len(books) == 1
+        assert books[0]["metadata"]
+        assert books[0]["availabilityV2"]
+        # The hydrated book is the product dictionary itself, so everything the
+        # feed carried -- ownership, dateAdded -- rides along untouched.
+        assert books[0] is product
+
     async def test_fetch_book_info_list_retry_and_unrecoverable_error(
         self,
         overdrive_api_fixture: OverdriveAPIFixture,

--- a/tests/manager/integration/license/overdrive/test_crawl.py
+++ b/tests/manager/integration/license/overdrive/test_crawl.py
@@ -213,7 +213,7 @@ class TestCrawlCursor:
 
         if faults:
             assert isinstance(step, CrawlFault)
-            assert "Refusing to reap across a gap" in step.reason
+            assert "cannot be shown to reach the end of the list" in step.reason
         else:
             assert isinstance(step, CrawlCursor)
 
@@ -228,7 +228,7 @@ class TestCrawlCursor:
         step = cursor.advance(page_of(listed=identifiers("only"), total_items=6000))
 
         assert isinstance(step, CrawlFault)
-        assert "Refusing to reap across a gap" in step.reason
+        assert "leaving a strip of the list uncovered" in step.reason
         assert "already crawled at 4000" in step.reason
 
     def test_page_size_change_faults(self) -> None:
@@ -245,7 +245,7 @@ class TestCrawlCursor:
         )
 
         assert isinstance(step, CrawlFault)
-        assert "whose paging changed underneath it" in step.reason
+        assert "no longer describes the list" in step.reason
 
     def test_serialization_round_trip(self) -> None:
         """A cursor survives the JSON wire format a task kwarg travels as."""
@@ -307,7 +307,7 @@ class TestCrawlComplete:
             assert fault is None
         else:
             assert isinstance(fault, CrawlFault)
-            assert "Refusing to reap on an incomplete crawl" in fault.reason
+            assert "distinct titles" in fault.reason
 
     def test_allowance_stays_under_a_page(self) -> None:
         """A lost page must never be excused, whatever page size Overdrive applied.

--- a/tests/manager/integration/license/overdrive/test_importer.py
+++ b/tests/manager/integration/license/overdrive/test_importer.py
@@ -18,9 +18,15 @@ from palace.manager.integration.license.overdrive.api import (
     BookInfoEndpoint,
     OverdriveAPI,
 )
+from palace.manager.integration.license.overdrive.crawl import (
+    CrawlComplete,
+    CrawlCursor,
+    ProductPage,
+)
 from palace.manager.integration.license.overdrive.importer import (
     FeedImportResult,
     OverdriveImporter,
+    ProductsImportResult,
 )
 from palace.manager.integration.license.overdrive.representation import (
     OverdriveRepresentationExtractor,
@@ -664,6 +670,234 @@ class TestOverdriveImporter:
         # Circulation should be applied for both books
         assert mock_apply_circ.call_count == 2
 
+        assert result.processed_count == 2
+
+    @staticmethod
+    def _product_page(
+        *product_ids: str, total_items: int, limit: int = 100
+    ) -> ProductPage:
+        """Build a ProductPage whose products carry only ids, hydration-ready."""
+        products = tuple({"id": product_id} for product_id in product_ids)
+        listed = tuple(
+            IdentifierData(type=Identifier.OVERDRIVE_ID, identifier=product_id.lower())
+            for product_id in product_ids
+        )
+        return ProductPage(
+            listed=listed,
+            unowned=(),
+            total_items=total_items,
+            limit=limit,
+            products=products,
+        )
+
+    def _mock_extractor(self, importer: OverdriveImporter) -> tuple[Mock, Mock]:
+        """Point the importer's extractor at bibliographic/circulation mocks."""
+        mock_bibliographic = Mock(spec=BibliographicData)
+        mock_bibliographic.needs_apply.return_value = True
+        mock_circulation = Mock(spec=CirculationData)
+        mock_circulation.needs_apply.return_value = True
+        importer._extractor.book_info_to_bibliographic = Mock(
+            return_value=mock_bibliographic
+        )
+        importer._extractor.book_info_to_circulation = Mock(
+            return_value=mock_circulation
+        )
+        return mock_bibliographic, mock_circulation
+
+    def test_import_products_page_basic(
+        self,
+        db: DatabaseTransactionFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """A page of the product-list crawl is hydrated and processed."""
+        collection = overdrive_api_fixture.collection
+        registry = services_fixture.services.integration_registry.license_providers()
+        api = overdrive_api_fixture.api
+
+        importer = OverdriveImporter(
+            db=db.session, collection=collection, registry=registry, api=api
+        )
+        self._mock_extractor(importer)
+
+        page = self._product_page("overdrive-id-1", total_items=1)
+        endpoint = BookInfoEndpoint(url="http://products/?offset=0")
+        api.product_page_endpoint = Mock(return_value=endpoint)
+        api.fetch_product_page = Mock(return_value=page)
+        api.hydrate_products = AsyncMock(
+            return_value=[
+                {
+                    "id": "overdrive-id-1",
+                    "metadata": {"title": "A Book"},
+                    "availabilityV2": {"copiesOwned": 1},
+                }
+            ]
+        )
+        mock_apply_bib = Mock()
+        mock_apply_circ = Mock()
+
+        result = importer.import_products_page(
+            apply_bibliographic=mock_apply_bib,
+            apply_circulation=mock_apply_circ,
+            cursor=CrawlCursor(),
+        )
+
+        assert isinstance(result, ProductsImportResult)
+        assert result.processed_count == 1
+        # The whole collection arrived in one page, so the crawl is complete.
+        assert isinstance(result.step, CrawlComplete)
+        assert result.step.single_page
+
+        # The page was requested at the cursor's offset, and hydration was
+        # handed the page's raw products with metadata fetched upfront (this
+        # is a main collection -- there is no parent identifier set).
+        api.product_page_endpoint.assert_called_once_with(
+            0, OverdriveImporter.DEFAULT_PAGE_SIZE
+        )
+        api.fetch_product_page.assert_called_once_with(endpoint)
+        hydrate_kwargs = api.hydrate_products.call_args.kwargs
+        assert api.hydrate_products.call_args.args == (page.products,)
+        assert hydrate_kwargs["fetch_metadata"] is True
+        assert hydrate_kwargs["fetch_availability"] is True
+
+        assert mock_apply_bib.call_count == 1
+        assert mock_apply_circ.call_count == 1
+
+    def test_import_products_page_advances_cursor(
+        self,
+        db: DatabaseTransactionFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """A page from a larger collection hands back the cursor for the next one."""
+        collection = overdrive_api_fixture.collection
+        registry = services_fixture.services.integration_registry.license_providers()
+        api = overdrive_api_fixture.api
+
+        importer = OverdriveImporter(
+            db=db.session, collection=collection, registry=registry, api=api
+        )
+        self._mock_extractor(importer)
+
+        api.product_page_endpoint = Mock(
+            return_value=BookInfoEndpoint(url="http://products/?offset=0")
+        )
+        api.fetch_product_page = Mock(
+            return_value=self._product_page(
+                "overdrive-id-1", total_items=250, limit=100
+            )
+        )
+        api.hydrate_products = AsyncMock(return_value=[])
+
+        result = importer.import_products_page(
+            apply_bibliographic=Mock(),
+            apply_circulation=Mock(),
+            cursor=CrawlCursor(),
+        )
+
+        # The first page learned the paging facts; the walk jumps to the end.
+        assert isinstance(result.step, CrawlCursor)
+        assert result.step.offset == 150
+        assert result.step.total_items == 250
+
+    def test_import_products_page_with_identifier_set(
+        self,
+        db: DatabaseTransactionFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        services_fixture: ServicesFixture,
+        redis_fixture: RedisFixture,
+    ):
+        """Processed identifiers land in the run's identifier set."""
+        collection = overdrive_api_fixture.collection
+        registry = services_fixture.services.integration_registry.license_providers()
+        api = overdrive_api_fixture.api
+
+        identifier_set = IdentifierSet(redis_fixture.client, ["import", "test"])
+        importer = OverdriveImporter(
+            db=db.session,
+            collection=collection,
+            registry=registry,
+            api=api,
+            identifier_set=identifier_set,
+        )
+        self._mock_extractor(importer)
+
+        api.product_page_endpoint = Mock(
+            return_value=BookInfoEndpoint(url="http://products/?offset=0")
+        )
+        api.fetch_product_page = Mock(
+            return_value=self._product_page("overdrive-id-1", total_items=1)
+        )
+        api.hydrate_products = AsyncMock(
+            return_value=[
+                {
+                    "id": "overdrive-id-1",
+                    "metadata": {"title": "A Book"},
+                    "availabilityV2": {"copiesOwned": 1},
+                }
+            ]
+        )
+
+        importer.import_products_page(
+            apply_bibliographic=Mock(),
+            apply_circulation=Mock(),
+            cursor=CrawlCursor(),
+        )
+
+        assert identifier_set.get() == {
+            IdentifierData(type=Identifier.OVERDRIVE_ID, identifier="overdrive-id-1")
+        }
+
+    def test_import_products_page_with_parent_identifiers_skips_metadata(
+        self,
+        db: DatabaseTransactionFixture,
+        overdrive_api_fixture: OverdriveAPIFixture,
+        services_fixture: ServicesFixture,
+    ):
+        """An advantage collection's crawl fetches metadata lazily, as the feed
+        import does: books already imported by the parent skip the lookup."""
+        collection = overdrive_api_fixture.collection
+        registry = services_fixture.services.integration_registry.license_providers()
+        api = overdrive_api_fixture.api
+
+        mock_parent_set = Mock(spec=IdentifierSet)
+        mock_parent_set.get.return_value = {
+            IdentifierData(type=Identifier.OVERDRIVE_ID, identifier="overdrive-id-1")
+        }
+        importer = OverdriveImporter(
+            db=db.session,
+            collection=collection,
+            registry=registry,
+            api=api,
+            parent_identifier_set=mock_parent_set,
+        )
+        self._mock_extractor(importer)
+
+        api.product_page_endpoint = Mock(
+            return_value=BookInfoEndpoint(url="http://products/?offset=0")
+        )
+        api.fetch_product_page = Mock(
+            return_value=self._product_page(
+                "overdrive-id-1", "overdrive-id-3", total_items=2
+            )
+        )
+        api.hydrate_products = AsyncMock(
+            return_value=[
+                {"id": "overdrive-id-1", "availabilityV2": {"copiesOwned": 1}},
+                {"id": "overdrive-id-3", "availabilityV2": {"copiesOwned": 1}},
+            ]
+        )
+        api.metadata_lookup = Mock(return_value={"title": "New Book"})
+
+        result = importer.import_products_page(
+            apply_bibliographic=Mock(),
+            apply_circulation=Mock(),
+            cursor=CrawlCursor(),
+        )
+
+        assert api.hydrate_products.call_args.kwargs["fetch_metadata"] is False
+        # Only the book absent from the parent set needed a metadata lookup.
+        assert api.metadata_lookup.call_count == 1
         assert result.processed_count == 2
 
 


### PR DESCRIPTION
## Description

Moves the Overdrive full import (`import_all=True`) off the update feed and onto the same product-list crawl the reaper walks. Stacked on #3628, which built the crawl; this PR makes it serve both consumers that need every title.

- **Hydration splits out of the page fetch.** `fetch_book_info_list` fused two jobs: walking the update feed's pages, and fetching each title's metadata and availability documents. The per-title half moves to `hydrate_products`, which takes raw product dictionaries from any source and attaches the documents; `fetch_book_info_list` delegates to it, unchanged in behavior. This is also the single place a later switch to Overdrive's bulk metadata and bulk availability endpoints will land.
- **The full import walks the product list.** It used to sweep the whole collection through the update feed with `lastUpdateTime` pinned to the epoch — an ordering that reshuffles on every circulation event anywhere in the collection, so a multi-hour walk over it skips titles exactly the way the reaper's forward walk did, and `totalItems` decrements in step so no count check can see it. The `import_all` path now drives the same `CrawlCursor` over the `dateAdded:asc` product list — backwards, overlapping pages, ending on a fresh page at offset 0 — with the importer hydrating each page's raw products (`OverdriveImporter.import_products_page`). The parent/child metadata optimization carries over unchanged: an Advantage collection's crawl still fetches metadata lazily, skipping titles the parent already imported.
- **The crawl's faults become consumer-neutral.** The cursor's fault messages ended with the reaper's consequence ("Refusing to reap across a gap"), which stopped making sense the moment a second consumer appeared. The reasons now state the arithmetic only, and each consumer appends its own consequence: the reaper aborts exactly as before, while the import — where nothing acts on a title's *absence* — keeps what it imported. A structural fault ends the import's crawl but still returns the identifier set (a child import can use a partial set), leaving the import timestamp unchanged so the incomplete sweep is not recorded as a finished import; a count shortfall at the completeness gate is a warning and the import finishes.

The delta import is untouched — the update feed is the right primitive for harvesting changes; what it is wrong for is enumerating everything. Per-title hydration still costs a metadata and an availability request per title; cutting that ~50× with the bulk endpoints is the next PR in the stack. A full-import page queued by the previous release carries its feed url and is finished the way it was started, so in-flight runs survive a deploy; the crawl takes over runs that begin afterwards.

## Motivation and Context

Follow-on to #3628, second step of unifying Overdrive's harvest paths onto one crawl machinery. The skip mechanism this fixes is the one that PR measured live: removing (or re-updating) a title mid-walk shifts everything behind it down one position under offset paging, and the update-feed ordering churns constantly — the worst possible ordering to page a multi-hour backfill over. The product list's `dateAdded` ordering is immutable and its ties are stable, which is why the reaper's cursor walks it; a full import needs exactly the same coverage guarantees, just with a different response to faults.

## How Has This Been Tested?

- Unit tests covering: `import_products_page` at the importer level — hydration flags for main vs Advantage collections, cursor hand-back, identifier-set population, and lazy metadata for titles in the parent set; the task-level crawl path — a fresh cursor on `import_all`, the cursor round-tripping through `task.replace()`, a fault keeping the partial result while leaving the timestamp untouched, the completeness gate warning without failing the run, and a legacy feed-url page being honored on the old path; and `hydrate_products` hydrating raw product dictionaries in place. The end-to-end group test now drives a full import from raw HTTP fixtures (product page over the sync client, metadata and availability over the async client) through the apply queue to database records.
- `tox -e py312-docker` over `tests/manager/celery`, `tests/manager/integration/license/opds`, `tests/manager/integration/license/overdrive`, and `tests/manager/scripts/test_overdrive.py` — 886 passing.
- `mypy` clean across 1,160 source files.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
