### PR TITLE
Handle empty values array for patron ID candidate SAML attribute (PP-4917)

### DIFF
--- a/src/palace/manager/integration/patron_auth/saml/metadata/model.py
+++ b/src/palace/manager/integration/patron_auth/saml/metadata/model.py
@@ -1384,7 +1384,17 @@ class SAMLSubjectPatronIDExtractor:
 
                     # NOTE: It takes the first value.
                     # TODO: Any reason not to handle multiple values here?
-                    patron_id_candidate = patron_id_attribute_obj.values[0]
+
+                    # An attribute can be present without a usable value. The SAML
+                    # library drops empty AttributeValue elements, so an attribute
+                    # with only empty values arrives with an empty values list, and
+                    # a nested NameID element with no text arrives as a None value.
+                    # Skip such attributes and move on to the next candidate.
+                    values = patron_id_attribute_obj.values
+                    if not values or not values[0]:
+                        continue
+
+                    patron_id_candidate = values[0]
                     patron_id = self._extract_patron_id(patron_id_candidate)
 
                     if patron_id is not None:

--- a/tests/manager/integration/patron_auth/saml/metadata/test_model.py
+++ b/tests/manager/integration/patron_auth/saml/metadata/test_model.py
@@ -578,6 +578,133 @@ class TestSAMLSubjectPatronIDExtractor:
                 "eduPersonUniqueId",
                 id="transient-name-id-with-matching-attribute",
             ),
+            pytest.param(
+                SAMLSubject(
+                    "http://idp.example.com",
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED.value, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=[],
+                            ),
+                            SAMLAttribute(
+                                name=SAMLAttributeType.uid.name, values=["4"]
+                            ),
+                        ]
+                    ),
+                ),
+                "4",
+                True,
+                None,
+                None,
+                "uid",
+                id="empty-values-falls-back-to-next-attribute",
+            ),
+            pytest.param(
+                SAMLSubject(
+                    "http://idp.example.com",
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED.value, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=[],
+                            )
+                        ]
+                    ),
+                ),
+                "1",
+                True,
+                None,
+                None,
+                "NameID",
+                id="empty-values-falls-back-to-name-id",
+            ),
+            pytest.param(
+                SAMLSubject(
+                    "http://idp.example.com",
+                    SAMLNameID(
+                        SAMLNameIDFormat.TRANSIENT.value, "", "", "transient-value"
+                    ),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=[],
+                            )
+                        ]
+                    ),
+                ),
+                None,
+                True,
+                None,
+                None,
+                None,
+                id="empty-values-no-usable-candidate",
+            ),
+            pytest.param(
+                SAMLSubject(
+                    "http://idp.example.com",
+                    SAMLNameID(
+                        SAMLNameIDFormat.TRANSIENT.value, "", "", "transient-value"
+                    ),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=[None],
+                            )
+                        ]
+                    ),
+                ),
+                None,
+                True,
+                None,
+                saml_strings.PATRON_ID_REGULAR_EXPRESSION_ORG,
+                None,
+                id="none-value-skipped-with-regex",
+            ),
+            pytest.param(
+                SAMLSubject(
+                    "http://idp.example.com",
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED.value, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=[""],
+                            )
+                        ]
+                    ),
+                ),
+                "1",
+                True,
+                None,
+                None,
+                "NameID",
+                id="empty-string-value-falls-back-to-name-id",
+            ),
+            pytest.param(
+                SAMLSubject(
+                    "http://idp.example.com",
+                    SAMLNameID(SAMLNameIDFormat.UNSPECIFIED.value, "", "", "1"),
+                    SAMLAttributeStatement(
+                        [
+                            SAMLAttribute(
+                                name=SAMLAttributeType.eduPersonUniqueId.name,
+                                values=[None, "12345"],
+                            )
+                        ]
+                    ),
+                ),
+                "1",
+                True,
+                None,
+                None,
+                "NameID",
+                id="falsy-first-value-skips-whole-attribute",
+            ),
         ],
     )
     def test(


### PR DESCRIPTION
## Description

- During SAML patron ID extraction, skip a patron ID candidate attribute that has no usable value (an empty values list, or an empty/missing first value) and fall back to the next candidate attribute, then to the NameID (if permitted and available).
- If no usable candidate remains, authentication now fails with the "cannot determine patron" problem detail instead of an internal server error.
- Added test coverage for the fallback paths.

## Motivation and Context

An identity provider may map an empty-valued attribute onto a configured patron ID candidate (observed in the field with an empty "Organization" mapped to `eduPersonUniqueId`). The SAML library drops empty `AttributeValue` elements, so the attribute arrives with an empty values list and extraction crashed with an `IndexError`, returning a 500 to the patron during login. The same guard also fixes a `TypeError` raised when a `None` value (from an empty nested `NameID` inside an `AttributeValue`) was matched against a configured patron ID regular expression.

There is one deliberate behavior change. An attribute whose first value is an empty string previously yielded `""` as the patron ID; it is now skipped, with fallback to the NameID. Empty strings are unreachable from live SAML parsing (the library strips empty `AttributeValue` text), so no data migration is needed.

[Jira PP-4917]

## How Has This Been Tested?

- Added the aforementioned fallback case tests.
- All tests pass locally.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.