### PR TITLE
Reduce the Overdrive reaper to a twice-monthly schedule (PP-4983)

### DIFF
--- a/src/palace/manager/service/celery/celery.py
+++ b/src/palace/manager/service/celery/celery.py
@@ -303,7 +303,16 @@ def beat_schedule() -> dict[str, Any]:
         },
         "overdrive_reap_all_collections": {
             "task": overdrive.reap_all_collections.name,
-            "schedule": crontab(minute="0", hour="23"),  # Once a day at 11:00 PM
+            # TODO: Reap more often than this once PP-4983 is addressed.
+            # The reaper makes one blocking single-title availability request
+            # per title, so a daily run consumes 90+% of the available cycles on
+            # the workers processing the default queue for managers with many
+            # Overdrive collections, delaying every other task. As a temporary
+            # fix we reap twice a month so the queue is only monopolized two
+            # days a month instead of every day.
+            "schedule": crontab(
+                minute="0", hour="23", day_of_month="5,20"
+            ),  # On the 5th and 20th of the month at 11:00 PM
         },
         "bibliotheca_import_all_collections": {
             "task": bibliotheca.import_all_collections.name,


### PR DESCRIPTION
## Description

Moves the `overdrive_reap_all_collections` beat entry from daily at 11:00 PM to the 5th and 20th of the month at 11:00 PM, and adds a TODO recording why the frequency is this low.

## Motivation and Context

PP-4983. The Overdrive reaper makes one blocking single-title availability request per title, so on managers with many Overdrive collections a daily run consumes 90+% of the available cycles on the workers processing the `default` queue and delays every other task on it.

This is a stopgap to ease the immediate contention. We should be able to back this out once we've done some work to improve the performance of the reaper.

## How Has This Been Tested?

Confirmed the schedule parses as intended (`crontab(minute="0", hour="23", day_of_month="5,20")` → `0 23 5,20 * *`). `day_of_month` is already used elsewhere in this schedule (`generate_playtime_report`). No behavior in the task itself changed, only its cadence.

## Checklist

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
